### PR TITLE
Fix pushing CI docs

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -7,4 +7,11 @@ if [ -z "$DOCS_DIR" ] || [ -z "$BUILD_DIR" ]; then
   exit 1
 fi
 
-scripts/build_docs.sh -d "$DOCS_DIR" -o "$BUILD_DIR"
+echo "creating build directory"
+mkdir -p "$BUILD_DIR"
+
+echo "copying markdown docs and config"
+rsync -av "$DOCS_DIR/" "$BUILD_DIR/sources"
+
+echo "generating and building docs"
+scripts/build_docs.sh -d "$BUILD_DIR/sources" -o "$BUILD_DIR/html"

--- a/ci/push_docs.sh
+++ b/ci/push_docs.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 if [ -z "$GH_TOKEN" ] || [ -z "$GH_MAIL" ] || [ -z "$GH_NAME" ]; then
   echo "Environment configuration missing, exiting... "
   exit 1

--- a/ci/push_docs.sh
+++ b/ci/push_docs.sh
@@ -26,7 +26,7 @@ echo $message
 
 # Copy files
 echo "Copying files to Wiki"
-rsync -av --delete $DOCS_DIR $TEMP_DIR/ --exclude .git
+rsync -av --delete $DOCS_DIR $TEMP_DIR/ --exclude .git --exclude_from "$DOCS_DIR/wiki_exclude"
 
 # Setup credentials for wiki
 cd $TEMP_DIR

--- a/ci/push_gh_pages.sh
+++ b/ci/push_gh_pages.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 if [ -z "$GH_TOKEN" ] || [ -z "$GH_MAIL" ] || [ -z "$GH_NAME" ] || [ -z "$DOCS_DIR" ] || [ -z "$BUILD_DIR" ]; then
   echo "Environment configuration missing, exiting... "
   exit 1

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -9,6 +9,8 @@ component implementations.
 Documentation located in the `docs/` directory collects description of the whole processor.
 In `Overview` a high level overview of CoreBlocks can be found.
 
+Html versions of these pages and API documentation generated from code are available at [kuznia-rdzeni.github.io/coreblocks/](https://kuznia-rdzeni.github.io/coreblocks/)
+
 
 ```{mermaid}
 graph

--- a/docs/wiki_exclude
+++ b/docs/wiki_exclude
@@ -1,0 +1,3 @@
+conf.py
+api.md
+home.md


### PR DESCRIPTION
Fixes #326

Sphinx build options were changed in #247, which by some weird relation changed output directory of html files from `build/html` to `build`. Push script failed with non existing `html` directory.

Instead of simply changing the directory to copy I changed build structure a little bit to be more intuitive (affects only CI scripts)
Now it looks like that: 
* `.rst` files are generated by sphinx to `build/sources`. 
* Our markdowns files are copied to `build/sources`. (previously everything happened in `docs/` directory together with rst files). 
* Html files are generated by sphinx to `build/html`.
* `build/html` is pushed to www, `docs/` are pushed to wiki

With this change `.rst` files generated by sphinx are no longer pushed to our wiki. I see no sense in doning that, as github wiki can't parse rst directives and now we only have api and index file with only `.include` directives.

EDIT: .rst files are ignored by wiki completely, and these api and home files are hand written .md for sphinx. I will exclude them manually from copy to wiki build. - Completed, files in exclude_list will require initial manual deletion from wiki after merge of this PR