### PR TITLE
One-hot implementation change

### DIFF
--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -58,7 +58,7 @@ def OneHotSwitch(m: Module, test: Value):
             i = (n & -n).bit_length() - 1
             if n - (1 << i) != 0:
                 raise ValueError("%d not in one-hot representation" % n)
-            with m.Case("-" * (count - i - 1) + "1" + "-" * i):
+            with m.Case(n):
                 yield
 
     with m.Switch(test):

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -46,7 +46,6 @@ def OneHotSwitch(m: Module, test: Value):
     test : Signal
         The signal being tested.
     """
-    count = len(test)
 
     @contextmanager
     def case(n: Optional[int] = None):


### PR DESCRIPTION
In the current version of Amaranth we are using, the current implementation of one-hot multiplexers does not seem to generate them correctly on synthesis. However, somehow, plain switch does.

For now, I think that keeping our one-hot primitives is a good thing, if just for stating intention and error checking.