### PR TITLE
Fix debug_signals method bug introduced in #334

### DIFF
--- a/coreblocks/stages/func_blocks_unifier.py
+++ b/coreblocks/stages/func_blocks_unifier.py
@@ -64,5 +64,5 @@ class FuncBlocksUnifier(Elaboratable):
         return {
             "get_result": self.get_result.debug_signals(),
             "update": self.update.debug_signals(),
-            "rs_blocks": {i: auto_debug_signals(b) for i, (b,_) in enumerate(self.rs_blocks)},
+            "rs_blocks": {i: auto_debug_signals(b) for i, (b, _) in enumerate(self.rs_blocks)},
         }

--- a/coreblocks/stages/func_blocks_unifier.py
+++ b/coreblocks/stages/func_blocks_unifier.py
@@ -64,5 +64,5 @@ class FuncBlocksUnifier(Elaboratable):
         return {
             "get_result": self.get_result.debug_signals(),
             "update": self.update.debug_signals(),
-            "rs_blocks": {i: auto_debug_signals(b) for i, b in enumerate(self.rs_blocks)},
+            "rs_blocks": {i: auto_debug_signals(b) for i, (b,_) in enumerate(self.rs_blocks)},
         }


### PR DESCRIPTION
I have found by coincidence, that #334 introduced a bug to `debug_signals` method and because of that core tests with traces failed. Here is a fix for that issue.

This case also show, that #316 is needed, so that problems with traces can be found before merge.