### PR TITLE
ISA String improvements

### DIFF
--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -180,6 +180,11 @@ _instructions_by_optype = {
     OpType.SRET: [
         Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.SRET, rd_zero=True, rs1_zero=True),  # sret
     ],
+    OpType.SFENCEVMA: [
+        Encoding(
+            Opcode.SYSTEM, Funct3.PRIV, Funct7.SFENCEVMA, rd_zero=True, instr_type_override=InstrType.R
+        ),  # sfence.vma
+    ],
 }
 
 

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -178,9 +178,6 @@ _instructions_by_optype = {
     OpType.SRET: [
         Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.SRET),  # sret
     ],
-    OpType.SFENCEVMA: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, Funct7.SFENCEVMA),  # sfence.vma
-    ],
 }
 
 

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -175,6 +175,12 @@ _instructions_by_optype = {
         Encoding(Opcode.OP, Funct3.SH2ADD, Funct7.SH2ADD),
         Encoding(Opcode.OP, Funct3.SH3ADD, Funct7.SH3ADD),
     ],
+    OpType.SRET: [
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.SRET),  # sret
+    ],
+    OpType.SFENCEVMA: [
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, Funct7.SFENCEVMA),  # sfence.vma
+    ],
 }
 
 

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TypeVar, Type, Protocol, runtime_checkable, Any
 from amaranth.utils import log2_int
 
-from .isa import ISA, gen_isa_string
+from .isa import ISA, gen_isa_string, Extension
 from .icache_params import ICacheParameters
 from .fu_params import extensions_supported
 from ..peripherals.wishbone import WishboneParameters
@@ -109,3 +109,10 @@ class GenParams(DependentCache):
         self.rob_entries_bits = cfg.rob_entries_bits
         self.rs_entries_bits = (self.rs_entries - 1).bit_length()
         self.start_pc = cfg.start_pc
+
+        toolchain_str_extensions = extensions
+        # Zmmul extension is not commonly available in toolchains yet, substitue it with M superset
+        if Extension.ZMMUL in toolchain_str_extensions:
+            toolchain_str_extensions ^= Extension.ZMMUL
+            toolchain_str_extensions |= Extension.M
+        self._toolchain_isa_str = gen_isa_string(toolchain_str_extensions, cfg.xlen, skip_internal=True)

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TypeVar, Type, Any
 from amaranth.utils import log2_int
 
-from .isa import ISA, gen_isa_string, Extension
+from .isa import ISA, gen_isa_string
 from .icache_params import ICacheParameters
 from .fu_params import extensions_supported
 from ..peripherals.wishbone import WishboneParameters
@@ -105,9 +105,4 @@ class GenParams(DependentCache):
         self.max_rs_entries_bits = (self.max_rs_entries - 1).bit_length()
         self.start_pc = cfg.start_pc
 
-        toolchain_str_extensions = extensions
-        # Zmmul extension is not commonly available in toolchains yet, substitue it with M superset
-        if Extension.ZMMUL in toolchain_str_extensions:
-            toolchain_str_extensions ^= Extension.ZMMUL
-            toolchain_str_extensions |= Extension.M
-        self._toolchain_isa_str = gen_isa_string(toolchain_str_extensions, cfg.xlen, skip_internal=True)
+        self._toolchain_isa_str = gen_isa_string(extensions, cfg.xlen, skip_internal=True)

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -81,7 +81,6 @@ class Funct7(BitEnum, width=7):
     BCLR = BEXT = 0b0100100
     BINV = 0b0110100
     BSET = 0b0010100
-    SFENCEVMA = 0b0001001
 
 
 class Funct12(BitEnum, width=12):

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -81,11 +81,13 @@ class Funct7(BitEnum, width=7):
     BCLR = BEXT = 0b0100100
     BINV = 0b0110100
     BSET = 0b0010100
+    SFENCEVMA = 0b0001001
 
 
 class Funct12(BitEnum, width=12):
     ECALL = 0b000000000000
     EBREAK = 0b000000000001
+    SRET = 0b000100000010
     MRET = 0b001100000010
     WFI = 0b000100000101
 

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -176,6 +176,10 @@ class Extension(IntFlag):
     ZBS = auto()
     #: Total store ordering
     ZTSO = auto()
+    #: Coreblocks internal categorizing extension: Machine-Mode Privilieged Instructions
+    XINTMACHINEMODE = auto()
+    #: Coreblocks internal categorizing extension: Supervisor Instructions
+    XINTSUPERVISOR = auto()
     #: General extension containing all basic operations
     G = I | M | A | F | D | ZICSR | ZIFENCEI
 

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -81,6 +81,7 @@ class Funct7(BitEnum, width=7):
     BCLR = BEXT = 0b0100100
     BINV = 0b0110100
     BSET = 0b0010100
+    SFENCEVMA = 0b0001001
 
 
 class Funct12(BitEnum, width=12):

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -327,11 +327,15 @@ def gen_isa_string(extensions: Extension, isa_xlen: int) -> str:
         isa_str += "g"
         extensions ^= Extension.G
 
+    previous_multi_letter = False
     for ext in Extension:
         if ext in extensions:
             ext_name = str(ext.name).lower()
-            if ext_name[0] == "z" or ext_name[0] == "x":
-                ext_name = "_" + ext_name
+
+            if previous_multi_letter:
+                isa_str += "_"
+            previous_multi_letter = len(ext_name) > 1
+
             isa_str += ext_name
 
     return isa_str

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -317,7 +317,7 @@ class ISA:
         self.csr_alen = 12
 
 
-def gen_isa_string(extensions: Extension, isa_xlen: int) -> str:
+def gen_isa_string(extensions: Extension, isa_xlen: int, *, skip_internal: bool = True) -> str:
     isa_str = "rv"
 
     isa_str += str(isa_xlen)
@@ -331,6 +331,9 @@ def gen_isa_string(extensions: Extension, isa_xlen: int) -> str:
     for ext in Extension:
         if ext in extensions:
             ext_name = str(ext.name).lower()
+
+            if skip_internal and ext_name.startswith("xint"):
+                continue
 
             if previous_multi_letter:
                 isa_str += "_"

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -316,7 +316,7 @@ class ISA:
         self.csr_alen = 12
 
 
-def gen_isa_string(extensions: Extension, isa_xlen: int, *, skip_internal: bool = True) -> str:
+def gen_isa_string(extensions: Extension, isa_xlen: int, *, skip_internal: bool = False) -> str:
     isa_str = "rv"
 
     isa_str += str(isa_xlen)

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -34,6 +34,7 @@ class OpType(IntEnum):
     SINGLE_BIT_MANIPULATION = auto()
     ADDRESS_GENERATION = auto()
     SRET = auto()
+    SFENCEVMA = auto()
 
 
 #
@@ -82,6 +83,7 @@ optypes_by_extensions = {
     ],
     Extension.XINTSUPERVISOR: [
         OpType.SRET,
+        OpType.SFENCEVMA,
     ],
 }
 

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -54,6 +54,8 @@ optypes_by_extensions = {
         OpType.LOAD,
         OpType.STORE,
         OpType.FENCE,
+        OpType.ECALL,
+        OpType.EBREAK,
     ],
     Extension.ZIFENCEI: [
         OpType.FENCEI,
@@ -75,8 +77,6 @@ optypes_by_extensions = {
         OpType.ADDRESS_GENERATION,
     ],
     Extension.XINTMACHINEMODE: [
-        OpType.ECALL,
-        OpType.EBREAK,
         OpType.MRET,
         OpType.WFI,
     ],

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -53,10 +53,6 @@ optypes_by_extensions = {
         OpType.LOAD,
         OpType.STORE,
         OpType.FENCE,
-        OpType.ECALL,
-        OpType.EBREAK,
-        OpType.MRET,
-        OpType.WFI,
     ],
     Extension.ZIFENCEI: [
         OpType.FENCEI,
@@ -76,6 +72,12 @@ optypes_by_extensions = {
     ],
     Extension.ZBA: [
         OpType.ADDRESS_GENERATION,
+    ],
+    Extension.XINTMACHINEMODE: [
+        OpType.ECALL,
+        OpType.EBREAK,
+        OpType.MRET,
+        OpType.WFI,
     ],
 }
 

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -33,6 +33,8 @@ class OpType(IntEnum):
     DIV_REM = auto()
     SINGLE_BIT_MANIPULATION = auto()
     ADDRESS_GENERATION = auto()
+    SRET = auto()
+    SFENCEVMA = auto()
 
 
 #
@@ -78,6 +80,10 @@ optypes_by_extensions = {
         OpType.EBREAK,
         OpType.MRET,
         OpType.WFI,
+    ],
+    Extension.XINTSUPERVISOR: [
+        OpType.SRET,
+        OpType.SFENCEVMA,
     ],
 }
 

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -34,7 +34,6 @@ class OpType(IntEnum):
     SINGLE_BIT_MANIPULATION = auto()
     ADDRESS_GENERATION = auto()
     SRET = auto()
-    SFENCEVMA = auto()
 
 
 #
@@ -83,7 +82,6 @@ optypes_by_extensions = {
     ],
     Extension.XINTSUPERVISOR: [
         OpType.SRET,
-        OpType.SFENCEVMA,
     ],
 }
 

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -143,6 +143,8 @@ class TestDecoder(TestCaseWithSimulator):
     DECODER_TESTS_XINTSUPERVISOR = [
         # SRET
         InstrTest(0x10200073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.SRET, op=OpType.SRET),
+        # SFENCE.VMA
+        InstrTest(0x12208073, Opcode.SYSTEM, Funct3.PRIV, Funct7.SFENCEVMA, rs1=1, rs2=2, op=OpType.SFENCEVMA),
     ]
 
     def setUp(self):

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -103,14 +103,6 @@ class TestDecoder(TestCaseWithSimulator):
             fm=FenceFm.NONE,
             op=OpType.FENCE,
         ),
-        # ECALL
-        InstrTest(0x00000073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, rd=0, rs1=0, op=OpType.ECALL),
-        # EBREAK
-        InstrTest(0x00100073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, rd=0, rs1=0, op=OpType.EBREAK),
-        # MRET
-        InstrTest(0x30200073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET, rd=0, rs1=0, op=OpType.MRET),
-        # WFI
-        InstrTest(0x10500073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.WFI, rd=0, rs1=0, op=OpType.WFI),
     ]
     DECODER_TESTS_ZIFENCEI = [
         InstrTest(0x0000100F, Opcode.MISC_MEM, Funct3.FENCEI, rd=0, rs1=0, imm=0, op=OpType.FENCEI),
@@ -137,9 +129,27 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x02716233, Opcode.OP, Funct3.REM, Funct7.MULDIV, rd=4, rs1=2, rs2=7, op=OpType.DIV_REM),
         InstrTest(0x02A47233, Opcode.OP, Funct3.REMU, Funct7.MULDIV, rd=4, rs1=8, rs2=10, op=OpType.DIV_REM),
     ]
+    DECODER_TESTS_XINTMACHINEMODE = [
+        # ECALL
+        InstrTest(0x00000073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, rd=0, rs1=0, op=OpType.ECALL),
+        # EBREAK
+        InstrTest(0x00100073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, rd=0, rs1=0, op=OpType.EBREAK),
+        # MRET
+        InstrTest(0x30200073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET, rd=0, rs1=0, op=OpType.MRET),
+        # WFI
+        InstrTest(0x10500073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.WFI, rd=0, rs1=0, op=OpType.WFI),
+    ]
+    DECODER_TESTS_XINTSUPERVISOR = [
+        # SRET
+        InstrTest(0x10200073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.SRET, rd=0, rs1=0, op=OpType.SRET),
+    ]
 
     def setUp(self):
-        gen = GenParams(test_core_config.replace(_implied_extensions=Extension.G))
+        gen = GenParams(
+            test_core_config.replace(
+                _implied_extensions=Extension.G | Extension.XINTMACHINEMODE | Extension.XINTSUPERVISOR
+            )
+        )
         self.decoder = InstrDecoder(gen)
         self.cnt = 1
 
@@ -213,4 +223,12 @@ class TestDecoder(TestCaseWithSimulator):
 
     def test_illegal(self):
         for test in self.DECODER_TESTS_ILLEGAL:
+            self.do_test(test)
+
+    def test_xintmachinemode(self):
+        for test in self.DECODER_TESTS_XINTMACHINEMODE:
+            self.do_test(test)
+
+    def test_xintsupervisor(self):
+        for test in self.DECODER_TESTS_XINTSUPERVISOR:
             self.do_test(test)

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -103,6 +103,10 @@ class TestDecoder(TestCaseWithSimulator):
             fm=FenceFm.NONE,
             op=OpType.FENCE,
         ),
+        # ECALL
+        InstrTest(0x00000073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, rd=0, rs1=0, op=OpType.ECALL),
+        # EBREAK
+        InstrTest(0x00100073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, rd=0, rs1=0, op=OpType.EBREAK),
     ]
     DECODER_TESTS_ZIFENCEI = [
         InstrTest(0x0000100F, Opcode.MISC_MEM, Funct3.FENCEI, rd=0, rs1=0, imm=0, op=OpType.FENCEI),
@@ -130,10 +134,6 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x02A47233, Opcode.OP, Funct3.REMU, Funct7.MULDIV, rd=4, rs1=8, rs2=10, op=OpType.DIV_REM),
     ]
     DECODER_TESTS_XINTMACHINEMODE = [
-        # ECALL
-        InstrTest(0x00000073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, rd=0, rs1=0, op=OpType.ECALL),
-        # EBREAK
-        InstrTest(0x00100073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, rd=0, rs1=0, op=OpType.EBREAK),
         # MRET
         InstrTest(0x30200073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET, rd=0, rs1=0, op=OpType.MRET),
         # WFI

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -17,7 +17,7 @@ class TestConfigurationsISAString(TestCase):
 
     TEST_CASES = [
         ISAStrTest(basic_core_config, "rv32i", "rv32", "rv32i"),
-        ISAStrTest(full_core_config, "rv32i_zicsr_zmmul_zba", "rv32_zicsr_zmmul_zba", "rv32i_zicsr_zmmul_zba"),
+        ISAStrTest(full_core_config, "rv32izicsr_zmmul_zba", "rv32zicsr_zmmul_zba", "rv32izicsr_zmmul_zba"),
         ISAStrTest(tiny_core_config, "rv32i", "rv32", "rv32i"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),
     ]

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -268,7 +268,7 @@ class TestCoreAsmSource(TestCoreBase):
                 [
                     "riscv64-unknown-elf-as",
                     "-mabi=ilp32",
-                    "-march=rv32im_zicsr",  # TODO: take from gp.isa_str when binutils will be updated to support zmmul
+                    f"-march={self.gp._toolchain_isa_str}",
                     "-o",
                     asm_tmp.name,
                     self.base_dir + self.source_file,

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -268,7 +268,9 @@ class TestCoreAsmSource(TestCoreBase):
                 [
                     "riscv64-unknown-elf-as",
                     "-mabi=ilp32",
-                    f"-march={self.gp._toolchain_isa_str}",
+                    # Specified manually, because toolchains from most distributions don't support new extensioins
+                    # and this test should be accessible locally.
+                    "-march=rv32im_zicsr",
                     "-o",
                     asm_tmp.name,
                     self.base_dir + self.source_file,


### PR DESCRIPTION
Provides multiple ISA string improvements
* separates machine mode instructions from I to custom XIntMachinemode and XIntSupervisor extensions
* Adds supervisor mode instructions (I had to revert sfence.vma due to issues and combinational loops in decoding, I will make separate PR with changes to decoder)
* Uses generated ISA string for assembler in core tests
* Improved `_` insertion in ISA string