### PR TITLE
Fix Verilator on cocotb

### DIFF
--- a/.github/workflows/cocotb.yml
+++ b/.github/workflows/cocotb.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           pip3 install -r requirements-dev.txt
-          apt-get update && apt-get install -y gcc-riscv64-unknown-elf iverilog
+          apt-get update && apt-get install -y gcc-riscv64-unknown-elf
 
       - name: Initialize submodules
         run: git submodule update --init --recursive

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ pyright==1.1.302
 Sphinx==5.1.1
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-mermaid==0.7.1
-cocotb==1.7.2
+git+https://github.com/cocotb/cocotb@249ebe0c145cdec46781c6ae379d406e0de30287
 cocotb-bus==0.2.1
 pytest==7.2.2
 pyelftools==0.29

--- a/test/cocotb/Makefile
+++ b/test/cocotb/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 
 # defaults
-SIM ?= icarus
+SIM ?= verilator
 TOPLEVEL_LANG ?= verilog
 
 VERILOG_SOURCES += $(PWD)/../../core.v
@@ -12,6 +12,11 @@ TOPLEVEL = top
 
 # MODULE is the basename of the Python test file
 MODULE = test
+
+# Yosys/Amaranth borkedness workaround
+ifeq ($(SIM),verilator)
+  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC
+endif
 
 # include cocotb's make rules to take care of the simulator setup
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/cocotb/test.py
+++ b/test/cocotb/test.py
@@ -48,7 +48,11 @@ class WishboneBus(Bus):
     rty: ModifiableObject
 
     def __init__(self, entity, name):
-        super().__init__(entity, name, self._signals, self._optional_signals, bus_separator="__")
+        # case_insensitive is a workaround for cocotb_bus/verilator problem
+        # see https://github.com/cocotb/cocotb/issues/3259
+        super().__init__(
+            entity, name, self._signals, self._optional_signals, bus_separator="__", case_insensitive=False
+        )
 
 
 class ReplyStatus(Enum):


### PR DESCRIPTION
So, there is some silliness in `cocotb_bus` which prevented Verilator from working right. (https://github.com/cocotb/cocotb/issues/3259)

Also updated `cocotb` to the development version to benefit from updates to the Verilator support.