### PR TITLE
Bump linter versions

### DIFF
--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -180,7 +180,6 @@ class MulUnit(Elaboratable):
 
         @def_method(m, self.issue)
         def _(arg):
-
             m.d.comb += decoder.exec_fn.eq(arg.exec_fn)
             i1, i2 = get_input(arg)
 

--- a/coreblocks/stages/func_blocks_unifier.py
+++ b/coreblocks/stages/func_blocks_unifier.py
@@ -54,7 +54,7 @@ class FuncBlocksUnifier(Elaboratable):
         m.submodules["result_collector"] = self.result_collector
         m.submodules["update_combiner"] = self.update_combiner
 
-        for (name, unifier) in self.unifiers.items():
+        for name, unifier in self.unifiers.items():
             m.submodules[name] = unifier
 
         return m

--- a/coreblocks/transactions/lib.py
+++ b/coreblocks/transactions/lib.py
@@ -665,7 +665,7 @@ class ManyToOneConnectTrans(Elaboratable):
 
         self.count = len(self.get_results)
 
-    def elaborate(self, platfrom):
+    def elaborate(self, platform):
         m = Module()
 
         for i in range(self.count):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 -r requirements.txt
-black==22.3.0
+black==23.3.0
 docutils==0.15.2
-flake8==4.0.1
-pep8-naming==0.13.2
+flake8==6.0.0
+pep8-naming==0.13.3
 git+https://github.com/kristopher38/riscv-python-model@b5d0737#riscv-model
 markupsafe==2.0.1
 myst-parser==0.18.0
 numpydoc==1.5.0
 parameterized==0.8.1
 pre-commit==2.16.0
-pyright==1.1.251
+pyright==1.1.302
 Sphinx==5.1.1
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-mermaid==0.7.1

--- a/test/frontend/test_decode.py
+++ b/test/frontend/test_decode.py
@@ -15,7 +15,6 @@ class TestElaboratable(Elaboratable):
         self.gp = gen_params
 
     def elaborate(self, platform):
-
         m = Module()
         tm = TransactionModule(m)
 
@@ -74,6 +73,5 @@ class TestFetch(TestCaseWithSimulator):
         self.assertEqual(decoded["regs_l"]["rl_s1_v"], 1)
 
     def test(self):
-
         with self.run_simulation(self.test_module) as sim:
             sim.add_sync_process(self.decode_test_proc)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -22,7 +22,6 @@ class TestElaboratable(Elaboratable):
         self.gp = gen_params
 
     def elaborate(self, platform):
-
         m = Module()
         tm = TransactionModule(m)
 
@@ -113,7 +112,6 @@ class TestFetch(TestCaseWithSimulator):
                 yield
 
     def test(self):
-
         with self.run_simulation(self.test_module) as sim:
             sim.add_sync_process(self.wishbone_slave)
             sim.add_sync_process(self.fetch_out_check)

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -59,7 +59,7 @@ class TestAlu(TestCaseWithSimulator):
 
     def check_fn(self, fn, out_fn):
         def process():
-            for (in1, in2) in self.test_inputs:
+            for in1, in2 in self.test_inputs:
                 returned_out = yield from self.yield_signals(fn, C(in1, self.gen.isa.xlen), C(in2, self.gen.isa.xlen))
                 mask = 2**self.gen.isa.xlen - 1
                 correct_out = out_fn(in1 & mask, in2 & mask) & mask

--- a/test/scheduler/test_wakeup_select.py
+++ b/test/scheduler/test_wakeup_select.py
@@ -55,7 +55,7 @@ class TestWakeupSelect(TestCaseWithSimulator):
 
     def random_entry(self, layout) -> RecordIntDict:
         result = {}
-        for (key, width_or_layout) in layout:
+        for key, width_or_layout in layout:
             if isinstance(width_or_layout, int):
                 result[key] = random.randrange(width_or_layout)
             elif isclass(width_or_layout) and issubclass(width_or_layout, Enum):

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -105,7 +105,6 @@ class TestCSRUnit(TestCaseWithSimulator):
     def process_test(self):
         yield from self.dut.fetch_continue.enable()
         for _ in range(self.cycles):
-
             yield from self.random_wait()
             yield self.dut.rob_single_insn.eq(0)
 

--- a/test/transactions/test_adapter.py
+++ b/test/transactions/test_adapter.py
@@ -55,7 +55,6 @@ class Consumer(Elaboratable):
 
 class TestElaboratable(Elaboratable):
     def __init__(self):
-
         self.echo = Echo()
         self.consumer = Consumer()
         self.io_echo = TestbenchIO(AdapterTrans(self.echo.action))

--- a/test/transactions/test_transactions.py
+++ b/test/transactions/test_transactions.py
@@ -303,7 +303,7 @@ class TestTransactionPriorities(TestCaseWithSimulator):
         def process():
             to_do = 5 * [(0, 1), (1, 0), (1, 1)]
             random.shuffle(to_do)
-            for (r1, r2) in to_do:
+            for r1, r2 in to_do:
                 yield m.r1.eq(r1)
                 yield m.r2.eq(r2)
                 yield


### PR DESCRIPTION
For some reason, my distro-provided versions of packages (black 23.1.0) result in

    scripts/lint.sh format

causing such changes.  They do not look so bad IMO, but it is quite unsettling to work with 9 not formatted files.

Also included is a fix for a typo causing my pyright 1.1.282 to throw errors.

I am only not sure about changes to test/transactions/test_assign.py (pep8-naming==0.13.3 and flake8==6.0.0 do not like variables named lowercase L),
because I realised that the file is straight up unreadable to me, the one-letter field/variable names look way more like obfuscated code than example names.  My suggestion would be field1, field2, field3 instead of a, b, c.  WDYT?