### PR TITLE
Move from Docker Hub to GitHub Container Registry

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: docker://kuzniardzeni/amaranth-synth:ecp5
+    container: ghcr.io/kuznia-rdzeni/amaranth-synth:ecp5
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Because [Docker scales down its free service for open source organizations](https://blog.alexellis.io/docker-is-deleting-open-source-images/), I thought we could move our Docker image to Github.