### PR TITLE
Transaction-friendly IO

### DIFF
--- a/transactions/_utils.py
+++ b/transactions/_utils.py
@@ -3,7 +3,7 @@ import itertools
 from amaranth import *
 
 __all__ = [
-    "Scheduler", "_graph_ccs"
+    "Scheduler", "_graph_ccs", "_coerce_record"
 ]
 
 class Scheduler(Elaboratable):
@@ -56,4 +56,8 @@ def _graph_ccs(gr):
 
     return ccs
 
-
+def _coerce_record(int_or_layout):
+    if isinstance(int_or_layout, int):
+        return Record([('data', int_or_layout)])
+    else:
+        return Record(int_or_layout)

--- a/transactions/lib.py
+++ b/transactions/lib.py
@@ -1,6 +1,7 @@
 
 from amaranth import *
 from .core import *
+from ._utils import _coerce_record
 
 __all__ = [
     "FIFO",
@@ -14,12 +15,13 @@ __all__ = [
 import amaranth.lib.fifo
 
 class FIFO(Elaboratable):
-    def __init__(self, width, depth):
-        self.width = width
+    def __init__(self, data_layout, depth):
+        data_record = _coerce_record(data_layout)
+        self.width = len(data_record)
         self.depth = depth
 
-        self.read = Method(o=width)
-        self.write = Method(i=width)
+        self.read = Method(o=data_record.layout)
+        self.write = Method(i=data_record.layout)
 
     def elaborate(self, platform):
         m = Module()
@@ -88,14 +90,14 @@ class ClickOut(Elaboratable):
 # Testbench-friendly input/output
 
 class AdapterTrans(Elaboratable):
-    def __init__(self, iface : Method, i=[], o=[]):
-        self.input_fmt = i
-        self.output_fmt = o
+    def __init__(self, iface : Method, i=0, o=0):
         self.iface = iface
         self.en = Signal()
         self.done = Signal()
-        self.data_in = Record(self.input_fmt)
-        self.data_out = Record(self.output_fmt)
+        self.data_in = _coerce_record(i)
+        self.data_out = _coerce_record(o)
+        self.input_fmt = self.data_in.layout
+        self.output_fmt = self.data_out.layout
 
     def elaborate(self, platform):
         m = Module()


### PR DESCRIPTION
Here's a solution that I've been using to move data in and out in a transaction-based code in a testbench. There's one common class `DummyIO` that works for both input and output. Data layout and method to call for input/output have to be provided. There are a few signals to interface with in the testbench: `data_in` and `data_out` to send and receive data, `en` signal which works like a request to perform the transaction (to put or get data), and `done` signal which is high when either input was successfully put in or the data has been taken out (and is available to read on the same clock cycle). Example usage in a testbench - reading output:
```Python
yield out.en.eq(1)
yield
while (yield out.done) != 1:
    yield
assert((yield out.data_out.some_signal) == some_value)
yield out.en.eq(0)
```
Input:
```Python
yield inp.en.eq(1)
yield inp.data_in.some_signal.eq(some_value)
yield
while (yield inp.done) != 1:
    yield
yield inp.en.eq(0)
```