### PR TITLE
ci: Fix failed lint returning 0

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -16,6 +16,7 @@ sub_verify() {
     python3 -m flake8 \
       --max-line-length=$MAX_LINE_LENGTH \
       --ignore=F401,F403,F405 .
+    exit $?
 }
 
 sub_format(){


### PR DESCRIPTION
Jobs are successful despite failing the formatting check (https://github.com/kuznia-rdzeni/coreblocks/runs/6441052339?check_suite_focus=true#step:5:7).