### PR TITLE
Looser typing of returned dicts in tests

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -12,6 +12,7 @@ from coreblocks.transactions.lib import AdapterBase
 
 T = TypeVar("T")
 RecordIntDict = Mapping[str, Union[int, "RecordIntDict"]]
+RecordIntDictRet = Mapping[str, Any]  # full typing hard to work with
 TestGen = Generator[Command | Value | Statement | None, Any, T]
 
 
@@ -84,18 +85,18 @@ class TestbenchIO(Elaboratable):
         yield from self.enable()
         yield from set_inputs(data, self.adapter.data_in)
 
-    def call_result(self) -> TestGen[Optional[RecordIntDict]]:
+    def call_result(self) -> TestGen[Optional[RecordIntDictRet]]:
         if (yield self.adapter.done):
             return (yield from get_outputs(self.adapter.data_out))
         return None
 
-    def call_do(self) -> TestGen[RecordIntDict]:
+    def call_do(self) -> TestGen[RecordIntDictRet]:
         while not (outputs := (yield from self.call_result())):
             yield
         yield from self.disable()
         return outputs
 
-    def call(self, data: RecordIntDict = {}) -> TestGen[RecordIntDict]:
+    def call(self, data: RecordIntDict = {}) -> TestGen[RecordIntDictRet]:
         yield from self.call_init(data)
         yield
         return (yield from self.call_do())

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -4,7 +4,7 @@ from amaranth.sim import *
 import random
 
 from collections import deque
-from typing import Iterable, Callable, cast
+from typing import Iterable, Callable
 from parameterized import parameterized, parameterized_class
 
 from .common import TestCaseWithSimulator, TestbenchIO
@@ -127,7 +127,7 @@ class TestTransactionConflict(TestCaseWithSimulator):
                     yield
                 tgt(i)
                 r = yield from io.call({"data": i})
-                chk(cast(int, r["data"]))
+                chk(r["data"])
 
         return process
 


### PR DESCRIPTION
Until a better solution is found, I propose to loosen typing of dicts returned from methods etc. in testing, as the current type can't really be used without casts.