### PR TITLE
[RFC] Extended simulator

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -3,7 +3,6 @@ import os
 import functools
 from contextlib import contextmanager, nullcontext
 from typing import Callable, Generic, Mapping, Union, Generator, TypeVar, Optional, Any, cast
-from enum import Enum, auto
 
 from amaranth import *
 from amaranth.hdl.ast import Statement
@@ -137,6 +136,7 @@ class SimpleTestCircuit(Elaboratable, Generic[_T_HasElaborate]):
     def debug_signals(self):
         return [io.debug_signals() for io in self._io.values()]
 
+
 class SimulatorTestCaseBase(unittest.TestCase):
     def prepare_context(self, module, sim):
         test_name = unittest.TestCase.id(self)
@@ -173,6 +173,7 @@ class SimulatorTestCaseBase(unittest.TestCase):
         for _ in range(cycle_cnt):
             yield
 
+
 class TestCaseWithSimulator(SimulatorTestCaseBase):
     @contextmanager
     def run_simulation(self, module: HasElaborate, max_cycles: float = 10e4):
@@ -187,6 +188,7 @@ class TestCaseWithSimulator(SimulatorTestCaseBase):
             sim.run_until(clk_period * max_cycles)
             self.assertFalse(sim.advance(), "Simulation time limit exceeded")
 
+
 class TestCaseWithExtendedSimulator(SimulatorTestCaseBase):
     @contextmanager
     def run_simulation(self, module: HasElaborate, max_cycles: float = 10e4):
@@ -199,6 +201,7 @@ class TestCaseWithExtendedSimulator(SimulatorTestCaseBase):
         ctx = self.prepare_context(module, sim)
 
         sim.run_until(ctx)
+
 
 class TestbenchIO(Elaboratable):
     def __init__(self, adapter: AdapterBase):
@@ -290,7 +293,7 @@ class TestbenchIO(Elaboratable):
         *,
         enable: Optional[Callable[[], bool]] = None,
         extra_settle_count: int = 0,
-        read_only_phase=False
+        read_only_phase=False,
     ) -> TestGen[None]:
         enable = enable or (lambda: True)
         yield from self.set_enable(enable())
@@ -318,11 +321,13 @@ class TestbenchIO(Elaboratable):
         *,
         enable: Optional[Callable[[], bool]] = None,
         extra_settle_count: int = 0,
-        read_only_phase = False
+        read_only_phase=False,
     ) -> TestGen[None]:
         yield Passive()
         while True:
-            yield from self.method_handle(function, enable=enable, extra_settle_count=extra_settle_count, read_only_phase=read_only_phase)
+            yield from self.method_handle(
+                function, enable=enable, extra_settle_count=extra_settle_count, read_only_phase=read_only_phase
+            )
 
     # Debug signals
 

--- a/test/simulation.py
+++ b/test/simulation.py
@@ -1,0 +1,193 @@
+from dataclasses import dataclass
+import functools
+from contextlib import contextmanager, nullcontext
+from typing import Callable, Generic, Mapping, Union, Generator, TypeVar, Optional, Any, cast
+from enum import Enum, auto
+from collections import deque
+
+from amaranth import *
+from amaranth.hdl.ast import Statement
+from amaranth.sim import *
+from amaranth.sim.core import Command
+
+__all__ = ['SimulatorWrapper', 'WaitReadOnly']
+
+T = TypeVar("T")
+
+#TODO: - read-only-phase, początkowy odstęp, muteksy, zmienne warunkowe
+# Narzut czasowy: 2%-3%
+
+class CoreblockSimulationError(RuntimeError):
+    pass
+
+class CoreblockCommand():
+    pass
+
+class CoreblockSimulationEvent():
+    pass
+
+class CondVar(CoreblockSimulationEvent):
+    def __init__(self):
+        self.wait_queue : deque['SyncProcessWrapper'] = deque()
+
+@dataclass
+class WaitFor(CoreblockCommand):
+    event : CondVar
+
+@dataclass
+class Emit(CoreblockCommand):
+    event : CondVar
+
+class WaitReadOnly(CoreblockCommand):
+    pass
+
+class SyncProcessState(Enum):
+    Invalid = auto()
+    Running = auto()
+    WaitNextCycle = auto()
+    WaitReadOnly = auto()
+    WaitFor = auto()
+    BeginingOfNewCycle = auto()
+
+class SimulationState(Enum):
+    Normal = auto()
+    ReadOnly = auto()
+    NextCycle = auto()
+
+class SyncProcessWrapper():
+    def __init__(self, simulator : 'SimulatorWrapper', proc):
+        self.org_proc = proc
+        self.state = SyncProcessState.Running
+        self.simulator = simulator
+
+    def expect_simulation_state(self, sim_state):
+        if self.simulator.state != sim_state:
+            raise CoreblockSimulationError(f"Wrong simulation state, expected: {sim_state} current: {self.simulator.state}")
+
+    def change_state(self, new_state):
+        if new_state == SyncProcessState.BeginingOfNewCycle:
+            raise RuntimeError("State BeginingOfNewCycle can be set only by SimulatorWrapper.")
+        self.state = new_state
+        self.simulator.process_state_changed()
+
+    def wait_next_cycle(self):
+        self.change_state(SyncProcessState.WaitNextCycle)
+        yield
+        self.change_state(SyncProcessState.Running)
+
+    def wait_read_only(self):
+        self.change_state(SyncProcessState.WaitReadOnly)
+        while self.simulator.state != SimulationState.ReadOnly:
+            yield Settle()
+        self.change_state(SyncProcessState.Running)
+
+    def handle_statement(self, cmd):
+        self.expect_simulation_state(SimulationState.Normal)
+        return (yield cmd)
+    
+    def wait_for(self, cmd : WaitFor):
+        self.change_state(SyncProcessState.WaitFor)
+        
+        cmd.event.wait_queue.append(self)
+        while True:
+            while self.simulator.state != SimulationState.NextCycle:
+                if self.state == SyncProcessState.Running:
+                    return
+                yield Settle()
+            self.change_state(SyncProcessState.WaitNextCycle)
+            yield
+            self.change_state(SyncProcessState.WaitFor)
+
+    def handle_emit(self, cmd: Emit):
+        for p in cmd.event.wait_queue:
+            p.change_state(SyncProcessState.Running)
+
+    def _wrapping_function(self):
+        response = None
+        org_corutine = self.org_proc()
+        try:
+            while True:
+                # call orginal test process and catch data yielded by it in `command` variable
+                command = org_corutine.send(response)
+                if command is None:
+                    yield from self.wait_next_cycle()
+                elif type(command) is Statement:
+                    response = yield from self.handle_statement(command)
+                elif type(command) is WaitReadOnly:
+                    yield from self.wait_read_only()
+                elif type(command) is Emit:
+                    self.handle_emit(command)
+                elif type(command) is WaitFor:
+                    yield from self.wait_for(command)
+                # Pass everything else to amaranth simulator without modifications
+                else:
+                    response = yield command
+        except StopIteration:
+            self.change_state(SyncProcessState.WaitNextCycle)
+
+class SimulatorWrapper():
+    def __init__(self, module, clk_period, max_cycles):
+        self.clk_period = clk_period
+        self.module = module
+        self.max_cycles = max_cycles
+
+        self.process_list : list[SyncProcessWrapper] = []
+        self.state : SimulationState = SimulationState.Normal
+
+        self.sim = Simulator(self.module)
+        self.sim.add_clock(self.clk_period)
+
+    def add_sync_process(self, org_proc):
+        proc = SyncProcessWrapper(self, org_proc)
+        self.process_list.append(proc)
+        self.sim.add_sync_process(proc._wrapping_function)
+
+    def _process_state_changed_in_read_only(self):
+        all_next_cycle = all(self._transform_proces_list(lambda p: (p.state == SyncProcessState.WaitNextCycle) or (p.state == SyncProcessState.WaitFor)))
+        if all_next_cycle:
+            if any(self._transform_proces_list(lambda p: (p.state == SyncProcessState.WaitFor))):
+                self.state = SimulationState.NextCycle
+            else:
+                self._start_new_cycle()
+
+    @staticmethod
+    def _process_waiting(p : SyncProcessWrapper):
+        return (p.state == SyncProcessState.WaitReadOnly) or (p.state == SyncProcessState.WaitNextCycle) or (p.state == SyncProcessState.WaitFor)
+
+    def _transform_proces_list(self, f : Callable[[SyncProcessWrapper], T]) -> list[T]:
+        return [f(p) for p in self.process_list]
+
+    def _start_new_cycle(self):
+        self.state = SimulationState.Normal
+        for p in self.process_list:
+            p.state = SyncProcessState.BeginingOfNewCycle
+
+    def _process_state_changed_in_normal(self):
+        any_wait_read_only = any([ (p.state == SyncProcessState.WaitReadOnly) for p in self.process_list ])
+        any_wait_for = any(self._transform_proces_list(lambda p: (p.state == SyncProcessState.WaitFor)))
+        all_wait = all(self._transform_proces_list(self._process_waiting))
+        if all_wait:
+            if any_wait_read_only:
+                self.state = SimulationState.ReadOnly
+            elif any_wait_for:
+                self.state = SimulationState.NextCycle
+            else:
+                self._start_new_cycle()
+
+    def _process_state_changed_in_next_state(self):
+        all_next_cycle = all(self._transform_proces_list(lambda p: (p.state == SyncProcessState.WaitNextCycle)))
+        if all_next_cycle:
+            self._start_new_cycle()
+
+    def process_state_changed(self):
+        if self.state == SimulationState.Normal:
+            self._process_state_changed_in_normal()
+        elif self.state == SimulationState.ReadOnly:
+            self._process_state_changed_in_read_only()
+        elif self.state == SimulationState.NextCycle:
+            self._process_state_changed_in_next_state()
+
+    def run_until(self, ctx):
+        with ctx:
+            self.sim.run_until(self.clk_period * self.max_cycles)
+            assert self.sim.advance() == False, "Simulation time limit exceeded"

--- a/test/simulation.py
+++ b/test/simulation.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
-import functools
-from contextlib import contextmanager, nullcontext
-from typing import Callable, Generic, Mapping, Union, Generator, TypeVar, Optional, Any, cast
+from typing import TypeVar, Callable
 from enum import Enum, auto
 from collections import deque
 import logging
@@ -9,38 +7,45 @@ import logging
 from amaranth import *
 from amaranth.hdl.ast import Statement
 from amaranth.sim import *
-from amaranth.sim.core import Command
 
-__all__ = ['SimulatorWrapper', 'WaitReadOnly']
+__all__ = ["SimulatorWrapper", "WaitReadOnly"]
 
 T = TypeVar("T")
 
-#TODO: - read-only-phase, początkowy odstęp, muteksy, zmienne warunkowe
+# TODO: - read-only-phase, początkowy odstęp, muteksy, zmienne warunkowe
 # Narzut czasowy: 2%-3%
+
 
 class CoreblockSimulationError(RuntimeError):
     pass
 
-class CoreblockCommand():
+
+class CoreblockCommand:
     pass
 
-class CoreblockSimulationEvent():
+
+class CoreblockSimulationEvent:
     pass
+
 
 class CondVar(CoreblockSimulationEvent):
     def __init__(self):
-        self.wait_queue : deque['SyncProcessWrapper'] = deque()
+        self.wait_queue: deque["SyncProcessWrapper"] = deque()
+
 
 @dataclass
 class WaitFor(CoreblockCommand):
-    event : CondVar
+    event: CondVar
+
 
 @dataclass
 class Emit(CoreblockCommand):
-    event : CondVar
+    event: CondVar
+
 
 class WaitReadOnly(CoreblockCommand):
     pass
+
 
 class SyncProcessState(Enum):
     Invalid = auto()
@@ -50,20 +55,24 @@ class SyncProcessState(Enum):
     WaitFor = auto()
     BeginingOfNewCycle = auto()
 
+
 class SimulationState(Enum):
     Normal = auto()
     ReadOnly = auto()
     NextCycle = auto()
 
-class SyncProcessWrapper():
-    def __init__(self, simulator : 'SimulatorWrapper', proc):
+
+class SyncProcessWrapper:
+    def __init__(self, simulator: "SimulatorWrapper", proc):
         self.org_proc = proc
         self.state = SyncProcessState.Running
         self.simulator = simulator
 
     def expect_simulation_state(self, sim_state):
         if self.simulator.state != sim_state:
-            raise CoreblockSimulationError(f"Wrong simulation state, expected: {sim_state} current: {self.simulator.state}")
+            raise CoreblockSimulationError(
+                f"Wrong simulation state, expected: {sim_state} current: {self.simulator.state}"
+            )
 
     def change_state(self, new_state):
         if new_state == SyncProcessState.BeginingOfNewCycle:
@@ -88,10 +97,10 @@ class SyncProcessWrapper():
     def handle_statement(self, cmd):
         self.expect_simulation_state(SimulationState.Normal)
         return (yield cmd)
-    
-    def wait_for(self, cmd : WaitFor):
+
+    def wait_for(self, cmd: WaitFor):
         self.change_state(SyncProcessState.WaitFor)
-        
+
         cmd.event.wait_queue.append(self)
         while True:
             while self.simulator.state != SimulationState.NextCycle:
@@ -129,14 +138,15 @@ class SyncProcessWrapper():
         except StopIteration:
             self.change_state(SyncProcessState.WaitNextCycle)
 
-class SimulatorWrapper():
+
+class SimulatorWrapper:
     def __init__(self, module, clk_period, max_cycles):
         self.clk_period = clk_period
         self.module = module
         self.max_cycles = max_cycles
 
-        self.process_list : list[SyncProcessWrapper] = []
-        self.state : SimulationState = SimulationState.Normal
+        self.process_list: list[SyncProcessWrapper] = []
+        self.state: SimulationState = SimulationState.Normal
 
         self.sim = Simulator(self.module)
         self.sim.add_clock(self.clk_period)
@@ -145,7 +155,7 @@ class SimulatorWrapper():
         proc = SyncProcessWrapper(self, org_proc)
         self.process_list.append(proc)
         self.sim.add_sync_process(proc._wrapping_function)
-    
+
     def _change_state(self, new_state):
         logging.debug(f"Old state: {self.state} New state: {new_state}")
         self._print_process_states()
@@ -156,7 +166,11 @@ class SimulatorWrapper():
             logging.debug(f"\t{p.org_proc}\t{p.state}")
 
     def _process_state_changed_in_read_only(self):
-        all_next_cycle = all(self._transform_proces_list(lambda p: (p.state == SyncProcessState.WaitNextCycle) or (p.state == SyncProcessState.WaitFor)))
+        all_next_cycle = all(
+            self._transform_proces_list(
+                lambda p: (p.state == SyncProcessState.WaitNextCycle) or (p.state == SyncProcessState.WaitFor)
+            )
+        )
         if all_next_cycle:
             if any(self._transform_proces_list(lambda p: (p.state == SyncProcessState.WaitFor))):
                 self._change_state(SimulationState.NextCycle)
@@ -164,10 +178,14 @@ class SimulatorWrapper():
                 self._start_new_cycle()
 
     @staticmethod
-    def _process_waiting(p : SyncProcessWrapper):
-        return (p.state == SyncProcessState.WaitReadOnly) or (p.state == SyncProcessState.WaitNextCycle) or (p.state == SyncProcessState.WaitFor)
+    def _process_waiting(p: SyncProcessWrapper):
+        return (
+            (p.state == SyncProcessState.WaitReadOnly)
+            or (p.state == SyncProcessState.WaitNextCycle)
+            or (p.state == SyncProcessState.WaitFor)
+        )
 
-    def _transform_proces_list(self, f : Callable[[SyncProcessWrapper], T]) -> list[T]:
+    def _transform_proces_list(self, f: Callable[[SyncProcessWrapper], T]) -> list[T]:
         return [f(p) for p in self.process_list]
 
     def _start_new_cycle(self):
@@ -175,10 +193,10 @@ class SimulatorWrapper():
         for p in self.process_list:
             p.state = SyncProcessState.BeginingOfNewCycle
         self._print_process_states()
-        logging.debug("---------------- NEW CYCLE ----------------") 
+        logging.debug("---------------- NEW CYCLE ----------------")
 
     def _process_state_changed_in_normal(self):
-        any_wait_read_only = any([ (p.state == SyncProcessState.WaitReadOnly) for p in self.process_list ])
+        any_wait_read_only = any([(p.state == SyncProcessState.WaitReadOnly) for p in self.process_list])
         any_wait_for = any(self._transform_proces_list(lambda p: (p.state == SyncProcessState.WaitFor)))
         all_wait = all(self._transform_proces_list(self._process_waiting))
         if all_wait:
@@ -205,4 +223,4 @@ class SimulatorWrapper():
     def run_until(self, ctx):
         with ctx:
             self.sim.run_until(self.clk_period * self.max_cycles)
-            assert self.sim.advance() == False, "Simulation time limit exceeded"
+            assert self.sim.advance() is False, "Simulation time limit exceeded"

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -6,6 +6,7 @@ from coreblocks.params import ROBLayouts, RFLayouts, GenParams, LSULayouts, Sche
 from coreblocks.params.configurations import test_core_config
 
 from ..common import *
+from ..simulation import *
 from collections import deque
 import random
 
@@ -48,7 +49,7 @@ class RetirementTestCircuit(Elaboratable):
         return tm
 
 
-class RetirementTest(TestCaseWithSimulator):
+class RetirementTest(TestCaseWithExtendedSimulator):
     def setUp(self):
         self.gen_params = GenParams(test_core_config)
         self.rf_exp_q = deque()
@@ -103,11 +104,11 @@ class RetirementTest(TestCaseWithSimulator):
             self.assertFalse(self.submit_q)
             self.assertFalse(self.rf_free_q)
 
-        @def_method_mock(lambda: retc.mock_rf_free, sched_prio=1)
+        @def_method_mock(lambda: retc.mock_rf_free, read_only_phase=True)
         def rf_free_process(reg_id):
             self.assertEqual(reg_id, self.rf_free_q.popleft())
 
-        @def_method_mock(lambda: retc.mock_lsu_commit, sched_prio=1)
+        @def_method_mock(lambda: retc.mock_lsu_commit, read_only_phase=True)
         def lsu_commit_process(rob_id):
             self.assertEqual(rob_id, self.lsu_commit_q.popleft())
 

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -81,9 +81,11 @@ class RetirementTest(TestCaseWithExtendedSimulator):
 
     def test_rand(self):
         retc = RetirementTestCircuit(self.gen_params)
+        print()
 
         @def_method_mock(lambda: retc.mock_rob_retire, enable=lambda: bool(self.submit_q))
         def submit_process():
+            print("submit")
             return self.submit_q.popleft()
 
         def free_reg_process():
@@ -106,10 +108,12 @@ class RetirementTest(TestCaseWithExtendedSimulator):
 
         @def_method_mock(lambda: retc.mock_rf_free, read_only_phase=True)
         def rf_free_process(reg_id):
+            print("rf free")
             self.assertEqual(reg_id, self.rf_free_q.popleft())
 
-        @def_method_mock(lambda: retc.mock_lsu_commit, read_only_phase=True)
+        @def_method_mock(lambda: retc.mock_lsu_commit, read_only_phase=True, sched_prio=0)
         def lsu_commit_process(rob_id):
+            print("lsu commit")
             self.assertEqual(rob_id, self.lsu_commit_q.popleft())
 
         with self.run_simulation(retc) as sim:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -4,7 +4,7 @@ from coreblocks.transactions import TransactionModule
 from coreblocks.transactions.lib import AdapterTrans
 from coreblocks.utils import align_to_power_of_two
 
-from .common import TestCaseWithSimulator, TestbenchIO
+from .common import TestCaseWithSimulator, TestbenchIO, TestCaseWithExtendedSimulator
 
 from coreblocks.core import Core
 from coreblocks.params import GenParams
@@ -82,7 +82,7 @@ def gen_riscv_lui_instr(dst, imm):
     return 0b0110111 | dst << 7 | imm << 12
 
 
-class TestCoreBase(TestCaseWithSimulator):
+class TestCoreBase(TestCaseWithExtendedSimulator):
     gp: GenParams
     m: TestElaboratable
 


### PR DESCRIPTION
We have nice framework to write normal code, but we still use low level tools (eg. Settle) in our tests. They have a lot of corner cases and it is hard to write tests which looks good and are easy to read. On the other hand our production code is going to be more complicated, so we need a better way to write tests.

I thought about writing unit tests in cocotb, but solution has some drawbacks:
- no direct support from amaranth
- need to go through verilog
- if  we use verilog then we loose our method abstraction
- non interface signals in verilog have strange names
- one unit tests would compose from two files (makefile and python code)

So I have decided to make exploration by coding and check how hard it will be to add more abstract commands to amaranth simulator. It looks like it is doable, here I present changes which add:
- SimulatorWrapper - in our simulation each cycle have 3 phases: Normal (standard simulation as known from amaranth), ReadOnly (only reading is allowed), NextCycle (all process ended this cycle and we are going to the next)
- ReadOnly - works simmilar to Settle() but wait till all process want to go to the next cycle, or want to be in ReadOnly phase
- WaitFor / Emit - conditional variables to synchronise different test process

Current status:
- Extended simulator is backward compatible with all synchronous tests
- First tests with ReadOnly works
- No tests to check if WaitFor/Emit works
- naming of classes and variables have to be improved

I would be happy to hear what you think about such changes.
- Do you think, that there will be useful?
- Have you some ideas for improvements?