### PR TITLE
Optype refactor

### DIFF
--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -103,7 +103,7 @@ class Alu(Elaboratable):
         return m
 
 
-class AluFuncUnit(Elaboratable):
+class AluFuncUnit(FuncUnit, Elaboratable):
     def __init__(self, gen: GenParams):
         self.gen = gen
 

--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -104,8 +104,6 @@ class Alu(Elaboratable):
 
 
 class AluFuncUnit(Elaboratable):
-    optypes = AluFn.get_op_types()
-
     def __init__(self, gen: GenParams):
         self.gen = gen
 
@@ -143,4 +141,4 @@ class ALUComponent(FunctionalComponentParams):
         return AluFuncUnit(gen_params)
 
     def get_optypes(self) -> set[OpType]:
-        return AluFuncUnit.optypes
+        return AluFn.get_op_types()

--- a/coreblocks/fu/jumpbranch.py
+++ b/coreblocks/fu/jumpbranch.py
@@ -110,7 +110,7 @@ class JumpBranch(Elaboratable):
         return m
 
 
-class JumpBranchFuncUnit(Elaboratable):
+class JumpBranchFuncUnit(FuncUnit, Elaboratable):
     def __init__(self, gen: GenParams):
         self.gen = gen
 

--- a/coreblocks/fu/jumpbranch.py
+++ b/coreblocks/fu/jumpbranch.py
@@ -111,8 +111,6 @@ class JumpBranch(Elaboratable):
 
 
 class JumpBranchFuncUnit(Elaboratable):
-    optypes = JumpBranchFn.get_op_types()
-
     def __init__(self, gen: GenParams):
         self.gen = gen
 
@@ -165,4 +163,4 @@ class JumpComponent(FunctionalComponentParams):
         return unit
 
     def get_optypes(self) -> set[OpType]:
-        return JumpBranchFuncUnit.optypes
+        return JumpBranchFn.get_op_types()

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -90,8 +90,6 @@ class MulUnit(Elaboratable):
         Method used for getting result of requested computation.
     """
 
-    optypes = MulFn.get_op_types()
-
     def __init__(self, gen: GenParams, mul_type: MulType, dsp_width: int = 32):
         """
         Parameters
@@ -218,4 +216,4 @@ class MulComponent(FunctionalComponentParams):
         return MulUnit(gen_params, self.mul_unit_type, self.dsp_width)
 
     def get_optypes(self) -> set[OpType]:
-        return MulUnit.optypes
+        return MulFn.get_op_types()

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -77,7 +77,7 @@ class MulType(IntEnum):
     RECURSIVE_MUL = 2
 
 
-class MulUnit(Elaboratable):
+class MulUnit(FuncUnit, Elaboratable):
     """
     Module responsible for handling every kind of multiplication based on selected unsigned integer multiplication
     module. It uses standard FuncUnitLayout.

--- a/coreblocks/fu/zbs.py
+++ b/coreblocks/fu/zbs.py
@@ -91,8 +91,6 @@ class ZbsUnit(Elaboratable):
         Method used for getting result of requested computation.
     """
 
-    optypes = ZbsFunction.get_op_types()
-
     def __init__(self, gen_params: GenParams):
         layouts = gen_params.get(FuncUnitLayouts)
 
@@ -129,4 +127,4 @@ class ZbsComponent(FunctionalComponentParams):
         return ZbsUnit(gen_params)
 
     def get_optypes(self) -> set[OpType]:
-        return ZbsUnit.optypes
+        return ZbsFunction.get_op_types()

--- a/coreblocks/fu/zbs.py
+++ b/coreblocks/fu/zbs.py
@@ -79,7 +79,7 @@ class Zbs(Elaboratable):
         return m
 
 
-class ZbsUnit(Elaboratable):
+class ZbsUnit(FuncUnit, Elaboratable):
     """
     Module responsible for executing Zbs instructions.
 

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -211,8 +211,6 @@ class LSUDummy(Elaboratable):
         Used to inform LSU that new instruction have been retired.
     """
 
-    optypes = {OpType.LOAD, OpType.STORE}
-
     def __init__(self, gen_params: GenParams, bus: WishboneMaster) -> None:
         """
         Parameters
@@ -294,4 +292,4 @@ class LSUBlockComponent(BlockComponentParams):
         return unit
 
     def get_optypes(self) -> set[OpType]:
-        return LSUDummy.optypes
+        return {OpType.LOAD, OpType.STORE}

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -186,7 +186,7 @@ class LSUDummyInternals(Elaboratable):
         return m
 
 
-class LSUDummy(Elaboratable):
+class LSUDummy(FuncBlock, Elaboratable):
     """
     Very simple LSU, which serializes all stores and loads.
     It isn't fully compliant with RiscV spec. Doesn't support checking if

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -37,5 +37,5 @@ class FunctionalComponentParams(ABC):
         raise NotImplementedError()
 
 
-def optypes_supported(block_components: Iterable[BlockComponentParams]) -> set["OpType"]:
-    return {optype for block in block_components for optype in block.get_optypes()}
+def optypes_supported(components: Iterable[BlockComponentParams | FunctionalComponentParams]) -> set["OpType"]:
+    return {optype for component in components for optype in component.get_optypes()}

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -361,7 +361,7 @@ class Scheduler(Elaboratable):
         rob_put: Method,
         rf_read1: Method,
         rf_read2: Method,
-        reservation_stations: Sequence[FuncBlock],
+        reservation_stations: Sequence[tuple[FuncBlock, set[OpType]]],
         gen_params: GenParams
     ):
         """
@@ -429,13 +429,13 @@ class Scheduler(Elaboratable):
         m.submodules.rs_selector = RSSelection(
             gen_params=self.gen_params,
             get_instr=reg_alloc_out_buf.read,
-            rs_select=[(rs.select, rs.optypes) for rs in self.rs],
+            rs_select=[(rs.select, optypes) for rs, optypes in self.rs],
             push_instr=rs_select_out_buf.write,
         )
 
         m.submodules.rs_insertion = RSInsertion(
             get_instr=rs_select_out_buf.read,
-            rs_insert=[rs.insert for rs in self.rs],
+            rs_insert=[rs.insert for rs, _ in self.rs],
             rf_read1=self.rf_read1,
             rf_read2=self.rf_read2,
             gen_params=self.gen_params,

--- a/coreblocks/stages/func_blocks_unifier.py
+++ b/coreblocks/stages/func_blocks_unifier.py
@@ -20,13 +20,13 @@ class FuncBlocksUnifier(Elaboratable):
         blocks: Iterable[BlockComponentParams],
         extra_methods_required: Iterable[UnifierKey],
     ):
-        self.rs_blocks = [block.get_module(gen_params) for block in blocks]
+        self.rs_blocks = [(block.get_module(gen_params), block.get_optypes()) for block in blocks]
         self.extra_methods_required = extra_methods_required
 
-        self.result_collector = Collector([block.get_result for block in self.rs_blocks])
+        self.result_collector = Collector([block.get_result for block, _ in self.rs_blocks])
         self.get_result = self.result_collector.method
 
-        self.update_combiner = MethodProduct([block.update for block in self.rs_blocks])
+        self.update_combiner = MethodProduct([block.update for block, _ in self.rs_blocks])
         self.update = self.update_combiner.method
 
         self.unifiers: dict[str, Unifier] = {}
@@ -48,7 +48,7 @@ class FuncBlocksUnifier(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        for n, unit in enumerate(self.rs_blocks):
+        for n, (unit, _) in enumerate(self.rs_blocks):
             m.submodules[f"rs_block_{n}"] = unit
 
         m.submodules["result_collector"] = self.result_collector

--- a/coreblocks/stages/rs_func_block.py
+++ b/coreblocks/stages/rs_func_block.py
@@ -12,7 +12,7 @@ from coreblocks.transactions.lib import Collector
 __all__ = ["RSFuncBlock", "RSBlockComponent"]
 
 
-class RSFuncBlock(Elaboratable):
+class RSFuncBlock(FuncBlock, Elaboratable):
     """
     Module combining multiple functional units with single RS unit. With
     input interface of RS and output interface of single FU.

--- a/coreblocks/stages/rs_func_block.py
+++ b/coreblocks/stages/rs_func_block.py
@@ -19,8 +19,6 @@ class RSFuncBlock(Elaboratable):
 
     Attributes
     ----------
-    optypes: set[OpType]
-        Set of `OpType`\\s supported by this unit.
     insert: Method
         RS insert method.
     select: Method
@@ -32,7 +30,7 @@ class RSFuncBlock(Elaboratable):
         layout described by `FuncUnitLayouts`.
     """
 
-    def __init__(self, gen_params: GenParams, func_units: Iterable[FuncUnit], rs_entries: int):
+    def __init__(self, gen_params: GenParams, func_units: Iterable[tuple[FuncUnit, set[OpType]]], rs_entries: int):
         """
         Parameters
         ----------
@@ -48,7 +46,6 @@ class RSFuncBlock(Elaboratable):
         self.fu_layouts = gen_params.get(FuncUnitLayouts)
         self.func_units = list(func_units)
         self.rs_entries = rs_entries
-        self.optypes = set.union(*(func_unit.optypes for func_unit in func_units))
 
         self.insert = Method(i=self.rs_layouts.insert_in)
         self.select = Method(o=self.rs_layouts.select_out)
@@ -61,10 +58,10 @@ class RSFuncBlock(Elaboratable):
         m.submodules.rs = self.rs = RS(
             gen_params=self.gen_params,
             rs_entries=self.rs_entries,
-            ready_for=(func_unit.optypes for func_unit in self.func_units),
+            ready_for=(optypes for _, optypes in self.func_units),
         )
 
-        for n, func_unit in enumerate(self.func_units):
+        for n, (func_unit, _) in enumerate(self.func_units):
             wakeup_select = WakeupSelect(
                 gen_params=self.gen_params,
                 get_ready=self.rs.get_ready_list[n],
@@ -74,7 +71,7 @@ class RSFuncBlock(Elaboratable):
             m.submodules[f"func_unit_{n}"] = func_unit
             m.submodules[f"wakeup_select_{n}"] = wakeup_select
 
-        m.submodules.collector = collector = Collector([func_unit.accept for func_unit in self.func_units])
+        m.submodules.collector = collector = Collector([func_unit.accept for func_unit, _ in self.func_units])
 
         self.insert.proxy(m, self.rs.insert)
         self.select.proxy(m, self.rs.select)
@@ -101,9 +98,9 @@ class RSBlockComponent(BlockComponentParams):
     rs_entries: int
 
     def get_module(self, gen_params: GenParams) -> FuncBlock:
-        modules = list(u.get_module(gen_params) for u in self.func_units)
+        modules = list((u.get_module(gen_params), u.get_optypes()) for u in self.func_units)
         rs_unit = RSFuncBlock(gen_params=gen_params, func_units=modules, rs_entries=self.rs_entries)
         return rs_unit
 
     def get_optypes(self) -> set[OpType]:
-        return {optype for unit in self.func_units for optype in unit.get_optypes()}
+        return optypes_supported(self.func_units)

--- a/coreblocks/structs_common/csr.py
+++ b/coreblocks/structs_common/csr.py
@@ -152,7 +152,7 @@ class CSRRegister(Elaboratable):
         return m
 
 
-class CSRUnit(Elaboratable):
+class CSRUnit(FuncBlock, Elaboratable):
     """
     Unit for performing Control and Status Regitsters computations.
 

--- a/coreblocks/structs_common/csr.py
+++ b/coreblocks/structs_common/csr.py
@@ -176,8 +176,6 @@ class CSRUnit(Elaboratable):
         to the next pipeline stage.
     """
 
-    optypes = {OpType.CSR_REG, OpType.CSR_IMM}
-
     def __init__(self, gen_params: GenParams, rob_single_instr: Signal):
         """
         Parameters
@@ -335,4 +333,4 @@ class CSRBlockComponent(BlockComponentParams):
         return unit
 
     def get_optypes(self) -> set[OpType]:
-        return CSRUnit.optypes
+        return {OpType.CSR_REG, OpType.CSR_IMM}

--- a/coreblocks/utils/protocols.py
+++ b/coreblocks/utils/protocols.py
@@ -2,7 +2,6 @@ from amaranth import *
 
 from typing import Protocol
 from coreblocks.transactions import Method
-from coreblocks.params import OpType
 from ._typing import HasElaborate
 
 
@@ -20,13 +19,11 @@ class Unifier(Protocol):
 
 
 class FuncUnit(HasElaborate, Protocol):
-    optypes: set[OpType]
     issue: Method
     accept: Method
 
 
 class FuncBlock(HasElaborate, Protocol):
-    optypes: set[OpType]
     insert: Method
     select: Method
     update: Method

--- a/test/fu/test_jb_unit.py
+++ b/test/fu/test_jb_unit.py
@@ -19,7 +19,6 @@ class JumpBranchWrapper(Elaboratable):
         self.jb = JumpBranchFuncUnit(GenParams(test_core_config))
         self.issue = self.jb.issue
         self.accept = Method(o=gen_params.get(FuncUnitLayouts).accept + gen_params.get(FetchLayouts).branch_verify)
-        self.optypes = set()
 
     def elaborate(self, platform):
         m = Module()
@@ -40,7 +39,7 @@ class JumpBranchWrapperComponent(FunctionalComponentParams):
         return JumpBranchWrapper(gen_params)
 
     def get_optypes(self) -> set[OpType]:
-        return JumpBranchFuncUnit.optypes
+        return JumpBranchFn.get_op_types()
 
 
 @staticmethod

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -42,10 +42,9 @@ class SchedulerTestCircuit(Elaboratable):
 
         # mocked RSFuncBlock
         class MockedRSFuncBlock(FuncBlock):
-            def __init__(self, select, insert, optypes):
+            def __init__(self, select, insert):
                 self.select = select
                 self.insert = insert
-                self.optypes = optypes
 
             update: Method
             get_result: Method
@@ -71,7 +70,7 @@ class SchedulerTestCircuit(Elaboratable):
             method_rs_insert.append(insert_adapter)
             self.rs_alloc.append(select_test)
             self.rs_insert.append(insert_test)
-            rs_blocks.append((MockedRSFuncBlock(alloc_adapter.iface, insert_adapter.iface, rs), rs))
+            rs_blocks.append((MockedRSFuncBlock(alloc_adapter.iface, insert_adapter.iface), rs))
 
             m.submodules[f"rs_alloc_{i}"] = self.rs_alloc[i]
             m.submodules[f"rs_insert_{i}"] = self.rs_insert[i]


### PR DESCRIPTION
I think I know one reason why @wojpok struggles so much with his task (#333). It's because our code has schizophrenia with regards to how supported optypes are reported from functional units and blocks. Initially, it was done through the units and blocks themselves; later, the `Component` classes were added for core configuration, which duplicate the same functionality. This PR cleans this up, by removing the `optype` attributes from functional units and blocks.

I also use the occasion to do another minor change: derive the functional units and blocks from the appropriate protocols. This improves readability and error checking a little.