### PR TITLE
Added OneHotSwitch generator to make writing one-hots switch easier.

### DIFF
--- a/coreblocks/transactions/_utils.py
+++ b/coreblocks/transactions/_utils.py
@@ -1,34 +1,13 @@
 import itertools
-from typing import Iterable, Literal, TypeAlias, TypeVar, Mapping, Optional, overload
+from typing import Iterable, TypeAlias, TypeVar, Mapping
 from amaranth import *
 from .._typing import LayoutLike
+from coreblocks.utils import OneHotSwitch
 
-__all__ = ["Scheduler", "_graph_ccs", "MethodLayout", "_coerce_layout", "ROGraph", "Graph", "GraphCC", "OneHotSwitch"]
+__all__ = ["Scheduler", "_graph_ccs", "MethodLayout", "_coerce_layout", "ROGraph", "Graph", "GraphCC"]
 
 
 T = TypeVar("T")
-
-
-@overload
-def OneHotSwitch(m: Module, in_signal: Value, *, default: Literal[True]) -> Iterable[Optional[int]]:
-    ...
-
-
-@overload
-def OneHotSwitch(m: Module, in_signal: Value, *, default: Literal[False] = False) -> Iterable[int]:
-    ...
-
-
-def OneHotSwitch(m: Module, in_signal: Value, *, default: bool = False) -> Iterable[Optional[int]]:
-    count = len(in_signal)
-    with m.Switch(in_signal):
-        for i in range(count):
-            with m.Case("-" * (count - i - 1) + "1" + "-" * i):
-                yield i
-        if default:
-            with m.Case():
-                yield None
-    return
 
 
 class Scheduler(Elaboratable):

--- a/coreblocks/utils.py
+++ b/coreblocks/utils.py
@@ -1,11 +1,33 @@
 from enum import Enum
-from typing import Iterable, Mapping
+from typing import Iterable, Literal, Mapping, Optional, overload
 from amaranth import *
 from amaranth.hdl.ast import Assign
 from coreblocks._typing import ValueLike
 
 
-__all__ = ["AssignType", "assign"]
+__all__ = ["AssignType", "assign", "OneHotSwitch"]
+
+
+@overload
+def OneHotSwitch(m: Module, in_signal: Value, *, default: Literal[True]) -> Iterable[Optional[int]]:
+    ...
+
+
+@overload
+def OneHotSwitch(m: Module, in_signal: Value, *, default: Literal[False] = False) -> Iterable[int]:
+    ...
+
+
+def OneHotSwitch(m: Module, in_signal: Value, *, default: bool = False) -> Iterable[Optional[int]]:
+    count = len(in_signal)
+    with m.Switch(in_signal):
+        for i in range(count):
+            with m.Case("-" * (count - i - 1) + "1" + "-" * i):
+                yield i
+        if default:
+            with m.Case():
+                yield None
+    return
 
 
 class AssignType(Enum):

--- a/coreblocks/wishbone.py
+++ b/coreblocks/wishbone.py
@@ -6,7 +6,7 @@ from typing import List
 import operator
 
 from coreblocks.transactions import Method
-from coreblocks.transactions._utils import OneHotSwitch
+from coreblocks.utils import OneHotSwitch
 
 
 class WishboneParameters:


### PR DESCRIPTION
I have observed, that we use in many places one hot switches (two such switches we have in code and there are more in pull requests). Writing such switches is a little bit problematic, because we have to generate string of "-" and "1". So to make it easier I created OneHotSwitch function, which generates for us such switch. This commit also added usage of this generator in two places, which we have in our code already.

Please comment, about a way to set default case value, because I am not sure if my proposition is the cleanest way.