### PR TITLE
Deterministic eager scheduler

### DIFF
--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from typing import Union, List
+from types import MethodType
 from amaranth import *
 from ._utils import *
 
@@ -49,7 +50,7 @@ class TransactionManager(Elaboratable):
         self.methods = {}
         self.methodargs = {}
         self.conflicts = []
-        self.cc_scheduler = cc_scheduler
+        self.cc_scheduler = MethodType(cc_scheduler, self)
 
     def add_conflict(self, end1: Union["Transaction", "Method"], end2: Union["Transaction", "Method"]) -> None:
         self.conflicts.append((end1, end2))
@@ -102,7 +103,7 @@ class TransactionManager(Elaboratable):
         gr = self._conflict_graph()
 
         for cc in _graph_ccs(gr):
-            self.cc_scheduler(self, m, gr, cc)
+            self.cc_scheduler(m, gr, cc)
 
         for method, transactions in self.methods.items():
             granted = Signal(len(transactions))


### PR DESCRIPTION
The round-robin scheduling (within each connected component of the conflict graph) was replaced with deterministic, eager scheduling with a fixed order. This is a simplified version of scheduling in Bluespec. Using this scheduling method, multiple transactions from a given CC can be scheduled in a single cycle, as long as they don't conflict. There is no guarantee of optimality or fairness, however.

I'm leaving this as a PR for now so that it can be compared with the round-robin scheduler. This is also untested; tests and testing CI are needed.