### PR TITLE
Add python3 -m prefix to pyright command

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -43,7 +43,7 @@ sub_format(){
 }
 
 sub_check_types(){
-    pyright
+    python3 -m pyright
 }
 
 sub_verify(){


### PR DESCRIPTION
Fixes missing prefix.