### PR TITLE
ZBA enable flag

### DIFF
--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -60,9 +60,8 @@ class Alu(Elaboratable):
     def __init__(self, gen: GenParams, alu_fn=AluFn()):
         self.gen = gen
         self.zba_enable = alu_fn.zba_enable
-        self.alu_fn = alu_fn
 
-        self.fn = self.alu_fn.get_function()
+        self.fn = alu_fn.get_function()
         self.in1 = Signal(gen.isa.xlen)
         self.in2 = Signal(gen.isa.xlen)
 

--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -1,7 +1,5 @@
 from typing import Sequence
-from typing_extensions import override
 from amaranth import *
-from amaranth import Value
 
 from coreblocks.transactions import *
 from coreblocks.transactions.core import def_method
@@ -40,31 +38,22 @@ class AluFn(DecoderManager):
         SH3ADD = auto()  # Logic left shift by 3 and add
 
     def get_instructions(self) -> Sequence[tuple]:
-        return (
-            [
-                (self.Fn.ADD, OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
-                (self.Fn.SUB, OpType.ARITHMETIC, Funct3.ADD, Funct7.SUB),
-                (self.Fn.SLT, OpType.COMPARE, Funct3.SLT),
-                (self.Fn.SLTU, OpType.COMPARE, Funct3.SLTU),
-                (self.Fn.XOR, OpType.LOGIC, Funct3.XOR),
-                (self.Fn.OR, OpType.LOGIC, Funct3.OR),
-                (self.Fn.AND, OpType.LOGIC, Funct3.AND),
-                (self.Fn.SLL, OpType.SHIFT, Funct3.SLL),
-                (self.Fn.SRL, OpType.SHIFT, Funct3.SR, Funct7.SL),
-                (self.Fn.SRA, OpType.SHIFT, Funct3.SR, Funct7.SA),
-            ]
-            + [
-                (self.Fn.SH1ADD, OpType.ADDRESS_GENERATION, Funct3.SH1ADD, Funct7.SH1ADD),
-                (self.Fn.SH2ADD, OpType.ADDRESS_GENERATION, Funct3.SH2ADD, Funct7.SH2ADD),
-                (self.Fn.SH3ADD, OpType.ADDRESS_GENERATION, Funct3.SH3ADD, Funct7.SH3ADD),
-            ]
-            if self.zba_enable
-            else []
-        )
-
-    @override
-    def get_function(self) -> Value:
-        return Signal(shape=unsigned(len(self.get_instructions())))
+        return [
+            (self.Fn.ADD, OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
+            (self.Fn.SUB, OpType.ARITHMETIC, Funct3.ADD, Funct7.SUB),
+            (self.Fn.SLT, OpType.COMPARE, Funct3.SLT),
+            (self.Fn.SLTU, OpType.COMPARE, Funct3.SLTU),
+            (self.Fn.XOR, OpType.LOGIC, Funct3.XOR),
+            (self.Fn.OR, OpType.LOGIC, Funct3.OR),
+            (self.Fn.AND, OpType.LOGIC, Funct3.AND),
+            (self.Fn.SLL, OpType.SHIFT, Funct3.SLL),
+            (self.Fn.SRL, OpType.SHIFT, Funct3.SR, Funct7.SL),
+            (self.Fn.SRA, OpType.SHIFT, Funct3.SR, Funct7.SA),
+        ] + [
+            (self.Fn.SH1ADD, OpType.ADDRESS_GENERATION, Funct3.SH1ADD, Funct7.SH1ADD),
+            (self.Fn.SH2ADD, OpType.ADDRESS_GENERATION, Funct3.SH2ADD, Funct7.SH2ADD),
+            (self.Fn.SH3ADD, OpType.ADDRESS_GENERATION, Funct3.SH3ADD, Funct7.SH3ADD),
+        ] * self.zba_enable
 
 
 class Alu(Elaboratable):

--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -68,10 +68,10 @@ class AluFn(DecoderManager):
 
 
 class Alu(Elaboratable):
-    def __init__(self, gen: GenParams, zba_enable=True):
+    def __init__(self, gen: GenParams, alu_fn=AluFn()):
         self.gen = gen
-        self.zba_enable = zba_enable
-        self.alu_fn = AluFn(zba_enable=zba_enable)
+        self.zba_enable = alu_fn.zba_enable
+        self.alu_fn = alu_fn
 
         self.fn = self.alu_fn.get_function()
         self.in1 = Signal(gen.isa.xlen)
@@ -135,7 +135,7 @@ class AluFuncUnit(FuncUnit, Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        m.submodules.alu = alu = Alu(self.gen, zba_enable=self.alu_fn.zba_enable)
+        m.submodules.alu = alu = Alu(self.gen, alu_fn=self.alu_fn)
         m.submodules.fifo = fifo = FIFO(self.gen.get(FuncUnitLayouts).accept, 2)
         m.submodules.decoder = decoder = self.alu_fn.get_decoder(self.gen)
 

--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -15,48 +15,71 @@ __all__ = ["AluFuncUnit", "ALUComponent"]
 
 from coreblocks.utils.protocols import FuncUnit
 
+class Fn(IntFlag):
+    ADD = auto()  # Addition
+    SLL = auto()  # Logic left shift
+    XOR = auto()  # Bitwise xor
+    SRL = auto()  # Logic right shift
+    OR = auto()  # Bitwise or
+    AND = auto()  # Bitwise and
+    SUB = auto()  # Subtraction
+    SRA = auto()  # Arithmetic right shift
+    SLT = auto()  # Set if less than (signed)
+    SLTU = auto()  # Set if less than (unsigned)
+    
+    # ZBA extension
+    SH1ADD = auto()  # Logic left shift by 1 and add
+    SH2ADD = auto()  # Logic left shift by 2 and add
+    SH3ADD = auto()  # Logic left shift by 3 and add
 
 class AluFn(DecoderManager):
-    class Fn(IntFlag):
-        ADD = auto()  # Addition
-        SLL = auto()  # Logic left shift
-        XOR = auto()  # Bitwise xor
-        SRL = auto()  # Logic right shift
-        OR = auto()  # Bitwise or
-        AND = auto()  # Bitwise and
-        SUB = auto()  # Subtraction
-        SRA = auto()  # Arithmetic right shift
-        SLT = auto()  # Set if less than (signed)
-        SLTU = auto()  # Set if less than (unsigned)
-        # ZBA extension
-        SH1ADD = auto()  # Logic left shift by 1 and add
-        SH2ADD = auto()  # Logic left shift by 2 and add
-        SH3ADD = auto()  # Logic left shift by 3 and add
+    def __init__(self, zba_enable=False) -> None:
+        self.zba_enable = zba_enable
 
-    @classmethod
-    def get_instructions(cls) -> Sequence[tuple]:
+        class Fn(IntFlag):
+            ADD = auto()  # Addition
+            SLL = auto()  # Logic left shift
+            XOR = auto()  # Bitwise xor
+            SRL = auto()  # Logic right shift
+            OR = auto()  # Bitwise or
+            AND = auto()  # Bitwise and
+            SUB = auto()  # Subtraction
+            SRA = auto()  # Arithmetic right shift
+            SLT = auto()  # Set if less than (signed)
+            SLTU = auto()  # Set if less than (unsigned)
+            
+            if self.zba_enable:
+                SH1ADD = auto()  # Logic left shift by 1 and add
+                SH2ADD = auto()  # Logic left shift by 2 and add
+                SH3ADD = auto()  # Logic left shift by 3 and add
+
+        self.Fn = Fn
+
+    def get_instructions(self) -> Sequence[tuple]:
         return [
-            (cls.Fn.ADD, OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
-            (cls.Fn.SUB, OpType.ARITHMETIC, Funct3.ADD, Funct7.SUB),
-            (cls.Fn.SLT, OpType.COMPARE, Funct3.SLT),
-            (cls.Fn.SLTU, OpType.COMPARE, Funct3.SLTU),
-            (cls.Fn.XOR, OpType.LOGIC, Funct3.XOR),
-            (cls.Fn.OR, OpType.LOGIC, Funct3.OR),
-            (cls.Fn.AND, OpType.LOGIC, Funct3.AND),
-            (cls.Fn.SLL, OpType.SHIFT, Funct3.SLL),
-            (cls.Fn.SRL, OpType.SHIFT, Funct3.SR, Funct7.SL),
-            (cls.Fn.SRA, OpType.SHIFT, Funct3.SR, Funct7.SA),
-            (cls.Fn.SH1ADD, OpType.ADDRESS_GENERATION, Funct3.SH1ADD, Funct7.SH1ADD),
-            (cls.Fn.SH2ADD, OpType.ADDRESS_GENERATION, Funct3.SH2ADD, Funct7.SH2ADD),
-            (cls.Fn.SH3ADD, OpType.ADDRESS_GENERATION, Funct3.SH3ADD, Funct7.SH3ADD),
+            (Fn.ADD, OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
+            (Fn.SUB, OpType.ARITHMETIC, Funct3.ADD, Funct7.SUB),
+            (Fn.SLT, OpType.COMPARE, Funct3.SLT),
+            (Fn.SLTU, OpType.COMPARE, Funct3.SLTU),
+            (Fn.XOR, OpType.LOGIC, Funct3.XOR),
+            (Fn.OR, OpType.LOGIC, Funct3.OR),
+            (Fn.AND, OpType.LOGIC, Funct3.AND),
+            (Fn.SLL, OpType.SHIFT, Funct3.SLL),
+            (Fn.SRL, OpType.SHIFT, Funct3.SR, Funct7.SL),
+            (Fn.SRA, OpType.SHIFT, Funct3.SR, Funct7.SA),
+            (Fn.SH1ADD, OpType.ADDRESS_GENERATION, Funct3.SH1ADD, Funct7.SH1ADD),
+            (Fn.SH2ADD, OpType.ADDRESS_GENERATION, Funct3.SH2ADD, Funct7.SH2ADD),
+            (Fn.SH3ADD, OpType.ADDRESS_GENERATION, Funct3.SH3ADD, Funct7.SH3ADD),
         ]
 
 
 class Alu(Elaboratable):
-    def __init__(self, gen: GenParams):
+    def __init__(self, gen: GenParams, zba_enable = False):
         self.gen = gen
+        self.zba_enable = zba_enable
+        self.alu_fn = AluFn(zba_enable=zba_enable)
 
-        self.fn = AluFn.get_function()
+        self.fn = self.alu_fn.get_function()
         self.in1 = Signal(gen.isa.xlen)
         self.in2 = Signal(gen.isa.xlen)
 
@@ -69,32 +92,34 @@ class Alu(Elaboratable):
         xlen_log = self.gen.isa.xlen_log
 
         with OneHotSwitch(m, self.fn) as OneHotCase:
-            with OneHotCase(AluFn.Fn.ADD):
+            with OneHotCase(Fn.ADD):
                 m.d.comb += self.out.eq(self.in1 + self.in2)
-            with OneHotCase(AluFn.Fn.SLL):
+            with OneHotCase(Fn.SLL):
                 m.d.comb += self.out.eq(self.in1 << self.in2[0:xlen_log])
-            with OneHotCase(AluFn.Fn.XOR):
+            with OneHotCase(Fn.XOR):
                 m.d.comb += self.out.eq(self.in1 ^ self.in2)
-            with OneHotCase(AluFn.Fn.SRL):
+            with OneHotCase(Fn.SRL):
                 m.d.comb += self.out.eq(self.in1 >> self.in2[0:xlen_log])
-            with OneHotCase(AluFn.Fn.OR):
+            with OneHotCase(Fn.OR):
                 m.d.comb += self.out.eq(self.in1 | self.in2)
-            with OneHotCase(AluFn.Fn.AND):
+            with OneHotCase(Fn.AND):
                 m.d.comb += self.out.eq(self.in1 & self.in2)
-            with OneHotCase(AluFn.Fn.SUB):
+            with OneHotCase(Fn.SUB):
                 m.d.comb += self.out.eq(self.in1 - self.in2)
-            with OneHotCase(AluFn.Fn.SRA):
+            with OneHotCase(Fn.SRA):
                 m.d.comb += self.out.eq(Cat(self.in1, Repl(self.in1[xlen - 1], xlen)) >> self.in2[0:xlen_log])
-            with OneHotCase(AluFn.Fn.SLT):
+            with OneHotCase(Fn.SLT):
                 m.d.comb += self.out.eq(self.in1.as_signed() < self.in2.as_signed())
-            with OneHotCase(AluFn.Fn.SLTU):
+            with OneHotCase(Fn.SLTU):
                 m.d.comb += self.out.eq(self.in1 < self.in2)
-            with OneHotCase(AluFn.Fn.SH1ADD):
-                m.d.comb += self.out.eq((self.in1 << 1) + self.in2)
-            with OneHotCase(AluFn.Fn.SH2ADD):
-                m.d.comb += self.out.eq((self.in1 << 2) + self.in2)
-            with OneHotCase(AluFn.Fn.SH3ADD):
-                m.d.comb += self.out.eq((self.in1 << 3) + self.in2)
+
+            if self.zba_enable:
+                with OneHotCase(Fn.SH1ADD):
+                    m.d.comb += self.out.eq((self.in1 << 1) + self.in2)
+                with OneHotCase(Fn.SH2ADD):
+                    m.d.comb += self.out.eq((self.in1 << 2) + self.in2)
+                with OneHotCase(Fn.SH3ADD):
+                    m.d.comb += self.out.eq((self.in1 << 3) + self.in2)
 
         # so that Amaranth allows us to use add_clock
         dummy = Signal()
@@ -104,10 +129,11 @@ class Alu(Elaboratable):
 
 
 class AluFuncUnit(Elaboratable):
-    optypes = AluFn.get_op_types()
+    optypes = AluFn().get_op_types()
 
-    def __init__(self, gen: GenParams):
+    def __init__(self, gen: GenParams, zba_enable = False):
         self.gen = gen
+        self.zba_enable = zba_enable
 
         layouts = gen.get(FuncUnitLayouts)
 
@@ -117,9 +143,9 @@ class AluFuncUnit(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        m.submodules.alu = alu = Alu(self.gen)
+        m.submodules.alu = alu = Alu(self.gen, zba_enable=self.zba_enable)
         m.submodules.fifo = fifo = FIFO(self.gen.get(FuncUnitLayouts).accept, 2)
-        m.submodules.decoder = decoder = AluFn.get_decoder(self.gen)
+        m.submodules.decoder = decoder = AluFn(zba_enable=self.zba_enable).get_decoder(self.gen)
 
         @def_method(m, self.accept)
         def _():
@@ -139,8 +165,11 @@ class AluFuncUnit(Elaboratable):
 
 
 class ALUComponent(FunctionalComponentParams):
+    def __init__(self, zba_enable = True):
+        self.zba_enable = zba_enable
+
     def get_module(self, gen_params: GenParams) -> FuncUnit:
-        return AluFuncUnit(gen_params)
+        return AluFuncUnit(gen_params, zba_enable=self.zba_enable)
 
     def get_optypes(self) -> set[OpType]:
-        return AluFuncUnit.optypes
+        return AluFn(zba_enable=self.zba_enable).get_op_types()

--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -15,6 +15,7 @@ __all__ = ["AluFuncUnit", "ALUComponent"]
 
 from coreblocks.utils.protocols import FuncUnit
 
+
 class Fn(IntFlag):
     ADD = auto()  # Addition
     SLL = auto()  # Logic left shift
@@ -26,11 +27,12 @@ class Fn(IntFlag):
     SRA = auto()  # Arithmetic right shift
     SLT = auto()  # Set if less than (signed)
     SLTU = auto()  # Set if less than (unsigned)
-    
+
     # ZBA extension
     SH1ADD = auto()  # Logic left shift by 1 and add
     SH2ADD = auto()  # Logic left shift by 2 and add
     SH3ADD = auto()  # Logic left shift by 3 and add
+
 
 class AluFn(DecoderManager):
     def __init__(self, zba_enable=False) -> None:
@@ -47,7 +49,7 @@ class AluFn(DecoderManager):
             SRA = auto()  # Arithmetic right shift
             SLT = auto()  # Set if less than (signed)
             SLTU = auto()  # Set if less than (unsigned)
-            
+
             if self.zba_enable:
                 SH1ADD = auto()  # Logic left shift by 1 and add
                 SH2ADD = auto()  # Logic left shift by 2 and add
@@ -74,7 +76,7 @@ class AluFn(DecoderManager):
 
 
 class Alu(Elaboratable):
-    def __init__(self, gen: GenParams, zba_enable = False):
+    def __init__(self, gen: GenParams, zba_enable=False):
         self.gen = gen
         self.zba_enable = zba_enable
         self.alu_fn = AluFn(zba_enable=zba_enable)
@@ -131,7 +133,7 @@ class Alu(Elaboratable):
 class AluFuncUnit(Elaboratable):
     optypes = AluFn().get_op_types()
 
-    def __init__(self, gen: GenParams, zba_enable = False):
+    def __init__(self, gen: GenParams, zba_enable=False):
         self.gen = gen
         self.zba_enable = zba_enable
 
@@ -165,7 +167,7 @@ class AluFuncUnit(Elaboratable):
 
 
 class ALUComponent(FunctionalComponentParams):
-    def __init__(self, zba_enable = True):
+    def __init__(self, zba_enable=True):
         self.zba_enable = zba_enable
 
     def get_module(self, gen_params: GenParams) -> FuncUnit:

--- a/coreblocks/fu/fu_decoder.py
+++ b/coreblocks/fu/fu_decoder.py
@@ -66,8 +66,7 @@ class DecoderManager:
 
     """
 
-    @classmethod
-    def get_instructions(cls) -> Sequence[tuple]:
+    def get_instructions(self) -> Sequence[tuple]:
         raise NotImplementedError
 
     """
@@ -79,9 +78,8 @@ class DecoderManager:
         List of OpTypes.
     """
 
-    @classmethod
-    def get_op_types(cls) -> set[OpType]:
-        return {instr[1] for instr in cls.get_instructions()}
+    def get_op_types(self) -> set[OpType]:
+        return {instr[1] for instr in self.get_instructions()}
 
     """
     Method returning auto generated instruction decoder.
@@ -97,14 +95,13 @@ class DecoderManager:
         List of OpTypes.
     """
 
-    @classmethod
-    def get_decoder(cls, gen_params: GenParams) -> Decoder:
+    def get_decoder(self, gen_params: GenParams) -> Decoder:
         # check how many different op types are there
-        op_types = cls.get_op_types()
+        op_types = self.get_op_types()
         multiple_op_types = len(op_types) > 1
 
         # if multiple op types detected, request op_type check in decoder
-        return Decoder(gen_params, cls.Fn, cls.get_instructions(), check_optype=multiple_op_types)
+        return Decoder(gen_params, self.Fn, self.get_instructions(), check_optype=multiple_op_types)
 
     """
     Method returning Signal Object for decoder, called function in FU blocks
@@ -115,6 +112,5 @@ class DecoderManager:
         Signal object.
     """
 
-    @classmethod
-    def get_function(cls) -> Value:
-        return Signal(cls.Fn)
+    def get_function(self) -> Value:
+        return Signal(self.Fn)

--- a/coreblocks/fu/jumpbranch.py
+++ b/coreblocks/fu/jumpbranch.py
@@ -18,7 +18,6 @@ __all__ = ["JumpBranchFuncUnit", "JumpComponent"]
 
 
 class JumpBranchFn(DecoderManager):
-    @unique
     class Fn(IntFlag):
         JAL = auto()
         JALR = auto()
@@ -30,18 +29,17 @@ class JumpBranchFn(DecoderManager):
         BGE = auto()
         BGEU = auto()
 
-    @classmethod
-    def get_instructions(cls) -> Sequence[tuple]:
+    def get_instructions(self) -> Sequence[tuple]:
         return [
-            (cls.Fn.BEQ, OpType.BRANCH, Funct3.BEQ),
-            (cls.Fn.BNE, OpType.BRANCH, Funct3.BNE),
-            (cls.Fn.BLT, OpType.BRANCH, Funct3.BLT),
-            (cls.Fn.BLTU, OpType.BRANCH, Funct3.BLTU),
-            (cls.Fn.BGE, OpType.BRANCH, Funct3.BGE),
-            (cls.Fn.BGEU, OpType.BRANCH, Funct3.BGEU),
-            (cls.Fn.JAL, OpType.JAL),
-            (cls.Fn.JALR, OpType.JALR, Funct3.JALR),
-            (cls.Fn.AUIPC, OpType.AUIPC),
+            (self.Fn.BEQ, OpType.BRANCH, Funct3.BEQ),
+            (self.Fn.BNE, OpType.BRANCH, Funct3.BNE),
+            (self.Fn.BLT, OpType.BRANCH, Funct3.BLT),
+            (self.Fn.BLTU, OpType.BRANCH, Funct3.BLTU),
+            (self.Fn.BGE, OpType.BRANCH, Funct3.BGE),
+            (self.Fn.BGEU, OpType.BRANCH, Funct3.BGEU),
+            (self.Fn.JAL, OpType.JAL),
+            (self.Fn.JALR, OpType.JALR, Funct3.JALR),
+            (self.Fn.AUIPC, OpType.AUIPC),
         ]
 
 
@@ -50,7 +48,7 @@ class JumpBranch(Elaboratable):
         self.gen_params = gen_params
 
         xlen = gen_params.isa.xlen
-        self.fn = JumpBranchFn.get_function()
+        self.fn = JumpBranchFn().get_function()
         self.in1 = Signal(xlen)
         self.in2 = Signal(xlen)
         self.in_pc = Signal(xlen)
@@ -111,7 +109,7 @@ class JumpBranch(Elaboratable):
 
 
 class JumpBranchFuncUnit(Elaboratable):
-    optypes = JumpBranchFn.get_op_types()
+    optypes = JumpBranchFn().get_op_types()
 
     def __init__(self, gen: GenParams):
         self.gen = gen
@@ -128,7 +126,7 @@ class JumpBranchFuncUnit(Elaboratable):
         m.submodules.jb = jb = JumpBranch(self.gen)
         m.submodules.fifo_res = fifo_res = FIFO(self.gen.get(FuncUnitLayouts).accept, 2)
         m.submodules.fifo_branch = fifo_branch = FIFO(self.gen.get(FetchLayouts).branch_verify, 2)
-        m.submodules.decoder = decoder = JumpBranchFn.get_decoder(self.gen)
+        m.submodules.decoder = decoder = JumpBranchFn().get_decoder(self.gen)
 
         @def_method(m, self.accept)
         def _():

--- a/coreblocks/fu/jumpbranch.py
+++ b/coreblocks/fu/jumpbranch.py
@@ -44,11 +44,11 @@ class JumpBranchFn(DecoderManager):
 
 
 class JumpBranch(Elaboratable):
-    def __init__(self, gen_params: GenParams):
+    def __init__(self, gen_params: GenParams, fn=JumpBranchFn()):
         self.gen_params = gen_params
 
         xlen = gen_params.isa.xlen
-        self.fn = JumpBranchFn().get_function()
+        self.fn = fn.get_function()
         self.in1 = Signal(xlen)
         self.in2 = Signal(xlen)
         self.in_pc = Signal(xlen)
@@ -123,7 +123,7 @@ class JumpBranchFuncUnit(FuncUnit, Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        m.submodules.jb = jb = JumpBranch(self.gen)
+        m.submodules.jb = jb = JumpBranch(self.gen, fn=self.jb_fn)
         m.submodules.fifo_res = fifo_res = FIFO(self.gen.get(FuncUnitLayouts).accept, 2)
         m.submodules.fifo_branch = fifo_branch = FIFO(self.gen.get(FetchLayouts).branch_verify, 2)
         m.submodules.decoder = decoder = self.jb_fn.get_decoder(self.gen)

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -90,7 +90,7 @@ class MulUnit(Elaboratable):
 
     optypes = MulFn().get_op_types()
 
-    def __init__(self, gen: GenParams, mul_type: MulType, dsp_width: int = 32):
+    def __init__(self, gen: GenParams, mul_type: MulType, dsp_width: int = 32, mul_fn=MulFn()):
         """
         Parameters
         ----------
@@ -106,6 +106,8 @@ class MulUnit(Elaboratable):
         self.issue = Method(i=layouts.issue)
         self.accept = Method(o=layouts.accept)
 
+        self.mul_fn = mul_fn
+
     def elaborate(self, platform):
         m = Module()
 
@@ -119,7 +121,7 @@ class MulUnit(Elaboratable):
             ],
             2,
         )
-        m.submodules.decoder = decoder = MulFn().get_decoder(self.gen)
+        m.submodules.decoder = decoder = self.mul_fn.get_decoder(self.gen)
 
         # Selecting unsigned integer multiplication module
         match self.mul_type:
@@ -211,9 +213,10 @@ class MulComponent(FunctionalComponentParams):
     mul_unit_type: MulType
     _: KW_ONLY
     dsp_width: int = 32
+    mul_fn = MulFn()
 
     def get_module(self, gen_params: GenParams) -> FuncUnit:
         return MulUnit(gen_params, self.mul_unit_type, self.dsp_width)
 
     def get_optypes(self) -> set[OpType]:
-        return MulUnit.optypes
+        return self.mul_fn.get_op_types()

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -1,4 +1,4 @@
-from enum import IntFlag, unique, IntEnum, auto
+from enum import IntFlag, IntEnum, auto
 from typing import Sequence, Tuple
 from dataclasses import KW_ONLY, dataclass
 
@@ -27,7 +27,6 @@ class MulFn(DecoderManager):
     Hot wire enum of 5 different multiplication operations.
     """
 
-    @unique
     class Fn(IntFlag):
         MUL = auto()  # Lower part multiplication
         MULH = auto()  # Upper part multiplication signed×signed
@@ -37,13 +36,12 @@ class MulFn(DecoderManager):
         #
         # MULW = auto()  # Multiplication of lower half of bits
 
-    @classmethod
-    def get_instructions(cls) -> Sequence[tuple]:
+    def get_instructions(self) -> Sequence[tuple]:
         return [
-            (cls.Fn.MUL, OpType.MUL, Funct3.MUL),
-            (cls.Fn.MULH, OpType.MUL, Funct3.MULH),
-            (cls.Fn.MULHU, OpType.MUL, Funct3.MULHU),
-            (cls.Fn.MULHSU, OpType.MUL, Funct3.MULHSU),
+            (self.Fn.MUL, OpType.MUL, Funct3.MUL),
+            (self.Fn.MULH, OpType.MUL, Funct3.MULH),
+            (self.Fn.MULHU, OpType.MUL, Funct3.MULHU),
+            (self.Fn.MULHSU, OpType.MUL, Funct3.MULHSU),
         ]
 
 
@@ -90,7 +88,7 @@ class MulUnit(Elaboratable):
         Method used for getting result of requested computation.
     """
 
-    optypes = MulFn.get_op_types()
+    optypes = MulFn().get_op_types()
 
     def __init__(self, gen: GenParams, mul_type: MulType, dsp_width: int = 32):
         """
@@ -121,7 +119,7 @@ class MulUnit(Elaboratable):
             ],
             2,
         )
-        m.submodules.decoder = decoder = MulFn.get_decoder(self.gen)
+        m.submodules.decoder = decoder = MulFn().get_decoder(self.gen)
 
         # Selecting unsigned integer multiplication module
         match self.mul_type:

--- a/coreblocks/fu/zbs.py
+++ b/coreblocks/fu/zbs.py
@@ -50,11 +50,11 @@ class Zbs(Elaboratable):
         gen_params: Core generation parameters.
     """
 
-    def __init__(self, gen_params: GenParams):
+    def __init__(self, gen_params: GenParams, function=ZbsFunction()):
         self.gen_params = gen_params
 
         self.xlen = gen_params.isa.xlen
-        self.function = ZbsFunction().get_function()
+        self.function = function.get_function()
         self.in1 = Signal(self.xlen)
         self.in2 = Signal(self.xlen)
 
@@ -102,7 +102,7 @@ class ZbsUnit(FuncUnit, Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        m.submodules.zbs = zbs = Zbs(self.gen_params)
+        m.submodules.zbs = zbs = Zbs(self.gen_params, function=self.zbs_fn)
         m.submodules.result_fifo = result_fifo = FIFO(self.gen_params.get(FuncUnitLayouts).accept, 2)
         m.submodules.decoder = decoder = self.zbs_fn.get_decoder(self.gen_params)
 

--- a/coreblocks/fu/zbs.py
+++ b/coreblocks/fu/zbs.py
@@ -23,13 +23,12 @@ class ZbsFunction(DecoderManager):
         BINV = auto()  # Bit invert
         BSET = auto()  # Bit set
 
-    @classmethod
-    def get_instructions(cls) -> Sequence[tuple]:
+    def get_instructions(self) -> Sequence[tuple]:
         return [
-            (cls.Fn.BCLR, OpType.SINGLE_BIT_MANIPULATION, Funct3.BCLR, Funct7.BCLR),
-            (cls.Fn.BEXT, OpType.SINGLE_BIT_MANIPULATION, Funct3.BEXT, Funct7.BEXT),
-            (cls.Fn.BINV, OpType.SINGLE_BIT_MANIPULATION, Funct3.BINV, Funct7.BINV),
-            (cls.Fn.BSET, OpType.SINGLE_BIT_MANIPULATION, Funct3.BSET, Funct7.BSET),
+            (self.Fn.BCLR, OpType.SINGLE_BIT_MANIPULATION, Funct3.BCLR, Funct7.BCLR),
+            (self.Fn.BEXT, OpType.SINGLE_BIT_MANIPULATION, Funct3.BEXT, Funct7.BEXT),
+            (self.Fn.BINV, OpType.SINGLE_BIT_MANIPULATION, Funct3.BINV, Funct7.BINV),
+            (self.Fn.BSET, OpType.SINGLE_BIT_MANIPULATION, Funct3.BSET, Funct7.BSET),
         ]
 
 
@@ -55,7 +54,7 @@ class Zbs(Elaboratable):
         self.gen_params = gen_params
 
         self.xlen = gen_params.isa.xlen
-        self.function = ZbsFunction.get_function()
+        self.function = ZbsFunction().get_function()
         self.in1 = Signal(self.xlen)
         self.in2 = Signal(self.xlen)
 
@@ -91,7 +90,7 @@ class ZbsUnit(Elaboratable):
         Method used for getting result of requested computation.
     """
 
-    optypes = ZbsFunction.get_op_types()
+    optypes = ZbsFunction().get_op_types()
 
     def __init__(self, gen_params: GenParams):
         layouts = gen_params.get(FuncUnitLayouts)
@@ -105,7 +104,7 @@ class ZbsUnit(Elaboratable):
 
         m.submodules.zbs = zbs = Zbs(self.gen_params)
         m.submodules.result_fifo = result_fifo = FIFO(self.gen_params.get(FuncUnitLayouts).accept, 2)
-        m.submodules.decoder = decoder = ZbsFunction.get_decoder(self.gen_params)
+        m.submodules.decoder = decoder = ZbsFunction().get_decoder(self.gen_params)
 
         @def_method(m, self.accept)
         def _(arg):

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -10,7 +10,7 @@ from coreblocks.transactions.lib import *
 
 from ..common import TestCaseWithSimulator, TestbenchIO
 
-from coreblocks.fu.alu import AluFn, Alu, AluFuncUnit
+from coreblocks.fu.alu import AluFn, Alu, AluFuncUnit, Fn
 from coreblocks.params import *
 from coreblocks.params.configurations import test_core_config
 
@@ -39,7 +39,7 @@ class TestAlu(TestCaseWithSimulator):
 
     def setUp(self):
         self.gen = GenParams(test_core_config)
-        self.alu = Alu(self.gen)
+        self.alu = Alu(self.gen, zba_enable=True)
 
         random.seed(42)
 
@@ -69,34 +69,34 @@ class TestAlu(TestCaseWithSimulator):
             sim.add_process(process)
 
     def test_add(self):
-        self.check_fn(AluFn.Fn.ADD, operator.add)
+        self.check_fn(Fn.ADD, operator.add)
 
     def test_sll(self):
-        self.check_fn(AluFn.Fn.SLL, lambda in1, in2: in1 << (in2 & (self.gen.isa.xlen - 1)))
+        self.check_fn(Fn.SLL, lambda in1, in2: in1 << (in2 & (self.gen.isa.xlen - 1)))
 
     def test_xor(self):
-        self.check_fn(AluFn.Fn.XOR, operator.xor)
+        self.check_fn(Fn.XOR, operator.xor)
 
     def test_srl(self):
-        self.check_fn(AluFn.Fn.SRL, lambda in1, in2: in1 >> (in2 & (self.gen.isa.xlen - 1)))
+        self.check_fn(Fn.SRL, lambda in1, in2: in1 >> (in2 & (self.gen.isa.xlen - 1)))
 
     def test_or(self):
-        self.check_fn(AluFn.Fn.OR, operator.or_)
+        self.check_fn(Fn.OR, operator.or_)
 
     def test_and(self):
-        self.check_fn(AluFn.Fn.AND, operator.and_)
+        self.check_fn(Fn.AND, operator.and_)
 
     def test_sub(self):
-        self.check_fn(AluFn.Fn.SUB, operator.sub)
+        self.check_fn(Fn.SUB, operator.sub)
 
     def test_sh1add(self):
-        self.check_fn(AluFn.Fn.SH1ADD, lambda in1, in2: (in1 << 1) + in2)
+        self.check_fn(Fn.SH1ADD, lambda in1, in2: (in1 << 1) + in2)
 
     def test_sh2add(self):
-        self.check_fn(AluFn.Fn.SH2ADD, lambda in1, in2: (in1 << 2) + in2)
+        self.check_fn(Fn.SH2ADD, lambda in1, in2: (in1 << 2) + in2)
 
     def test_sh3add(self):
-        self.check_fn(AluFn.Fn.SH3ADD, lambda in1, in2: (in1 << 3) + in2)
+        self.check_fn(Fn.SH3ADD, lambda in1, in2: (in1 << 3) + in2)
 
     def test_sra(self):
         def sra(in1, in2):
@@ -107,16 +107,16 @@ class TestAlu(TestCaseWithSimulator):
             else:
                 return in1 >> in2
 
-        self.check_fn(AluFn.Fn.SRA, sra)
+        self.check_fn(Fn.SRA, sra)
 
     def test_slt(self):
         self.check_fn(
-            AluFn.Fn.SLT,
+            Fn.SLT,
             lambda in1, in2: _cast_to_int_xlen(in1, self.gen.isa.xlen) < _cast_to_int_xlen(in2, self.gen.isa.xlen),
         )
 
     def test_sltu(self):
-        self.check_fn(AluFn.Fn.SLTU, operator.lt)
+        self.check_fn(Fn.SLTU, operator.lt)
 
 
 class AluFuncUnitTestCircuit(Elaboratable):
@@ -127,7 +127,7 @@ class AluFuncUnitTestCircuit(Elaboratable):
         m = Module()
         tm = TransactionModule(m)
 
-        m.submodules.func_unit = func_unit = AluFuncUnit(self.gen)
+        m.submodules.func_unit = func_unit = AluFuncUnit(self.gen, zba_enable=True)
 
         # mocked input and output
         m.submodules.issue_method = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -39,7 +39,7 @@ class TestAlu(TestCaseWithSimulator):
 
     def setUp(self):
         self.gen = GenParams(test_core_config)
-        self.alu = Alu(self.gen, zba_enable=True)
+        self.alu = Alu(self.gen)
 
         random.seed(42)
 

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -126,7 +126,7 @@ class AluFuncUnitTestCircuit(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        m.submodules.func_unit = func_unit = AluFuncUnit(self.gen, zba_enable=True)
+        m.submodules.func_unit = func_unit = AluFuncUnit(self.gen)
 
         # mocked input and output
         m.submodules.issue_method = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -10,7 +10,7 @@ from coreblocks.transactions.lib import *
 
 from ..common import TestCaseWithSimulator, TestbenchIO
 
-from coreblocks.fu.alu import AluFn, Alu, AluFuncUnit, Fn
+from coreblocks.fu.alu import Alu, AluFuncUnit, Fn
 from coreblocks.params import *
 from coreblocks.params.configurations import test_core_config
 

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -10,7 +10,7 @@ from coreblocks.transactions.lib import *
 
 from ..common import TestCaseWithSimulator, TestbenchIO
 
-from coreblocks.fu.alu import Alu, AluFuncUnit, Fn
+from coreblocks.fu.alu import Alu, AluFuncUnit, AluFn
 from coreblocks.params import *
 from coreblocks.params.configurations import test_core_config
 
@@ -69,34 +69,34 @@ class TestAlu(TestCaseWithSimulator):
             sim.add_process(process)
 
     def test_add(self):
-        self.check_fn(Fn.ADD, operator.add)
+        self.check_fn(AluFn.Fn.ADD, operator.add)
 
     def test_sll(self):
-        self.check_fn(Fn.SLL, lambda in1, in2: in1 << (in2 & (self.gen.isa.xlen - 1)))
+        self.check_fn(AluFn.Fn.SLL, lambda in1, in2: in1 << (in2 & (self.gen.isa.xlen - 1)))
 
     def test_xor(self):
-        self.check_fn(Fn.XOR, operator.xor)
+        self.check_fn(AluFn.Fn.XOR, operator.xor)
 
     def test_srl(self):
-        self.check_fn(Fn.SRL, lambda in1, in2: in1 >> (in2 & (self.gen.isa.xlen - 1)))
+        self.check_fn(AluFn.Fn.SRL, lambda in1, in2: in1 >> (in2 & (self.gen.isa.xlen - 1)))
 
     def test_or(self):
-        self.check_fn(Fn.OR, operator.or_)
+        self.check_fn(AluFn.Fn.OR, operator.or_)
 
     def test_and(self):
-        self.check_fn(Fn.AND, operator.and_)
+        self.check_fn(AluFn.Fn.AND, operator.and_)
 
     def test_sub(self):
-        self.check_fn(Fn.SUB, operator.sub)
+        self.check_fn(AluFn.Fn.SUB, operator.sub)
 
     def test_sh1add(self):
-        self.check_fn(Fn.SH1ADD, lambda in1, in2: (in1 << 1) + in2)
+        self.check_fn(AluFn.Fn.SH1ADD, lambda in1, in2: (in1 << 1) + in2)
 
     def test_sh2add(self):
-        self.check_fn(Fn.SH2ADD, lambda in1, in2: (in1 << 2) + in2)
+        self.check_fn(AluFn.Fn.SH2ADD, lambda in1, in2: (in1 << 2) + in2)
 
     def test_sh3add(self):
-        self.check_fn(Fn.SH3ADD, lambda in1, in2: (in1 << 3) + in2)
+        self.check_fn(AluFn.Fn.SH3ADD, lambda in1, in2: (in1 << 3) + in2)
 
     def test_sra(self):
         def sra(in1, in2):
@@ -107,16 +107,16 @@ class TestAlu(TestCaseWithSimulator):
             else:
                 return in1 >> in2
 
-        self.check_fn(Fn.SRA, sra)
+        self.check_fn(AluFn.Fn.SRA, sra)
 
     def test_slt(self):
         self.check_fn(
-            Fn.SLT,
+            AluFn.Fn.SLT,
             lambda in1, in2: _cast_to_int_xlen(in1, self.gen.isa.xlen) < _cast_to_int_xlen(in2, self.gen.isa.xlen),
         )
 
     def test_sltu(self):
-        self.check_fn(Fn.SLTU, operator.lt)
+        self.check_fn(AluFn.Fn.SLTU, operator.lt)
 
 
 class AluFuncUnitTestCircuit(Elaboratable):

--- a/test/fu/test_fu_decoder.py
+++ b/test/fu/test_fu_decoder.py
@@ -40,9 +40,9 @@ class TestFuDecoder(TestCaseWithSimulator):
         return (yield decoder.decode_fn)
 
     def run_test_case(self, decoder_manager: Type[DecoderManager], test_inputs: Sequence[tuple]) -> None:
-        instructions = decoder_manager.get_instructions()
-        decoder = decoder_manager.get_decoder(self.gen_params)
-        op_type_dependent = len(decoder_manager.get_op_types()) != 1
+        instructions = decoder_manager().get_instructions()
+        decoder = decoder_manager().get_decoder(self.gen_params)
+        op_type_dependent = len(decoder_manager().get_op_types()) != 1
 
         def process():
             for test_input in test_inputs:

--- a/test/fu/test_fu_decoder.py
+++ b/test/fu/test_fu_decoder.py
@@ -1,5 +1,5 @@
 import random
-from typing import Sequence, Generator, Type
+from typing import Sequence, Generator
 from amaranth import *
 from amaranth.sim import *
 
@@ -39,10 +39,10 @@ class TestFuDecoder(TestCaseWithSimulator):
 
         return (yield decoder.decode_fn)
 
-    def run_test_case(self, decoder_manager: Type[DecoderManager], test_inputs: Sequence[tuple]) -> None:
-        instructions = decoder_manager().get_instructions()
-        decoder = decoder_manager().get_decoder(self.gen_params)
-        op_type_dependent = len(decoder_manager().get_op_types()) != 1
+    def run_test_case(self, decoder_manager: DecoderManager, test_inputs: Sequence[tuple]) -> None:
+        instructions = decoder_manager.get_instructions()
+        decoder = decoder_manager.get_decoder(self.gen_params)
+        op_type_dependent = len(decoder_manager.get_op_types()) != 1
 
         def process():
             for test_input in test_inputs:
@@ -77,19 +77,20 @@ class TestFuDecoder(TestCaseWithSimulator):
                 INST4 = auto()
                 INST5 = auto()
 
-            @classmethod
-            def get_instructions(cls) -> Sequence[tuple]:
+            def get_instructions(self) -> Sequence[tuple]:
                 return [
-                    (cls.Fn.INST1, OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
-                    (cls.Fn.INST2, OpType.ARITHMETIC, Funct3.AND, Funct7.SUB),
-                    (cls.Fn.INST3, OpType.ARITHMETIC, Funct3.OR, Funct7.ADD),
-                    (cls.Fn.INST4, OpType.ARITHMETIC, Funct3.XOR, Funct7.ADD),
-                    (cls.Fn.INST5, OpType.ARITHMETIC, Funct3.BGEU, Funct7.ADD),
+                    (self.Fn.INST1, OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
+                    (self.Fn.INST2, OpType.ARITHMETIC, Funct3.AND, Funct7.SUB),
+                    (self.Fn.INST3, OpType.ARITHMETIC, Funct3.OR, Funct7.ADD),
+                    (self.Fn.INST4, OpType.ARITHMETIC, Funct3.XOR, Funct7.ADD),
+                    (self.Fn.INST5, OpType.ARITHMETIC, Funct3.BGEU, Funct7.ADD),
                 ]
 
-        test_inputs = list(DM.get_instructions()) + list(self.generate_random_instructions())
+        decoder_manager = DM()
 
-        self.run_test_case(DM, test_inputs)
+        test_inputs = list(decoder_manager.get_instructions()) + list(self.generate_random_instructions())
+
+        self.run_test_case(decoder_manager, test_inputs)
 
     def test_2(self) -> None:
         # same op type, different instruction length
@@ -101,19 +102,20 @@ class TestFuDecoder(TestCaseWithSimulator):
                 INST4 = auto()
                 INST5 = auto()
 
-            @classmethod
-            def get_instructions(cls) -> Sequence[tuple]:
+            def get_instructions(self) -> Sequence[tuple]:
                 return [
-                    (cls.Fn.INST1, OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
-                    (cls.Fn.INST2, OpType.ARITHMETIC, Funct3.AND),
-                    (cls.Fn.INST3, OpType.ARITHMETIC, Funct3.OR, Funct7.BEXT),
-                    (cls.Fn.INST4, OpType.ARITHMETIC, Funct3.XOR),
-                    (cls.Fn.INST5, OpType.ARITHMETIC, Funct3.BGEU, Funct7.BSET),
+                    (self.Fn.INST1, OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
+                    (self.Fn.INST2, OpType.ARITHMETIC, Funct3.AND),
+                    (self.Fn.INST3, OpType.ARITHMETIC, Funct3.OR, Funct7.BEXT),
+                    (self.Fn.INST4, OpType.ARITHMETIC, Funct3.XOR),
+                    (self.Fn.INST5, OpType.ARITHMETIC, Funct3.BGEU, Funct7.BSET),
                 ]
 
-        test_inputs = list(DM.get_instructions()) + list(self.generate_random_instructions())
+        decoder_manager = DM()
 
-        self.run_test_case(DM, test_inputs)
+        test_inputs = list(decoder_manager.get_instructions()) + list(self.generate_random_instructions())
+
+        self.run_test_case(decoder_manager, test_inputs)
 
     def test_3(self) -> None:
         # diffecrent op types, different instruction length
@@ -125,16 +127,17 @@ class TestFuDecoder(TestCaseWithSimulator):
                 INST4 = auto()
                 INST5 = auto()
 
-            @classmethod
-            def get_instructions(cls) -> Sequence[tuple]:
+            def get_instructions(self) -> Sequence[tuple]:
                 return [
-                    (cls.Fn.INST1, OpType.AUIPC, Funct3.ADD, Funct7.ADD),
-                    (cls.Fn.INST2, OpType.MUL, Funct3.AND),
-                    (cls.Fn.INST3, OpType.ARITHMETIC, Funct3.OR, Funct7.BEXT),
-                    (cls.Fn.INST4, OpType.COMPARE),
-                    (cls.Fn.INST5, OpType.ARITHMETIC, Funct3.BGEU, Funct7.BSET),
+                    (self.Fn.INST1, OpType.AUIPC, Funct3.ADD, Funct7.ADD),
+                    (self.Fn.INST2, OpType.MUL, Funct3.AND),
+                    (self.Fn.INST3, OpType.ARITHMETIC, Funct3.OR, Funct7.BEXT),
+                    (self.Fn.INST4, OpType.COMPARE),
+                    (self.Fn.INST5, OpType.ARITHMETIC, Funct3.BGEU, Funct7.BSET),
                 ]
 
-        test_inputs = list(DM.get_instructions()) + list(self.generate_random_instructions())
+        decoder_manager = DM()
 
-        self.run_test_case(DM, test_inputs)
+        test_inputs = list(decoder_manager.get_instructions()) + list(self.generate_random_instructions())
+
+        self.run_test_case(decoder_manager, test_inputs)


### PR DESCRIPTION
Yet another ZBA enable concept

What changed:

- All Decoder Managers are now instances not static classes
- ALU op codes are defined statically because there are no collisions and this approach is much simpler
- ALU components now accepts optional flag in constructors that disables/enables ZBA extension
  By default its enabled in ALU component and disabled in other classes