### PR TITLE
Nicer UnifierKey

### DIFF
--- a/coreblocks/params/dependencies.py
+++ b/coreblocks/params/dependencies.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from abc import ABCMeta, abstractmethod, ABC
+from abc import abstractmethod, ABC
 from collections.abc import Callable
 from typing import Any, Generic, TypeVar
 
@@ -84,15 +84,7 @@ class ListKey(Generic[T], DependencyKey[T, list[T]]):
         return data
 
 
-class UnifierKeyMeta(ABCMeta):
-    def __new__(cls, name, bases, classdict, unifier: Callable[[list[Method]], Unifier], **kwargs):
-        classdict["unifier"] = unifier
-        result = type.__new__(cls, name, bases, classdict, **kwargs)
-        return result
-
-
-class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]], metaclass=UnifierKeyMeta,
-                 unifier=lambda _, __: {}):
+class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
     """Base class for method unifier dependency keys.
 
     Method unifier dependency keys are used to collect methods to be called by
@@ -102,6 +94,10 @@ class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]], metac
     """
 
     unifier: Callable[[list[Method]], Unifier]
+
+    def __init_subclass__(cls, unifier: Callable[[list[Method]], Unifier], **kwargs) -> None:
+        cls.unifier = unifier
+        return super().__init_subclass__(**kwargs)
 
     def combine(self, data: list[Method]) -> tuple[Method, dict[str, Unifier]]:
         if len(data) == 1:

--- a/coreblocks/params/dependencies.py
+++ b/coreblocks/params/dependencies.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
-from abc import abstractmethod, ABC
+from abc import ABCMeta, abstractmethod, ABC
+from collections.abc import Callable
 from typing import Any, Generic, TypeVar
 
 from coreblocks.transactions import Method
@@ -83,7 +84,15 @@ class ListKey(Generic[T], DependencyKey[T, list[T]]):
         return data
 
 
-class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
+class UnifierKeyMeta(ABCMeta):
+    def __new__(cls, name, bases, classdict, unifier: Callable[[list[Method]], Unifier], **kwargs):
+        classdict["unifier"] = unifier
+        result = type.__new__(cls, name, bases, classdict, **kwargs)
+        return result
+
+
+class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]], metaclass=UnifierKeyMeta,
+                 unifier=lambda _, __: {}):
     """Base class for method unifier dependency keys.
 
     Method unifier dependency keys are used to collect methods to be called by
@@ -92,7 +101,7 @@ class UnifierKey(DependencyKey[Method, tuple[Method, dict[str, Unifier]]]):
     allows to customize the calling behavior.
     """
 
-    unifier: type[Unifier]
+    unifier: Callable[[list[Method]], Unifier]
 
     def combine(self, data: list[Method]) -> tuple[Method, dict[str, Unifier]]:
         if len(data) == 1:

--- a/coreblocks/params/keys.py
+++ b/coreblocks/params/keys.py
@@ -1,9 +1,8 @@
 from amaranth import *
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from coreblocks.params.dependencies import SimpleKey, UnifierKey
 from coreblocks.transactions.lib import MethodProduct, Collector
 from coreblocks.peripherals.wishbone import WishboneMaster
-from coreblocks.utils.protocols import Unifier
 
 
 __all__ = [
@@ -24,10 +23,10 @@ class ROBSingleKey(SimpleKey[Signal]):
 
 
 @dataclass(frozen=True)
-class InstructionCommitKey(UnifierKey):
-    unifier: type[Unifier] = field(default=MethodProduct, init=False)
+class InstructionCommitKey(UnifierKey, unifier=MethodProduct):
+    pass
 
 
 @dataclass(frozen=True)
-class BranchResolvedKey(UnifierKey):
-    unifier: type[Unifier] = field(default=Collector, init=False)
+class BranchResolvedKey(UnifierKey, unifier=Collector):
+    pass


### PR DESCRIPTION
This PR uses `__init_subclass__` to make the `UnifierKey` definitions simpler. Also, unifier type is generalized.