### PR TITLE
Refactor dependency management and fu config

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -1,6 +1,6 @@
 from amaranth import *
 
-from coreblocks.params.fu_params import DependencyManager
+from coreblocks.params.dependencies import DependencyManager
 from coreblocks.stages.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.transactions.lib import FIFO, ConnectTrans
 from coreblocks.params.layouts import *

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -1,6 +1,6 @@
 from enum import IntFlag, unique, IntEnum
 from typing import Tuple
-from dataclasses import dataclass
+from dataclasses import KW_ONLY, dataclass
 
 from amaranth import *
 
@@ -248,6 +248,7 @@ class MulUnit(Elaboratable):
 @dataclass(frozen=True)
 class MulComponent(FunctionalComponentParams):
     mul_unit_type: MulType
+    _: KW_ONLY
     dsp_width: int = 32
 
     def get_module(self, gen_params: GenParams) -> FuncUnit:

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -1,5 +1,6 @@
 from enum import IntFlag, unique, IntEnum
 from typing import Tuple
+from dataclasses import dataclass
 
 from amaranth import *
 
@@ -244,10 +245,10 @@ class MulUnit(Elaboratable):
         return m
 
 
+@dataclass(frozen=True)
 class MulComponent(FunctionalComponentParams):
-    def __init__(self, mul_unit_type: MulType, *, dsp_width: int = 32):
-        self.mul_unit_type = mul_unit_type
-        self.dsp_width = dsp_width
+    mul_unit_type: MulType
+    dsp_width: int = 32
 
     def get_module(self, gen_params: GenParams) -> FuncUnit:
         return MulUnit(gen_params, self.mul_unit_type, self.dsp_width)

--- a/coreblocks/params/__init__.py
+++ b/coreblocks/params/__init__.py
@@ -4,3 +4,4 @@ from .genparams import *  # noqa: F401
 from .layouts import *  # noqa: F401
 from .fu_params import *  # noqa: F401
 from .keys import *  # noqa: F401
+from .dependencies import *  # noqa: F401

--- a/coreblocks/params/dependencies.py
+++ b/coreblocks/params/dependencies.py
@@ -1,0 +1,141 @@
+from collections import defaultdict
+
+from abc import abstractmethod, ABC
+from typing import Any, Generic, TypeVar
+
+from coreblocks.transactions import Method
+from coreblocks.utils.protocols import Unifier
+
+
+__all__ = [
+    "DependencyManager",
+    "DependencyKey",
+]
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class DependencyKey(Generic[T, U], ABC):
+    """Base class for dependency keys.
+
+    Dependency keys are used to access dependencies in the `DependencyManager`.
+    Concrete instances of dependency keys should be frozen data classes.
+
+    Parameters
+    ----------
+    lock_on_get: bool, default: True
+        Specifies if no new dependencies should be added to key if it was already read by `get_dependency`.
+    empty_valid: bool, default : False
+        Specifies if getting key dependency without any added dependencies is valid. If set to `False`, that
+        action would cause raising `KeyError`.
+    """
+
+    @abstractmethod
+    def combine(self, data: list[T]) -> U:
+        """Combine multiple dependencies with the same key.
+
+        This method is used to generate the value returned from `get_dependency`
+        in the `DependencyManager`. It takes dependencies added to the key
+        using `add_dependency` and combines them to a single result.
+
+        Different implementations of `combine` give different combining behavior
+        for different kinds of keys.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def __hash__(self) -> int:
+        """The `__hash__` method is made abstract so that only concrete keys
+        can be instanced. It is automatically overridden in frozen data
+        classes.
+        """
+        raise NotImplementedError()
+
+    lock_on_get: bool = True
+    empty_valid: bool = False
+
+
+class SimpleKey(Generic[T], DependencyKey[T, T]):
+    """Base class for simple dependency keys.
+
+    Simple dependency keys are used when there is an one-to-one relation between
+    keys and dependencies. If more than one dependency is added to a simple key,
+    an error is raised.
+    """
+
+    def combine(self, data: list[T]) -> T:
+        if len(data) != 1:
+            raise RuntimeError(f"Key {self} assigned {len(data)} values, expected 1")
+        return data[0]
+
+
+class ListKey(Generic[T], DependencyKey[T, list[T]]):
+    """Base class for list key.
+
+    List keys are useed when there is an one-to-many relation between keys
+    and dependecies. Provides list of dependencies.
+    """
+
+    empty_valid = True
+
+    def combine(self, data: list[T]) -> list[T]:
+        return data
+
+
+class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
+    """Base class for method unifier dependency keys.
+
+    Method unifier dependency keys are used to collect methods to be called by
+    some part of the core. As multiple modules may wish to be called, a method
+    unifier is used to present a single method interface to the caller, which
+    allows to customize the calling behavior.
+    """
+
+    unifier: type[Unifier]
+
+    def combine(self, data: list[Method]) -> tuple[Method, dict[str, Unifier]]:
+        if len(data) == 1:
+            return data[0], {}
+        else:
+            unifiers: dict[str, Unifier] = {}
+            unifier_inst = self.unifier(data)
+            unifiers[self.__class__.__name__ + "_unifier"] = unifier_inst
+            method = unifier_inst.method
+        return method, unifiers
+
+
+class DependencyManager:
+    """Dependency manager.
+
+    Tracks dependencies across the core.
+    """
+
+    def __init__(self):
+        self.dependencies = defaultdict[DependencyKey, list](list)
+        self.locked_dependencies: set[DependencyKey] = set()
+
+    def add_dependency(self, key: DependencyKey[T, Any], dependency: T) -> None:
+        """Adds a new dependency to a key.
+
+        Depending on the key type, a key can have a single dependency or
+        multple dependencies added to it.
+        """
+
+        if key in self.locked_dependencies:
+            raise KeyError(f"Trying to add dependency to {key} that was already read and is locked")
+
+        self.dependencies[key].append(dependency)
+
+    def get_dependency(self, key: DependencyKey[Any, U]) -> U:
+        """Gets the dependency for a key.
+
+        The way dependencies are interpreted is dependent on the key type.
+        """
+        if not key.empty_valid and key not in self.dependencies:
+            raise KeyError(f"Dependency {key} not provided")
+
+        if key.lock_on_get:
+            self.locked_dependencies.add(key)
+
+        return key.combine(self.dependencies[key])

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -1,9 +1,13 @@
 from abc import abstractmethod, ABC
 from typing import Iterable
 
-import coreblocks.params.genparams as gp
-import coreblocks.params.optypes as optypes
 from coreblocks.utils.protocols import FuncBlock, FuncUnit
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from coreblocks.params.genparams import GenParams
+    from coreblocks.params.optypes import OpType
 
 
 __all__ = [
@@ -15,23 +19,23 @@ __all__ = [
 
 class BlockComponentParams(ABC):
     @abstractmethod
-    def get_module(self, gen_params: gp.GenParams) -> FuncBlock:
+    def get_module(self, gen_params: "GenParams") -> FuncBlock:
         raise NotImplementedError()
 
     @abstractmethod
-    def get_optypes(self) -> set[optypes.OpType]:
+    def get_optypes(self) -> set["OpType"]:
         raise NotImplementedError()
 
 
 class FunctionalComponentParams(ABC):
     @abstractmethod
-    def get_module(self, gen_params: gp.GenParams) -> FuncUnit:
+    def get_module(self, gen_params: "GenParams") -> FuncUnit:
         raise NotImplementedError()
 
     @abstractmethod
-    def get_optypes(self) -> set[optypes.OpType]:
+    def get_optypes(self) -> set["OpType"]:
         raise NotImplementedError()
 
 
-def optypes_supported(block_components: Iterable[BlockComponentParams]) -> set[optypes.OpType]:
+def optypes_supported(block_components: Iterable[BlockComponentParams]) -> set["OpType"]:
     return {optype for block in block_components for optype in block.get_optypes()}

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -1,150 +1,16 @@
-from __future__ import annotations
-from collections import defaultdict
-
 from abc import abstractmethod, ABC
-from typing import Any, Iterable, Generic, TypeVar
+from typing import Iterable
 
 import coreblocks.params.genparams as gp
 import coreblocks.params.optypes as optypes
-from coreblocks.transactions import Method
-from coreblocks.utils.protocols import FuncBlock, FuncUnit, Unifier
+from coreblocks.utils.protocols import FuncBlock, FuncUnit
 
 
 __all__ = [
-    "DependencyManager",
     "BlockComponentParams",
     "FunctionalComponentParams",
     "optypes_supported",
-    "DependencyKey",
 ]
-
-T = TypeVar("T")
-U = TypeVar("U")
-
-
-class DependencyKey(Generic[T, U], ABC):
-    """Base class for dependency keys.
-
-    Dependency keys are used to access dependencies in the `DependencyManager`.
-    Concrete instances of dependency keys should be frozen data classes.
-
-    Parameters
-    ----------
-    lock_on_get: bool, default: True
-        Specifies if no new dependencies should be added to key if it was already read by `get_dependency`.
-    empty_valid: bool, default : False
-        Specifies if getting key dependency without any added dependencies is valid. If set to `False`, that
-        action would cause raising `KeyError`.
-    """
-
-    @abstractmethod
-    def combine(self, data: list[T]) -> U:
-        """Combine multiple dependencies with the same key.
-
-        This method is used to generate the value returned from `get_dependency`
-        in the `DependencyManager`. It takes dependencies added to the key
-        using `add_dependency` and combines them to a single result.
-
-        Different implementations of `combine` give different combining behavior
-        for different kinds of keys.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def __hash__(self) -> int:
-        """The `__hash__` method is made abstract so that only concrete keys
-        can be instanced. It is automatically overridden in frozen data
-        classes.
-        """
-        raise NotImplementedError()
-
-    lock_on_get: bool = True
-    empty_valid: bool = False
-
-
-class SimpleKey(Generic[T], DependencyKey[T, T]):
-    """Base class for simple dependency keys.
-
-    Simple dependency keys are used when there is an one-to-one relation between
-    keys and dependencies. If more than one dependency is added to a simple key,
-    an error is raised.
-    """
-
-    def combine(self, data: list[T]) -> T:
-        if len(data) != 1:
-            raise RuntimeError(f"Key {self} assigned {len(data)} values, expected 1")
-        return data[0]
-
-
-class ListKey(Generic[T], DependencyKey[T, list[T]]):
-    """Base class for list key.
-
-    List keys are useed when there is an one-to-many relation between keys
-    and dependecies. Provides list of dependencies.
-    """
-
-    empty_valid = True
-
-    def combine(self, data: list[T]) -> list[T]:
-        return data
-
-
-class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
-    """Base class for method unifier dependency keys.
-
-    Method unifier dependency keys are used to collect methods to be called by
-    some part of the core. As multiple modules may wish to be called, a method
-    unifier is used to present a single method interface to the caller, which
-    allows to customize the calling behavior.
-    """
-
-    unifier: type[Unifier]
-
-    def combine(self, data: list[Method]) -> tuple[Method, dict[str, Unifier]]:
-        if len(data) == 1:
-            return data[0], {}
-        else:
-            unifiers: dict[str, Unifier] = {}
-            unifier_inst = self.unifier(data)
-            unifiers[self.__class__.__name__ + "_unifier"] = unifier_inst
-            method = unifier_inst.method
-        return method, unifiers
-
-
-class DependencyManager:
-    """Dependency manager.
-
-    Tracks dependencies across the core.
-    """
-
-    def __init__(self):
-        self.dependencies = defaultdict[DependencyKey, list](list)
-        self.locked_dependencies: set[DependencyKey] = set()
-
-    def add_dependency(self, key: DependencyKey[T, Any], dependency: T) -> None:
-        """Adds a new dependency to a key.
-
-        Depending on the key type, a key can have a single dependency or
-        multple dependencies added to it.
-        """
-
-        if key in self.locked_dependencies:
-            raise KeyError(f"Trying to add dependency to {key} that was already read and is locked")
-
-        self.dependencies[key].append(dependency)
-
-    def get_dependency(self, key: DependencyKey[Any, U]) -> U:
-        """Gets the dependency for a key.
-
-        The way dependencies are interpreted is dependent on the key type.
-        """
-        if not key.empty_valid and key not in self.dependencies:
-            raise KeyError(f"Dependency {key} not provided")
-
-        if key.lock_on_get:
-            self.locked_dependencies.add(key)
-
-        return key.combine(self.dependencies[key])
 
 
 class BlockComponentParams(ABC):

--- a/coreblocks/params/keys.py
+++ b/coreblocks/params/keys.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from coreblocks.params.fu_params import SimpleKey, UnifierKey
+from coreblocks.params.dependencies import SimpleKey, UnifierKey
 from coreblocks.transactions.lib import MethodProduct, Collector
 from coreblocks.peripherals.wishbone import WishboneMaster
 from coreblocks.utils.protocols import Unifier

--- a/coreblocks/stages/func_blocks_unifier.py
+++ b/coreblocks/stages/func_blocks_unifier.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from amaranth import *
 
 from coreblocks.params import GenParams, BlockComponentParams, DependencyManager
-from coreblocks.params.fu_params import UnifierKey
+from coreblocks.params.dependencies import UnifierKey
 from coreblocks.transactions import Method
 from coreblocks.transactions.lib import MethodProduct, Collector
 

--- a/coreblocks/stages/rs_func_block.py
+++ b/coreblocks/stages/rs_func_block.py
@@ -1,4 +1,6 @@
+from collections.abc import Collection
 from amaranth import *
+from dataclasses import dataclass
 from coreblocks.params import *
 from coreblocks.structs_common.rs import RS
 from coreblocks.scheduler.wakeup_select import WakeupSelect
@@ -78,10 +80,10 @@ class RSFuncBlock(Elaboratable):
         return m
 
 
+@dataclass(frozen=True)
 class RSBlockComponent(BlockComponentParams):
-    def __init__(self, func_units: Iterable[FunctionalComponentParams], rs_entries: int):
-        self.func_units = func_units
-        self.rs_entries = rs_entries
+    func_units: Collection[FunctionalComponentParams]
+    rs_entries: int
 
     def get_module(self, gen_params: GenParams) -> FuncBlock:
         modules = list(u.get_module(gen_params) for u in self.func_units)


### PR DESCRIPTION
This PR contains three changes.

1. Separation of the `DependencyManager` stuff to a separate file.
2. Use of frozen dataclasses for `*ComponentParams`. This can play nice with #275. (I didn't make a dataclass out of attribute-less `*Params` classes. Should I?)
3. Removal of `from __future__ import annotations`. Its future (ahem) is uncertain, see #172.