### PR TITLE
Precommit

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -5,7 +5,7 @@ from coreblocks.stages.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.transactions.core import Transaction, TModule
 from coreblocks.transactions.lib import FIFO, ConnectTrans
 from coreblocks.params.layouts import *
-from coreblocks.params.keys import InstructionCommitKey, BranchResolvedKey, InstructionPrecommitKey, WishboneDataKey
+from coreblocks.params.keys import BranchResolvedKey, InstructionPrecommitKey, WishboneDataKey
 from coreblocks.params.genparams import GenParams
 from coreblocks.frontend.decode import Decode
 from coreblocks.structs_common.rat import FRAT, RRAT
@@ -61,7 +61,7 @@ class Core(Elaboratable):
         self.func_blocks_unifier = FuncBlocksUnifier(
             gen_params=gen_params,
             blocks=gen_params.func_units_config,
-            extra_methods_required=[InstructionPrecommitKey(), InstructionCommitKey(), BranchResolvedKey()],
+            extra_methods_required=[InstructionPrecommitKey(), BranchResolvedKey()],
         )
 
         self.announcement = ResultAnnouncement(
@@ -123,7 +123,6 @@ class Core(Elaboratable):
             free_rf_put=free_rf_fifo.write,
             rf_free=rf.free,
             precommit=self.func_blocks_unifier.get_extra_method(InstructionPrecommitKey()),
-            commit=self.func_blocks_unifier.get_extra_method(InstructionCommitKey()),
         )
 
         m.submodules.csr_generic = GenericCSRRegisters(self.gen_params)

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -5,7 +5,7 @@ from coreblocks.stages.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.transactions.core import Transaction, TModule
 from coreblocks.transactions.lib import FIFO, ConnectTrans
 from coreblocks.params.layouts import *
-from coreblocks.params.keys import InstructionCommitKey, BranchResolvedKey, WishboneDataKey
+from coreblocks.params.keys import InstructionCommitKey, BranchResolvedKey, InstructionPrecommitKey, WishboneDataKey
 from coreblocks.params.genparams import GenParams
 from coreblocks.frontend.decode import Decode
 from coreblocks.structs_common.rat import FRAT, RRAT
@@ -61,7 +61,7 @@ class Core(Elaboratable):
         self.func_blocks_unifier = FuncBlocksUnifier(
             gen_params=gen_params,
             blocks=gen_params.func_units_config,
-            extra_methods_required=[InstructionCommitKey(), BranchResolvedKey()],
+            extra_methods_required=[InstructionPrecommitKey(), InstructionCommitKey(), BranchResolvedKey()],
         )
 
         self.announcement = ResultAnnouncement(
@@ -117,11 +117,13 @@ class Core(Elaboratable):
         m.submodules.func_blocks_unifier = self.func_blocks_unifier
         m.submodules.retirement = Retirement(
             self.gen_params,
+            rob_peek=rob.peek,
             rob_retire=rob.retire,
             r_rat_commit=rrat.commit,
             free_rf_put=free_rf_fifo.write,
             rf_free=rf.free,
-            lsu_commit=self.func_blocks_unifier.get_extra_method(InstructionCommitKey()),
+            precommit=self.func_blocks_unifier.get_extra_method(InstructionPrecommitKey()),
+            commit=self.func_blocks_unifier.get_extra_method(InstructionCommitKey()),
         )
 
         m.submodules.csr_generic = GenericCSRRegisters(self.gen_params)

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -229,7 +229,7 @@ class LSUDummy(FuncBlock, Elaboratable):
         self.select = Method(o=self.lsu_layouts.rs_select_out)
         self.update = Method(i=self.lsu_layouts.rs_update_in)
         self.get_result = Method(o=self.fu_layouts.accept)
-        self.precommit = Method(i=self.lsu_layouts.precommit_in, o=self.lsu_layouts.precommit_out)
+        self.precommit = Method(i=self.lsu_layouts.precommit)
         self.commit = Method(i=self.lsu_layouts.commit)
 
         self.bus = bus
@@ -273,7 +273,7 @@ class LSUDummy(FuncBlock, Elaboratable):
 
         @def_method(m, self.precommit)
         def _(rob_id: Value):
-            return {"stall": 0}  # TODO: I/O reads
+            pass  # TODO: I/O reads
 
         @def_method(m, self.commit)
         def _(rob_id: Value):

--- a/coreblocks/params/dependencies.py
+++ b/coreblocks/params/dependencies.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from abc import ABCMeta, abstractmethod, ABC
+from abc import abstractmethod, ABC
 from collections.abc import Callable
 from typing import Any, Generic, TypeVar
 
@@ -84,15 +84,7 @@ class ListKey(Generic[T], DependencyKey[T, list[T]]):
         return data
 
 
-class UnifierKeyMeta(ABCMeta):
-    def __new__(cls, name, bases, classdict, unifier: Callable[[list[Method]], Unifier], **kwargs):
-        classdict["unifier"] = unifier
-        result = type.__new__(cls, name, bases, classdict, **kwargs)
-        return result
-
-
-class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]], metaclass=UnifierKeyMeta,
-                 unifier=lambda _, __: {}):
+class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
     """Base class for method unifier dependency keys.
 
     Method unifier dependency keys are used to collect methods to be called by
@@ -102,6 +94,10 @@ class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]], metac
     """
 
     unifier: Callable[[list[Method]], Unifier]
+
+    def __init_subclass__(cls, unifier: Callable[[list[Method]], Unifier], **kwargs) -> None:
+        cls.unifier = unifier
+        return super().__init_subclass__(**kwargs)
 
     def combine(self, data: list[Method]) -> tuple[Method, dict[str, Unifier]]:
         if len(data) == 1:

--- a/coreblocks/params/dependencies.py
+++ b/coreblocks/params/dependencies.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from abc import abstractmethod, ABC
+from collections.abc import Callable, Collection
 from typing import Any, Generic, TypeVar
 
 from coreblocks.transactions import Method
@@ -92,7 +93,7 @@ class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
     allows to customize the calling behavior.
     """
 
-    unifier: type[Unifier]
+    unifier: Callable[[Collection[Method]], Unifier]
 
     def combine(self, data: list[Method]) -> tuple[Method, dict[str, Unifier]]:
         if len(data) == 1:

--- a/coreblocks/params/keys.py
+++ b/coreblocks/params/keys.py
@@ -26,15 +26,8 @@ class ROBSingleKey(SimpleKey[Signal]):
     pass
 
 
-def precommit_combiner(m: TModule, vals: list[Record]):
-    return {"stall": Cat(val.stall for val in vals).any()}
-
-
-precommit_unifier = partial(MethodProduct, combiner=([("stall", 1)], precommit_combiner))
-
-
 @dataclass(frozen=True)
-class InstructionPrecommitKey(UnifierKey, unifier=precommit_unifier):
+class InstructionPrecommitKey(UnifierKey, unifier=MethodProduct):
     pass
 
 

--- a/coreblocks/params/keys.py
+++ b/coreblocks/params/keys.py
@@ -1,6 +1,9 @@
+from collections.abc import Callable
 from amaranth import *
 from dataclasses import dataclass, field
+from functools import partial
 from coreblocks.params.dependencies import SimpleKey, UnifierKey
+from coreblocks.transactions.core import Method, TModule
 from coreblocks.transactions.lib import MethodProduct, Collector
 from coreblocks.peripherals.wishbone import WishboneMaster
 from coreblocks.utils.protocols import Unifier
@@ -8,7 +11,9 @@ from coreblocks.utils.protocols import Unifier
 
 __all__ = [
     "WishboneDataKey",
+    "ROBSingleKey",
     "InstructionCommitKey",
+    "InstructionPrecommitKey",
     "BranchResolvedKey",
 ]
 
@@ -23,11 +28,25 @@ class ROBSingleKey(SimpleKey[Signal]):
     pass
 
 
+def precommit_combiner(m: TModule, vals: list[Record]):
+    return {"stall": Cat(val.stall for val in vals).any()}
+
+
+precommit_unifier = partial(MethodProduct, combiner=([("stall", 1)], precommit_combiner))
+
+
+@dataclass(frozen=True)
+class InstructionPrecommitKey(UnifierKey):
+    unifier: Callable[[list[Method]], Unifier] = field(
+        default=precommit_unifier, init=False
+    )
+
+
 @dataclass(frozen=True)
 class InstructionCommitKey(UnifierKey):
-    unifier: type[Unifier] = field(default=MethodProduct, init=False)
+    unifier: Callable[[list[Method]], Unifier] = field(default=MethodProduct, init=False)
 
 
 @dataclass(frozen=True)
 class BranchResolvedKey(UnifierKey):
-    unifier: type[Unifier] = field(default=Collector, init=False)
+    unifier: Callable[[list[Method]], Unifier] = field(default=Collector, init=False)

--- a/coreblocks/params/keys.py
+++ b/coreblocks/params/keys.py
@@ -6,7 +6,6 @@ from coreblocks.peripherals.wishbone import WishboneMaster
 
 __all__ = [
     "WishboneDataKey",
-    "InstructionCommitKey",
     "InstructionPrecommitKey",
     "BranchResolvedKey",
 ]
@@ -19,11 +18,6 @@ class WishboneDataKey(SimpleKey[WishboneMaster]):
 
 @dataclass(frozen=True)
 class InstructionPrecommitKey(UnifierKey, unifier=MethodProduct):
-    pass
-
-
-@dataclass(frozen=True)
-class InstructionCommitKey(UnifierKey, unifier=MethodProduct):
     pass
 
 

--- a/coreblocks/params/keys.py
+++ b/coreblocks/params/keys.py
@@ -1,12 +1,10 @@
-from collections.abc import Callable
 from amaranth import *
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from coreblocks.params.dependencies import SimpleKey, UnifierKey
-from coreblocks.transactions.core import Method, TModule
+from coreblocks.transactions.core import TModule
 from coreblocks.transactions.lib import MethodProduct, Collector
 from coreblocks.peripherals.wishbone import WishboneMaster
-from coreblocks.utils.protocols import Unifier
 
 
 __all__ = [
@@ -36,17 +34,15 @@ precommit_unifier = partial(MethodProduct, combiner=([("stall", 1)], precommit_c
 
 
 @dataclass(frozen=True)
-class InstructionPrecommitKey(UnifierKey):
-    unifier: Callable[[list[Method]], Unifier] = field(
-        default=precommit_unifier, init=False
-    )
+class InstructionPrecommitKey(UnifierKey, unifier=precommit_unifier):
+    pass
 
 
 @dataclass(frozen=True)
-class InstructionCommitKey(UnifierKey):
-    unifier: Callable[[list[Method]], Unifier] = field(default=MethodProduct, init=False)
+class InstructionCommitKey(UnifierKey, unifier=MethodProduct):
+    pass
 
 
 @dataclass(frozen=True)
-class BranchResolvedKey(UnifierKey):
-    unifier: Callable[[list[Method]], Unifier] = field(default=Collector, init=False)
+class BranchResolvedKey(UnifierKey, unifier=Collector):
+    pass

--- a/coreblocks/params/keys.py
+++ b/coreblocks/params/keys.py
@@ -1,15 +1,11 @@
-from amaranth import *
 from dataclasses import dataclass
-from functools import partial
 from coreblocks.params.dependencies import SimpleKey, UnifierKey
-from coreblocks.transactions.core import TModule
 from coreblocks.transactions.lib import MethodProduct, Collector
 from coreblocks.peripherals.wishbone import WishboneMaster
 
 
 __all__ = [
     "WishboneDataKey",
-    "ROBSingleKey",
     "InstructionCommitKey",
     "InstructionPrecommitKey",
     "BranchResolvedKey",
@@ -18,11 +14,6 @@ __all__ = [
 
 @dataclass(frozen=True)
 class WishboneDataKey(SimpleKey[WishboneMaster]):
-    pass
-
-
-@dataclass(frozen=True)
-class ROBSingleKey(SimpleKey[Signal]):
     pass
 
 

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -316,12 +316,8 @@ class LSULayouts:
 
         self.rs_update_in = rs_interface.update_in
 
-        self.precommit_in = [
+        self.precommit = [
             ("rob_id", gen_params.rob_entries_bits),
-        ]
-
-        self.precommit_out = [
-            ("stall", 1),
         ]
 
         self.commit = [

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -140,7 +140,7 @@ class ROBLayouts:
             ("done", 1),
         ]
 
-        self.retire_layout = [("rob_data", self.data_layout), ("rob_id", gen_params.rob_entries_bits)]
+        self.peek_layout = [("rob_data", self.data_layout), ("rob_id", gen_params.rob_entries_bits)]
 
 
 class RSInterfaceLayouts:
@@ -315,6 +315,14 @@ class LSULayouts:
         self.rs_select_out = rs_interface.select_out
 
         self.rs_update_in = rs_interface.update_in
+
+        self.precommit_in = [
+            ("rob_id", gen_params.rob_entries_bits),
+        ]
+
+        self.precommit_out = [
+            ("stall", 1),
+        ]
 
         self.commit = [
             ("rob_id", gen_params.rob_entries_bits),

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -168,6 +168,17 @@ class RSInterfaceLayouts:
         self.update_in = [("tag", gen_params.phys_regs_bits), ("value", gen_params.isa.xlen)]
 
 
+class RetirementLayouts:
+    def __init__(self, gen_params: GenParams):
+        self.precommit = [
+            ("rob_id", gen_params.rob_entries_bits),
+        ]
+
+        self.commit = [
+            ("rob_id", gen_params.rob_entries_bits),
+        ]
+
+
 class RSLayouts:
     def __init__(self, gen_params: GenParams):
         rs_interface = gen_params.get(RSInterfaceLayouts)
@@ -316,13 +327,11 @@ class LSULayouts:
 
         self.rs_update_in = rs_interface.update_in
 
-        self.precommit = [
-            ("rob_id", gen_params.rob_entries_bits),
-        ]
+        retirement = gen_params.get(RetirementLayouts)
 
-        self.commit = [
-            ("rob_id", gen_params.rob_entries_bits),
-        ]
+        self.precommit = retirement.precommit
+
+        self.commit = retirement.commit
 
 
 class CSRLayouts:
@@ -359,3 +368,7 @@ class CSRLayouts:
         self.rs_select_out = rs_interface.select_out
 
         self.rs_update_in = rs_interface.update_in
+
+        retirement = gen_params.get(RetirementLayouts)
+
+        self.precommit = retirement.precommit

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -177,10 +177,6 @@ class RetirementLayouts:
             ("rob_id", gen_params.rob_entries_bits),
         ]
 
-        self.commit = [
-            ("rob_id", gen_params.rob_entries_bits),
-        ]
-
 
 class RSLayouts:
     def __init__(self, gen_params: GenParams):
@@ -333,8 +329,6 @@ class LSULayouts:
         retirement = gen_params.get(RetirementLayouts)
 
         self.precommit = retirement.precommit
-
-        self.commit = retirement.commit
 
 
 class CSRLayouts:

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -140,7 +140,10 @@ class ROBLayouts:
             ("done", 1),
         ]
 
-        self.peek_layout = [("rob_data", self.data_layout), ("rob_id", gen_params.rob_entries_bits)]
+        self.peek_layout = self.retire_layout = [
+            ("rob_data", self.data_layout),
+            ("rob_id", gen_params.rob_entries_bits),
+        ]
 
 
 class RSInterfaceLayouts:

--- a/coreblocks/stages/retirement.py
+++ b/coreblocks/stages/retirement.py
@@ -43,8 +43,7 @@ class Retirement(Elaboratable):
                 self.precommit(m, rob_id=rob_entry.rob_id)
 
         with Transaction().body(m):
-            rob_entry = self.rob_peek(m)
-            self.rob_retire(m)
+            rob_entry = self.rob_retire(m)
 
             # set rl_dst -> rp_dst in R-RAT
             rat_out = self.r_rat_commit(m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rob_entry.rob_data.rp_dst)

--- a/coreblocks/stages/retirement.py
+++ b/coreblocks/stages/retirement.py
@@ -10,17 +10,21 @@ class Retirement(Elaboratable):
         self,
         gen_params: GenParams,
         *,
+        rob_peek: Method,
         rob_retire: Method,
         r_rat_commit: Method,
         free_rf_put: Method,
         rf_free: Method,
-        lsu_commit: Method
+        precommit: Method,
+        commit: Method
     ):
+        self.rob_peek = rob_peek
         self.rob_retire = rob_retire
         self.r_rat_commit = r_rat_commit
         self.free_rf_put = free_rf_put
         self.rf_free = rf_free
-        self.lsu_commit = lsu_commit
+        self.precommit = precommit
+        self.commit = commit
 
         self.instret_csr = DoubleCounterCSR(gen_params, CSRAddress.INSTRET, CSRAddress.INSTRETH)
 
@@ -30,18 +34,22 @@ class Retirement(Elaboratable):
         m.submodules.instret_csr = self.instret_csr
 
         with Transaction().body(m):
-            rob_entry = self.rob_retire(m)
+            rob_entry = self.rob_peek(m)
+            stall = self.precommit(m, rob_id=rob_entry.rob_id)
 
-            # set rl_dst -> rp_dst in R-RAT
-            rat_out = self.r_rat_commit(m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rob_entry.rob_data.rp_dst)
+            with m.If(~stall.stall):
+                self.rob_retire(m)
 
-            self.rf_free(m, rat_out.old_rp_dst)
-            self.lsu_commit(m, rob_id=rob_entry.rob_id)
+                # set rl_dst -> rp_dst in R-RAT
+                rat_out = self.r_rat_commit(m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rob_entry.rob_data.rp_dst)
 
-            # put old rp_dst to free RF list
-            with m.If(rat_out.old_rp_dst):  # don't put rp0 to free list - reserved to no-return instructions
-                self.free_rf_put(m, rat_out.old_rp_dst)
+                self.rf_free(m, rat_out.old_rp_dst)
+                self.commit(m, rob_id=rob_entry.rob_id)
 
-            self.instret_csr.increment(m)
+                # put old rp_dst to free RF list
+                with m.If(rat_out.old_rp_dst):  # don't put rp0 to free list - reserved to no-return instructions
+                    self.free_rf_put(m, rat_out.old_rp_dst)
+
+                self.instret_csr.increment(m)
 
         return m

--- a/coreblocks/structs_common/csr.py
+++ b/coreblocks/structs_common/csr.py
@@ -8,7 +8,7 @@ from coreblocks.params.dependencies import DependencyManager, ListKey
 from coreblocks.params.fu_params import BlockComponentParams
 from coreblocks.params.layouts import FetchLayouts, FuncUnitLayouts, CSRLayouts
 from coreblocks.params.isa import BitEnum, Funct3
-from coreblocks.params.keys import BranchResolvedKey, ROBSingleKey
+from coreblocks.params.keys import BranchResolvedKey, InstructionPrecommitKey
 from coreblocks.params.optypes import OpType
 from coreblocks.utils.protocols import FuncBlock
 
@@ -176,21 +176,18 @@ class CSRUnit(FuncBlock, Elaboratable):
         to the next pipeline stage.
     """
 
-    def __init__(self, gen_params: GenParams, rob_single_instr: Signal):
+    def __init__(self, gen_params: GenParams):
         """
         Parameters
         ----------
         gen_params: GenParams
             Core generation parameters.
-        rob_single_instr: Signal, in
-            Signalls that there is only one instruction left in `ROB`.
         fetch_continue: Method
             Method to resume `Fetch` unit from stalled PC.
         """
         self.gen_params = gen_params
         self.dependency_manager = gen_params.get(DependencyManager)
 
-        self.rob_empty = rob_single_instr
         self.fetch_continue = Method(o=gen_params.get(FetchLayouts).branch_verify)
 
         # Standard RS interface
@@ -200,6 +197,7 @@ class CSRUnit(FuncBlock, Elaboratable):
         self.insert = Method(i=self.csr_layouts.rs_insert_in)
         self.update = Method(i=self.csr_layouts.rs_update_in)
         self.get_result = Method(o=self.fu_layouts.accept)
+        self.precommit = Method(i=self.csr_layouts.precommit)
 
         self.regfile: dict[int, tuple[Method, Method]] = {}
 
@@ -219,12 +217,13 @@ class CSRUnit(FuncBlock, Elaboratable):
         ready_to_process = Signal()
         done = Signal()
         accepted = Signal()
+        rob_sfx_empty = Signal()
 
         current_result = Signal(self.gen_params.isa.xlen)
 
         instr = Record(self.csr_layouts.rs_data_layout + [("valid", 1)])
 
-        m.d.comb += ready_to_process.eq(self.rob_empty & instr.valid & (instr.rp_s1 == 0))
+        m.d.comb += ready_to_process.eq(rob_sfx_empty & instr.valid & (instr.rp_s1 == 0))
 
         # RISCV Zicsr spec Table 1.1
         should_read_csr = Signal()
@@ -321,15 +320,20 @@ class CSRUnit(FuncBlock, Elaboratable):
         def _():
             return {"next_pc": instr.pc + self.gen_params.isa.ilen_bytes}
 
+        # Generate rob_sfx_empty signal from precommit
+        @def_method(m, self.precommit)
+        def _(rob_id):
+            m.d.comb += rob_sfx_empty.eq(instr.rob_id == rob_id)
+
         return m
 
 
 class CSRBlockComponent(BlockComponentParams):
     def get_module(self, gen_params: GenParams) -> FuncBlock:
         connections = gen_params.get(DependencyManager)
-        rob_single = connections.get_dependency(ROBSingleKey())
-        unit = CSRUnit(gen_params, rob_single)
+        unit = CSRUnit(gen_params)
         connections.add_dependency(BranchResolvedKey(), unit.fetch_continue)
+        connections.add_dependency(InstructionPrecommitKey(), unit.precommit)
         return unit
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/structs_common/rob.py
+++ b/coreblocks/structs_common/rob.py
@@ -12,7 +12,7 @@ class ReorderBuffer(Elaboratable):
         self.put = Method(i=layouts.data_layout, o=layouts.id_layout)
         self.mark_done = Method(i=layouts.id_layout)
         self.peek = Method(o=layouts.peek_layout, nonexclusive=True)
-        self.retire = Method()
+        self.retire = Method(o=layouts.retire_layout)
         self.data = Array(Record(layouts.internal_layout) for _ in range(2**gen_params.rob_entries_bits))
 
     def elaborate(self, platform):
@@ -32,6 +32,9 @@ class ReorderBuffer(Elaboratable):
         def _():
             m.d.sync += start_idx.eq(start_idx + 1)
             m.d.sync += self.data[start_idx].done.eq(0)
+            # TODO: because of a problem with mocking nonexclusive methods,
+            # retire replicates functionality of peek
+            return {"rob_data": self.data[start_idx].rob_data, "rob_id": start_idx}
 
         @def_method(m, self.put, ready=put_possible)
         def _(arg):

--- a/coreblocks/structs_common/rob.py
+++ b/coreblocks/structs_common/rob.py
@@ -1,8 +1,6 @@
 from amaranth import *
 from ..transactions import Method, def_method, TModule
 from ..params import GenParams, ROBLayouts
-from ..params.dependencies import DependencyManager
-from ..params.keys import ROBSingleKey
 
 __all__ = ["ReorderBuffer"]
 
@@ -16,9 +14,6 @@ class ReorderBuffer(Elaboratable):
         self.peek = Method(o=layouts.peek_layout, nonexclusive=True)
         self.retire = Method()
         self.data = Array(Record(layouts.internal_layout) for _ in range(2**gen_params.rob_entries_bits))
-        self.single_entry = Signal()
-        connections = gen_params.get(DependencyManager)
-        connections.add_dependency(ROBSingleKey(), self.single_entry)
 
     def elaborate(self, platform):
         m = TModule()
@@ -28,8 +23,6 @@ class ReorderBuffer(Elaboratable):
 
         peek_possible = start_idx != end_idx
         put_possible = (end_idx + 1)[0 : len(end_idx)] != start_idx
-
-        m.d.comb += self.single_entry.eq((start_idx + 1)[0 : len(start_idx)] == end_idx)
 
         @def_method(m, self.peek, ready=peek_possible)
         def _():

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -87,7 +87,7 @@ class DummyLSUTestCircuit(Elaboratable):
         m.submodules.insert_mock = self.insert = TestbenchIO(AdapterTrans(func_unit.insert))
         m.submodules.update_mock = self.update = TestbenchIO(AdapterTrans(func_unit.update))
         m.submodules.get_result_mock = self.get_result = TestbenchIO(AdapterTrans(func_unit.get_result))
-        m.submodules.commit_mock = self.commit = TestbenchIO(AdapterTrans(func_unit.commit))
+        m.submodules.precommit_mock = self.precommit = TestbenchIO(AdapterTrans(func_unit.precommit))
         self.io_in = WishboneInterfaceWrapper(self.bus.wbMaster)
         m.submodules.bus = self.bus
         return m
@@ -318,7 +318,7 @@ class TestDummyLSUStores(TestCaseWithSimulator):
         self.announce_queue = deque()
         self.mem_data_queue = deque()
         self.get_result_data = deque()
-        self.commit_data = deque()
+        self.precommit_data = deque()
         self.generate_instr(2**7, 2**7)
 
     def random_wait(self):
@@ -352,6 +352,7 @@ class TestDummyLSUStores(TestCaseWithSimulator):
             ret = yield from self.test_module.select.call()
             self.assertEqual(ret["rs_entry_id"], 0)
             yield from self.test_module.insert.call(rs_data=req, rs_entry_id=0)
+            self.precommit_data.appendleft(req["rob_id"])
             announc = self.announce_queue.pop()
             for j in range(2):
                 if announc[j] is not None:
@@ -363,21 +364,20 @@ class TestDummyLSUStores(TestCaseWithSimulator):
         for i in range(self.tests_number):
             v = yield from self.test_module.get_result.call()
             rob_id = self.get_result_data.pop()
-            self.commit_data.appendleft(rob_id)
             self.assertEqual(v["rob_id"], rob_id)
             self.assertEqual(v["rp_dst"], 0)
             yield from self.random_wait()
 
-    def commiter(self):
+    def precommiter(self):
         for i in range(self.tests_number):
-            while len(self.commit_data) == 0:
+            while len(self.precommit_data) == 0:
                 yield
-            rob_id = self.commit_data.pop()
-            yield from self.test_module.commit.call(rob_id=rob_id)
+            rob_id = self.precommit_data.pop()
+            yield from self.test_module.precommit.call(rob_id=rob_id)
 
     def test(self):
         with self.run_simulation(self.test_module) as sim:
             sim.add_sync_process(self.wishbone_slave)
             sim.add_sync_process(self.inserter)
             sim.add_sync_process(self.get_resulter)
-            sim.add_sync_process(self.commiter)
+            sim.add_sync_process(self.precommiter)

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -33,8 +33,6 @@ class RetirementTestCircuit(Elaboratable):
 
         m.submodules.mock_rf_free = self.mock_rf_free = TestbenchIO(Adapter(i=rf_layouts.rf_free))
 
-        m.submodules.mock_lsu_commit = self.mock_lsu_commit = TestbenchIO(Adapter(i=lsu_layouts.commit))
-
         m.submodules.mock_lsu_precommit = self.mock_lsu_precommit = TestbenchIO(Adapter(i=lsu_layouts.precommit))
 
         m.submodules.retirement = self.retirement = Retirement(
@@ -44,7 +42,6 @@ class RetirementTestCircuit(Elaboratable):
             r_rat_commit=self.rat.commit,
             free_rf_put=self.free_rf.write,
             rf_free=self.mock_rf_free.adapter.iface,
-            commit=self.mock_lsu_commit.adapter.iface,
             precommit=self.mock_lsu_precommit.adapter.iface,
         )
 
@@ -123,10 +120,6 @@ class RetirementTest(TestCaseWithSimulator):
         def lsu_precommit_process(rob_id):
             self.assertEqual(rob_id, self.lsu_precommit_q.popleft())
 
-        @def_method_mock(lambda: retc.mock_lsu_commit, sched_prio=2)
-        def lsu_commit_process(rob_id):
-            self.assertEqual(rob_id, self.lsu_commit_q.popleft())
-
         with self.run_simulation(retc) as sim:
             sim.add_sync_process(retire_process)
             sim.add_sync_process(peek_process)
@@ -134,4 +127,3 @@ class RetirementTest(TestCaseWithSimulator):
             sim.add_sync_process(rat_process)
             sim.add_sync_process(rf_free_process)
             sim.add_sync_process(lsu_precommit_process)
-            sim.add_sync_process(lsu_commit_process)

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -58,7 +58,6 @@ class RetirementTest(TestCaseWithSimulator):
         self.submit_q = deque()
         self.rf_free_q = deque()
         self.precommit_q = deque()
-        self.lsu_commit_q = deque()
 
         random.seed(8)
         self.cycles = 256
@@ -76,7 +75,6 @@ class RetirementTest(TestCaseWithSimulator):
                 rat_state[rl] = rp
                 self.rat_map_q.append({"rl_dst": rl, "rp_dst": rp})
                 self.submit_q.append({"rob_data": {"rl_dst": rl, "rp_dst": rp}, "rob_id": rob_id})
-                self.lsu_commit_q.append(rob_id)
                 self.precommit_q.append(rob_id)
             # note: overwriting with the same rp or having duplicate nonzero rps in rat shouldn't happen in reality
             # (and the retirement code doesn't have any special behaviour to handle these cases), but in this simple

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -15,7 +15,7 @@ class RetirementTestCircuit(Elaboratable):
         self.gen_params = gen_params
 
     def elaborate(self, platform):
-        m = Module()
+        m = TModule()
 
         rob_layouts = self.gen_params.get(ROBLayouts)
         rf_layouts = self.gen_params.get(RFLayouts)
@@ -27,19 +27,25 @@ class RetirementTestCircuit(Elaboratable):
             scheduler_layouts.free_rf_layout, 2**self.gen_params.phys_regs_bits
         )
 
+        m.submodules.mock_rob_peek = self.mock_rob_peek = TestbenchIO(Adapter(o=rob_layouts.peek_layout))
+
         m.submodules.mock_rob_retire = self.mock_rob_retire = TestbenchIO(Adapter(o=rob_layouts.retire_layout))
 
         m.submodules.mock_rf_free = self.mock_rf_free = TestbenchIO(Adapter(i=rf_layouts.rf_free))
 
         m.submodules.mock_lsu_commit = self.mock_lsu_commit = TestbenchIO(Adapter(i=lsu_layouts.commit))
 
+        m.submodules.mock_lsu_precommit = self.mock_lsu_precommit = TestbenchIO(Adapter(i=lsu_layouts.precommit))
+
         m.submodules.retirement = self.retirement = Retirement(
             self.gen_params,
             rob_retire=self.mock_rob_retire.adapter.iface,
+            rob_peek=self.mock_rob_peek.adapter.iface,
             r_rat_commit=self.rat.commit,
             free_rf_put=self.free_rf.write,
             rf_free=self.mock_rf_free.adapter.iface,
-            lsu_commit=self.mock_lsu_commit.adapter.iface,
+            commit=self.mock_lsu_commit.adapter.iface,
+            precommit=self.mock_lsu_precommit.adapter.iface,
         )
 
         m.submodules.free_rf_fifo_adapter = self.free_rf_adapter = TestbenchIO(AdapterTrans(self.free_rf.read))
@@ -54,6 +60,7 @@ class RetirementTest(TestCaseWithSimulator):
         self.rat_map_q = deque()
         self.submit_q = deque()
         self.rf_free_q = deque()
+        self.lsu_precommit_q = deque()
         self.lsu_commit_q = deque()
 
         random.seed(8)
@@ -73,6 +80,7 @@ class RetirementTest(TestCaseWithSimulator):
                 self.rat_map_q.append({"rl_dst": rl, "rp_dst": rp})
                 self.submit_q.append({"rob_data": {"rl_dst": rl, "rp_dst": rp}, "rob_id": rob_id})
                 self.lsu_commit_q.append(rob_id)
+                self.lsu_precommit_q.append(rob_id)
             # note: overwriting with the same rp or having duplicate nonzero rps in rat shouldn't happen in reality
             # (and the retirement code doesn't have any special behaviour to handle these cases), but in this simple
             # test we don't care to make sure that the randomly generated inputs are correct in this way.
@@ -80,9 +88,14 @@ class RetirementTest(TestCaseWithSimulator):
     def test_rand(self):
         retc = RetirementTestCircuit(self.gen_params)
 
-        @def_method_mock(lambda: retc.mock_rob_retire, enable=lambda: bool(self.submit_q))
-        def submit_process():
+        @def_method_mock(lambda: retc.mock_rob_retire, enable=lambda: bool(self.submit_q), sched_prio=1)
+        def retire_process():
             return self.submit_q.popleft()
+
+        # TODO: mocking really seems to dislike nonexclusive methods for some reason
+        @def_method_mock(lambda: retc.mock_rob_peek, enable=lambda: bool(self.submit_q))
+        def peek_process():
+            return self.submit_q[0]
 
         def free_reg_process():
             while self.rf_exp_q:
@@ -102,17 +115,23 @@ class RetirementTest(TestCaseWithSimulator):
             self.assertFalse(self.submit_q)
             self.assertFalse(self.rf_free_q)
 
-        @def_method_mock(lambda: retc.mock_rf_free, sched_prio=1)
+        @def_method_mock(lambda: retc.mock_rf_free, sched_prio=2)
         def rf_free_process(reg_id):
             self.assertEqual(reg_id, self.rf_free_q.popleft())
 
-        @def_method_mock(lambda: retc.mock_lsu_commit, sched_prio=1)
+        @def_method_mock(lambda: retc.mock_lsu_precommit, sched_prio=2)
+        def lsu_precommit_process(rob_id):
+            self.assertEqual(rob_id, self.lsu_precommit_q.popleft())
+
+        @def_method_mock(lambda: retc.mock_lsu_commit, sched_prio=2)
         def lsu_commit_process(rob_id):
             self.assertEqual(rob_id, self.lsu_commit_q.popleft())
 
         with self.run_simulation(retc) as sim:
-            sim.add_sync_process(submit_process)
+            sim.add_sync_process(retire_process)
+            sim.add_sync_process(peek_process)
             sim.add_sync_process(free_reg_process)
             sim.add_sync_process(rat_process)
             sim.add_sync_process(rf_free_process)
+            sim.add_sync_process(lsu_precommit_process)
             sim.add_sync_process(lsu_commit_process)

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -15,7 +15,7 @@ class RetirementTestCircuit(Elaboratable):
         self.gen_params = gen_params
 
     def elaborate(self, platform):
-        m = TModule()
+        m = Module()
 
         rob_layouts = self.gen_params.get(ROBLayouts)
         rf_layouts = self.gen_params.get(RFLayouts)

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -19,14 +19,13 @@ class CSRUnitTestCircuit(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        self.rob_single_insn = Signal()
-
-        m.submodules.dut = self.dut = CSRUnit(self.gen_params, self.rob_single_insn)
+        m.submodules.dut = self.dut = CSRUnit(self.gen_params)
 
         m.submodules.select = self.select = TestbenchIO(AdapterTrans(self.dut.select))
         m.submodules.insert = self.insert = TestbenchIO(AdapterTrans(self.dut.insert))
         m.submodules.update = self.update = TestbenchIO(AdapterTrans(self.dut.update))
         m.submodules.accept = self.accept = TestbenchIO(AdapterTrans(self.dut.get_result))
+        m.submodules.precommit = self.precommit = TestbenchIO(AdapterTrans(self.dut.precommit))
 
         m.submodules.fetch_continue = self.fetch_continue = TestbenchIO(AdapterTrans(self.dut.fetch_continue))
 
@@ -112,7 +111,6 @@ class TestCSRUnit(TestCaseWithSimulator):
         yield from self.dut.fetch_continue.enable()
         for _ in range(self.cycles):
             yield from self.random_wait()
-            yield self.dut.rob_single_insn.eq(0)
 
             op = yield from self.generate_instruction()
 
@@ -125,7 +123,7 @@ class TestCSRUnit(TestCaseWithSimulator):
                 yield from self.dut.update.call(tag=op["exp"]["rs1"]["rp_s1"], value=op["exp"]["rs1"]["value"])
 
             yield from self.random_wait()
-            yield self.dut.rob_single_insn.eq(1)
+            yield from self.dut.precommit.call()
 
             yield from self.random_wait()
             res = yield from self.dut.accept.call()

--- a/test/structs_common/test_reorder_buffer.py
+++ b/test/structs_common/test_reorder_buffer.py
@@ -48,16 +48,14 @@ class TestReorderBuffer(TestCaseWithSimulator):
                 self.assertEqual(is_ready, 0)  # transaction should not be ready if there is nothing to retire
             else:
                 regs, rob_id_exp = self.retire_queue.get()
-                results = yield from self.m.retire.call()
+                results = yield from self.m.peek.call()
+                yield from self.m.retire.call()
                 phys_reg = results["rob_data"]["rp_dst"]
                 self.assertEqual(rob_id_exp, results["rob_id"])
                 self.assertIn(phys_reg, self.executed_list)
                 self.executed_list.remove(phys_reg)
 
                 yield Settle()
-                self.assertEqual(
-                    (yield self.m._dut.single_entry), len(self.executed_list) + len(self.to_execute_list) == 1
-                )
                 self.assertEqual(results["rob_data"], regs)
                 self.regs_left_queue.put(phys_reg)
 


### PR DESCRIPTION
This PR introduces precommit to the retirement stage. It signals to functional blocks that an instruction is first to be committed. This is done independent of the completion of the instruction, so that side effects can start processing on precommit. Currently, the intended users are the CSR and LSU functional blocks.

Below is the original description of the PR.

In reference to the discussion in #351, here is a simple, quick-and-dirty proposal for adding precommits to the retirement stage, which allows to stall the retirement stage (e.g. because the instruction needs to perform a side effect to be committed). I imagine that this could be useful for LSU and CSR. This is not the only possible implementation, ~another way would be to call the precommit method once (here, it returns a stall flag), and have the commit method locked until side effects are performed~ edit: locking commit method is a bad idea, as this would basically lock instructions from other FUs as well.

A discussion is welcome.

Edit: slipped a ~metaclass~ `__init_subclass__` to UnifierKey to make the subclass declarations look less noisy, sorry. I can move it to another PR later if nobody objects.

Edit: @piotro888 made me realize the implementation here is not what I wanted, ~I'll prepare a modified one later~ I made necessary modifications.