### PR TITLE
Auto debug signals from list

### DIFF
--- a/coreblocks/utils/debug_signals.py
+++ b/coreblocks/utils/debug_signals.py
@@ -14,6 +14,9 @@ def auto_debug_signals(thing) -> SignalBundle:
     slist: list[SignalBundle] = []
     smap: dict[str, SignalBundle] = {}
 
+    if "__dict__" not in dir(thing):
+        return []
+
     for v in vars(thing):
         a = getattr(thing, v)
         if isinstance(a, HasDebugSignals):
@@ -27,6 +30,18 @@ def auto_debug_signals(thing) -> SignalBundle:
             smap[v] = a
         elif isinstance(a, Signal) or isinstance(a, Record):
             slist.append(a)
+        elif isinstance(a, list):
+            submap={}
+            for i, e in enumerate(a):
+                if isinstance(e, HasDebugSignals):
+                    e.name = f"{v}[{i}]"
+                    submap[e.name] = e.debug_signals()
+                else:
+                    sublist = auto_debug_signals(e)
+                    if sublist:
+                        submap[f"{v}[{i}]"] = sublist
+            if submap:
+                smap[v]=submap
 
     slist.append(smap)
     return slist

--- a/coreblocks/utils/debug_signals.py
+++ b/coreblocks/utils/debug_signals.py
@@ -31,17 +31,16 @@ def auto_debug_signals(thing) -> SignalBundle:
         elif isinstance(a, Signal) or isinstance(a, Record):
             slist.append(a)
         elif isinstance(a, list):
-            submap={}
+            submap = {}
             for i, e in enumerate(a):
                 if isinstance(e, HasDebugSignals):
-                    e.name = f"{v}[{i}]"
-                    submap[e.name] = e.debug_signals()
+                    submap[f"{v}[{i}]"] = e.debug_signals()
                 else:
                     sublist = auto_debug_signals(e)
                     if sublist:
                         submap[f"{v}[{i}]"] = sublist
             if submap:
-                smap[v]=submap
+                smap[v] = submap
 
     slist.append(smap)
     return slist


### PR DESCRIPTION
As a part of debuging #260 I have found that `auto_debug_signals` have problems when methods are in list. Here is extension which add support for this case.