### PR TITLE
RS configuration: proposed changes to @lekcyjna123's proposed changes

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -42,7 +42,7 @@ class Core(Elaboratable):
         self.func_blocks_unifier = FuncBlocksUnifier(
             gen_params=gen_params,
             blocks=gen_params.func_units_config,
-            connections=ComponentConnections().set_dependency(WishboneDataKey(), wb_master_data),
+            connections=ComponentConnections().with_dependency(WishboneDataKey(), wb_master_data),
             extra_methods_required=[InstructionCommitKey(), BranchResolvedKey()],
         )
 
@@ -83,7 +83,7 @@ class Core(Elaboratable):
         )
 
         m.submodules.verify_branch = ConnectTrans(
-            self.func_blocks_unifier.get_connected(BranchResolvedKey()), self.fetch.verify_branch
+            self.func_blocks_unifier.get_extra_method(BranchResolvedKey()), self.fetch.verify_branch
         )
 
         m.submodules.announcement = self.announcement
@@ -93,7 +93,7 @@ class Core(Elaboratable):
             r_rat_commit=rrat.commit,
             free_rf_put=free_rf_fifo.write,
             rf_free=rf.free,
-            lsu_commit=self.func_blocks_unifier.get_connected(InstructionCommitKey()),
+            lsu_commit=self.func_blocks_unifier.get_extra_method(InstructionCommitKey()),
         )
 
         return m

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -40,7 +40,7 @@ class Core(Elaboratable):
         self.ROB = ReorderBuffer(gen_params=self.gen_params)
 
         connections = gen_params.get(DependencyManager)
-        connections.with_dependency(WishboneDataKey(), wb_master_data)
+        connections.add_dependency(WishboneDataKey(), wb_master_data)
 
         self.func_blocks_unifier = FuncBlocksUnifier(
             gen_params=gen_params,

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -1,6 +1,6 @@
 from amaranth import *
 
-from coreblocks.params.fu_params import ComponentConnections, DependencyKey
+from coreblocks.params.fu_params import ComponentConnections, WishboneDataKey
 from coreblocks.stages.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.transactions.lib import FIFO, ConnectTrans
 from coreblocks.params.layouts import *
@@ -16,7 +16,6 @@ from coreblocks.stages.retirement import Retirement
 from coreblocks.peripherals.wishbone import WishboneMaster
 from coreblocks.frontend.fetch import Fetch
 from coreblocks.utils.fifo import BasicFifo
-from coreblocks.transactions.lib import MethodProduct
 
 __all__ = ["Core"]
 
@@ -43,10 +42,7 @@ class Core(Elaboratable):
         self.func_blocks_unifier = FuncBlocksUnifier(
             gen_params=gen_params,
             blocks=gen_params.func_units_config,
-            #TODO Remove MethodProduct as it is simply stub
-            connections=ComponentConnections().set_dependency(
-                DependencyKey("wishbone_data", WishboneMaster, MethodProduct), wb_master_data
-            ),
+            connections=ComponentConnections().set_dependency(WishboneDataKey(), wb_master_data),
             extra_methods_required=[InstructionCommitKey(), BranchResolvedKey()],
         )
 
@@ -86,7 +82,9 @@ class Core(Elaboratable):
             gen_params=self.gen_params,
         )
 
-        m.submodules.verify_branch = ConnectTrans(self.func_blocks_unifier.get_connected(BranchResolvedKey()), self.fetch.verify_branch)
+        m.submodules.verify_branch = ConnectTrans(
+            self.func_blocks_unifier.get_connected(BranchResolvedKey()), self.fetch.verify_branch
+        )
 
         m.submodules.announcement = self.announcement
         m.submodules.func_blocks_unifier = self.func_blocks_unifier

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -1,6 +1,6 @@
 from amaranth import *
 
-from coreblocks.params.fu_params import ComponentConnections
+from coreblocks.params.fu_params import DependencyManager
 from coreblocks.stages.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.transactions.lib import FIFO, ConnectTrans
 from coreblocks.params.layouts import *
@@ -39,10 +39,12 @@ class Core(Elaboratable):
         self.RF = RegisterFile(gen_params=self.gen_params)
         self.ROB = ReorderBuffer(gen_params=self.gen_params)
 
+        connections = gen_params.get(DependencyManager)
+        connections.with_dependency(WishboneDataKey(), wb_master_data)
+
         self.func_blocks_unifier = FuncBlocksUnifier(
             gen_params=gen_params,
             blocks=gen_params.func_units_config,
-            connections=ComponentConnections().with_dependency(WishboneDataKey(), wb_master_data),
             extra_methods_required=[InstructionCommitKey(), BranchResolvedKey()],
         )
 

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -1,10 +1,10 @@
 from amaranth import *
 
-from coreblocks.params.fu_params import ComponentConnections, WishboneDataKey
+from coreblocks.params.fu_params import ComponentConnections
 from coreblocks.stages.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.transactions.lib import FIFO, ConnectTrans
 from coreblocks.params.layouts import *
-from coreblocks.params.fu_params import InstructionCommitKey, BranchResolvedKey
+from coreblocks.params.keys import InstructionCommitKey, BranchResolvedKey, WishboneDataKey
 from coreblocks.params.genparams import GenParams
 from coreblocks.frontend.decode import Decode
 from coreblocks.structs_common.rat import FRAT, RRAT

--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -145,7 +145,7 @@ class AluFuncUnit(Elaboratable):
 
 
 class ALUComponent(FunctionalComponentParams):
-    def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncUnit:
+    def get_module(self, gen_params: GenParams) -> FuncUnit:
         return AluFuncUnit(gen_params)
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/fu/jumpbranch.py
+++ b/coreblocks/fu/jumpbranch.py
@@ -175,8 +175,9 @@ class JumpBranchFuncUnit(Elaboratable):
 
 
 class JumpComponent(FunctionalComponentParams):
-    def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncUnit:
+    def get_module(self, gen_params: GenParams) -> FuncUnit:
         unit = JumpBranchFuncUnit(gen_params)
+        connections = gen_params.get(DependencyManager)
         connections.with_dependency(BranchResolvedKey(), unit.branch_result)
         return unit
 

--- a/coreblocks/fu/jumpbranch.py
+++ b/coreblocks/fu/jumpbranch.py
@@ -178,7 +178,7 @@ class JumpComponent(FunctionalComponentParams):
     def get_module(self, gen_params: GenParams) -> FuncUnit:
         unit = JumpBranchFuncUnit(gen_params)
         connections = gen_params.get(DependencyManager)
-        connections.with_dependency(BranchResolvedKey(), unit.branch_result)
+        connections.add_dependency(BranchResolvedKey(), unit.branch_result)
         return unit
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/fu/jumpbranch.py
+++ b/coreblocks/fu/jumpbranch.py
@@ -177,7 +177,7 @@ class JumpBranchFuncUnit(Elaboratable):
 class JumpComponent(FunctionalComponentParams):
     def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncUnit:
         unit = JumpBranchFuncUnit(gen_params)
-        connections.register_method(BranchResolvedKey(), unit.branch_result)
+        connections.with_dependency(BranchResolvedKey(), unit.branch_result)
         return unit
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -6,7 +6,7 @@ from amaranth import *
 from coreblocks.fu.unsigned_multiplication.fast_recursive import RecursiveUnsignedMul
 from coreblocks.fu.unsigned_multiplication.sequence import SequentialUnsignedMul
 from coreblocks.fu.unsigned_multiplication.shift import ShiftUnsignedMul
-from coreblocks.params.fu_params import FunctionalComponentParams, ComponentConnections
+from coreblocks.params.fu_params import FunctionalComponentParams
 from coreblocks.params import Funct3, CommonLayouts, GenParams, FuncUnitLayouts, OpType
 from coreblocks.transactions import *
 from coreblocks.transactions.core import def_method
@@ -249,7 +249,7 @@ class MulComponent(FunctionalComponentParams):
         self.mul_unit_type = mul_unit_type
         self.dsp_width = dsp_width
 
-    def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncUnit:
+    def get_module(self, gen_params: GenParams) -> FuncUnit:
         return MulUnit(gen_params, self.mul_unit_type, self.dsp_width)
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/fu/zbs.py
+++ b/coreblocks/fu/zbs.py
@@ -9,7 +9,6 @@ from coreblocks.params import (
     OpType,
     Funct7,
     FunctionalComponentParams,
-    ComponentConnections,
 )
 from coreblocks.transactions import Method
 from coreblocks.transactions.lib import FIFO
@@ -169,7 +168,7 @@ class ZbsUnit(Elaboratable):
 
 
 class ZbsComponent(FunctionalComponentParams):
-    def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncUnit:
+    def get_module(self, gen_params: GenParams) -> FuncUnit:
         return ZbsUnit(gen_params)
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -289,7 +289,8 @@ class LSUDummy(Elaboratable):
 
 
 class LSUBlockComponent(BlockComponentParams):
-    def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncBlock:
+    def get_module(self, gen_params: GenParams) -> FuncBlock:
+        connections = gen_params.get(DependencyManager)
         wb_master = connections.get_dependency(WishboneDataKey())
         unit = LSUDummy(gen_params, wb_master)
         connections.with_dependency(InstructionCommitKey(), unit.commit)

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -1,6 +1,5 @@
 from amaranth import *
 
-from coreblocks.transactions.lib import MethodProduct
 from coreblocks.transactions import Method, def_method, Transaction
 from coreblocks.params import *
 from coreblocks.peripherals.wishbone import WishboneMaster
@@ -291,7 +290,7 @@ class LSUDummy(Elaboratable):
 
 class LSUBlockComponent(BlockComponentParams):
     def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncBlock:
-        wb_master = connections.register_dependency(DependencyKey("wishbone_data", WishboneMaster, MethodProduct))
+        wb_master = connections.get_dependency(WishboneDataKey())
         unit = LSUDummy(gen_params, wb_master)
         connections.register_method(InstructionCommitKey(), unit.commit)
         return unit

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -293,7 +293,7 @@ class LSUBlockComponent(BlockComponentParams):
         connections = gen_params.get(DependencyManager)
         wb_master = connections.get_dependency(WishboneDataKey())
         unit = LSUDummy(gen_params, wb_master)
-        connections.with_dependency(InstructionCommitKey(), unit.commit)
+        connections.add_dependency(InstructionCommitKey(), unit.commit)
         return unit
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -292,7 +292,7 @@ class LSUBlockComponent(BlockComponentParams):
     def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncBlock:
         wb_master = connections.get_dependency(WishboneDataKey())
         unit = LSUDummy(gen_params, wb_master)
-        connections.register_method(InstructionCommitKey(), unit.commit)
+        connections.with_dependency(InstructionCommitKey(), unit.commit)
         return unit
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/params/__init__.py
+++ b/coreblocks/params/__init__.py
@@ -1,6 +1,5 @@
 from .isa import *  # noqa: F401
 from .optypes import *  # noqa: F401
-from .unifiers import *  # noqa: F401
 from .genparams import *  # noqa: F401
 from .layouts import *  # noqa: F401
 from .fu_params import *  # noqa: F401

--- a/coreblocks/params/__init__.py
+++ b/coreblocks/params/__init__.py
@@ -3,3 +3,4 @@ from .optypes import *  # noqa: F401
 from .genparams import *  # noqa: F401
 from .layouts import *  # noqa: F401
 from .fu_params import *  # noqa: F401
+from .keys import *  # noqa: F401

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -27,6 +27,10 @@ class DependencyKey(Generic[T, U], ABC):
     def combine(self, data: list[T]) -> U:
         raise NotImplementedError()
 
+    @abstractmethod
+    def __hash__(self) -> int:
+        raise NotImplementedError()
+
 
 class SimpleKey(Generic[T], DependencyKey[T, T]):
     def combine(self, data: list[T]) -> T:

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 from collections import defaultdict
 
 from abc import abstractmethod, ABC
-from dataclasses import dataclass, field
 from typing import Any, Iterable, Generic, TypeVar
 
 import coreblocks.params.genparams as gp
 import coreblocks.params.optypes as optypes
 from coreblocks.transactions import Method
 from coreblocks.utils.protocols import FuncBlock, FuncUnit, Unifier
-from coreblocks.transactions.lib import MethodProduct, Collector
-from coreblocks.peripherals.wishbone import WishboneMaster
 
 
 __all__ = [
@@ -19,9 +16,6 @@ __all__ = [
     "FunctionalComponentParams",
     "optypes_supported",
     "DependencyKey",
-    "WishboneDataKey",
-    "InstructionCommitKey",
-    "BranchResolvedKey",
 ]
 
 T = TypeVar("T")
@@ -53,21 +47,6 @@ class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
             unifiers[self.__class__.__name__ + "_unifier"] = unifier_inst
             method = unifier_inst.method
         return method, unifiers
-
-
-@dataclass(frozen=True)
-class WishboneDataKey(SimpleKey[WishboneMaster]):
-    pass
-
-
-@dataclass(frozen=True)
-class InstructionCommitKey(UnifierKey):
-    unifier: type[Unifier] = field(default=MethodProduct, init=False)
-
-
-@dataclass(frozen=True)
-class BranchResolvedKey(UnifierKey):
-    unifier: type[Unifier] = field(default=Collector, init=False)
 
 
 # extra constructor parameters of FuncBlock

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -11,7 +11,7 @@ from coreblocks.utils.protocols import FuncBlock, FuncUnit, Unifier
 
 
 __all__ = [
-    "ComponentConnections",
+    "DependencyManager",
     "BlockComponentParams",
     "FunctionalComponentParams",
     "optypes_supported",
@@ -54,11 +54,11 @@ class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
 
 
 # extra constructor parameters of FuncBlock
-class ComponentConnections:
+class DependencyManager:
     def __init__(self):
         self.dependencies = defaultdict[DependencyKey, list](list)
 
-    def with_dependency(self, key: DependencyKey[T, Any], dependency: T) -> ComponentConnections:
+    def with_dependency(self, key: DependencyKey[T, Any], dependency: T) -> DependencyManager:
         self.dependencies[key].append(dependency)
         return self
 
@@ -70,7 +70,7 @@ class ComponentConnections:
 
 class BlockComponentParams(ABC):
     @abstractmethod
-    def get_module(self, gen_params: gp.GenParams, connections: ComponentConnections) -> FuncBlock:
+    def get_module(self, gen_params: gp.GenParams) -> FuncBlock:
         raise NotImplementedError()
 
     @abstractmethod
@@ -80,7 +80,7 @@ class BlockComponentParams(ABC):
 
 class FunctionalComponentParams(ABC):
     @abstractmethod
-    def get_module(self, gen_params: gp.GenParams, connections: ComponentConnections) -> FuncUnit:
+    def get_module(self, gen_params: gp.GenParams) -> FuncUnit:
         raise NotImplementedError()
 
     @abstractmethod

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -58,9 +58,8 @@ class DependencyManager:
     def __init__(self):
         self.dependencies = defaultdict[DependencyKey, list](list)
 
-    def with_dependency(self, key: DependencyKey[T, Any], dependency: T) -> DependencyManager:
+    def add_dependency(self, key: DependencyKey[T, Any], dependency: T) -> None:
         self.dependencies[key].append(dependency)
-        return self
 
     def get_dependency(self, key: DependencyKey[Any, U]) -> U:
         if key not in self.dependencies:

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from inspect import signature
 from typing import TypeVar, Type, Protocol, runtime_checkable
 
 from .isa import ISA
@@ -17,7 +18,12 @@ class DependentCache:
     def get(self, cls: Type[T]) -> T:
         v = self._depcache.get(cls, None)
         if v is None:
-            v = self._depcache[cls] = cls(self)
+            sig = signature(cls)
+            if "gen_params" in sig.parameters:
+                v = cls(gen_params=self)
+            else:
+                v = cls()
+            self._depcache[cls] = v
         return v
 
 

--- a/coreblocks/params/keys.py
+++ b/coreblocks/params/keys.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, field
+from coreblocks.params.fu_params import SimpleKey, UnifierKey
+from coreblocks.transactions.lib import MethodProduct, Collector
+from coreblocks.peripherals.wishbone import WishboneMaster
+from coreblocks.utils.protocols import Unifier
+
+
+__all__ = [
+    "WishboneDataKey",
+    "InstructionCommitKey",
+    "BranchResolvedKey",
+]
+
+
+@dataclass(frozen=True)
+class WishboneDataKey(SimpleKey[WishboneMaster]):
+    pass
+
+
+@dataclass(frozen=True)
+class InstructionCommitKey(UnifierKey):
+    unifier: type[Unifier] = field(default=MethodProduct, init=False)
+
+
+@dataclass(frozen=True)
+class BranchResolvedKey(UnifierKey):
+    unifier: type[Unifier] = field(default=Collector, init=False)

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -186,48 +186,48 @@ class FetchLayouts:
 
 
 class DecodeLayouts:
-    def __init__(self, gen: GenParams):
-        common = gen.get(CommonLayouts)
+    def __init__(self, gen_params: GenParams):
+        common = gen_params.get(CommonLayouts)
         self.decoded_instr = [
             ("opcode", Opcode),
             ("illegal", 1),
             ("exec_fn", common.exec_fn),
             ("regs_l", common.regs_l),
-            ("imm", gen.isa.xlen),
-            ("pc", gen.isa.xlen),
+            ("imm", gen_params.isa.xlen),
+            ("pc", gen_params.isa.xlen),
         ]
 
 
 class FuncUnitLayouts:
-    def __init__(self, gen: GenParams):
-        common = gen.get(CommonLayouts)
+    def __init__(self, gen_params: GenParams):
+        common = gen_params.get(CommonLayouts)
 
         self.issue = [
-            ("s1_val", gen.isa.xlen),
-            ("s2_val", gen.isa.xlen),
-            ("rp_dst", gen.phys_regs_bits),
-            ("rob_id", gen.rob_entries_bits),
+            ("s1_val", gen_params.isa.xlen),
+            ("s2_val", gen_params.isa.xlen),
+            ("rp_dst", gen_params.phys_regs_bits),
+            ("rob_id", gen_params.rob_entries_bits),
             ("exec_fn", common.exec_fn),
-            ("imm", gen.isa.xlen),
-            ("pc", gen.isa.xlen),
+            ("imm", gen_params.isa.xlen),
+            ("pc", gen_params.isa.xlen),
         ]
 
         self.accept = [
-            ("rob_id", gen.rob_entries_bits),
-            ("result", gen.isa.xlen),
-            ("rp_dst", gen.phys_regs_bits),
+            ("rob_id", gen_params.rob_entries_bits),
+            ("result", gen_params.isa.xlen),
+            ("rp_dst", gen_params.phys_regs_bits),
         ]
 
 
 class UnsignedMulUnitLayouts:
-    def __init__(self, gen: GenParams):
+    def __init__(self, gen_params: GenParams):
         self.issue = [
-            ("i1", gen.isa.xlen),
-            ("i2", gen.isa.xlen),
+            ("i1", gen_params.isa.xlen),
+            ("i2", gen_params.isa.xlen),
         ]
 
         self.accept = [
-            ("o", 2 * gen.isa.xlen),
+            ("o", 2 * gen_params.isa.xlen),
         ]
 
 

--- a/coreblocks/params/unifiers.py
+++ b/coreblocks/params/unifiers.py
@@ -1,4 +1,0 @@
-from coreblocks.transactions.lib import MethodProduct, Collector
-from coreblocks.utils.protocols import Unifier
-
-#TODO Remove file

--- a/coreblocks/stages/func_blocks_unifier.py
+++ b/coreblocks/stages/func_blocks_unifier.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 from amaranth import *
 
-from coreblocks.params import GenParams, BlockComponentParams, ComponentConnections
+from coreblocks.params import GenParams, BlockComponentParams, DependencyManager
 from coreblocks.params.fu_params import UnifierKey
 from coreblocks.transactions import Method
 from coreblocks.transactions.lib import MethodProduct, Collector
@@ -18,10 +18,9 @@ class FuncBlocksUnifier(Elaboratable):
         *,
         gen_params: GenParams,
         blocks: Iterable[BlockComponentParams],
-        connections: ComponentConnections,
         extra_methods_required: Iterable[UnifierKey],
     ):
-        self.rs_blocks = [block.get_module(gen_params=gen_params, connections=connections) for block in blocks]
+        self.rs_blocks = [block.get_module(gen_params) for block in blocks]
         self.extra_methods_required = extra_methods_required
 
         self.result_collector = Collector([block.get_result for block in self.rs_blocks])
@@ -32,6 +31,8 @@ class FuncBlocksUnifier(Elaboratable):
 
         self.unifiers: dict[str, Unifier] = {}
         self.extra_methods: dict[UnifierKey, Method] = {}
+
+        connections = gen_params.get(DependencyManager)
 
         for key in extra_methods_required:
             method, unifiers = connections.get_dependency(key)

--- a/coreblocks/stages/rs_func_block.py
+++ b/coreblocks/stages/rs_func_block.py
@@ -83,8 +83,8 @@ class RSBlockComponent(BlockComponentParams):
         self.func_units = func_units
         self.rs_entries = rs_entries
 
-    def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncBlock:
-        modules = list(u.get_module(gen_params, connections) for u in self.func_units)
+    def get_module(self, gen_params: GenParams) -> FuncBlock:
+        modules = list(u.get_module(gen_params) for u in self.func_units)
         rs_unit = RSFuncBlock(gen_params=gen_params, func_units=modules, rs_entries=self.rs_entries)
         return rs_unit
 

--- a/test/fu/functional_common.py
+++ b/test/fu/functional_common.py
@@ -5,7 +5,7 @@ from typing import Dict, Callable, Any
 from amaranth import Elaboratable, Module
 
 from coreblocks.params import GenParams
-from coreblocks.params.fu_params import FunctionalComponentParams, ComponentConnections
+from coreblocks.params.fu_params import FunctionalComponentParams
 from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 from test.common import TestbenchIO, TestCaseWithSimulator, test_gen_params
@@ -31,7 +31,7 @@ class FunctionalTestCircuit(Elaboratable):
         m = Module()
         tm = TransactionModule(m)
 
-        m.submodules.func_unit = func_unit = self.func_unit.get_module(self.gen, ComponentConnections())
+        m.submodules.func_unit = func_unit = self.func_unit.get_module(self.gen)
 
         # mocked input and output
         m.submodules.issue_method = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))

--- a/test/fu/test_jb_unit.py
+++ b/test/fu/test_jb_unit.py
@@ -35,7 +35,7 @@ class JumpBranchWrapper(Elaboratable):
 
 
 class JumpBranchWrapperComponent(FunctionalComponentParams):
-    def get_module(self, gen_params: GenParams, connections: ComponentConnections) -> FuncUnit:
+    def get_module(self, gen_params: GenParams) -> FuncUnit:
         return JumpBranchWrapper(gen_params)
 
     def get_optypes(self) -> set[OpType]:


### PR DESCRIPTION
Instead of reviewing, I proposed some changes myself. Have fun! Changes:

* Removed `name` from keys. Subclassing is an approach which is more descriptive and less prone to typos, so should be the default. Keys which have parameters are still possible, but should be created explicitly.
* Removed `dep_type` too. As the key type implies the dependency type (in the recommended use case), it's not needed.
* Created a hierarchy of abstract key classes:
  - `DependencyKey` is the base one. It has two type parameters: one for values related to the key, and the second for the values returned from the key.
  - `SimpleKey` is for keys which relate to a single value.
  - `UnifierKey` is for keys relating to potentially multiple methods, combined by an `Unifier`.
  These abstract key classes should never be instanced, they are for subclassing.
* Modified `ComponentConnections` so that all kinds of keys are treated the same.

Edit: More changes:

* Renamed `ComponentConnections` to `DependencyManager`, as that's what it does. If we use the dependency framework for something else later, it won't look weird.
* Removed passing `DependencyManager` around using a parameter. We already have something passed everywhere as a parameter, it's `GenParams`, and we can leverage it for this purpose, too.
* Added a safeguard to prevent instantiation of abstract key classes.
* Removed method chaining from adding dependencies. Method chaining is not idiomatic in Python, this is the only place with method chaining in Coreblocks, and it doesn't give a lot of benefit too, as adding dependencies is rarely done.