### PR TITLE
MustUse cleanups for TransactionModule refactor

### DIFF
--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -16,6 +16,7 @@ __all__ = [
     "align_to_power_of_two",
     "bits_from_int",
     "ModuleConnector",
+    "silence_mustuse"
 ]
 
 
@@ -347,3 +348,10 @@ class ModuleConnector(Elaboratable):
             m.submodules[name] = elem
 
         return m
+
+@contextmanager
+def silence_mustuse(elaboratable: Elaboratable):
+    elaboratable._MustUse__silence = True  # type: ignore
+    yield
+    # if exception happens, this is unreachable
+    elaboratable._MustUse__silence = False  # type: ignore

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -16,7 +16,7 @@ __all__ = [
     "align_to_power_of_two",
     "bits_from_int",
     "ModuleConnector",
-    "silence_mustuse"
+    "silence_mustuse",
 ]
 
 
@@ -348,6 +348,7 @@ class ModuleConnector(Elaboratable):
             m.submodules[name] = elem
 
         return m
+
 
 @contextmanager
 def silence_mustuse(elaboratable: Elaboratable):

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -352,7 +352,8 @@ class ModuleConnector(Elaboratable):
 
 @contextmanager
 def silence_mustuse(elaboratable: Elaboratable):
-    elaboratable._MustUse__silence = True  # type: ignore
-    yield
-    # if exception happens, this is unreachable
-    elaboratable._MustUse__silence = False  # type: ignore
+    try:
+        yield
+    except:
+        elaboratable._MustUse__silence = True  # type: ignore
+        raise

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -7,7 +7,6 @@ from amaranth.sim import Settle, Passive
 from coreblocks.params import GenParams, RSLayouts, SchedulerLayouts, OpType, Opcode, Funct3, Funct7
 from coreblocks.params.configurations import test_core_config
 from coreblocks.scheduler.scheduler import RSSelection
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import FIFO, Adapter, AdapterTrans
 from test.common import TestCaseWithSimulator, TestbenchIO
 
@@ -21,7 +20,6 @@ class RSSelector(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         rs_layouts = self.gen_params.get(RSLayouts)
         scheduler_layouts = self.gen_params.get(SchedulerLayouts)
@@ -44,7 +42,7 @@ class RSSelector(Elaboratable):
             push_instr=out_fifo.write,
         )
 
-        return tm
+        return m
 
 
 class TestRSSelect(TestCaseWithSimulator):

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -7,7 +7,6 @@ from amaranth.sim import Settle
 from parameterized import parameterized_class
 from coreblocks.stages.rs_func_block import RSBlockComponent
 
-from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import FIFO, AdapterTrans, Adapter
 from coreblocks.scheduler.scheduler import Scheduler
 from coreblocks.structs_common.rf import RegisterFile
@@ -25,7 +24,6 @@ class SchedulerTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         rs_layouts = self.gen_params.get(RSLayouts)
         decode_layouts = self.gen_params.get(DecodeLayouts)
@@ -90,7 +88,7 @@ class SchedulerTestCircuit(Elaboratable):
             gen_params=self.gen_params,
         )
 
-        return tm
+        return m
 
 
 @parameterized_class(

--- a/test/scheduler/test_wakeup_select.py
+++ b/test/scheduler/test_wakeup_select.py
@@ -24,7 +24,6 @@ class WakeupTestCircuit(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        tm = TransactionModule(m)
 
         ready_mock = Adapter(o=self.layouts.get_ready_list_out)
         take_row_mock = Adapter(i=self.layouts.take_in, o=self.layouts.take_out)
@@ -39,7 +38,7 @@ class WakeupTestCircuit(Elaboratable):
         dummy = Signal()
         m.d.sync += dummy.eq(1)
 
-        return tm
+        return m
 
 
 class TestWakeupSelect(TestCaseWithSimulator):


### PR DESCRIPTION
This PR addresses the reasons for the MustUse warnings, instead of painting over them.