### PR TITLE
Run workflows of feature branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - 'feature/**'
   pull_request:
     branches:
       - master
+      - 'feature/**'
 
 jobs:
   test:


### PR DESCRIPTION
This change makes the CI run workflows automatically on branches named `feature/<name>`. As of now this only includes `feature/interrupts`.