### PR TITLE
Fix transactions without methods bug

### DIFF
--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -145,7 +145,7 @@ class TransactionManager(Elaboratable):
             gr[transaction].add(transaction2)
             gr[transaction2].add(transaction)
 
-        for transaction in self.methods_by_transaction.keys():
+        for transaction in self.transactions:
             gr[transaction] = set()
 
         for transaction, methods in self.methods_by_transaction.items():


### PR DESCRIPTION
Defining a transaction without any called methods leads to an exception. This fixes this problem.

A test for such a situation will be introduced in #124 .