### PR TITLE
Refactor tests with TransactionModule

### DIFF
--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -12,6 +12,7 @@ from itertools import count, chain
 
 from coreblocks.utils import AssignType, assign
 from ._utils import *
+from ..utils import silence_mustuse
 from ..utils._typing import StatementLike, ValueLike, SignalBundle, HasElaborate
 from .graph import Owned, OwnershipGraph, Direction
 
@@ -281,13 +282,16 @@ class TransactionManager(Elaboratable):
         return method_uses
 
     def elaborate(self, platform):
-        method_map = MethodMap(self.transactions)
-        relations = [
-            Relation(**relation, start=elem)
-            for elem in method_map.methods_and_transactions
-            for relation in elem.relations
-        ]
-        cgr, rgr, porder = TransactionManager._conflict_graph(method_map, relations)
+        # In the following, various problems in the transaction set-up are detected.
+        # The exception triggers an unused Elaboratable warning.
+        with silence_mustuse(self):
+            method_map = MethodMap(self.transactions)
+            relations = [
+                Relation(**relation, start=elem)
+                for elem in method_map.methods_and_transactions
+                for relation in elem.relations
+            ]
+            cgr, rgr, porder = TransactionManager._conflict_graph(method_map, relations)
 
         m = Module()
 
@@ -350,8 +354,8 @@ class TransactionContext:
 
 class TransactionModule(Elaboratable):
     """
-    `TransactionModule` is used as wrapper on `Module` class,
-    which add support for transaction to the `Module`. It creates a
+    `TransactionModule` is used as wrapper on `Elaboratable` classes,
+    which adds support for transactions. It creates a
     `TransactionManager` which will handle transaction scheduling
     and can be used in definition of `Method`\\s and `Transaction`\\s.
     """
@@ -361,7 +365,7 @@ class TransactionModule(Elaboratable):
         Parameters
         ----------
         elaboratable: HasElaborate
-                The `Module` which should be wrapped to add support for
+                The `Elaboratable` which should be wrapped to add support for
                 transactions and methods.
         """
         if manager is None:
@@ -373,11 +377,15 @@ class TransactionModule(Elaboratable):
         return TransactionContext(self.transactionManager)
 
     def elaborate(self, platform):
-        m = Module()
-        with self.transaction_context():
-            m.submodules += Fragment.get(self.elaboratable, platform)
+        with silence_mustuse(self.transactionManager):
+            with self.transaction_context():
+                elaboratable = Fragment.get(self.elaboratable, platform)
 
-        m.submodules += self.transactionManager
+        m = Module()
+
+        m.submodules.main_module = elaboratable
+        m.submodules.transactionManager = self.transactionManager
+
         return m
 
 

--- a/coreblocks/utils/_typing.py
+++ b/coreblocks/utils/_typing.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Sequence, Tuple, Type, TypeAlias, Iterable, Mapping, runtime_checkable
+from typing import Protocol, Sequence, Tuple, Type, TypeAlias, Iterable, Mapping, runtime_checkable, Union
 from enum import Enum
 from amaranth import *
 from amaranth.hdl.ast import ShapeCastable, Statement, ValueCastable
@@ -17,7 +17,7 @@ LayoutList = list[Tuple[str, ShapeLike | "LayoutList"]]
 
 
 class HasElaborate(Protocol):
-    def elaborate(self, platform) -> "HasElaborate":
+    def elaborate(self, platform) -> Union["HasElaborate", Fragment]:
         ...
 
 

--- a/coreblocks/utils/_typing.py
+++ b/coreblocks/utils/_typing.py
@@ -17,7 +17,7 @@ LayoutList = list[Tuple[str, ShapeLike | "LayoutList"]]
 
 
 class HasElaborate(Protocol):
-    def elaborate(self, platform) -> Union["HasElaborate", Fragment]:
+    def elaborate(self, platform) -> "HasElaborate":
         ...
 
 

--- a/coreblocks/utils/_typing.py
+++ b/coreblocks/utils/_typing.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Sequence, Tuple, Type, TypeAlias, Iterable, Mapping, runtime_checkable, Union
+from typing import Protocol, Sequence, Tuple, Type, TypeAlias, Iterable, Mapping, runtime_checkable
 from enum import Enum
 from amaranth import *
 from amaranth.hdl.ast import ShapeCastable, Statement, ValueCastable

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -16,6 +16,7 @@ __all__ = [
     "align_to_power_of_two",
     "bits_from_int",
     "ModuleConnector",
+    "silence_mustuse",
 ]
 
 
@@ -347,3 +348,12 @@ class ModuleConnector(Elaboratable):
             m.submodules[name] = elem
 
         return m
+
+
+@contextmanager
+def silence_mustuse(elaboratable: Elaboratable):
+    try:
+        yield
+    except:
+        elaboratable._MustUse__silence = True  # type: ignore
+        raise

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -5,7 +5,6 @@ from amaranth import *
 from amaranth.hdl.ast import Assign, ArrayProxy
 from amaranth.lib import data
 from ._typing import ValueLike, LayoutList, SignalBundle
-import coreblocks.transactions.core
 
 
 __all__ = [
@@ -326,20 +325,17 @@ class ModuleConnector(Elaboratable):
     added as its submodules.
     """
 
-    def __init__(self, *args, wrap_with_tm: bool = False, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Parameters
         ----------
         *args
             Modules which should be named as anonymous submodules.
-        wrap_with_tm : bool
-            If True generated Module is wrapped using TransactionModule
         **kwargs
             Modules which will be added as named submodules.
         """
         self.args = args
         self.kwargs = kwargs
-        self.wrap_with_tm = wrap_with_tm
 
     def elaborate(self, platform):
         m = Module()
@@ -350,6 +346,4 @@ class ModuleConnector(Elaboratable):
         for name, elem in self.kwargs.items():
             m.submodules[name] = elem
 
-        if self.wrap_with_tm:
-            return coreblocks.transactions.core.TransactionModule(m)
         return m

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -5,6 +5,7 @@ from amaranth import *
 from amaranth.hdl.ast import Assign, ArrayProxy
 from amaranth.lib import data
 from ._typing import ValueLike, LayoutList, SignalBundle
+import coreblocks.transactions.core
 
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
     "flatten_signals",
     "align_to_power_of_two",
     "bits_from_int",
+    "ModuleConnector",
 ]
 
 
@@ -324,17 +326,20 @@ class ModuleConnector(Elaboratable):
     added as its submodules.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, wrap_with_tm : bool = False, **kwargs):
         """
         Parameters
         ----------
         *args
             Modules which should be named as anonymous submodules.
+        wrap_with_tm : bool
+            If True generated Module is wrapped using TransactionModule
         **kwargs
             Modules which will be added as named submodules.
         """
         self.args = args
         self.kwargs = kwargs
+        self.wrap_with_tm = wrap_with_tm
 
     def elaborate(self, platform):
         m = Module()
@@ -345,4 +350,6 @@ class ModuleConnector(Elaboratable):
         for name, elem in self.kwargs.items():
             m.submodules[name] = elem
 
+        if self.wrap_with_tm:
+            return coreblocks.transactions.core.TransactionModule(m)
         return m

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -317,16 +317,18 @@ def bits_from_int(num: int, lower: int, length: int):
     """Returns [`lower`:`lower`+`length`) bits from integer `num`."""
     return (num >> lower) & (1 << (length) - 1)
 
+
 class ModuleConnector(Elaboratable):
     """
     An Elaboratable to create a new module, which will have all arguments
     added as its submodules.
     """
+
     def __init__(self, *args, **kwargs):
         """
         Parameters
         ----------
-        *args 
+        *args
             Modules which should be named as anonymous submodules.
         **kwargs
             Modules which will be added as named submodules.

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -354,6 +354,6 @@ class ModuleConnector(Elaboratable):
 def silence_mustuse(elaboratable: Elaboratable):
     try:
         yield
-    except:
+    except Exception:
         elaboratable._MustUse__silence = True  # type: ignore
         raise

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -326,7 +326,7 @@ class ModuleConnector(Elaboratable):
     added as its submodules.
     """
 
-    def __init__(self, *args, wrap_with_tm : bool = False, **kwargs):
+    def __init__(self, *args, wrap_with_tm: bool = False, **kwargs):
         """
         Parameters
         ----------

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -316,3 +316,31 @@ def align_to_power_of_two(num: int, power: int) -> int:
 def bits_from_int(num: int, lower: int, length: int):
     """Returns [`lower`:`lower`+`length`) bits from integer `num`."""
     return (num >> lower) & (1 << (length) - 1)
+
+class ModuleConnector(Elaboratable):
+    """
+    An Elaboratable to create a new module, which will have all arguments
+    added as its submodules.
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        *args 
+            Modules which should be named as anonymous submodules.
+        **kwargs
+            Modules which will be added as named submodules.
+        """
+        self.args = args
+        self.kwargs = kwargs
+
+    def elaborate(self, platform):
+        m = Module()
+
+        for elem in self.args:
+            m.submodules += elem
+
+        for name, elem in self.kwargs.items():
+            m.submodules[name] = elem
+
+        return m

--- a/scripts/core_graph.py
+++ b/scripts/core_graph.py
@@ -3,6 +3,7 @@
 import pathlib
 import sys
 from argparse import ArgumentParser, FileType
+from amaranth import *
 
 par = ArgumentParser()
 par.add_argument("-p", "--prune", action="store_true", help="ignore disconnected nodes")
@@ -17,10 +18,13 @@ from coreblocks.params.genparams import GenParams  # noqa: E402
 from coreblocks.transactions.graph import TracingFragment  # noqa: E402
 from test.test_core import TestElaboratable  # noqa: E402
 from coreblocks.params.configurations import basic_core_config  # noqa: E402
+from coreblocks.transactions.core import TransactionModule  # noqa: E402
 
 gp = GenParams(basic_core_config)
-elaboratable = TestElaboratable(gp)
-fragment = TracingFragment.get(elaboratable, platform=None).prepare()
+m = Module()
+tm = TransactionModule(m)
+m.submodules.elaboratable = TestElaboratable(gp)
+fragment = TracingFragment.get(tm, platform=None).prepare()
 
 core = fragment
 while not hasattr(core, "transactionManager"):

--- a/scripts/core_graph.py
+++ b/scripts/core_graph.py
@@ -21,9 +21,8 @@ from coreblocks.params.configurations import basic_core_config  # noqa: E402
 from coreblocks.transactions.core import TransactionModule  # noqa: E402
 
 gp = GenParams(basic_core_config)
-m = Module()
-tm = TransactionModule(m)
-m.submodules.elaboratable = TestElaboratable(gp)
+elaboratable = TestElaboratable(gp)
+tm = TransactionModule(elaboratable)
 fragment = TracingFragment.get(tm, platform=None).prepare()
 
 core = fragment

--- a/scripts/core_graph.py
+++ b/scripts/core_graph.py
@@ -3,7 +3,6 @@
 import pathlib
 import sys
 from argparse import ArgumentParser, FileType
-from amaranth import *
 
 par = ArgumentParser()
 par.add_argument("-p", "--prune", action="store_true", help="ignore disconnected nodes")

--- a/test/common.py
+++ b/test/common.py
@@ -121,7 +121,6 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         dummy = Signal()
         m.d.sync += dummy.eq(1)
@@ -133,7 +132,7 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
                 self._io[name] = TestbenchIO(AdapterTrans(attr))
                 m.submodules += self._io[name]
 
-        return tm
+        return m
 
     def debug_signals(self):
         return [io.debug_signals() for io in self._io.values()]

--- a/test/common.py
+++ b/test/common.py
@@ -121,6 +121,7 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
 
     def elaborate(self, platform):
         m = Module()
+        tm = TransactionModule(m)
 
         dummy = Signal()
         m.d.sync += dummy.eq(1)
@@ -132,7 +133,7 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
                 self._io[name] = TestbenchIO(AdapterTrans(attr))
                 m.submodules += self._io[name]
 
-        return m
+        return tm
 
     def debug_signals(self):
         return [io.debug_signals() for io in self._io.values()]

--- a/test/common.py
+++ b/test/common.py
@@ -15,7 +15,7 @@ from amaranth._unused import UnusedMustUse
 from coreblocks.transactions.core import SignalBundle, Method, TransactionModule
 from coreblocks.transactions.lib import AdapterBase, AdapterTrans
 from coreblocks.transactions._utils import method_def_helper
-from coreblocks.utils import ValueLike, HasElaborate, HasDebugSignals, auto_debug_signals, LayoutLike, ModuleConnector
+from coreblocks.utils import ValueLike, HasElaborate, HasDebugSignals, auto_debug_signals, LayoutLike
 from .gtkw_extension import write_vcd_ext
 
 
@@ -143,7 +143,7 @@ class TestCaseWithSimulator(unittest.TestCase):
     def run_simulation(self, circuit: HasElaborate, max_cycles: float = 10e4):
         if isinstance(circuit, TransactionModule):
             raise TypeError("run_simulation should get ")
-        tm = ModuleConnector(wrap_with_tm=True, circuit=circuit)
+        tm = TransactionModule(circuit)
         test_name = unittest.TestCase.id(self)
         clk_period = 1e-6
 

--- a/test/common.py
+++ b/test/common.py
@@ -15,7 +15,7 @@ from amaranth._unused import UnusedMustUse
 from coreblocks.transactions.core import SignalBundle, Method, TransactionModule
 from coreblocks.transactions.lib import AdapterBase, AdapterTrans
 from coreblocks.transactions._utils import method_def_helper
-from coreblocks.utils import ValueLike, HasElaborate, HasDebugSignals, auto_debug_signals, LayoutLike
+from coreblocks.utils import ValueLike, HasElaborate, HasDebugSignals, auto_debug_signals, LayoutLike, ModuleConnector
 from .gtkw_extension import write_vcd_ext
 
 
@@ -144,9 +144,7 @@ class TestCaseWithSimulator(unittest.TestCase):
     def run_simulation(self, circuit : HasElaborate, max_cycles: float = 10e4):
         if isinstance(circuit, TransactionModule):
             raise TypeError("run_simulation should get ")
-        m = Module()
-        tm = TransactionModule(m)
-        m.submodules.circuit = circuit
+        tm = ModuleConnector(wrap_with_tm = True, circuit = circuit)
         test_name = unittest.TestCase.id(self)
         clk_period = 1e-6
 

--- a/test/common.py
+++ b/test/common.py
@@ -140,10 +140,10 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
 
 class TestCaseWithSimulator(unittest.TestCase):
     @contextmanager
-    def run_simulation(self, circuit : HasElaborate, max_cycles: float = 10e4):
+    def run_simulation(self, circuit: HasElaborate, max_cycles: float = 10e4):
         if isinstance(circuit, TransactionModule):
             raise TypeError("run_simulation should get ")
-        tm = ModuleConnector(wrap_with_tm = True, circuit = circuit)
+        tm = ModuleConnector(wrap_with_tm=True, circuit=circuit)
         test_name = unittest.TestCase.id(self)
         clk_period = 1e-6
 
@@ -389,7 +389,8 @@ def def_method_mock(
 
     return decorator
 
-def silence_must_use_warnings(f : Callable[[], T]) -> T:
+
+def silence_must_use_warnings(f: Callable[[], T]) -> T:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UnusedMustUse)
         ret = f()

--- a/test/frontend/test_decode.py
+++ b/test/frontend/test_decode.py
@@ -1,6 +1,5 @@
 from amaranth import Elaboratable, Module
 
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans, FIFO
 
 from ..common import TestCaseWithSimulator, TestbenchIO

--- a/test/frontend/test_decode.py
+++ b/test/frontend/test_decode.py
@@ -16,7 +16,6 @@ class TestElaboratable(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         fifo_in = FIFO(self.gp.get(FetchLayouts).raw_instr, depth=2)
         fifo_out = FIFO(self.gp.get(DecodeLayouts).decoded_instr, depth=2)
@@ -32,7 +31,7 @@ class TestElaboratable(Elaboratable):
         m.submodules.fifo_in = fifo_in
         m.submodules.fifo_out = fifo_out
 
-        return tm
+        return m
 
 
 class TestFetch(TestCaseWithSimulator):

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -5,8 +5,6 @@ import random
 from amaranth import Elaboratable, Module
 from amaranth.sim import Passive
 
-from coreblocks.transactions import TransactionModule
-
 from coreblocks.transactions.core import Method
 from coreblocks.transactions.lib import AdapterTrans, FIFO, Adapter
 from coreblocks.frontend.fetch import Fetch
@@ -42,7 +40,6 @@ class TestElaboratable(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         self.icache = MockedICache(self.gp)
 
@@ -57,7 +54,7 @@ class TestElaboratable(Elaboratable):
         m.submodules.verify_branch = self.verify_branch
         m.submodules.fifo = fifo
 
-        return tm
+        return m
 
 
 class TestFetch(TestCaseWithSimulator):

--- a/test/frontend/test_icache.py
+++ b/test/frontend/test_icache.py
@@ -6,7 +6,6 @@ from amaranth import Elaboratable, Module
 from amaranth.sim import Passive, Settle
 from amaranth.utils import log2_int
 
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans, Adapter
 from coreblocks.frontend.icache import SimpleWBCacheRefiller, ICache, ICacheBypass, CacheRefillerInterface
 from coreblocks.params import GenParams, ICacheLayouts
@@ -24,7 +23,6 @@ class SimpleWBCacheRefillerTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         wb_params = WishboneParameters(
             data_width=self.gp.isa.xlen,
@@ -44,7 +42,7 @@ class SimpleWBCacheRefillerTestCircuit(Elaboratable):
 
         self.wb_ctrl = WishboneInterfaceWrapper(self.wb_master.wbMaster)
 
-        return tm
+        return m
 
 
 @parameterized_class(
@@ -142,7 +140,6 @@ class ICacheBypassTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         wb_params = WishboneParameters(
             data_width=self.gp.isa.xlen,
@@ -156,7 +153,7 @@ class ICacheBypassTestCircuit(Elaboratable):
 
         self.wb_ctrl = WishboneInterfaceWrapper(self.wb_master.wbMaster)
 
-        return tm
+        return m
 
 
 @parameterized_class(
@@ -270,7 +267,6 @@ class ICacheTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         m.submodules.refiller = self.refiller = MockedCacheRefiller(self.gp)
         m.submodules.cache = self.cache = ICache(self.gp.get(ICacheLayouts), self.cp, self.refiller)
@@ -278,7 +274,7 @@ class ICacheTestCircuit(Elaboratable):
         m.submodules.accept_res = self.accept_res = TestbenchIO(AdapterTrans(self.cache.accept_res))
         m.submodules.flush_cache = self.flush_cache = TestbenchIO(AdapterTrans(self.cache.flush))
 
-        return tm
+        return m
 
 
 @parameterized_class(

--- a/test/fu/functional_common.py
+++ b/test/fu/functional_common.py
@@ -7,7 +7,6 @@ from amaranth import Elaboratable, Module
 from coreblocks.params import GenParams
 from coreblocks.params.configurations import test_core_config
 from coreblocks.params.fu_params import FunctionalComponentParams
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 from test.common import TestbenchIO, TestCaseWithSimulator
 
@@ -30,7 +29,6 @@ class FunctionalTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         m.submodules.func_unit = func_unit = self.func_unit.get_module(self.gen)
 
@@ -38,7 +36,7 @@ class FunctionalTestCircuit(Elaboratable):
         m.submodules.issue_method = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))
         m.submodules.accept_method = self.accept = TestbenchIO(AdapterTrans(func_unit.accept))
 
-        return tm
+        return m
 
 
 class GenericFunctionalTestUnit(TestCaseWithSimulator):

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -125,7 +125,6 @@ class AluFuncUnitTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         m.submodules.func_unit = func_unit = AluFuncUnit(self.gen)
 
@@ -133,7 +132,7 @@ class AluFuncUnitTestCircuit(Elaboratable):
         m.submodules.issue_method = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))
         m.submodules.accept_method = self.accept = TestbenchIO(AdapterTrans(func_unit.accept))
 
-        return tm
+        return m
 
 
 class TestAluFuncUnit(TestCaseWithSimulator):

--- a/test/fu/test_unsigned_mul_unit.py
+++ b/test/fu/test_unsigned_mul_unit.py
@@ -27,7 +27,6 @@ class UnsignedMultiplicationTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         m.submodules.func_unit = func_unit = self.mul_unit(self.gen)
 
@@ -35,7 +34,7 @@ class UnsignedMultiplicationTestCircuit(Elaboratable):
         m.submodules.issue_method = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))
         m.submodules.accept_method = self.accept = TestbenchIO(AdapterTrans(func_unit.accept))
 
-        return tm
+        return m
 
 
 @parameterized_class(

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -5,7 +5,6 @@ from typing import Optional
 from amaranth.sim import Settle, Passive
 
 from coreblocks.params import OpType, GenParams
-from coreblocks.transactions import TransactionModule
 from coreblocks.lsu.dummyLsu import LSUDummy
 from coreblocks.params.configurations import test_core_config
 from coreblocks.params.isa import *
@@ -75,7 +74,6 @@ class DummyLSUTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         wb_params = WishboneParameters(
             data_width=self.gen.isa.ilen,
@@ -92,7 +90,7 @@ class DummyLSUTestCircuit(Elaboratable):
         m.submodules.commit_mock = self.commit = TestbenchIO(AdapterTrans(func_unit.commit))
         self.io_in = WishboneInterfaceWrapper(self.bus.wbMaster)
         m.submodules.bus = self.bus
-        return tm
+        return m
 
 
 class TestDummyLSULoads(TestCaseWithSimulator):

--- a/test/peripherals/test_wishbone.py
+++ b/test/peripherals/test_wishbone.py
@@ -3,7 +3,6 @@ from collections import deque
 
 from coreblocks.peripherals.wishbone import *
 
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 
 from ..common import *
@@ -62,11 +61,10 @@ class TestWishboneMaster(TestCaseWithSimulator):
 
         def elaborate(self, platform):
             m = Module()
-            tm = TransactionModule(m)
             m.submodules.wbm = self.wbm = wbm = WishboneMaster(WishboneParameters())
             m.submodules.rqa = self.requestAdapter = TestbenchIO(AdapterTrans(wbm.request))
             m.submodules.rsa = self.resultAdapter = TestbenchIO(AdapterTrans(wbm.result))
-            return tm
+            return m
 
     def test_manual(self):
         twbm = TestWishboneMaster.WishboneMasterTestModule()
@@ -284,7 +282,6 @@ class WishboneMemorySlaveCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         m.submodules.mem_slave = self.mem_slave = WishboneMemorySlave(self.wb_params, **self.mem_args)
         m.submodules.mem_master = self.mem_master = WishboneMaster(self.wb_params)
@@ -293,7 +290,7 @@ class WishboneMemorySlaveCircuit(Elaboratable):
 
         m.d.comb += self.mem_master.wbMaster.connect(self.mem_slave.bus)
 
-        return tm
+        return m
 
 
 class TestWishboneMemorySlave(TestCaseWithSimulator):

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -7,7 +7,6 @@ from amaranth.sim import Settle, Passive
 from coreblocks.params import GenParams, RSLayouts, SchedulerLayouts, OpType, Opcode, Funct3, Funct7
 from coreblocks.params.configurations import test_core_config
 from coreblocks.scheduler.scheduler import RSSelection
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import FIFO, Adapter, AdapterTrans
 from test.common import TestCaseWithSimulator, TestbenchIO
 
@@ -21,7 +20,6 @@ class RSSelector(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         rs_layouts = self.gen_params.get(RSLayouts)
         scheduler_layouts = self.gen_params.get(SchedulerLayouts)
@@ -44,7 +42,7 @@ class RSSelector(Elaboratable):
             push_instr=out_fifo.write,
         )
 
-        return tm
+        return m
 
 
 class TestRSSelect(TestCaseWithSimulator):

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -7,7 +7,6 @@ from amaranth.sim import Settle
 from parameterized import parameterized_class
 from coreblocks.stages.rs_func_block import RSBlockComponent
 
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import FIFO, AdapterTrans, Adapter
 from coreblocks.scheduler.scheduler import Scheduler
 from coreblocks.structs_common.rf import RegisterFile
@@ -25,7 +24,6 @@ class SchedulerTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         rs_layouts = self.gen_params.get(RSLayouts)
         decode_layouts = self.gen_params.get(DecodeLayouts)
@@ -90,7 +88,7 @@ class SchedulerTestCircuit(Elaboratable):
             gen_params=self.gen_params,
         )
 
-        return tm
+        return m
 
 
 @parameterized_class(

--- a/test/scheduler/test_wakeup_select.py
+++ b/test/scheduler/test_wakeup_select.py
@@ -24,7 +24,6 @@ class WakeupTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         ready_mock = Adapter(o=self.layouts.get_ready_list_out)
         take_row_mock = Adapter(i=self.layouts.take_in, o=self.layouts.take_out)
@@ -39,7 +38,7 @@ class WakeupTestCircuit(Elaboratable):
         dummy = Signal()
         m.d.sync += dummy.eq(1)
 
-        return tm
+        return m
 
 
 class TestWakeupSelect(TestCaseWithSimulator):

--- a/test/stages/test_backend.py
+++ b/test/stages/test_backend.py
@@ -3,7 +3,6 @@ from operator import and_
 from functools import reduce
 
 from amaranth import *
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import FIFO, AdapterTrans, Adapter, ManyToOneConnectTrans
 from coreblocks.stages.backend import ResultAnnouncement
 from coreblocks.params.layouts import *
@@ -21,52 +20,50 @@ class BackendTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         self.lay_result = self.gen.get(FuncUnitLayouts).accept
         self.lay_rob_mark_done = self.gen.get(ROBLayouts).id_layout
         self.lay_rs_write = self.gen.get(RSLayouts).update_in
         self.lay_rf_write = self.gen.get(RFLayouts).rf_write
 
-        with tm.transaction_context():
-            # Initialize for each FU an FIFO which will be a stub for that FU
-            fu_fifos = []
-            get_results = []
-            for i in range(self.fu_count):
-                fifo = FIFO(self.lay_result, 16)
-                fu_fifos.append(fifo)
-                get_results.append(fifo.read)
-                m.submodules[f"fu_fifo_{i}"] = fifo
+        # Initialize for each FU an FIFO which will be a stub for that FU
+        fu_fifos = []
+        get_results = []
+        for i in range(self.fu_count):
+            fifo = FIFO(self.lay_result, 16)
+            fu_fifos.append(fifo)
+            get_results.append(fifo.read)
+            m.submodules[f"fu_fifo_{i}"] = fifo
 
-                fifo_in = TestbenchIO(AdapterTrans(fifo.write))
-                m.submodules[f"fu_fifo_{i}_in"] = fifo_in
-                self.fu_fifo_ins.append(fifo_in)
+            fifo_in = TestbenchIO(AdapterTrans(fifo.write))
+            m.submodules[f"fu_fifo_{i}_in"] = fifo_in
+            self.fu_fifo_ins.append(fifo_in)
 
-            # Create FUArbiter, which will serialize results from different FU's
-            serialized_results_fifo = FIFO(self.lay_result, 16)
-            m.submodules.serialized_results_fifo = serialized_results_fifo
-            m.submodules.fu_arbitration = ManyToOneConnectTrans(
-                get_results=get_results, put_result=serialized_results_fifo.write
-            )
+        # Create FUArbiter, which will serialize results from different FU's
+        serialized_results_fifo = FIFO(self.lay_result, 16)
+        m.submodules.serialized_results_fifo = serialized_results_fifo
+        m.submodules.fu_arbitration = ManyToOneConnectTrans(
+            get_results=get_results, put_result=serialized_results_fifo.write
+        )
 
-            # Create stubs for interfaces used by result announcement
-            self.rs_announce_val_tbio = TestbenchIO(Adapter(i=self.lay_rs_write, o=self.lay_rs_write))
-            m.submodules.rs_announce_val_tbio = self.rs_announce_val_tbio
-            self.rf_announce_val_tbio = TestbenchIO(Adapter(i=self.lay_rf_write, o=self.lay_rf_write))
-            m.submodules.rf_announce_val_tbio = self.rf_announce_val_tbio
-            self.rob_mark_done_tbio = TestbenchIO(Adapter(i=self.lay_rob_mark_done, o=self.lay_rob_mark_done))
-            m.submodules.rob_mark_done_tbio = self.rob_mark_done_tbio
+        # Create stubs for interfaces used by result announcement
+        self.rs_announce_val_tbio = TestbenchIO(Adapter(i=self.lay_rs_write, o=self.lay_rs_write))
+        m.submodules.rs_announce_val_tbio = self.rs_announce_val_tbio
+        self.rf_announce_val_tbio = TestbenchIO(Adapter(i=self.lay_rf_write, o=self.lay_rf_write))
+        m.submodules.rf_announce_val_tbio = self.rf_announce_val_tbio
+        self.rob_mark_done_tbio = TestbenchIO(Adapter(i=self.lay_rob_mark_done, o=self.lay_rob_mark_done))
+        m.submodules.rob_mark_done_tbio = self.rob_mark_done_tbio
 
-            # Create result announcement
-            m.submodules.result_announcement = ResultAnnouncement(
-                gen=self.gen,
-                get_result=serialized_results_fifo.read,
-                rob_mark_done=self.rob_mark_done_tbio.adapter.iface,
-                rs_write_val=self.rs_announce_val_tbio.adapter.iface,
-                rf_write_val=self.rf_announce_val_tbio.adapter.iface,
-            )
+        # Create result announcement
+        m.submodules.result_announcement = ResultAnnouncement(
+            gen=self.gen,
+            get_result=serialized_results_fifo.read,
+            rob_mark_done=self.rob_mark_done_tbio.adapter.iface,
+            rs_write_val=self.rs_announce_val_tbio.adapter.iface,
+            rf_write_val=self.rf_announce_val_tbio.adapter.iface,
+        )
 
-        return tm
+        return m
 
 
 class TestBackend(TestCaseWithSimulator):

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -16,7 +16,6 @@ class RetirementTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         rob_layouts = self.gen_params.get(ROBLayouts)
         rf_layouts = self.gen_params.get(RFLayouts)
@@ -45,7 +44,7 @@ class RetirementTestCircuit(Elaboratable):
 
         m.submodules.free_rf_fifo_adapter = self.free_rf_adapter = TestbenchIO(AdapterTrans(self.free_rf.read))
 
-        return tm
+        return m
 
 
 class RetirementTest(TestCaseWithSimulator):

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -18,7 +18,6 @@ class CSRUnitTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         self.rob_single_insn = Signal()
 
@@ -48,7 +47,7 @@ class CSRUnitTestCircuit(Elaboratable):
         # missing privilege
         # make_csr(0x100)
 
-        return tm
+        return m
 
 
 class TestCSRUnit(TestCaseWithSimulator):

--- a/test/structs_common/test_reorder_buffer.py
+++ b/test/structs_common/test_reorder_buffer.py
@@ -1,7 +1,6 @@
 from amaranth import Elaboratable, Module
 from amaranth.sim import Passive, Settle
 
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 
 from ..common import TestCaseWithSimulator, TestbenchIO
@@ -20,7 +19,6 @@ class TestElaboratable(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
         rb = ReorderBuffer(self.gp)
 
         self.rb = rb
@@ -33,7 +31,7 @@ class TestElaboratable(Elaboratable):
         m.submodules.io_update = self.io_update
         m.submodules.io_out = self.io_out
 
-        return tm
+        return m
 
 
 class TestReorderBuffer(TestCaseWithSimulator):

--- a/test/structs_common/test_rs.py
+++ b/test/structs_common/test_rs.py
@@ -2,7 +2,6 @@ from typing import Iterable, Optional
 from amaranth import Elaboratable, Module
 from amaranth.sim import Settle
 
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 
 from ..common import TestCaseWithSimulator, TestbenchIO, get_outputs
@@ -32,9 +31,8 @@ class TestElaboratable(Elaboratable):
         self.gp = gen_params
         self.ready_for = ready_for
 
-    def elaborate(self, platform) -> TransactionModule:
+    def elaborate(self, platform) -> Module:
         m = Module()
-        tm = TransactionModule(m)
         rs = RS(self.gp, 2**self.gp.rs_entries_bits, self.ready_for)
 
         self.rs = rs
@@ -52,7 +50,7 @@ class TestElaboratable(Elaboratable):
         for n, io_get_ready_list in enumerate(self.io_get_ready_list):
             m.submodules[f"io_get_ready_list_{n}"] = io_get_ready_list
 
-        return tm
+        return m
 
 
 class TestRSMethodInsert(TestCaseWithSimulator):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -45,7 +45,6 @@ class TestElaboratable(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         wb_instr_bus = WishboneBus(self.gp.wb_params)
         wb_data_bus = WishboneBus(self.gp.wb_params)
@@ -71,7 +70,7 @@ class TestElaboratable(Elaboratable):
         m.d.comb += wb_instr_bus.connect(self.wb_mem_slave.bus)
         m.d.comb += wb_data_bus.connect(self.wb_mem_slave_data.bus)
 
-        return tm
+        return m
 
 
 def gen_riscv_add_instr(dst, src1, src2):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,6 +1,5 @@
 from amaranth import Elaboratable, Module
 
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 from coreblocks.utils import align_to_power_of_two
 

--- a/test/transactions/test_adapter.py
+++ b/test/transactions/test_adapter.py
@@ -1,6 +1,6 @@
 from amaranth import *
 
-from coreblocks.transactions import TransactionModule, Method, def_method
+from coreblocks.transactions import Method, def_method
 from coreblocks.transactions.lib import AdapterTrans
 
 
@@ -62,14 +62,13 @@ class TestElaboratable(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         m.submodules.echo = self.echo
         m.submodules.io_echo = self.io_echo
         m.submodules.consumer = self.consumer
         m.submodules.io_consume = self.io_consume
 
-        return tm
+        return m
 
 
 class TestAdapterTrans(TestCaseWithSimulator):

--- a/test/transactions/test_methods.py
+++ b/test/transactions/test_methods.py
@@ -300,7 +300,6 @@ class QuadrupleCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         m.submodules.quadruple = self.quadruple
         m.submodules.tb = self.tb = TestbenchIO(AdapterTrans(self.quadruple.quadruple))
@@ -308,7 +307,7 @@ class QuadrupleCircuit(Elaboratable):
         dummy = Signal()
         m.d.sync += dummy.eq(1)
 
-        return tm
+        return m
 
 
 class Quadruple2(Elaboratable):
@@ -346,7 +345,6 @@ class TestQuadrupleCircuits(TestCaseWithSimulator):
 class ConditionalCallCircuit(Elaboratable):
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         meth = Method(i=data_layout(1))
 
@@ -362,13 +360,12 @@ class ConditionalCallCircuit(Elaboratable):
         dummy = Signal()
         m.d.sync += dummy.eq(1)
 
-        return tm
+        return m
 
 
 class ConditionalMethodCircuit1(Elaboratable):
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         meth = Method()
 
@@ -382,13 +379,12 @@ class ConditionalMethodCircuit1(Elaboratable):
         # so that Amaranth allows us to use add_clock
         dummy = Signal()
         m.d.sync += dummy.eq(1)
-        return tm
+        return m
 
 
 class ConditionalMethodCircuit2(Elaboratable):
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         meth = Method()
 
@@ -404,44 +400,40 @@ class ConditionalMethodCircuit2(Elaboratable):
         # so that Amaranth allows us to use add_clock
         dummy = Signal()
         m.d.sync += dummy.eq(1)
-        return tm
+        return m
 
 
 class ConditionalTransactionCircuit1(Elaboratable):
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         self.ready = Signal()
         m.submodules.tb = self.tb = TestbenchIO(Adapter())
 
-        with tm.transaction_context():
-            with Transaction().body(m, request=self.ready):
-                self.tb.adapter.iface(m)
+        with Transaction().body(m, request=self.ready):
+            self.tb.adapter.iface(m)
 
         # so that Amaranth allows us to use add_clock
         dummy = Signal()
         m.d.sync += dummy.eq(1)
-        return tm
+        return m
 
 
 class ConditionalTransactionCircuit2(Elaboratable):
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         self.ready = Signal()
         m.submodules.tb = self.tb = TestbenchIO(Adapter())
 
-        with tm.transaction_context():
-            with m.If(self.ready):
-                with Transaction().body(m):
-                    self.tb.adapter.iface(m)
+        with m.If(self.ready):
+            with Transaction().body(m):
+                self.tb.adapter.iface(m)
 
         # so that Amaranth allows us to use add_clock
         dummy = Signal()
         m.d.sync += dummy.eq(1)
-        return tm
+        return m
 
 
 class TestConditionals(TestCaseWithSimulator):
@@ -500,7 +492,6 @@ class TestConditionals(TestCaseWithSimulator):
 class NonexclusiveMethodCircuit(Elaboratable):
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         self.ready = Signal()
         self.running = Signal()
@@ -519,7 +510,7 @@ class NonexclusiveMethodCircuit(Elaboratable):
         # so that Amaranth allows us to use add_clock
         dummy = Signal()
         m.d.sync += dummy.eq(1)
-        return tm
+        return m
 
 
 class TestNonexclusiveMethod(TestCaseWithSimulator):

--- a/test/transactions/test_methods.py
+++ b/test/transactions/test_methods.py
@@ -1,7 +1,6 @@
 # amaranth: UnusedElaboratable=no
 from amaranth import *
 from amaranth.sim import *
-from amaranth._unused import UnusedMustUse
 
 from ..common import TestCaseWithSimulator, TestbenchIO, data_layout, silence_must_use_warnings
 
@@ -41,8 +40,8 @@ class TestDefMethod(TestCaseWithSimulator):
         def f():
             with self.assertRaises(error_type):
                 self.do_test_definition(definer)
+
         silence_must_use_warnings(f)
-        
 
     def test_fields_valid1(self):
         def definition(arg):

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -132,9 +132,7 @@ class ManyToOneConnectTransTestCircuit(Elaboratable):
         output = TestbenchIO(Adapter(i=self.lay))
         m.submodules.output = output
         self.output = output
-        m.submodules.fu_arbitration = ManyToOneConnectTrans(
-            get_results=get_results, put_result=output.adapter.iface
-        )
+        m.submodules.fu_arbitration = ManyToOneConnectTrans(get_results=get_results, put_result=output.adapter.iface)
 
         return m
 

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -116,29 +116,27 @@ class ManyToOneConnectTransTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         # dummy signal
         s = Signal()
         m.d.sync += s.eq(1)
 
-        with tm.transaction_context():
-            get_results = []
-            for i in range(self.count):
-                input = TestbenchIO(Adapter(o=self.lay))
-                get_results.append(input.adapter.iface)
-                m.submodules[f"input_{i}"] = input
-                self.inputs.append(input)
+        get_results = []
+        for i in range(self.count):
+            input = TestbenchIO(Adapter(o=self.lay))
+            get_results.append(input.adapter.iface)
+            m.submodules[f"input_{i}"] = input
+            self.inputs.append(input)
 
-            # Create ManyToOneConnectTrans, which will serialize results from different inputs
-            output = TestbenchIO(Adapter(i=self.lay))
-            m.submodules.output = output
-            self.output = output
-            m.submodules.fu_arbitration = ManyToOneConnectTrans(
-                get_results=get_results, put_result=output.adapter.iface
-            )
+        # Create ManyToOneConnectTrans, which will serialize results from different inputs
+        output = TestbenchIO(Adapter(i=self.lay))
+        m.submodules.output = output
+        self.output = output
+        m.submodules.fu_arbitration = ManyToOneConnectTrans(
+            get_results=get_results, put_result=output.adapter.iface
+        )
 
-        return tm
+        return m
 
 
 class TestManyToOneConnectTrans(TestCaseWithSimulator):
@@ -235,7 +233,6 @@ class MethodTransformerTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         # dummy signal
         s = Signal()
@@ -266,36 +263,35 @@ class MethodTransformerTestCircuit(Elaboratable):
             itransform = itransform_rec
             otransform = otransform_rec
 
-        with tm.transaction_context():
-            m.submodules.target = self.target = TestbenchIO(Adapter(i=layout, o=layout))
+        m.submodules.target = self.target = TestbenchIO(Adapter(i=layout, o=layout))
 
-            if self.use_methods:
-                imeth = Method(i=layout, o=layout)
-                ometh = Method(i=layout, o=layout)
+        if self.use_methods:
+            imeth = Method(i=layout, o=layout)
+            ometh = Method(i=layout, o=layout)
 
-                @def_method(m, imeth)
-                def _(arg: Record):
-                    return itransform(m, arg)
+            @def_method(m, imeth)
+            def _(arg: Record):
+                return itransform(m, arg)
 
-                @def_method(m, ometh)
-                def _(arg: Record):
-                    return otransform(m, arg)
+            @def_method(m, ometh)
+            def _(arg: Record):
+                return otransform(m, arg)
 
-                trans = MethodTransformer(
-                    self.target.adapter.iface, i_transform=(layout, imeth), o_transform=(layout, ometh)
-                )
-            else:
-                trans = MethodTransformer(
-                    self.target.adapter.iface,
-                    i_transform=(layout, itransform),
-                    o_transform=(layout, otransform),
-                )
+            trans = MethodTransformer(
+                self.target.adapter.iface, i_transform=(layout, imeth), o_transform=(layout, ometh)
+            )
+        else:
+            trans = MethodTransformer(
+                self.target.adapter.iface,
+                i_transform=(layout, itransform),
+                o_transform=(layout, otransform),
+            )
 
-            m.submodules.trans = trans
+        m.submodules.trans = trans
 
-            m.submodules.source = self.source = TestbenchIO(AdapterTrans(trans.method))
+        m.submodules.source = self.source = TestbenchIO(AdapterTrans(trans.method))
 
-        return tm
+        return m
 
 
 class TestMethodTransformer(TestCaseWithSimulator):
@@ -337,7 +333,6 @@ class MethodFilterTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         # dummy signal
         s = Signal()
@@ -345,28 +340,27 @@ class MethodFilterTestCircuit(Elaboratable):
 
         layout = data_layout(self.iosize)
 
-        with tm.transaction_context():
-            m.submodules.target = self.target = TestbenchIO(Adapter(i=layout, o=layout))
+        m.submodules.target = self.target = TestbenchIO(Adapter(i=layout, o=layout))
 
-            def condition(_, v):
-                return v[0]
+        def condition(_, v):
+            return v[0]
 
-            if self.use_methods:
-                cmeth = Method(i=layout, o=data_layout(1))
+        if self.use_methods:
+            cmeth = Method(i=layout, o=data_layout(1))
 
-                @def_method(m, cmeth)
-                def _(arg: Record):
-                    return condition(m, arg)
+            @def_method(m, cmeth)
+            def _(arg: Record):
+                return condition(m, arg)
 
-                filt = MethodFilter(self.target.adapter.iface, cmeth)
-            else:
-                filt = MethodFilter(self.target.adapter.iface, condition)
+            filt = MethodFilter(self.target.adapter.iface, cmeth)
+        else:
+            filt = MethodFilter(self.target.adapter.iface, condition)
 
-            m.submodules.filt = filt
+        m.submodules.filt = filt
 
-            m.submodules.source = self.source = TestbenchIO(AdapterTrans(filt.method))
+        m.submodules.source = self.source = TestbenchIO(AdapterTrans(filt.method))
 
-        return tm
+        return m
 
 
 class TestMethodFilter(TestCaseWithSimulator):
@@ -406,7 +400,6 @@ class MethodProductTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         # dummy signal
         s = Signal()
@@ -430,7 +423,7 @@ class MethodProductTestCircuit(Elaboratable):
 
         m.submodules.method = self.method = TestbenchIO(AdapterTrans(product.method))
 
-        return tm
+        return m
 
 
 class TestMethodProduct(TestCaseWithSimulator):

--- a/test/transactions/test_transactions.py
+++ b/test/transactions/test_transactions.py
@@ -9,7 +9,7 @@ from collections import deque
 from typing import Iterable, Callable
 from parameterized import parameterized, parameterized_class
 
-from ..common import TestCaseWithSimulator, TestbenchIO, data_layout
+from ..common import TestCaseWithSimulator, TestbenchIO, data_layout, silence_must_use_warnings
 
 from coreblocks.transactions import *
 from coreblocks.transactions.lib import Adapter, AdapterTrans
@@ -328,6 +328,8 @@ class TestTransactionPriorities(TestCaseWithSimulator):
         else:
             cm = contextlib.nullcontext()
 
-        with cm:
-            with self.run_simulation(m):
-                pass
+        def f():
+            with cm:
+                with self.run_simulation(m):
+                    pass
+        silence_must_use_warnings(f)

--- a/test/transactions/test_transactions.py
+++ b/test/transactions/test_transactions.py
@@ -328,4 +328,5 @@ class TestTransactionPriorities(TestCaseWithSimulator):
             with cm:
                 with self.run_simulation(m):
                     pass
+
         silence_must_use_warnings(f)

--- a/test/transactions/test_transactions.py
+++ b/test/transactions/test_transactions.py
@@ -222,17 +222,15 @@ class PriorityTestCircuit(Elaboratable):
 class TransactionPriorityTestCircuit(PriorityTestCircuit):
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
-        with tm.transaction_context():
-            transaction1 = Transaction()
-            transaction2 = Transaction()
+        transaction1 = Transaction()
+        transaction2 = Transaction()
 
-            with transaction1.body(m, request=self.r1):
-                m.d.comb += self.t1.eq(1)
+        with transaction1.body(m, request=self.r1):
+            m.d.comb += self.t1.eq(1)
 
-            with transaction2.body(m, request=self.r2):
-                m.d.comb += self.t2.eq(1)
+        with transaction2.body(m, request=self.r2):
+            m.d.comb += self.t2.eq(1)
 
         transaction1.add_conflict(transaction2, self.priority)
         if self.unsatisfiable:
@@ -242,7 +240,7 @@ class TransactionPriorityTestCircuit(PriorityTestCircuit):
         dummy = Signal()
         m.d.sync += dummy.eq(1)
 
-        return tm
+        return m
 
 
 class MethodPriorityTestCircuit(PriorityTestCircuit):
@@ -256,7 +254,6 @@ class MethodPriorityTestCircuit(PriorityTestCircuit):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         method1 = Method()
         method2 = Method()
@@ -269,12 +266,11 @@ class MethodPriorityTestCircuit(PriorityTestCircuit):
         def _():
             m.d.comb += self.t2.eq(1)
 
-        with tm.transaction_context():
-            with Transaction().body(m):
-                method1(m)
+        with Transaction().body(m):
+            method1(m)
 
-            with Transaction().body(m):
-                method2(m)
+        with Transaction().body(m):
+            method2(m)
 
         method1.add_conflict(method2, self.priority)
         if self.unsatisfiable:
@@ -284,7 +280,7 @@ class MethodPriorityTestCircuit(PriorityTestCircuit):
         dummy = Signal()
         m.d.sync += dummy.eq(1)
 
-        return tm
+        return m
 
 
 @parameterized_class(

--- a/test/utils/test_fifo.py
+++ b/test/utils/test_fifo.py
@@ -1,7 +1,6 @@
 from amaranth import *
 
 from coreblocks.utils.fifo import BasicFifo
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 
 from test.common import TestCaseWithSimulator, TestbenchIO, data_layout
@@ -16,7 +15,6 @@ class BasicFifoTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         m.submodules.fifo = self.fifo = BasicFifo(layout=data_layout(8), depth=self.depth)
 
@@ -24,7 +22,7 @@ class BasicFifoTestCircuit(Elaboratable):
         m.submodules.fifo_write = self.fifo_write = TestbenchIO(AdapterTrans(self.fifo.write))
         m.submodules.fifo_clear = self.fifo_clear = TestbenchIO(AdapterTrans(self.fifo.clear))
 
-        return tm
+        return m
 
 
 @parameterized_class(


### PR DESCRIPTION
As agreed I have prepared refactor of our unit tests and moved TransactionModule initialisation to TestCaseWithSimulator. 

Additionally I have added a `silence_must_use_warnings` which I need to silent warnings from tests which throw exceptions (TestDefMethod.invalid....). Before my changes modules were created only in one files so there was suppressed using amaranth tricks. Now I use there modules created in `test/common.py` so I needed to suppress more selectively. Of course live can not be easy and UnusedMustUse warning are raised in `__del__` function, which is invoked by garbage collector. So I have to invoke garbage collection by hand to be sure, that warning will be handled using proper context.

Depends on #317 