### PR TITLE
Decoder fix for shift immediate handling

### DIFF
--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -410,8 +410,8 @@ class InstrDecoder(Elaboratable):
             self._extract(15, uimm5),
         ]
 
-        with m.If((self.funct3 == Funct3.SLL) | (self.funct3 == Funct3.SR)):
-            m.d.comb += iimm12[5:11].eq(0)
+        with m.If((opcode == Opcode.OP_IMM) & ((self.funct3 == Funct3.SLL) | (self.funct3 == Funct3.SR))):
+            m.d.comb += iimm12.eq(instr[20:25])
 
         with m.Switch(instruction_type):
             with m.Case(InstrType.I):

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -86,7 +86,7 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x00D59503, Opcode.LOAD, Funct3.H, rd=10, rs1=11, imm=13, op=OpType.LOAD),
         InstrTest(0x00E65583, Opcode.LOAD, Funct3.HU, rd=11, rs1=12, imm=14, op=OpType.LOAD),
         InstrTest(0x00F6A603, Opcode.LOAD, Funct3.W, rd=12, rs1=13, imm=15, op=OpType.LOAD),
-        InstrTest(0xffA09703, Opcode.LOAD, Funct3.H, rd=14, rs1=1, imm=-6, op=OpType.LOAD),
+        InstrTest(0xFFA09703, Opcode.LOAD, Funct3.H, rd=14, rs1=1, imm=-6, op=OpType.LOAD),
         # Store
         InstrTest(0x00D70823, Opcode.STORE, Funct3.B, rs1=14, rs2=13, imm=16, op=OpType.STORE),
         InstrTest(0x00E798A3, Opcode.STORE, Funct3.H, rs1=15, rs2=14, imm=17, op=OpType.STORE),

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -55,7 +55,7 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x00C5A533, Opcode.OP, Funct3.SLT, Funct7.SLT, rd=10, rs1=11, rs2=12, op=OpType.COMPARE),
         InstrTest(0x00C5B533, Opcode.OP, Funct3.SLTU, Funct7.SLT, rd=10, rs1=11, rs2=12, op=OpType.COMPARE),
         # Logic
-        InstrTest(0xFFF04013, Opcode.OP_IMM, Funct3.XOR, rd=0, rs1=0, imm=0xFFFFFFFF, op=OpType.LOGIC),
+        InstrTest(0xFFF04013, Opcode.OP_IMM, Funct3.XOR, rd=0, rs1=0, imm=-1, op=OpType.LOGIC),
         InstrTest(0x3FF0E093, Opcode.OP_IMM, Funct3.OR, rd=1, rs1=1, imm=0x3FF, op=OpType.LOGIC),
         InstrTest(0x000FFF13, Opcode.OP_IMM, Funct3.AND, rd=30, rs1=31, imm=0, op=OpType.LOGIC),
         InstrTest(0x003140B3, Opcode.OP, Funct3.XOR, Funct7.XOR, rd=1, rs1=2, rs2=3, op=OpType.LOGIC),
@@ -72,7 +72,7 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x00777F17, Opcode.AUIPC, rd=30, imm=0x777 << 12, op=OpType.AUIPC),
         # Jumps
         InstrTest(0x000000EF, Opcode.JAL, rd=1, imm=0, op=OpType.JAL),
-        InstrTest(0xFFE100E7, Opcode.JALR, Funct3.JALR, rd=1, rs1=2, imm=0xFFFFFFFE, op=OpType.JALR),
+        InstrTest(0xFFE100E7, Opcode.JALR, Funct3.JALR, rd=1, rs1=2, imm=-2, op=OpType.JALR),
         # Branch
         InstrTest(0x00209463, Opcode.BRANCH, Funct3.BNE, rs1=1, rs2=2, imm=4 << 1, op=OpType.BRANCH),
         InstrTest(0x00310463, Opcode.BRANCH, Funct3.BEQ, rs1=2, rs2=3, imm=4 << 1, op=OpType.BRANCH),
@@ -86,6 +86,7 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x00D59503, Opcode.LOAD, Funct3.H, rd=10, rs1=11, imm=13, op=OpType.LOAD),
         InstrTest(0x00E65583, Opcode.LOAD, Funct3.HU, rd=11, rs1=12, imm=14, op=OpType.LOAD),
         InstrTest(0x00F6A603, Opcode.LOAD, Funct3.W, rd=12, rs1=13, imm=15, op=OpType.LOAD),
+        InstrTest(0xffA09703, Opcode.LOAD, Funct3.H, rd=14, rs1=1, imm=-6, op=OpType.LOAD),
         # Store
         InstrTest(0x00D70823, Opcode.STORE, Funct3.B, rs1=14, rs2=13, imm=16, op=OpType.STORE),
         InstrTest(0x00E798A3, Opcode.STORE, Funct3.H, rs1=15, rs2=14, imm=17, op=OpType.STORE),
@@ -175,7 +176,7 @@ class TestDecoder(TestCaseWithSimulator):
                 self.assertEqual((yield self.decoder.rs2), test.rs2)
 
             if test.imm is not None:
-                self.assertEqual((yield self.decoder.imm), test.imm)
+                self.assertEqual((yield self.decoder.imm.as_signed()), test.imm)
 
             if test.succ is not None:
                 self.assertEqual((yield self.decoder.succ), test.succ)


### PR DESCRIPTION
The decoder applied shift immediate special case for all I-type instructions, including LOAD, which borked decoding of these instructions. Found in #268.

This also fixes a weird interaction between Amaranth, Yosys verilog output, and Icarus Verilog. For some reason, iverilog (at least in the version present in Debian) has problems with bit vectors where part of them are set using `assign`, and the rest using `always`.