### PR TITLE
Fix FreeRF FIFO initialization

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -2,6 +2,7 @@ from amaranth import *
 
 from coreblocks.params.dependencies import DependencyManager
 from coreblocks.stages.func_blocks_unifier import FuncBlocksUnifier
+from coreblocks.transactions.core import Transaction
 from coreblocks.transactions.lib import FIFO, ConnectTrans
 from coreblocks.params.layouts import *
 from coreblocks.params.keys import InstructionCommitKey, BranchResolvedKey, WishboneDataKey
@@ -33,9 +34,7 @@ class Core(Elaboratable):
         # make fifo_fetch visible outside the core for injecting instructions
         self.fifo_fetch = FIFO(self.gen_params.get(FetchLayouts).raw_instr, 2)
         self.free_rf_fifo = BasicFifo(
-            self.gen_params.get(SchedulerLayouts).free_rf_layout,
-            2**self.gen_params.phys_regs_bits,
-            init=[i for i in range(1, 2**self.gen_params.phys_regs_bits)],
+            self.gen_params.get(SchedulerLayouts).free_rf_layout, 2**self.gen_params.phys_regs_bits
         )
         self.fetch = Fetch(self.gen_params, self.wb_master_instr, self.fifo_fetch.write)
         self.FRAT = FRAT(gen_params=self.gen_params)
@@ -107,5 +106,11 @@ class Core(Elaboratable):
             rf_free=rf.free,
             lsu_commit=self.func_blocks_unifier.get_extra_method(InstructionCommitKey()),
         )
+
+        # push all registers to FreeRF at reset. r0 should be skipped, stop when counter overflows to 0
+        free_rf_reg = Signal(self.gen_params.phys_regs_bits, reset=1)
+        with Transaction(name="InitFreeRFFifo").body(m, request=(free_rf_reg.bool())):
+            free_rf_fifo.write(m, free_rf_reg)
+            m.d.sync += free_rf_reg.eq(free_rf_reg + 1)
 
         return m

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -238,7 +238,7 @@ class TestCoreRandomized(TestCoreBase):
 
 @parameterized_class(
     ("name", "source_file", "instr_count", "expected_regvals"),
-    [("fibonacci", "fibonacci.asm", 1200, {2: 2971215073}), ("fibonacci_mem", "fibonacci_mem.asm", 500, {3: 55})],
+    [("fibonacci", "fibonacci.asm", 1200, {2: 2971215073}), ("fibonacci_mem", "fibonacci_mem.asm", 510, {3: 55})],
 )
 class TestCoreAsmSource(TestCoreBase):
     source_file: str

--- a/test/utils/test_fifo.py
+++ b/test/utils/test_fifo.py
@@ -11,15 +11,14 @@ import random
 
 
 class BasicFifoTestCircuit(Elaboratable):
-    def __init__(self, depth, init):
+    def __init__(self, depth):
         self.depth = depth
-        self.init = init
 
     def elaborate(self, platform):
         m = Module()
         tm = TransactionModule(m)
 
-        m.submodules.fifo = self.fifo = BasicFifo(layout=data_layout(8), depth=self.depth, init=self.init)
+        m.submodules.fifo = self.fifo = BasicFifo(layout=data_layout(8), depth=self.depth)
 
         m.submodules.fifo_read = self.fifo_read = TestbenchIO(AdapterTrans(self.fifo.read))
         m.submodules.fifo_write = self.fifo_write = TestbenchIO(AdapterTrans(self.fifo.write))
@@ -29,25 +28,18 @@ class BasicFifoTestCircuit(Elaboratable):
 
 
 @parameterized_class(
-    ("name", "depth", "init_len"),
+    ("name", "depth"),
     [
-        ("notpower_notfull", 5, 3),
-        ("notpower_full", 5, 5),
-        ("notpower_empty", 5, 0),
-        ("power_notfull", 4, 3),
-        ("power_full", 4, 4),
-        ("power_empty", 4, 0),
+        ("notpower", 5, 0),
+        ("power", 4, 0),
     ],
 )
 class TestBasicFifo(TestCaseWithSimulator):
     depth: int
-    init_len: int
 
     def test_randomized(self):
-        init_values = [x for x in range(self.init_len)]
-
-        fifoc = BasicFifoTestCircuit(depth=self.depth, init=init_values)
-        expq = deque(reversed(init_values))  # first expected element is at the start of init_list
+        fifoc = BasicFifoTestCircuit(depth=self.depth)
+        expq = deque()  # first expected element is at the start of init_list
 
         cycles = 256
         random.seed(42)

--- a/test/utils/test_fifo.py
+++ b/test/utils/test_fifo.py
@@ -30,8 +30,8 @@ class BasicFifoTestCircuit(Elaboratable):
 @parameterized_class(
     ("name", "depth"),
     [
-        ("notpower", 5, 0),
-        ("power", 4, 0),
+        ("notpower", 5),
+        ("power", 4),
     ],
 )
 class TestBasicFifo(TestCaseWithSimulator):
@@ -39,7 +39,7 @@ class TestBasicFifo(TestCaseWithSimulator):
 
     def test_randomized(self):
         fifoc = BasicFifoTestCircuit(depth=self.depth)
-        expq = deque()  # first expected element is at the start of init_list
+        expq = deque()
 
         cycles = 256
         random.seed(42)


### PR DESCRIPTION
This is a fix for issues reported in #268. Let's hope all tests will pass now!
The issue was that `init` parameter from Amaranth's `Memory` initializes memory to `init` only on full power cycle instead of reset (unlike everything else).  From docs: `Initial values. At power on, each storage element in this memory is initialized to the corresponding element of init`. Cocotb tests were the first test to actually use the reset signal. (debugging log in teams channel)

This PR initializes FreeRF with simple transaction that runs on reset and removes misleading init parameter from `BasicFIFO`.
Possible improvements (let me know what you think):
* `Retirement` Transcation could be `scheduled_before` this init transaction. This way it would not delay core by blocking retirement, and supply new regs when they are needed (and we can see that few cycles of delay in fibonacci mem test). That would involve passing retirement transaction from `elaborate` stage some dependecy key (it cannot be declared in constructor), so I have mixed feelings about that for now
* Make a variant of BasicFIFO that uses `Array` of Signals instead of `Memory`, that can be `init`ed like we want
