### PR TITLE
Generate isa_str from func units config

### DIFF
--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -2,13 +2,15 @@ from abc import abstractmethod, ABC
 from typing import Iterable
 
 from coreblocks.utils.protocols import FuncBlock, FuncUnit
+from coreblocks.params.isa import Extension, extension_implications
+from coreblocks.params.optypes import optypes_required_by_extensions
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Collection
+
 
 if TYPE_CHECKING:
     from coreblocks.params.genparams import GenParams
     from coreblocks.params.optypes import OpType
-
 
 __all__ = [
     "BlockComponentParams",
@@ -39,3 +41,50 @@ class FunctionalComponentParams(ABC):
 
 def optypes_supported(block_components: Iterable[BlockComponentParams]) -> set["OpType"]:
     return {optype for block in block_components for optype in block.get_optypes()}
+
+
+def _remove_implications(extensions: set[Extension]):
+    implied_extensions = set()
+    for ext in extensions:
+        if ext in extension_implications:
+            implied_extensions |= extension_implications[ext]
+    return extensions - implied_extensions
+
+
+## Move that to genparams?
+def extensions_supported(fu_config: Collection[BlockComponentParams]) -> tuple[set[Extension], set[Extension]]:
+    optypes = optypes_supported(fu_config)
+
+    # Fully and partially supported extensions
+    extensions_parital: set[Extension] = set()
+    # Fully supported extensions
+    extensions_full: set[Extension] = set()
+
+    # OK: Add global switch if we want to use partial extensions with warning of unsupported ops (and default for now). If not selected error if partial != full
+
+    for ext in Extension:
+        ext_added_optypes = optypes_required_by_extensions({ext}, resolve_implications=False, ignore_unsupported=True)
+        if ext_added_optypes & optypes:
+            extensions_parital.add(ext)
+
+        ext_all_optypes = optypes_required_by_extensions({ext}, resolve_implications=True, ignore_unsupported=True)
+        if optypes and ext_all_optypes and optypes.issuperset(ext_all_optypes):
+            extensions_full.add(ext)
+
+    # needed for extensions that just imply others without adding new optypes (like B).
+    # add them to partial extensions if they are fully supported for implied removal
+    extensions_parital |= extensions_full
+
+    # remove implied extensions
+    extensions_parital = _remove_implications(extensions_parital)
+    extensions_full = _remove_implications(extensions_full)
+
+    # special modifications
+
+    # TODO: convert to G; E->I (if gp); ISA STR ORDER MATTERS
+
+    #: generate isa strings in another function (isa_str, compiler_isa_str (bypass for zmull), extra info (with partial/full info and machine/sup mode)
+
+    print(extensions_parital, extensions_full)
+
+    return (extensions_parital, extensions_full)

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -201,11 +201,11 @@ _extension_requirements = {
     Extension.ZHINX: Extension.ZFH,
 }
 
-# Extensions which implicitly imply another extensions (can be joined using | operator)
-_extension_implications = {
-    Extension.F: Extension.ZICSR,
-    Extension.M: Extension.ZMMUL,
-    Extension.B: Extension.ZBA | Extension.ZBB | Extension.ZBC | Extension.ZBS,
+# Extensions which implicitly imply another extensions
+extension_implications = {
+    Extension.F: {Extension.ZICSR},
+    Extension.M: {Extension.ZMMUL},
+    Extension.B: {Extension.ZBA, Extension.ZBB, Extension.ZBC, Extension.ZBS},
 }
 
 
@@ -282,9 +282,10 @@ class ISA:
         if (self.extensions & Extension.E) and self.xlen != 32:
             raise RuntimeError("ISA extension E with XLEN != 32")
 
-        for ext, imply in _extension_implications.items():
+        for ext, imply_set in extension_implications.items():
             if ext in self.extensions:
-                self.extensions |= imply
+                for imply in imply_set:
+                    self.extensions |= imply
 
         for exclusive in _extension_exclusive:
             for i in range(len(exclusive)):

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -140,6 +140,10 @@ class Extension(IntFlag):
     V = auto()
     #: User-level interruptions
     N = auto()
+    #: Machine-Mode Privileged Instructions
+    MACHINE_MODE = auto()
+    #: Supervisor Instructions
+    SUPERVISOR = auto()
     #: Control and Status Register access
     ZICSR = auto()
     #: Instruction-Fetch fence operations

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -52,6 +52,8 @@ optypes_by_extensions = {
         OpType.LOAD,
         OpType.STORE,
         OpType.FENCE,
+    ],
+    Extension.MACHINE_MODE: [
         OpType.ECALL,
         OpType.EBREAK,
         OpType.MRET,

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -88,9 +88,11 @@ def optypes_required_by_extensions(
     optypes = set()
 
     if resolve_implications:
+        implied_extensions = set()
         for ext in extensions:
-            if ext in extension_implications:
-                extensions |= extension_implications[ext]
+            if ext in extension_implications and ext in optypes_by_extensions:
+                implied_extensions |= extension_implications[ext]
+        extensions |= implied_extensions
 
     for ext in extensions:
         if ext in optypes_by_extensions:

--- a/coreblocks/stages/rs_func_block.py
+++ b/coreblocks/stages/rs_func_block.py
@@ -1,6 +1,7 @@
 from collections.abc import Collection
 from amaranth import *
 from dataclasses import dataclass
+from typing import Iterable
 from coreblocks.params import *
 from coreblocks.structs_common.rs import RS
 from coreblocks.scheduler.wakeup_select import WakeupSelect


### PR DESCRIPTION
Easier said than done; it was is tricky to implement with extension implications. I needed to modify ISA and optype decoding to make it easier to implement. I also removed Privileged spec instructions from I extension, they don't belong to any extension.

Computes *partialy supported extensions* isa string and *fully suported extensions* isa string. We need to use *partial* isa string for decoder and compilers (if we want to temporarily support some OpTypes from extensions that are not yet completed (and maybe in some experimental configs)). Note that we still don't support `I` extension, `FENCE` is missing. 
Full ISA string would be used as extra information to user (printed later in gen verilog script; also with prvileged information, as it is not included in isa string) and with special flag in configuration, error could be raised if configuration where  `partial != full` would be used, as it may cause compiler to generate unsported instructions (and I think it should be enabled by default in export configurations in future).

TODO: Tests, add to GP, some extra conversions, compiler isa string (temporary for zmmul #289). 
Fixes #295 