### PR TITLE
Updated amaranth version, due to dropping support by pip for old syntax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 amaranth-yosys==0.10.0.dev46
-git+https://github.com/amaranth-lang/amaranth@64b96e1
+git+https://github.com/amaranth-lang/amaranth@e2f05197741bbf36d01c3baf03ae48931ede2c19

--- a/stubs/amaranth/hdl/ast.pyi
+++ b/stubs/amaranth/hdl/ast.pyi
@@ -8,7 +8,7 @@ from typing import Any, Iterable, Iterator, Mapping, NoReturn, Optional, Sequenc
 from enum import Enum
 from coreblocks.utils import ValueLike, ShapeLike, StatementLike
 
-__all__ = ["Shape", "signed", "unsigned", "Value", "Const", "C", "AnyConst", "AnySeq", "Operator", "Mux", "Part", "Slice", "Cat", "Repl", "Array", "ArrayProxy", "Signal", "ClockSignal", "ResetSignal", "UserValue", "ValueCastable", "Sample", "Past", "Stable", "Rose", "Fell", "Initial", "Statement", "Switch", "Property", "Assign", "Assert", "Assume", "Cover", "ValueKey", "ValueDict", "ValueSet", "SignalKey", "SignalDict", "SignalSet", "ValueLike", "ShapeLike", "StatementLike", "SwitchKey"]
+__all__ = ["Shape", "signed", "unsigned", "Value", "Const", "C", "AnyConst", "AnySeq", "Operator", "Mux", "Part", "Slice", "Cat", "Repl", "Array", "ArrayProxy", "Signal", "ClockSignal", "ResetSignal", "ValueCastable", "Sample", "Past", "Stable", "Rose", "Fell", "Initial", "Statement", "Switch", "Property", "Assign", "Assert", "Assume", "Cover", "ValueKey", "ValueDict", "ValueSet", "SignalKey", "SignalDict", "SignalSet", "ValueLike", "ShapeLike", "StatementLike", "SwitchKey"]
 
 
 T = TypeVar("T")
@@ -474,24 +474,6 @@ class ArrayProxy(Value):
         ...
     
     def __repr__(self) -> str:
-        ...
-    
-
-
-class UserValue(Value):
-    """Value with custom lowering.
-
-   """
-    @deprecated("instead of `UserValue`, use `Val", stacklevel=3)
-    def __init__(self, *, src_loc_at=...) -> None:
-        ...
-    
-    @abstractmethod
-    def lower(self): # -> None:
-        """Conversion to a concrete represe"""
-        ...
-    
-    def shape(self) -> Shape:
         ...
     
 


### PR DESCRIPTION
In ~https://github.com/amaranth-lang/amaranth/commit/ca77de5ed3ae19ef241f07bc56765f414db4d968~ https://github.com/amaranth-lang/amaranth/commit/732d62eb2412e38f6a0ccd4a6efc59a5c73898b7 there was fixed deprecated syntax in amaranth install script, which block installing amaranth on new pip versions. Updating requirements to use fixed version.