### PR TITLE
Generalize adapters

### DIFF
--- a/coreblocks/transactions/lib.py
+++ b/coreblocks/transactions/lib.py
@@ -134,9 +134,11 @@ class Adapter(AdapterBase):
         data_in = Signal.like(self.data_in)
         m.d.comb += data_in.eq(self.data_in)
 
-        with self.iface.body(m, ready=self.en, out=data_in) as data_out:
-            m.d.comb += self.data_out.eq(data_out)
+        @def_method(m, self.iface, ready=self.en)
+        def _(arg):
+            m.d.comb += self.data_out.eq(arg)
             m.d.comb += self.done.eq(1)
+            return data_in
 
         return m
 

--- a/test/common.py
+++ b/test/common.py
@@ -62,6 +62,7 @@ class TestbenchIO(Elaboratable):
     def call_result(self):
         if (yield self.adapter.done):
             return (yield from get_outputs(self.adapter.data_out))
+        return None
 
     def call_do(self):
         while not (outputs := (yield from self.call_result())):


### PR DESCRIPTION
This pull request adds an additional adapter class, `Adapter`, which adapts a `Method` to raw signals. It also modifies `TestbenchIO` so that it can work both with `Adapter` and `AdapterTrans`. This allows creating a testbench-controlled method.

Also, a `call_result` function is introduced in `TestbenchIO`, which allows to get a result without waiting (if it's already available).

Using this functionality, I have implemented a testbench for the transaction framework, which uncovered bugs fixed in #37. The testbench will be added in another pull request.

Edit: this also fixes a bug where `AdapterTrans` gives a `done` signal even when the method it is connected to is being called by a different transaction.