### PR TITLE
Improvement to ELK graph output

### DIFF
--- a/coreblocks/frontend/fetch.py
+++ b/coreblocks/frontend/fetch.py
@@ -42,7 +42,6 @@ class Fetch(Elaboratable):
         m.d.comb += req.addr.eq(self.pc >> 2)
         m.d.comb += req.sel.eq(2 ** (self.gp.isa.ilen // self.bus.wb_params.granularity) - 1)
 
-
         with Transaction(name="FetchRQ").body(m, request=(~stalled)):
             self.bus.request(m, req)
 

--- a/coreblocks/transactions/graph.py
+++ b/coreblocks/transactions/graph.py
@@ -122,7 +122,6 @@ class OwnershipGraph:
 
         return flag
 
-
     def dump(self, fp, format: Literal["dot", "elk", "mermaid"]):
         dumper = getattr(self, "dump_" + format)
         dumper(fp)


### PR DESCRIPTION
After some tweaking, I was able to obtain the following output from ELK:

![obraz](https://user-images.githubusercontent.com/509167/210774335-dd86e464-2ebb-47bf-8ecb-c43cfc7525a5.png)

I'm still unhappy about how edges are visually similar to node boundaries, but otherwise this looks not so bad.

Based on #171.