### PR TITLE
Decoder: set invalid registers to 0 and fix CSR decoding

### DIFF
--- a/coreblocks/frontend/decode.py
+++ b/coreblocks/frontend/decode.py
@@ -50,12 +50,10 @@ class Decode(Elaboratable):
                         "funct7": instr_decoder.funct7,
                     },
                     "regs_l": {
-                        "rl_dst": instr_decoder.rd,
-                        "rl_dst_v": instr_decoder.rd_v,
-                        "rl_s1": instr_decoder.rs1,
-                        "rl_s1_v": instr_decoder.rs1_v,
-                        "rl_s2": instr_decoder.rs2,
-                        "rl_s2_v": instr_decoder.rs2_v,
+                        # read/writes to phys reg 0 make no effect
+                        "rl_dst": Mux(instr_decoder.rd_v, instr_decoder.rd, 0),
+                        "rl_s1": Mux(instr_decoder.rs1_v, instr_decoder.rs1, 0),
+                        "rl_s2": Mux(instr_decoder.rs2_v, instr_decoder.rs2, 0),
                     },
                     "imm": instr_decoder.imm,
                     "csr": instr_decoder.csr,

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -199,6 +199,10 @@ class InstrDecoder(Elaboratable):
         Twelve bits function identifier.
     funct12_v: Signal(1), out
         Signals if decoded instruction has funct12 identifier.
+    rd: Signal(gen.isa.reg_cnt_log), out
+        Address of register to write instruction result.
+    rd_v: Signal(1), out
+        Signal if instruction writes to register.
     rs1: Signal(gen.isa.reg_cnt_log), out
         Address of register holding first input value.
     rs1_v: Signal(1), out

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -138,10 +138,12 @@ _instructions_by_optype = {
     OpType.FENCEI: [
         Encoding(Opcode.MISC_MEM, Funct3.FENCEI),  # fence.i
     ],
-    OpType.CSR: [
+    OpType.CSR_REG: [
         Encoding(Opcode.SYSTEM, Funct3.CSRRW),  # csrrw
         Encoding(Opcode.SYSTEM, Funct3.CSRRS),  # csrrs
         Encoding(Opcode.SYSTEM, Funct3.CSRRC),  # csrrc
+    ],
+    OpType.CSR_IMM: [
         Encoding(Opcode.SYSTEM, Funct3.CSRRWI),  # csrrwi
         Encoding(Opcode.SYSTEM, Funct3.CSRRSI),  # csrrsi
         Encoding(Opcode.SYSTEM, Funct3.CSRRCI),  # csrrci
@@ -473,10 +475,13 @@ class InstrDecoder(Elaboratable):
         with m.Else():
             m.d.comb += self.opcode.eq(opcode)
 
-        # Immediate correction
+        # CSR with immediate correction
 
-        with m.If(self.op == OpType.CSR):
-            m.d.comb += self.imm.eq(uimm5)
+        with m.If(self.op == OpType.CSR_IMM):
+            m.d.comb += [
+                self.imm.eq(uimm5),
+                self.rs1_v.eq(0),
+            ]
 
         # Illegal instruction detection
 

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -28,11 +28,8 @@ class CommonLayouts:
 
         self.regs_l = [
             ("rl_s1", gen_params.isa.reg_cnt_log),
-            ("rl_s1_v", 1),
             ("rl_s2", gen_params.isa.reg_cnt_log),
-            ("rl_s2_v", 1),
             ("rl_dst", gen_params.isa.reg_cnt_log),
-            ("rl_dst_v", 1),
         ]
 
         self.regs_p = [

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -27,7 +27,8 @@ class OpType(IntEnum):
     MRET = auto()
     WFI = auto()
     FENCEI = auto()
-    CSR = auto()
+    CSR_REG = auto()
+    CSR_IMM = auto()
     MUL = auto()
     DIV_REM = auto()
     SINGLE_BIT_MANIPULATION = auto()
@@ -60,7 +61,8 @@ optypes_by_extensions = {
         OpType.FENCEI,
     ],
     Extension.ZICSR: [
-        OpType.CSR,
+        OpType.CSR_REG,
+        OpType.CSR_IMM,
     ],
     Extension.M: [
         OpType.MUL,

--- a/test/frontend/test_decode.py
+++ b/test/frontend/test_decode.py
@@ -50,10 +50,8 @@ class TestFetch(TestCaseWithSimulator):
         self.assertEqual(decoded["exec_fn"]["op_type"], OpType.ARITHMETIC)
         self.assertEqual(decoded["exec_fn"]["funct3"], Funct3.ADD)
         self.assertEqual(decoded["regs_l"]["rl_dst"], 4)
-        self.assertEqual(decoded["regs_l"]["rl_dst_v"], 1)
         self.assertEqual(decoded["regs_l"]["rl_s1"], 5)
-        self.assertEqual(decoded["regs_l"]["rl_s1_v"], 1)
-        self.assertEqual(decoded["regs_l"]["rl_s2_v"], 0)
+        self.assertEqual(decoded["regs_l"]["rl_s2"], 0)
         self.assertEqual(decoded["imm"], 42)
 
         # testing an OP instruction (test copied from test_decoder.py)
@@ -66,11 +64,8 @@ class TestFetch(TestCaseWithSimulator):
         self.assertEqual(decoded["exec_fn"]["funct3"], Funct3.ADD)
         self.assertEqual(decoded["exec_fn"]["funct7"], Funct7.ADD)
         self.assertEqual(decoded["regs_l"]["rl_dst"], 1)
-        self.assertEqual(decoded["regs_l"]["rl_dst_v"], 1)
         self.assertEqual(decoded["regs_l"]["rl_s1"], 2)
-        self.assertEqual(decoded["regs_l"]["rl_s1_v"], 1)
         self.assertEqual(decoded["regs_l"]["rl_s2"], 3)
-        self.assertEqual(decoded["regs_l"]["rl_s1_v"], 1)
 
     def test(self):
         with self.run_simulation(self.test_module) as sim:

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -163,16 +163,16 @@ class TestDecoder(TestCaseWithSimulator):
             self.assertEqual((yield self.decoder.funct12_v), test.funct12 is not None)
 
             if test.rd is not None:
-                self.assertEqual((yield self.decoder.rd_v), 1)
                 self.assertEqual((yield self.decoder.rd), test.rd)
+            self.assertEqual((yield self.decoder.rd_v), test.rd is not None)
 
             if test.rs1 is not None:
-                self.assertEqual((yield self.decoder.rs1_v), 1)
                 self.assertEqual((yield self.decoder.rs1), test.rs1)
+            self.assertEqual((yield self.decoder.rs1_v), test.rs1 is not None)
 
             if test.rs2 is not None:
-                self.assertEqual((yield self.decoder.rs2_v), 1)
                 self.assertEqual((yield self.decoder.rs2), test.rs2)
+            self.assertEqual((yield self.decoder.rs2_v), test.rs2 is not None)
 
             if test.imm is not None:
                 self.assertEqual((yield self.decoder.imm), test.imm)

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -115,12 +115,12 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x0000100F, Opcode.MISC_MEM, Funct3.FENCEI, rd=0, rs1=0, imm=0, op=OpType.FENCEI),
     ]
     DECODER_TESTS_ZICSR = [
-        InstrTest(0x001A9A73, Opcode.SYSTEM, Funct3.CSRRW, rd=20, rs1=21, csr=0x01, op=OpType.CSR),
-        InstrTest(0x002B2AF3, Opcode.SYSTEM, Funct3.CSRRS, rd=21, rs1=22, csr=0x02, op=OpType.CSR),
-        InstrTest(0x004BBB73, Opcode.SYSTEM, Funct3.CSRRC, rd=22, rs1=23, csr=0x04, op=OpType.CSR),
-        InstrTest(0x001FDA73, Opcode.SYSTEM, Funct3.CSRRWI, rd=20, imm=0x1F, csr=0x01, op=OpType.CSR),
-        InstrTest(0x0027EAF3, Opcode.SYSTEM, Funct3.CSRRSI, rd=21, imm=0xF, csr=0x02, op=OpType.CSR),
-        InstrTest(0x00407B73, Opcode.SYSTEM, Funct3.CSRRCI, rd=22, imm=0x0, csr=0x04, op=OpType.CSR),
+        InstrTest(0x001A9A73, Opcode.SYSTEM, Funct3.CSRRW, rd=20, rs1=21, csr=0x01, op=OpType.CSR_REG),
+        InstrTest(0x002B2AF3, Opcode.SYSTEM, Funct3.CSRRS, rd=21, rs1=22, csr=0x02, op=OpType.CSR_REG),
+        InstrTest(0x004BBB73, Opcode.SYSTEM, Funct3.CSRRC, rd=22, rs1=23, csr=0x04, op=OpType.CSR_REG),
+        InstrTest(0x001FDA73, Opcode.SYSTEM, Funct3.CSRRWI, rd=20, imm=0x1F, csr=0x01, op=OpType.CSR_IMM),
+        InstrTest(0x0027EAF3, Opcode.SYSTEM, Funct3.CSRRSI, rd=21, imm=0xF, csr=0x02, op=OpType.CSR_IMM),
+        InstrTest(0x00407B73, Opcode.SYSTEM, Funct3.CSRRCI, rd=22, imm=0x0, csr=0x04, op=OpType.CSR_IMM),
     ]
     DECODER_TESTS_ILLEGAL = [
         InstrTest(0xFFFFFFFF, Opcode.OP_IMM, illegal=1),

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -330,11 +330,8 @@ class TestScheduler(TestCaseWithSimulator):
                         },
                         "regs_l": {
                             "rl_s1": rl_s1,
-                            "rl_s1_v": 1,
                             "rl_s2": rl_s2,
-                            "rl_s2_v": 1,
                             "rl_dst": rl_dst,
-                            "rl_dst_v": 1,
                         },
                         "imm": immediate,
                     }

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -87,7 +87,7 @@ class TestCSRUnit(TestCaseWithSimulator):
 
         return {
             "instr": {
-                "exec_fn": {"op_type": OpType.CSR, "funct3": op, "funct7": 0},
+                "exec_fn": {"op_type": OpType.CSR_IMM if imm_op else OpType.CSR_REG, "funct3": op, "funct7": 0},
                 "rp_s1": 0 if value_available or imm_op else rs1,
                 "rp_s1_reg": rs1,
                 "s1_val": exp["rs1"]["value"] if value_available and not imm_op else 0,


### PR DESCRIPTION
@tilk another fix for #268 .

Decoder produced `rl_s1_v, rl_s2_v and rl_rd_v` fields but they were not used anywehere.
It caused allocation of random registers (only a waste of resources, not breaking things), but Jump/Branch unit was the first FU that sometimes should produc results (AUIPC) and sometimes not (but according to FU convention it always pushed this result). In this case computed branch result was commited to random register (even if it was not valid like in BGEU).

This PR muxes invalid registers to 0 in decoder, so they have no effect on core (writes ignored, allocation ignored, reads ignored).

I also removed the ` rl_**_v` field from layout, which was pushed through whole core, because I don't feel like it will be useful anywhere. Functional Units only use source fields to computation based on FUs internal decoders. With this PR, RSes would not wait for 0 register (and I see no point in pushing random registers values through core), and in case of J/B unit produced result would be ignored if rd is not valid. 

Edit: Also fixes CSR decoding issue found by tilk. I decided to split `CSR_REG` and `CSR_IMM` `OpTypes`, as only `CSR_IMM` needs special correction to standard instruction encoding (part of it was done in both cases, but invalidating rs1 was not). It is also useful in `CSRUnit`