### PR TITLE
transactions: Add some sugar for method definition

### DIFF
--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -12,7 +12,7 @@ __all__ = [
     "Method",
     "eager_deterministic_cc_scheduler",
     "trivial_roundrobin_cc_scheduler",
-    "define_method",
+    "def_method",
 ]
 
 
@@ -253,38 +253,37 @@ class Transaction:
         return cls.current
 
 
-"""Define a method.
+def def_method(m, method, ready=C(1)):
+    """Define a method.
 
-This decorator allows to define transactional methods in more
-elegant way using Python's ``def`` syntax.
+    This decorator allows to define transactional methods in more
+    elegant way using Python's ``def`` syntax.
 
-The decorated function should take one argument, which will be a
-record with input signals and return a record with output signals.
+    The decorated function should take one argument, which will be a
+    record with input signals and return a record with output signals.
 
-Parameters
-----------
-m : Module
-    Module in which operations on signals should be executed.
-method : Method
-    The method whose body is going to be defined.
-ready : Signal
-    Signal to indicate if the method is ready to be run. By
-    default it is ``Const(1)``, so the method is always ready.
-    Assigned combinatorially to the ``ready`` attribute.
+    Parameters
+    ----------
+    m : Module
+        Module in which operations on signals should be executed.
+    method : Method
+        The method whose body is going to be defined.
+    ready : Signal
+        Signal to indicate if the method is ready to be run. By
+        default it is ``Const(1)``, so the method is always ready.
+        Assigned combinatorially to the ``ready`` attribute.
 
-Example
--------
-```
-m = Module()
-my_sum_method = Method(i=[("arg1",8),("arg2",8)], o=8)
-@define_method(m, my_sum_method)
-def _(data_in):
-    return data_in.arg1 + data_in.arg2
-```
-"""
+    Example
+    -------
+    ```
+    m = Module()
+    my_sum_method = Method(i=[("arg1",8),("arg2",8)], o=8)
+    @def_method(m, my_sum_method)
+    def _(data_in):
+        return data_in.arg1 + data_in.arg2
+    ```
+    """
 
-
-def define_method(m, method, ready=C(1)):
     def decorator(func):
         out = Record.like(method.data_out)
         ret_out = None

--- a/coreblocks/transactions/lib.py
+++ b/coreblocks/transactions/lib.py
@@ -23,12 +23,12 @@ class FIFO(Elaboratable):
 
         m.submodules.fifo = fifo = amaranth.lib.fifo.SyncFIFO(width=self.width, depth=self.depth)
 
-        @define_method(m, self.write, ready=fifo.w_rdy)
+        @def_method(m, self.write, ready=fifo.w_rdy)
         def _(arg):
             m.d.comb += fifo.w_en.eq(1)
             m.d.comb += fifo.w_data.eq(arg)
 
-        @define_method(m, self.read, ready=fifo.r_rdy)
+        @def_method(m, self.read, ready=fifo.r_rdy)
         def _(arg):
             m.d.comb += fifo.r_en.eq(1)
             return fifo.r_data
@@ -57,7 +57,7 @@ class ClickIn(Elaboratable):
         get_ready = Signal()
         get_data = Signal.like(self.dat)
 
-        @define_method(m, self.get, ready=get_ready)
+        @def_method(m, self.get, ready=get_ready)
         def _(arg):
             m.d.sync += get_ready.eq(0)
             return get_data
@@ -86,7 +86,7 @@ class ClickOut(Elaboratable):
         m.d.sync += btn1.eq(self.btn)
         m.d.sync += btn2.eq(btn1)
 
-        @define_method(m, self.put, ready=~btn2 & btn1)
+        @def_method(m, self.put, ready=~btn2 & btn1)
         def _(arg):
             m.d.sync += self.dat.eq(arg)
 


### PR DESCRIPTION
Here's the idea I suggested during our meeting. I added a decorator that allows to define method using Python functions. Two possible benefits are: 
* signals returned from a method are really *returned*,
* some connections can be moved out from `m.If` section without losing code brevity and clarity.

I'll add some documentation if we decide to merge this change.