### PR TITLE
Parametrize rs_entries in RSLayouts

### DIFF
--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -284,6 +284,8 @@ class LSUDummy(FuncBlock, Elaboratable):
 
 
 class LSUBlockComponent(BlockComponentParams):
+    rs_entries = 1
+
     def get_module(self, gen_params: GenParams) -> FuncBlock:
         connections = gen_params.get(DependencyManager)
         wb_master = connections.get_dependency(WishboneDataKey())

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -284,8 +284,6 @@ class LSUDummy(FuncBlock, Elaboratable):
 
 
 class LSUBlockComponent(BlockComponentParams):
-    rs_entries = 1
-
     def get_module(self, gen_params: GenParams) -> FuncBlock:
         connections = gen_params.get(DependencyManager)
         wb_master = connections.get_dependency(WishboneDataKey())
@@ -295,3 +293,6 @@ class LSUBlockComponent(BlockComponentParams):
 
     def get_optypes(self) -> set[OpType]:
         return {OpType.LOAD, OpType.STORE}
+
+    def get_rs_entry_count(self) -> int:
+        return 1

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -96,7 +96,7 @@ tiny_core_config = CoreConfiguration(
 full_core_config = CoreConfiguration(
     func_units_config=(
         RSBlockComponent([ALUComponent(zba_enable=True), ShiftUnitComponent(), JumpComponent()], rs_entries=4),
-        RSBlockComponent([MulComponent(mul_unit_type=MulType.SEQUENCE_MUL)], rs_entries=4),
+        RSBlockComponent([MulComponent(mul_unit_type=MulType.SEQUENCE_MUL)], rs_entries=2),
         LSUBlockComponent(),
         CSRBlockComponent(),
     ),

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -29,6 +29,10 @@ class BlockComponentParams(ABC):
     def get_optypes(self) -> set["OpType"]:
         raise NotImplementedError()
 
+    @abstractmethod
+    def get_rs_entry_count(self) -> int:
+        raise NotImplementedError()
+
 
 class FunctionalComponentParams(ABC):
     @abstractmethod

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -93,7 +93,7 @@ class GenParams(DependentCache):
         # if not optypes_required_by_extensions(self.isa.extensions) <= optypes_supported(func_units_config):
         #     raise Exception(f"Functional unit configuration fo not support all extension required by{isa_str}")
 
-        self.rs_entries = 1
+        self.max_rs_entries = 1
 
         @runtime_checkable
         class HasRSEntries(Protocol):
@@ -101,11 +101,11 @@ class GenParams(DependentCache):
 
         for block in self.func_units_config:
             if isinstance(block, HasRSEntries):
-                self.rs_entries = max(self.rs_entries, block.rs_entries)
+                self.max_rs_entries = max(self.max_rs_entries, block.rs_entries)
 
         self.rs_number_bits = (len(self.func_units_config) - 1).bit_length()
 
         self.phys_regs_bits = cfg.phys_regs_bits
         self.rob_entries_bits = cfg.rob_entries_bits
-        self.rs_entries_bits = (self.rs_entries - 1).bit_length()
+        self.max_rs_entries_bits = (self.max_rs_entries - 1).bit_length()
         self.start_pc = cfg.start_pc

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypeVar, Type, Protocol, runtime_checkable, Any
+from typing import TypeVar, Type, Any
 from amaranth.utils import log2_int
 
 from .isa import ISA, gen_isa_string
@@ -95,13 +95,8 @@ class GenParams(DependentCache):
 
         self.max_rs_entries = 1
 
-        @runtime_checkable
-        class HasRSEntries(Protocol):
-            rs_entries: int
-
         for block in self.func_units_config:
-            if isinstance(block, HasRSEntries):
-                self.max_rs_entries = max(self.max_rs_entries, block.rs_entries)
+            self.max_rs_entries = max(self.max_rs_entries, block.get_rs_entry_count())
 
         self.rs_number_bits = (len(self.func_units_config) - 1).bit_length()
 

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -95,7 +95,7 @@ class SchedulerLayouts:
             ("regs_p", common.regs_p),
             ("rob_id", gen_params.rob_entries_bits),
             ("rs_selected", gen_params.rs_number_bits),
-            ("rs_entry_id", gen_params.rs_entries_bits),
+            ("rs_entry_id", gen_params.max_rs_entries_bits),
             ("imm", gen_params.isa.xlen),
             ("csr", gen_params.isa.csr_alen),
             ("pc", gen_params.isa.xlen),
@@ -144,7 +144,7 @@ class ROBLayouts:
 
 
 class RSInterfaceLayouts:
-    def __init__(self, gen_params: GenParams):
+    def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         common = gen_params.get(CommonLayouts)
         self.data_layout = [
             ("rp_s1", gen_params.phys_regs_bits),
@@ -161,16 +161,16 @@ class RSInterfaceLayouts:
             ("pc", gen_params.isa.xlen),
         ]
 
-        self.select_out = [("rs_entry_id", gen_params.rs_entries_bits)]
+        self.select_out = [("rs_entry_id", rs_entries_bits)]
 
-        self.insert_in = [("rs_data", self.data_layout), ("rs_entry_id", gen_params.rs_entries_bits)]
+        self.insert_in = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
 
         self.update_in = [("tag", gen_params.phys_regs_bits), ("value", gen_params.isa.xlen)]
 
 
 class RSLayouts:
-    def __init__(self, gen_params: GenParams):
-        rs_interface = gen_params.get(RSInterfaceLayouts)
+    def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
+        rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
 
         self.data_layout = layout_subset(
             rs_interface.data_layout,
@@ -187,13 +187,13 @@ class RSLayouts:
             },
         )
 
-        self.insert_in = [("rs_data", self.data_layout), ("rs_entry_id", gen_params.rs_entries_bits)]
+        self.insert_in = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
 
         self.select_out = rs_interface.select_out
 
         self.update_in = rs_interface.update_in
 
-        self.take_in = [("rs_entry_id", gen_params.rs_entries_bits)]
+        self.take_in = [("rs_entry_id", rs_entries_bits)]
 
         self.take_out = layout_subset(
             rs_interface.data_layout,
@@ -208,7 +208,7 @@ class RSLayouts:
             },
         )
 
-        self.get_ready_list_out = [("ready_list", 2**gen_params.rs_entries_bits)]
+        self.get_ready_list_out = [("ready_list", 2**rs_entries_bits)]
 
 
 class ICacheLayouts:
@@ -295,7 +295,9 @@ class UnsignedMulUnitLayouts:
 
 class LSULayouts:
     def __init__(self, gen_params: GenParams):
-        rs_interface = gen_params.get(RSInterfaceLayouts)
+        self.rs_entries_bits = 0
+
+        rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=self.rs_entries_bits)
         self.rs_data_layout = layout_subset(
             rs_interface.data_layout,
             fields={
@@ -310,7 +312,7 @@ class LSULayouts:
             },
         )
 
-        self.rs_insert_in = [("rs_data", self.rs_data_layout), ("rs_entry_id", gen_params.rs_entries_bits)]
+        self.rs_insert_in = [("rs_data", self.rs_data_layout), ("rs_entry_id", self.rs_entries_bits)]
 
         self.rs_select_out = rs_interface.select_out
 
@@ -323,6 +325,8 @@ class LSULayouts:
 
 class CSRLayouts:
     def __init__(self, gen_params: GenParams):
+        self.rs_entries_bits = 0
+
         self.read = [
             ("data", gen_params.isa.xlen),
             ("read", 1),
@@ -334,7 +338,7 @@ class CSRLayouts:
         self._fu_read = [("data", gen_params.isa.xlen)]
         self._fu_write = [("data", gen_params.isa.xlen)]
 
-        rs_interface = gen_params.get(RSInterfaceLayouts)
+        rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=self.rs_entries_bits)
         self.rs_data_layout = layout_subset(
             rs_interface.data_layout,
             fields={
@@ -350,7 +354,7 @@ class CSRLayouts:
             },
         )
 
-        self.rs_insert_in = [("rs_data", self.rs_data_layout), ("rs_entry_id", gen_params.rs_entries_bits)]
+        self.rs_insert_in = [("rs_data", self.rs_data_layout), ("rs_entry_id", self.rs_entries_bits)]
 
         self.rs_select_out = rs_interface.select_out
 

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -320,14 +320,16 @@ class RSInsertion(Elaboratable):
                     "imm": instr.imm,
                     "csr": instr.csr,
                     "pc": instr.pc,
-                },
-                "rs_entry_id": instr.rs_entry_id,
+                }
             }
 
             for i, rs_insert in enumerate(self.rs_insert):
                 # connect only matching fields
                 arg = Record.like(rs_insert.data_in)
                 m.d.comb += assign(arg, data, fields=AssignType.COMMON)
+                # this assignment truncates signal width from max rs_entry_bits to target RS specific width
+                m.d.comb += arg.rs_entry_id.eq(instr.rs_entry_id)
+
                 with m.If(instr.rs_selected == i):
                     rs_insert(m, arg)
 

--- a/coreblocks/stages/rs_func_block.py
+++ b/coreblocks/stages/rs_func_block.py
@@ -93,3 +93,6 @@ class RSBlockComponent(BlockComponentParams):
 
     def get_optypes(self) -> set[OpType]:
         return optypes_supported(self.func_units)
+
+    def get_rs_entry_count(self) -> int:
+        return self.rs_entries

--- a/coreblocks/stages/rs_func_block.py
+++ b/coreblocks/stages/rs_func_block.py
@@ -41,10 +41,11 @@ class RSFuncBlock(FuncBlock, Elaboratable):
             Number of entries in RS.
         """
         self.gen_params = gen_params
-        self.rs_layouts = gen_params.get(RSLayouts)
+        self.rs_entries = rs_entries
+        self.rs_entries_bits = (rs_entries - 1).bit_length()
+        self.rs_layouts = gen_params.get(RSLayouts, rs_entries_bits=self.rs_entries_bits)
         self.fu_layouts = gen_params.get(FuncUnitLayouts)
         self.func_units = list(func_units)
-        self.rs_entries = rs_entries
 
         self.insert = Method(i=self.rs_layouts.insert_in)
         self.select = Method(o=self.rs_layouts.select_out)

--- a/coreblocks/structs_common/csr.py
+++ b/coreblocks/structs_common/csr.py
@@ -325,6 +325,8 @@ class CSRUnit(FuncBlock, Elaboratable):
 
 
 class CSRBlockComponent(BlockComponentParams):
+    rs_entries = 1
+
     def get_module(self, gen_params: GenParams) -> FuncBlock:
         connections = gen_params.get(DependencyManager)
         rob_single = connections.get_dependency(ROBSingleKey())

--- a/coreblocks/structs_common/csr.py
+++ b/coreblocks/structs_common/csr.py
@@ -325,8 +325,6 @@ class CSRUnit(FuncBlock, Elaboratable):
 
 
 class CSRBlockComponent(BlockComponentParams):
-    rs_entries = 1
-
     def get_module(self, gen_params: GenParams) -> FuncBlock:
         connections = gen_params.get(DependencyManager)
         rob_single = connections.get_dependency(ROBSingleKey())
@@ -336,3 +334,6 @@ class CSRBlockComponent(BlockComponentParams):
 
     def get_optypes(self) -> set[OpType]:
         return {OpType.CSR_REG, OpType.CSR_IMM}
+
+    def get_rs_entry_count(self) -> int:
+        return 1

--- a/coreblocks/structs_common/rs.py
+++ b/coreblocks/structs_common/rs.py
@@ -14,7 +14,9 @@ class RS(Elaboratable):
     ) -> None:
         ready_for = ready_for or ((op for op in OpType),)
         self.gen_params = gen_params
-        self.layouts = gen_params.get(RSLayouts)
+        self.rs_entries = rs_entries
+        self.rs_entries_bits = (rs_entries - 1).bit_length()
+        self.layouts = gen_params.get(RSLayouts, rs_entries_bits=self.rs_entries_bits)
         self.internal_layout = [
             ("rs_data", self.layouts.data_layout),
             ("rec_full", 1),
@@ -30,7 +32,6 @@ class RS(Elaboratable):
         self.ready_for = [list(op_list) for op_list in ready_for]
         self.get_ready_list = [Method(o=self.layouts.get_ready_list_out, nonexclusive=True) for _ in self.ready_for]
 
-        self.rs_entries = rs_entries
         self.data = Array(Record(self.internal_layout) for _ in range(self.rs_entries))
 
     def elaborate(self, platform):

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -21,7 +21,7 @@ class RSSelector(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        rs_layouts = self.gen_params.get(RSLayouts)
+        rs_layouts = self.gen_params.get(RSLayouts, rs_entries_bits=self.gen_params.max_rs_entries_bits)
         scheduler_layouts = self.gen_params.get(SchedulerLayouts)
 
         # data structures
@@ -102,7 +102,7 @@ class TestRSSelect(TestCaseWithSimulator):
 
     def create_rs_alloc_process(self, io: TestbenchIO, rs_id: int, rs_optypes: set[OpType], random_wait: int = 0):
         def mock():
-            random_entry = random.randrange(self.gen_params.rs_entries)
+            random_entry = random.randrange(self.gen_params.max_rs_entries)
             expected = self.instr_in.popleft()
             self.assertIn(expected["exec_fn"]["op_type"], rs_optypes)
             expected["rs_entry_id"] = random_entry

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -27,7 +27,7 @@ class SchedulerTestCircuit(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        rs_layouts = self.gen_params.get(RSLayouts)
+        rs_layouts = self.gen_params.get(RSLayouts, rs_entries_bits=self.gen_params.max_rs_entries_bits)
         decode_layouts = self.gen_params.get(DecodeLayouts)
         scheduler_layouts = self.gen_params.get(SchedulerLayouts)
 
@@ -349,7 +349,7 @@ class TestScheduler(TestCaseWithSimulator):
         def rs_alloc_process(io: TestbenchIO, rs_id: int):
             @def_method_mock(lambda: io)
             def process():
-                random_entry = random.randrange(self.gen_params.rs_entries)
+                random_entry = random.randrange(self.gen_params.max_rs_entries)
                 expected = self.expected_rename_queue.popleft()
                 expected["rs_entry_id"] = random_entry
                 self.expected_rs_entry_queue[rs_id].append(expected)

--- a/test/scheduler/test_wakeup_select.py
+++ b/test/scheduler/test_wakeup_select.py
@@ -20,7 +20,7 @@ from ..common import RecordIntDict, TestCaseWithSimulator, TestbenchIO
 class WakeupTestCircuit(Elaboratable):
     def __init__(self, gen_params: GenParams):
         self.gen_params = gen_params
-        self.layouts = gen_params.get(RSLayouts)
+        self.layouts = gen_params.get(RSLayouts, rs_entries_bits=gen_params.max_rs_entries_bits)
 
     def elaborate(self, platform):
         m = Module()
@@ -78,7 +78,7 @@ class TestWakeupSelect(TestCaseWithSimulator):
     def process(self):
         inserted_count = 0
         issued_count = 0
-        rs: list[Optional[RecordIntDict]] = [None for _ in range(self.m.gen_params.rs_entries)]
+        rs: list[Optional[RecordIntDict]] = [None for _ in range(self.m.gen_params.max_rs_entries)]
 
         yield from self.m.take_row_mock.enable()
         yield from self.m.issue_mock.enable()

--- a/test/stages/test_backend.py
+++ b/test/stages/test_backend.py
@@ -23,7 +23,7 @@ class BackendTestCircuit(Elaboratable):
 
         self.lay_result = self.gen.get(FuncUnitLayouts).accept
         self.lay_rob_mark_done = self.gen.get(ROBLayouts).id_layout
-        self.lay_rs_write = self.gen.get(RSLayouts).update_in
+        self.lay_rs_write = self.gen.get(RSLayouts, rs_entries_bits=self.gen.max_rs_entries_bits).update_in
         self.lay_rf_write = self.gen.get(RFLayouts).rf_write
 
         # Initialize for each FU an FIFO which will be a stub for that FU


### PR DESCRIPTION
Fixes #280.

rs_entries_bits is no longer common in the core and that caused error when trying to specify configuration with different rs sizes.

Now GenParams compute only maximum size of RS, that is used for RS Selection stage in Scheduler that is common to all RSes (and in generic tests).
Each RS uses internal layout with it own width (also for data storage), that is truncated from generic signal in RS Selection stage in Scheduler.