### PR TITLE
Make verify_branch know its origin with from_pc

### DIFF
--- a/coreblocks/frontend/fetch.py
+++ b/coreblocks/frontend/fetch.py
@@ -74,7 +74,7 @@ class Fetch(Elaboratable):
                 self.cont(m, data=res.instr, pc=pc)
 
         @def_method(m, self.verify_branch, ready=stalled)
-        def _(next_pc: Value):
+        def _(from_pc: Value, next_pc: Value):
             m.d.sync += speculative_pc.eq(next_pc)
             m.d.sync += stalled.eq(0)
 

--- a/coreblocks/fu/jumpbranch.py
+++ b/coreblocks/fu/jumpbranch.py
@@ -155,7 +155,7 @@ class JumpBranchFuncUnit(FuncUnit, Elaboratable):
 
             # skip writing next branch target for auipc
             with m.If(decoder.decode_fn != JumpBranchFn.Fn.AUIPC):
-                fifo_branch.write(m, next_pc=Mux(jb.taken, jb.jmp_addr, jb.reg_res))
+                fifo_branch.write(m, from_pc=jb.in_pc, next_pc=Mux(jb.taken, jb.jmp_addr, jb.reg_res))
 
         return m
 

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -252,6 +252,7 @@ class FetchLayouts:
         ]
 
         self.branch_verify = [
+            ("from_pc", gen_params.isa.xlen),
             ("next_pc", gen_params.isa.xlen),
         ]
 

--- a/coreblocks/structs_common/csr.py
+++ b/coreblocks/structs_common/csr.py
@@ -318,7 +318,7 @@ class CSRUnit(FuncBlock, Elaboratable):
 
         @def_method(m, self.fetch_continue, accepted)
         def _():
-            return {"next_pc": instr.pc + self.gen_params.isa.ilen_bytes}
+            return {"from_pc": instr.pc, "next_pc": instr.pc + self.gen_params.isa.ilen_bytes}
 
         # Generate rob_sfx_empty signal from precommit
         @def_method(m, self.precommit)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -130,7 +130,7 @@ class TestFetch(TestCaseWithSimulator):
             if instr["is_branch"]:
                 for _ in range(random.randrange(10)):
                     yield
-                yield from self.m.verify_branch.call(next_pc=instr["next_pc"])
+                yield from self.m.verify_branch.call(from_pc=instr["pc"], next_pc=instr["next_pc"])
 
             v = yield from self.m.io_out.call()
             self.assertEqual(v["pc"], instr["pc"])

--- a/test/fu/test_jb_unit.py
+++ b/test/fu/test_jb_unit.py
@@ -29,7 +29,13 @@ class JumpBranchWrapper(Elaboratable):
         def _(arg):
             res = self.jb.accept(m)
             br = self.jb.branch_result(m)
-            return {"next_pc": br.next_pc, "result": res.result, "rob_id": res.rob_id, "rp_dst": res.rp_dst}
+            return {
+                "from_pc": br.from_pc,
+                "next_pc": br.next_pc,
+                "result": res.result,
+                "rob_id": res.rob_id,
+                "rp_dst": res.rp_dst,
+            }
 
         return m
 
@@ -70,7 +76,7 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn.Fn, x
     next_pc &= max_int
     res &= max_int
 
-    return {"result": res, "next_pc": next_pc}
+    return {"result": res, "from_pc": pc, "next_pc": next_pc}
 
 
 @staticmethod


### PR DESCRIPTION
Like #375, split away from #348 to reduce the scope of the changeset and probably already useful in itself.