### PR TITLE
Fix graph in docs (update requirements-dev.txt)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ pre-commit==2.16.0
 pyright==1.1.302
 Sphinx==5.1.1
 sphinx-rtd-theme==1.0.0
-sphinxcontrib-mermaid==0.7.1
+sphinxcontrib-mermaid==0.8.1
 cocotb==1.7.2
 cocotb-bus==0.2.1
 pytest==7.2.2


### PR DESCRIPTION
Currently, the docs html contains the following line, generated by `sphinxcontrib-mermaid` package
```html
<script src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>
```
The problem is the latest version of `mermaid` doesn't contain this [file](https://unpkg.com/mermaid/dist/mermaid.min.js)
The solution is to include an older version of mermaid. The updated version of `sphinxcontrib-mermaid` does just that
```html
<script src="https://unpkg.com/mermaid@9.4.0/dist/mermaid.min.js"></script>
```