### PR TITLE
Make better gtkw files

### DIFF
--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Callable, Mapping, TypeAlias, Union, Optional, Tuple, Iterator
+from typing import Callable, Iterable, Mapping, TypeAlias, Union, Optional, Tuple, Iterator
 from types import MethodType
 from amaranth import *
 from amaranth import tracer
@@ -20,6 +20,7 @@ __all__ = [
 ]
 
 
+DebugSignals: TypeAlias = Signal | Record | Iterable["DebugSignals"] | Mapping[str, "DebugSignals"]
 ConflictGraph: TypeAlias = Graph["Transaction"]
 ConflictGraphCC: TypeAlias = GraphCC["Transaction"]
 TransactionScheduler: TypeAlias = Callable[["TransactionManager", Module, ConflictGraph, ConflictGraphCC], None]
@@ -383,6 +384,9 @@ class Transaction:
     def __repr__(self) -> str:
         return "(transaction {})".format(self.name)
 
+    def debug_signals(self) -> DebugSignals:
+        return [self.request, self.grant]
+
 
 def _connect_rec_with_possibly_dict(dst: Value | Record, src: RecordDict) -> list[Assign]:
     if not isinstance(src, dict):
@@ -557,6 +561,9 @@ class Method:
 
     def __repr__(self) -> str:
         return "(method {})".format(self.name)
+
+    def debug_signals(self) -> DebugSignals:
+        return [self.ready, self.run, self.data_in, self.data_out]
 
 
 def def_method(m: Module, method: Method, ready: ValueLike = C(1)):

--- a/coreblocks/transactions/lib.py
+++ b/coreblocks/transactions/lib.py
@@ -1,5 +1,6 @@
 from amaranth import *
 from .core import *
+from .core import DebugSignals
 from ._utils import _coerce_layout, MethodLayout
 
 __all__ = [
@@ -113,6 +114,9 @@ class AdapterBase(Elaboratable):
         self.iface = iface
         self.en = Signal()
         self.done = Signal()
+
+    def debug_signals(self) -> DebugSignals:
+        return [self.en, self.done, self.data_in, self.data_out]
 
 
 class AdapterTrans(AdapterBase):

--- a/stubs/amaranth/hdl/ast.pyi
+++ b/stubs/amaranth/hdl/ast.pyi
@@ -386,6 +386,7 @@ class Signal(Value, DUID):
     def __repr__(self) -> str:
         ...
     
+    decoder: Any
 
 
 @final

--- a/stubs/amaranth/sim/pysim.pyi
+++ b/stubs/amaranth/sim/pysim.pyi
@@ -30,7 +30,11 @@ class _VCDWriter:
     def close(self, timestamp):
         ...
     
-
+    vcd_file: Any
+    gtkw_file: Any
+    gtkw_save: Any
+    gtkw_names: Any
+    vcd_writer: Any
 
 class _Timeline:
     def __init__(self) -> None:

--- a/test/gtkw_extension.py
+++ b/test/gtkw_extension.py
@@ -1,0 +1,74 @@
+from typing import Iterable, Mapping
+from contextlib import contextmanager
+from amaranth.sim.pysim import _VCDWriter
+from amaranth import *
+
+
+def flatten(traces):
+    if isinstance(traces, Mapping):
+        for x in traces.values():
+            yield from flatten(x)
+    elif isinstance(traces, Iterable):
+        for x in traces:
+            yield from flatten(x)
+    elif isinstance(traces, Record):
+        for x in traces.fields.values():
+            yield from flatten(x)
+    else:
+        yield traces
+
+
+class _VCDWriterExt(_VCDWriter):
+    def __init__(self, fragment, *, vcd_file, gtkw_file, traces):
+        super().__init__(fragment=fragment, vcd_file=vcd_file, gtkw_file=gtkw_file, traces=list(flatten(traces)))
+        self._tree_traces = traces
+
+    def close(self, timestamp):
+        def gtkw_traces(traces):
+            if isinstance(traces, Mapping):
+                for k, v in traces.items():
+                    with self.gtkw_save.group(k):
+                        gtkw_traces(v)
+            elif isinstance(traces, Iterable):
+                for v in traces:
+                    gtkw_traces(v)
+            elif isinstance(traces, Record):
+                if len(traces.fields) > 1:
+                    with self.gtkw_save.group(traces.name):
+                        for v in traces.fields.values():
+                            gtkw_traces(v)
+                elif len(traces.fields) == 1:  # to make gtkwave view less verbose
+                    gtkw_traces(next(iter(traces.fields.values())))
+            elif isinstance(traces, Signal):
+                if len(traces) > 1 and not traces.decoder:
+                    suffix = "[{}:0]".format(len(traces) - 1)
+                else:
+                    suffix = ""
+                self.gtkw_save.trace(".".join(self.gtkw_names[traces]) + suffix)
+
+        if self.vcd_writer is not None:
+            self.vcd_writer.close(timestamp)
+
+        if self.gtkw_save is not None:
+            self.gtkw_save.dumpfile(self.vcd_file.name)
+            self.gtkw_save.dumpfile_size(self.vcd_file.tell())
+            self.gtkw_save.zoom_markers(-21)
+
+            self.gtkw_save.treeopen("top")
+            gtkw_traces(self._tree_traces)
+
+        if self.vcd_file is not None:
+            self.vcd_file.close()
+        if self.gtkw_file is not None:
+            self.gtkw_file.close()
+
+
+@contextmanager
+def write_vcd_ext(engine, vcd_file, gtkw_file, traces):
+    vcd_writer = _VCDWriterExt(engine._fragment, vcd_file=vcd_file, gtkw_file=gtkw_file, traces=traces)
+    try:
+        engine._vcd_writers.append(vcd_writer)
+        yield
+    finally:
+        vcd_writer.close(engine.now)
+        engine._vcd_writers.remove(vcd_writer)

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -197,7 +197,14 @@ class TestTransactionConflict(TestCaseWithSimulator):
         ]
     )
     def test_calls(self, name, prob1, prob2, probout):
-        with self.runSimulation(self.m) as sim:
+        def debug_signals():
+            return {
+                "in1": self.m.in1.debug_signals(),
+                "in2": self.m.in2.debug_signals(),
+                "out": self.m.out.debug_signals(),
+            }
+
+        with self.runSimulation(self.m, extra_signals=debug_signals) as sim:
             sim.add_sync_process(self.make_in1_process(prob1))
             sim.add_sync_process(self.make_in2_process(prob2))
             sim.add_sync_process(self.make_out_process(probout))


### PR DESCRIPTION
Even though we have easily generated VCD files from tests, debugging is still a chore: one has to add all the interesting signals to the view, each time the test is run (or save the prepared .gtkw file somewhere). This PR aims to change that.

For complex tests, the number of possibly interesting signals is huge (e.g. register values, RAT entries, etc.), and therefore using the gtkwave signal grouping is desirable. Unfortunately, Amaranth can't do it as it is now. So I implemented a hack, which allows specifying the interesting signals (or records!) hierarchically. I'm also adding a convention that Elaboratables and other classes can have a debug_signals method, which returns the signals which are interesting from the point of view of debugging.

Using functionality from this PR, one could generate interesting diagrams presenting the workings of the full core, hassle-free.