### PR TITLE
Added timeouts for workflows.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: ghcr.io/kuznia-rdzeni/amaranth-synth:ecp5
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     container: ghcr.io/kuznia-rdzeni/amaranth-synth:ecp5
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cocotb.yml
+++ b/.github/workflows/cocotb.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cocotb.yml
+++ b/.github/workflows/cocotb.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 4
+    timeout-minutes: 10
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   push_gh-pages:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_MAIL: ${{github.event.pusher.email}}

--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   push_gh-pages:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_MAIL: ${{github.event.pusher.email}}

--- a/.github/workflows/deploy_wiki.yml
+++ b/.github/workflows/deploy_wiki.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy-wiki:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy_wiki.yml
+++ b/.github/workflows/deploy_wiki.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-wiki:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -35,6 +36,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR should be first fix for issue, that in case of problems with tests our workflows can stuck and run way too long (till github default timeout which is 6 hours).

Fix problem reported in #300 