### PR TITLE
LSU addressing fix

### DIFF
--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -101,8 +101,7 @@ class LSUDummyInternals(Elaboratable):
 
         bytes_mask = self.prepare_bytes_mask(m, addr)
         req = Record(self.bus.requestLayout)
-        # make address aligned to 4
-        m.d.comb += req.addr.eq(addr >> 2)
+        m.d.comb += req.addr.eq(addr >> 2)  # calculate word address
         m.d.comb += req.we.eq(is_store)
         m.d.comb += req.sel.eq(bytes_mask)
         m.d.comb += req.data.eq(self.prepare_data_to_save(m, self.current_instr.s2_val, addr))

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -102,7 +102,7 @@ class LSUDummyInternals(Elaboratable):
         bytes_mask = self.prepare_bytes_mask(m, addr)
         req = Record(self.bus.requestLayout)
         # make address aligned to 4
-        m.d.comb += req.addr.eq(addr & ~0x3)
+        m.d.comb += req.addr.eq(addr >> 2)
         m.d.comb += req.we.eq(is_store)
         m.d.comb += req.sel.eq(bytes_mask)
         m.d.comb += req.data.eq(self.prepare_data_to_save(m, self.current_instr.s2_val, addr))

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -118,10 +118,9 @@ class TestDummyLSULoads(TestCaseWithSimulator):
 
             self.announce_queue.append(ann_data)
             exec_fn = {"op_type": op[0], "funct3": op[1], "funct7": 0}
-            mask = shift_mask_based_on_addr(mask, addr)
 
-            # calculate aligned address
-            rest = addr % 4
+            # calculate word address and mask
+            mask = shift_mask_based_on_addr(mask, addr)
             addr = addr >> 2
 
             rp_dst = random.randint(0, 2**self.gp.phys_regs_bits - 1)
@@ -229,7 +228,11 @@ class TestDummyLSULoadsCycles(TestCaseWithSimulator):
             "imm": imm,
         }
 
-        wish_data = {"addr": (s1_val + imm) >> 2, "mask": 0xF, "rnd_bytes": bytes.fromhex(f"{random.randint(0,2**32-1):08x}")}
+        wish_data = {
+            "addr": (s1_val + imm) >> 2,
+            "mask": 0xF,
+            "rnd_bytes": bytes.fromhex(f"{random.randint(0,2**32-1):08x}"),
+        }
         return instr, wish_data
 
     def setUp(self) -> None:
@@ -289,10 +292,9 @@ class TestDummyLSUStores(TestCaseWithSimulator):
                 self.announce_queue.append((ann_data2, ann_data1))
 
             exec_fn = {"op_type": op[0], "funct3": op[1], "funct7": 0}
-            mask = shift_mask_based_on_addr(mask, addr)
 
-            # calculate aligned address
-            rest = addr % 4
+            # calculate word address and mask
+            mask = shift_mask_based_on_addr(mask, addr)
             addr = addr >> 2
 
             rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -122,7 +122,7 @@ class TestDummyLSULoads(TestCaseWithSimulator):
 
             # calculate aligned address
             rest = addr % 4
-            addr = addr - rest
+            addr = addr >> 2
 
             rp_dst = random.randint(0, 2**self.gp.phys_regs_bits - 1)
             rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
@@ -229,7 +229,7 @@ class TestDummyLSULoadsCycles(TestCaseWithSimulator):
             "imm": imm,
         }
 
-        wish_data = {"addr": s1_val + imm, "mask": 0xF, "rnd_bytes": bytes.fromhex(f"{random.randint(0,2**32-1):08x}")}
+        wish_data = {"addr": (s1_val + imm) >> 2, "mask": 0xF, "rnd_bytes": bytes.fromhex(f"{random.randint(0,2**32-1):08x}")}
         return instr, wish_data
 
     def setUp(self) -> None:
@@ -293,7 +293,7 @@ class TestDummyLSUStores(TestCaseWithSimulator):
 
             # calculate aligned address
             rest = addr % 4
-            addr = addr - rest
+            addr = addr >> 2
 
             rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
             instr = {


### PR DESCRIPTION
Found while doing #268. Wishbone is word addressed, yet the LSU still sent byte addresses (with lower bits being 0). We missed that during CR.