### PR TITLE
Fix the core_graph script after merging #209, and other cleanups

### DIFF
--- a/constants/ecp5_platforms.py
+++ b/constants/ecp5_platforms.py
@@ -22,7 +22,7 @@ class ECP5BG381Platform(LatticeECP5Platform):
             "data_out",
             0,
             Pins(
-                " ".join(ecp5_bg381_pins[2:51]),
+                " ".join(ecp5_bg381_pins[2:49]),
                 dir="o",
             ),
         ),

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -1,0 +1,10 @@
+from coreblocks.params.fu_params import BlockComponentParams
+from coreblocks.fu.alu import ALUComponent
+from coreblocks.fu.jumpbranch import JumpComponent
+from coreblocks.lsu.dummyLsu import LSUBlockComponent
+from coreblocks.stages.rs_func_block import RSBlockComponent
+
+basic_configuration: list[BlockComponentParams] = [
+    RSBlockComponent([ALUComponent(), JumpComponent()], rs_entries=4),
+    LSUBlockComponent(),
+]

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -33,8 +33,8 @@ class GenParams(DependentCache):
         isa_str: str,
         func_units_config: list[BlockComponentParams],
         *,
-        phys_regs_bits: int = 7,
-        rob_entries_bits: int = 8,
+        phys_regs_bits: int = 6,
+        rob_entries_bits: int = 7,
         start_pc: int = 0,
     ):
         super().__init__()

--- a/scripts/core_graph
+++ b/scripts/core_graph
@@ -16,8 +16,12 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 from coreblocks.params.genparams import GenParams
 from coreblocks.transactions.graph import TracingFragment
 from test.test_core import TestElaboratable
+from coreblocks.fu.alu import ALUComponent
+from coreblocks.fu.jumpbranch import JumpComponent
+from coreblocks.lsu.dummyLsu import LSUBlockComponent
+from coreblocks.stages.rs_func_block import RSBlockComponent
 
-gp = GenParams("rv32i", phys_regs_bits=6, rob_entries_bits=7)
+gp = GenParams("rv32i", [RSBlockComponent([ALUComponent(), JumpComponent()], rs_entries=4), LSUBlockComponent()])
 elaboratable = TestElaboratable(gp)
 fragment = TracingFragment.get(elaboratable, platform=None).prepare()
 

--- a/scripts/core_graph
+++ b/scripts/core_graph
@@ -16,12 +16,9 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 from coreblocks.params.genparams import GenParams
 from coreblocks.transactions.graph import TracingFragment
 from test.test_core import TestElaboratable
-from coreblocks.fu.alu import ALUComponent
-from coreblocks.fu.jumpbranch import JumpComponent
-from coreblocks.lsu.dummyLsu import LSUBlockComponent
-from coreblocks.stages.rs_func_block import RSBlockComponent
+from coreblocks.params.configurations import basic_configuration
 
-gp = GenParams("rv32i", [RSBlockComponent([ALUComponent(), JumpComponent()], rs_entries=4), LSUBlockComponent()])
+gp = GenParams("rv32i", basic_configuration)
 elaboratable = TestElaboratable(gp)
 fragment = TracingFragment.get(elaboratable, platform=None).prepare()
 

--- a/scripts/synthesize
+++ b/scripts/synthesize
@@ -66,12 +66,9 @@ class TestElaboratable(Elaboratable):
 def synthesize(platform: str):
     from coreblocks.params.genparams import GenParams
     from constants.ecp5_platforms import ECP5BG381Platform
-    from coreblocks.fu.alu import ALUComponent
-    from coreblocks.fu.jumpbranch import JumpComponent
-    from coreblocks.lsu.dummyLsu import LSUBlockComponent
-    from coreblocks.stages.rs_func_block import RSBlockComponent
+    from coreblocks.params.configurations import basic_configuration
 
-    gp = GenParams("rv32i", [RSBlockComponent([ALUComponent(), JumpComponent()], rs_entries=4), LSUBlockComponent()])
+    gp = GenParams("rv32i", basic_configuration)
 
     if platform == "ecp5":
         ECP5BG381Platform().build(TestElaboratable(gen_params=gp, io_pins=6))

--- a/test/common.py
+++ b/test/common.py
@@ -382,7 +382,7 @@ def test_gen_params(
     isa_str: str,
     *,
     phys_regs_bits: int = 7,
-    rob_entries_bits: int = 8,
+    rob_entries_bits: int = 7,
     start_pc: int = 0,
     rs_entries: int = 4,
     rs_block_number: int = 2,

--- a/test/fu/test_mul_unit.py
+++ b/test/fu/test_mul_unit.py
@@ -38,10 +38,6 @@ ops = {
 }
 
 
-def gen_test_params(param):
-    pass
-
-
 @parameterized_class(
     ("name", "mul_unit"),
     [

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,9 +1,6 @@
 from amaranth import Elaboratable, Module
 
-from coreblocks.fu.alu import ALUComponent
-from coreblocks.fu.jumpbranch import JumpComponent
-from coreblocks.lsu.dummyLsu import LSUBlockComponent
-from coreblocks.stages.rs_func_block import RSBlockComponent
+from coreblocks.params.configurations import basic_configuration
 from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 
@@ -33,9 +30,6 @@ from riscvmodel.insn import (
 from riscvmodel.model import Model
 from riscvmodel.isa import InstructionRType, get_insns
 from riscvmodel.variant import RV32I
-
-
-_BASIC_CONFIGURATION = [RSBlockComponent([ALUComponent(), JumpComponent()], rs_entries=4), LSUBlockComponent()]
 
 
 class TestElaboratable(Elaboratable):
@@ -176,12 +170,7 @@ class TestCoreSimple(TestCoreBase):
         self.assertEqual((yield from self.get_arch_reg_val(5)), 1 << 12)
 
     def test_simple(self):
-        gp = GenParams(
-            "rv32i",
-            _BASIC_CONFIGURATION,
-            phys_regs_bits=6,
-            rob_entries_bits=7,
-        )
+        gp = GenParams("rv32i", basic_configuration)
         m = TestElaboratable(gp)
         self.m = m
 
@@ -207,12 +196,7 @@ class TestCoreRandomized(TestCoreBase):
         yield from self.compare_core_states(self.software_core)
 
     def test_randomized(self):
-        self.gp = GenParams(
-            "rv32i",
-            _BASIC_CONFIGURATION,
-            phys_regs_bits=6,
-            rob_entries_bits=7,
-        )
+        self.gp = GenParams("rv32i", basic_configuration)
         self.instr_count = 300
         random.seed(42)
 
@@ -271,7 +255,7 @@ class TestCoreAsmSource(TestCoreBase):
             self.assertEqual((yield from self.get_arch_reg_val(reg_id)), val)
 
     def test_asm_source(self):
-        self.gp = GenParams("rv32i", _BASIC_CONFIGURATION)
+        self.gp = GenParams("rv32i", basic_configuration)
         self.base_dir = "test/asm/"
         self.bin_src = []
 


### PR DESCRIPTION
~~This PR quick-and-dirty-fixes the core_graph script, as it still uses an old GenParams construction.~~ (To catch errors like this, implement #232.) This PR cleans up the default configuration of the core, so that it's the same in core_graph, synthesis and test_core. Also, the data structure sizes are now the same as they were before in synthesis.