### PR TITLE
Fix typo in __all__ in scheduler.py

### DIFF
--- a/coreblocks/scheduler.py
+++ b/coreblocks/scheduler.py
@@ -3,7 +3,7 @@ from coreblocks.transactions import Method, Transaction
 from coreblocks.layouts import SchedulerLayouts, ROBLayouts
 from coreblocks.genparams import GenParams
 
-__all__ = ["RegAllocation", "Renaming", "RobAllocation"]
+__all__ = ["RegAllocation", "Renaming", "ROBAllocation"]
 
 
 class RegAllocation(Elaboratable):


### PR DESCRIPTION
Pyright is currently printing a warning:
```
  /home/runner/work/coreblocks/coreblocks/coreblocks/scheduler.py:6:41 - warning: "RobAllocation" is specified in __all__ but is not present in module (reportUnsupportedDunderAll)
```