### PR TITLE
Add Dockerfile for RISCV toolchain

### DIFF
--- a/docker/riscv-toolchain.Dockerfile
+++ b/docker/riscv-toolchain.Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.10
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    autoconf automake autotools-dev curl python3 bc \
+    libmpc-dev libmpfr-dev libgmp-dev gawk build-essential \
+    bison flex texinfo gperf libtool patchutils zlib1g-dev \
+    libexpat-dev ninja-build git ca-certificates python-is-python3 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/riscv/riscv-gnu-toolchain && \
+    cd riscv-gnu-toolchain && \
+    git checkout 2023.05.14
+
+RUN cd riscv-gnu-toolchain && \
+    git submodule update --init --recursive
+
+RUN cd riscv-gnu-toolchain && \
+    ./configure --with-multilib-generator="rv32i-ilp32--a*zifence*zicsr;rv32im-ilp32--a*zifence*zicsr;rv32ic-ilp32--a*zifence*zicsr;rv32imc-ilp32--a*zifence*zicsr;rv32imfc-ilp32f--a*zifence" && \
+    make -j$(nproc)
+
+RUN rm -rf riscv-gnu-toolchain

--- a/docker/riscv-toolchain.Dockerfile
+++ b/docker/riscv-toolchain.Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && \
 RUN git clone https://github.com/riscv/riscv-gnu-toolchain && \
     cd riscv-gnu-toolchain && \
     git checkout 2023.05.14 && \
-    git submodule update --init --recursive && \
     ./configure --with-multilib-generator="rv32i-ilp32--a*zifence*zicsr;rv32im-ilp32--a*zifence*zicsr;rv32ic-ilp32--a*zifence*zicsr;rv32imc-ilp32--a*zifence*zicsr;rv32imfc-ilp32f--a*zifence" && \
     make -j$(nproc) && \
     cd / && rm -rf riscv-gnu-toolchain

--- a/docker/riscv-toolchain.Dockerfile
+++ b/docker/riscv-toolchain.Dockerfile
@@ -11,13 +11,8 @@ RUN apt-get update && \
 
 RUN git clone https://github.com/riscv/riscv-gnu-toolchain && \
     cd riscv-gnu-toolchain && \
-    git checkout 2023.05.14
-
-RUN cd riscv-gnu-toolchain && \
-    git submodule update --init --recursive
-
-RUN cd riscv-gnu-toolchain && \
+    git checkout 2023.05.14 && \
+    git submodule update --init --recursive && \
     ./configure --with-multilib-generator="rv32i-ilp32--a*zifence*zicsr;rv32im-ilp32--a*zifence*zicsr;rv32ic-ilp32--a*zifence*zicsr;rv32imc-ilp32--a*zifence*zicsr;rv32imfc-ilp32f--a*zifence" && \
-    make -j$(nproc)
-
-RUN rm -rf riscv-gnu-toolchain
+    make -j$(nproc) && \
+    cd / && rm -rf riscv-gnu-toolchain


### PR DESCRIPTION
So we can have an up-to-date toolchain with the standard library compiled for different extension subsets.

`rv32i-ilp32--a*zifence*zicsr;rv32im-ilp32--a*zifence*zicsr;rv32ic-ilp32--a*zifence*zicsr;rv32imc-ilp32--a*zifence*zicsr;rv32imfc-ilp32f--a*zifence` specifies that we want to build it for 5 architectures (each separated by `;`). `rv32i-ilp32--a*zifence*zicsr;` means we build a lib for arch `rv32i` with ABI `ilp32` and that the lib should be reused for architectures with `a`, `zifence`, `zicsr` extensions added (all combinations). 