### PR TITLE
Allow additional arguments in DependentCache

### DIFF
--- a/test/params/test_dependentcache.py
+++ b/test/params/test_dependentcache.py
@@ -5,7 +5,7 @@ from coreblocks.params.genparams import DependentCache
 
 class TestDependentCache(unittest.TestCase):
     class WithCache(DependentCache):
-        def __init__(self, x):
+        def __init__(self, x=1):
             super().__init__()
             self.x = x
 
@@ -16,6 +16,17 @@ class TestDependentCache(unittest.TestCase):
             self.__class__.count += 1
             self.x = wc.x
 
+    class CachedObjectWithArgs:
+        def __init__(self, wc, *, f, s):
+            self.wc = wc
+            self.f = f
+            self.s = s
+
+    class CachedObjectKwArgsOnly:
+        def __init__(self, *, f, s):
+            self.f = f
+            self.s = s
+
     def test_cache(self):
         count = TestDependentCache.CachedObject.count
         wc = TestDependentCache.WithCache(1)
@@ -24,3 +35,15 @@ class TestDependentCache(unittest.TestCase):
         obj2 = wc.get(TestDependentCache.CachedObject)
         self.assertEqual(TestDependentCache.CachedObject.count, count + 1)
         self.assertIs(obj, obj2)
+
+    def test_cache_kwargs(self):
+        wc = TestDependentCache.WithCache()
+        obj = wc.get(TestDependentCache.CachedObjectWithArgs, f=1, s=2)
+        self.assertEqual(obj.f, 1)
+        self.assertEqual(obj.s, 2)
+
+    def test_cache_kwargs_only(self):
+        wc = TestDependentCache.WithCache()
+        obj = wc.get(TestDependentCache.CachedObjectKwArgsOnly, f=1, s=2)
+        self.assertEqual(obj.f, 1)
+        self.assertEqual(obj.s, 2)


### PR DESCRIPTION
Allows to define keyword-only additional arguments in constructors of cached classes, without changing the old interface.
New cache entry will be created for each set of arguments for given class.
Additional arguments need to be specified each time `get` is called, allowing "parametrized" classes. 

Requirement for fix for RS layout issue (#280), which will depend on passing configurable width of Layout, that should also be accessed with cache.