### PR TITLE
Instruction decoder refactor

### DIFF
--- a/coreblocks/frontend/decode.py
+++ b/coreblocks/frontend/decode.py
@@ -46,8 +46,9 @@ class Decode(Elaboratable):
                     "illegal": instr_decoder.illegal,
                     "exec_fn": {
                         "op_type": instr_decoder.optype,
-                        "funct3": instr_decoder.funct3,
-                        "funct7": instr_decoder.funct7,
+                        # imm muxing in FUs depend on unused functs set to 0
+                        "funct3": Mux(instr_decoder.funct3_v, instr_decoder.funct3, 0),
+                        "funct7": Mux(instr_decoder.funct7_v, instr_decoder.funct7, 0),
                     },
                     "regs_l": {
                         # read/writes to phys reg 0 make no effect

--- a/coreblocks/frontend/decode.py
+++ b/coreblocks/frontend/decode.py
@@ -45,7 +45,7 @@ class Decode(Elaboratable):
                     "opcode": instr_decoder.opcode,
                     "illegal": instr_decoder.illegal,
                     "exec_fn": {
-                        "op_type": instr_decoder.op,
+                        "op_type": instr_decoder.optype,
                         "funct3": instr_decoder.funct3,
                         "funct7": instr_decoder.funct7,
                     },

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -370,7 +370,7 @@ class InstrDecoder(Elaboratable):
 
         for enc in supported_encodings:
             with m.If(
-                (self.opcode == enc.opcode if enc.opcode is not None else 1)
+                (opcode == enc.opcode if enc.opcode is not None else 1)
                 & (self.funct3 == enc.funct3 if enc.funct3 is not None else 1)
                 & (self.funct7 == enc.funct7 if enc.funct7 is not None else 1)
                 & (self.funct12 == enc.funct12 if enc.funct12 is not None else 1)

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -8,8 +8,6 @@ from coreblocks.params import *
 
 __all__ = ["InstrDecoder"]
 
-from coreblocks.utils import OneHotSwitchDynamic
-
 # Important
 #
 # In order to add new instructions to be decoded by this decoder assuming they do not required additional
@@ -23,10 +21,6 @@ _rd_itypes = [InstrType.R, InstrType.I, InstrType.U, InstrType.J]
 _rs1_itypes = [InstrType.R, InstrType.I, InstrType.S, InstrType.B]
 
 _rs2_itypes = [InstrType.R, InstrType.S, InstrType.B]
-
-_funct3_itypes = [InstrType.R, InstrType.I, InstrType.S, InstrType.B]
-
-_funct7_itypes = [InstrType.R]
 
 
 class Encoding:
@@ -43,6 +37,15 @@ class Encoding:
         Seven bits function identifier. If not exists for instruction then `None`.
     funct12: Optional[Funct12]
         Twelve bits function identifier. If not exists for instruction then `None`.
+    instr_type_override: Optional[InstrType]
+        Specify `InstrType` used for decoding of register and immediate for single opcode.
+        If set to `None` optype is determined from instrustion opcode, which is almost always correct.
+    rd_zero: bool
+        `rd` field is specifed as constant zero in instruction encoding. Other fields are decoded
+        accordingly to `InstrType`. Default is False.
+    rs1_zero: bool
+        `rs1` field is specifed as constant zero in instruction encoding. Other fields are decoded
+        accordingly to `InstrType`. Default is False.
     """
 
     def __init__(
@@ -51,11 +54,18 @@ class Encoding:
         funct3: Optional[Funct3] = None,
         funct7: Optional[Funct7] = None,
         funct12: Optional[Funct12] = None,
+        *,
+        instr_type_override: Optional[InstrType] = None,
+        rd_zero: bool = False,
+        rs1_zero: bool = False,
     ):
         self.opcode = opcode
         self.funct3 = funct3
         self.funct7 = funct7
         self.funct12 = funct12
+        self.instr_type_override = instr_type_override
+        self.rd_zero = rd_zero
+        self.rs1_zero = rs1_zero
 
 
 #
@@ -124,16 +134,16 @@ _instructions_by_optype = {
         Encoding(Opcode.MISC_MEM, Funct3.FENCE),  # fence
     ],
     OpType.ECALL: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL),  # ecall
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, rd_zero=True, rs1_zero=True),  # ecall
     ],
     OpType.EBREAK: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK),  # ebreak
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, rd_zero=True, rs1_zero=True),  # ebreak
     ],
     OpType.MRET: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET),  # mret
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET, rd_zero=True, rs1_zero=True),  # mret
     ],
     OpType.WFI: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.WFI),  # wfi
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.WFI, rd_zero=True, rs1_zero=True),  # wfi
     ],
     OpType.FENCEI: [
         Encoding(Opcode.MISC_MEM, Funct3.FENCEI),  # fence.i
@@ -223,7 +233,7 @@ class InstrDecoder(Elaboratable):
         Fence mode for `FENCE` instructions.
     csr: Signal(gen.isa.csr_alen), out
         Address of Control and Source Register for `CSR` instructions.
-    op: Signal(OpType), out
+    optype: Signal(OpType), out
         Operation type of instruction, used to define functional unit to perform this kind of instructions.
     illegal: Signal(1), out
         Signal if decoding of instruction was successful. If instruction do not fit into any supported
@@ -254,11 +264,8 @@ class InstrDecoder(Elaboratable):
         # Opcode and funct
         self.opcode = Signal(Opcode)
         self.funct3 = Signal(Funct3)
-        self.funct3_v = Signal()
         self.funct7 = Signal(Funct7)
-        self.funct7_v = Signal()
         self.funct12 = Signal(Funct12)
-        self.funct12_v = Signal()
 
         # Destination register
         self.rd = Signal(gen.isa.reg_cnt_log)
@@ -284,7 +291,7 @@ class InstrDecoder(Elaboratable):
         self.csr = Signal(gen.isa.csr_alen)
 
         # Operation type
-        self.op = Signal(OpType)
+        self.optype = Signal(OpType)
 
         # Illegal instruction
         self.illegal = Signal()
@@ -307,40 +314,22 @@ class InstrDecoder(Elaboratable):
         """
         return sig.eq(self.instr[start : start + len(sig)])
 
-    def _match(self, encodings: list[Encoding]) -> Value:
-        """
-        Creates amaranth value of instruction belonging into list of encodings.
-
-        Parameters
-        ----------
-        encodings: List[Encoding]
-            List of encoding to be checked against currently decoding instruction.
-
-        Returns
-        ----------
-        Value
-            Value of instruction having type of encodings in the list.
-        """
-        return reduce(
-            or_,
-            map(
-                lambda enc: (self.opcode == enc.opcode if enc.opcode is not None else 1)
-                & (self.funct3 == enc.funct3 if enc.funct3 is not None else 1)
-                & (self.funct7 == enc.funct7 if enc.funct7 is not None else 1)
-                & (self.funct12 == enc.funct12 if enc.funct12 is not None else 1)
-                & (
-                    (self.rd == 0) & (self.rs1 == 0) if enc.opcode == Opcode.SYSTEM and enc.funct3 == Funct3.PRIV else 1
-                ),
-                encodings,
-            ),
-        )
-
     def elaborate(self, platform):
         m = Module()
 
         # XXX: we always assume the synchronous domain to be present.
         dummy = Signal()
         m.d.sync += dummy.eq(1)
+
+        extensions = self.gen.isa.extensions
+        supported_encodings: set[Encoding] = set()
+        encoding_to_optype = dict()
+        for ext, optypes in optypes_by_extensions.items():
+            if extensions & ext:
+                for optype in optypes:
+                    for encoding in _instructions_by_optype[optype]:
+                        supported_encodings.add(encoding)
+                        encoding_to_optype[encoding] = optype
 
         # Opcode
 
@@ -350,7 +339,6 @@ class InstrDecoder(Elaboratable):
         # Instruction type
 
         instruction_type = Signal(InstrType)  # format of instruction
-        opcode_invalid = Signal()
 
         with m.Switch(opcode):
             with m.Case(Opcode.OP_IMM, Opcode.JALR, Opcode.LOAD, Opcode.MISC_MEM, Opcode.SYSTEM):
@@ -365,35 +353,53 @@ class InstrDecoder(Elaboratable):
                 m.d.comb += instruction_type.eq(InstrType.B)
             with m.Case(Opcode.STORE):
                 m.d.comb += instruction_type.eq(InstrType.S)
-            with m.Default():
-                m.d.comb += opcode_invalid.eq(1)
 
-        # Decode funct
+        # Decode and match instruction encoding
 
-        m.d.comb += self.funct3_v.eq(reduce(or_, (instruction_type == t for t in _funct3_itypes)))
-        with m.If(self.funct3_v):
-            m.d.comb += self._extract(12, self.funct3)
-
-        m.d.comb += self.funct7_v.eq(
-            reduce(or_, (instruction_type == t for t in _funct7_itypes))
-            | ((opcode == Opcode.OP_IMM) & ((self.funct3 == Funct3.SLL) | (self.funct3 == Funct3.SR)))
-        )
-        with m.If(self.funct7_v):
-            m.d.comb += self._extract(25, self.funct7)
-
-        m.d.comb += self.funct12_v.eq((opcode == Opcode.SYSTEM) & (self.funct3 == Funct3.PRIV))
-        with m.If(self.funct12_v):
-            m.d.comb += self._extract(20, self.funct12)
-
-        # Destination and source registers
+        m.d.comb += [
+            self._extract(12, self.funct3),
+            self._extract(25, self.funct7),
+            self._extract(20, self.funct12),
+        ]
 
         m.d.comb += [
             self._extract(7, self.rd),
-            self.rd_v.eq(reduce(or_, (instruction_type == t for t in _rd_itypes))),
             self._extract(15, self.rs1),
-            self.rs1_v.eq(reduce(or_, (instruction_type == t for t in _rs1_itypes))),
             self._extract(20, self.rs2),
-            self.rs2_v.eq(reduce(or_, (instruction_type == t for t in _rs2_itypes))),
+        ]
+
+        rd_invalid = Signal()
+        rs1_invalid = Signal()
+        rs2_invalid = Signal()
+
+        m.d.comb += self.optype.eq(OpType.UNKNOWN)
+
+        for enc in supported_encodings:
+            with m.If(
+                (self.opcode == enc.opcode if enc.opcode is not None else 1)
+                & (self.funct3 == enc.funct3 if enc.funct3 is not None else 1)
+                & (self.funct7 == enc.funct7 if enc.funct7 is not None else 1)
+                & (self.funct12 == enc.funct12 if enc.funct12 is not None else 1)
+                & (self.rd == 0 if enc.rd_zero else 1)
+                & (self.rs1 == 0 if enc.rs1_zero else 1)
+            ):
+                m.d.comb += self.optype.eq(encoding_to_optype[enc])
+
+                if enc.instr_type_override is not None:
+                    m.d.comb += instruction_type.eq(enc.instr_type_override)
+
+                m.d.comb += rd_invalid.eq(enc.rd_zero)
+                m.d.comb += rs1_invalid.eq(enc.rs1_zero)
+
+                if enc.funct12 is not None:
+                    m.d.comb += rs2_invalid.eq(1)
+
+        # Destination and source registers validity
+
+        m.d.comb += [
+            self.rd_v.eq(reduce(or_, (instruction_type == t for t in _rd_itypes)) & ~rd_invalid),
+            self.rs1_v.eq(reduce(or_, (instruction_type == t for t in _rs1_itypes)) & ~rs1_invalid),
+            self.rs2_v.eq(reduce(or_, (instruction_type == t for t in _rs2_itypes)) & ~rs2_invalid),
         ]
 
         # Immediate
@@ -443,24 +449,13 @@ class InstrDecoder(Elaboratable):
 
         m.d.comb += self._extract(20, self.csr)
 
-        # Operation type
+        # CSR with immediate correction
 
-        extensions = self.gen.isa.extensions
-        op_type_mask = Signal(len(OpType) - 1)
-
-        first_valid_optype = OpType.UNKNOWN.value + 1  # value of first OpType which is not UNKNOWN
-
-        for ext, optypes in optypes_by_extensions.items():
-            if extensions & ext:
-                for optype in optypes:
-                    list_of_encodings = _instructions_by_optype[optype]
-                    m.d.comb += op_type_mask[optype.value - first_valid_optype].eq(self._match(list_of_encodings))
-
-        for i in OneHotSwitchDynamic(m, op_type_mask, default=True):
-            if i is not None:
-                m.d.comb += self.op.eq(i + first_valid_optype)
-            else:  # default case
-                m.d.comb += self.op.eq(OpType.UNKNOWN)
+        with m.If(self.optype == OpType.CSR_IMM):
+            m.d.comb += [
+                self.imm.eq(uimm5),
+                self.rs1_v.eq(0),
+            ]
 
         # Instruction simplification
 
@@ -469,22 +464,14 @@ class InstrDecoder(Elaboratable):
             m.d.comb += [
                 self.opcode.eq(Opcode.OP_IMM),
                 self.funct3.eq(Funct3.ADD),
-                self.funct3_v.eq(1),
                 self.rs1.eq(0),
+                self.rs1_v.eq(1),
             ]
         with m.Else():
             m.d.comb += self.opcode.eq(opcode)
 
-        # CSR with immediate correction
-
-        with m.If(self.op == OpType.CSR_IMM):
-            m.d.comb += [
-                self.imm.eq(uimm5),
-                self.rs1_v.eq(0),
-            ]
-
         # Illegal instruction detection
 
-        m.d.comb += self.illegal.eq(opcode_invalid | (self.op == OpType.UNKNOWN))
+        m.d.comb += self.illegal.eq(self.optype == OpType.UNKNOWN)
 
         return m

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -1,3 +1,4 @@
+from dataclasses import KW_ONLY, dataclass
 from functools import reduce
 from operator import or_
 from typing import Optional
@@ -23,11 +24,12 @@ _rs1_itypes = [InstrType.R, InstrType.I, InstrType.S, InstrType.B]
 _rs2_itypes = [InstrType.R, InstrType.S, InstrType.B]
 
 
+@dataclass(frozen=True)
 class Encoding:
     """
     Class representing encoding of single RISC-V instruction.
 
-    Attributes
+    Parameters
     ----------
     opcode: Opcode
         Opcode of instruction.
@@ -48,24 +50,14 @@ class Encoding:
         accordingly to `InstrType`. Default is False.
     """
 
-    def __init__(
-        self,
-        opcode: Opcode,
-        funct3: Optional[Funct3] = None,
-        funct7: Optional[Funct7] = None,
-        funct12: Optional[Funct12] = None,
-        *,
-        instr_type_override: Optional[InstrType] = None,
-        rd_zero: bool = False,
-        rs1_zero: bool = False,
-    ):
-        self.opcode = opcode
-        self.funct3 = funct3
-        self.funct7 = funct7
-        self.funct12 = funct12
-        self.instr_type_override = instr_type_override
-        self.rd_zero = rd_zero
-        self.rs1_zero = rs1_zero
+    opcode: Opcode
+    funct3: Optional[Funct3] = None
+    funct7: Optional[Funct7] = None
+    funct12: Optional[Funct12] = None
+    _ = KW_ONLY
+    instr_type_override: Optional[InstrType] = None
+    rd_zero: bool = False
+    rs1_zero: bool = False
 
 
 #

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -459,6 +459,7 @@ class InstrDecoder(Elaboratable):
             m.d.comb += [
                 self.opcode.eq(Opcode.OP_IMM),
                 self.funct3.eq(Funct3.ADD),
+                self.funct3_v.eq(1),
                 self.rs1.eq(0),
                 self.rs1_v.eq(1),
             ]

--- a/test/frontend/test_decode.py
+++ b/test/frontend/test_decode.py
@@ -47,6 +47,7 @@ class TestFetch(TestCaseWithSimulator):
         self.assertEqual(decoded["illegal"], 0)
         self.assertEqual(decoded["exec_fn"]["op_type"], OpType.ARITHMETIC)
         self.assertEqual(decoded["exec_fn"]["funct3"], Funct3.ADD)
+        self.assertEqual(decoded["exec_fn"]["funct7"], 0)
         self.assertEqual(decoded["regs_l"]["rl_dst"], 4)
         self.assertEqual(decoded["regs_l"]["rl_s1"], 5)
         self.assertEqual(decoded["regs_l"]["rl_s2"], 0)

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -157,12 +157,15 @@ class TestDecoder(TestCaseWithSimulator):
 
             if test.funct3 is not None:
                 self.assertEqual((yield self.decoder.funct3), test.funct3)
+            self.assertEqual((yield self.decoder.funct3_v), test.funct3 is not None)
 
             if test.funct7 is not None:
                 self.assertEqual((yield self.decoder.funct7), test.funct7)
+            self.assertEqual((yield self.decoder.funct7_v), test.funct7 is not None)
 
             if test.funct12 is not None:
                 self.assertEqual((yield self.decoder.funct12), test.funct12)
+            self.assertEqual((yield self.decoder.funct12_v), test.funct12 is not None)
 
             if test.rd is not None:
                 self.assertEqual((yield self.decoder.rd), test.rd)

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -48,7 +48,7 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x02A28213, Opcode.OP_IMM, Funct3.ADD, rd=4, rs1=5, imm=42, op=OpType.ARITHMETIC),
         InstrTest(0x003100B3, Opcode.OP, Funct3.ADD, Funct7.ADD, rd=1, rs1=2, rs2=3, op=OpType.ARITHMETIC),
         InstrTest(0x40418133, Opcode.OP, Funct3.ADD, Funct7.SUB, rd=2, rs1=3, rs2=4, op=OpType.ARITHMETIC),
-        InstrTest(0x001230B7, Opcode.OP_IMM, Funct3.ADD, rd=1, imm=0x123 << 12, op=OpType.ARITHMETIC),
+        InstrTest(0x001230B7, Opcode.OP_IMM, Funct3.ADD, rd=1, rs1=0, imm=0x123 << 12, op=OpType.ARITHMETIC),
         # Compare
         InstrTest(0x07BF2A13, Opcode.OP_IMM, Funct3.SLT, rd=20, rs1=30, imm=123, op=OpType.COMPARE),
         InstrTest(0x0FFFBA93, Opcode.OP_IMM, Funct3.SLTU, rd=21, rs1=31, imm=0xFF, op=OpType.COMPARE),
@@ -104,13 +104,13 @@ class TestDecoder(TestCaseWithSimulator):
             op=OpType.FENCE,
         ),
         # ECALL
-        InstrTest(0x00000073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, rd=0, rs1=0, op=OpType.ECALL),
+        InstrTest(0x00000073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, op=OpType.ECALL),
         # EBREAK
-        InstrTest(0x00100073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, rd=0, rs1=0, op=OpType.EBREAK),
+        InstrTest(0x00100073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, op=OpType.EBREAK),
         # MRET
-        InstrTest(0x30200073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET, rd=0, rs1=0, op=OpType.MRET),
+        InstrTest(0x30200073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET, op=OpType.MRET),
         # WFI
-        InstrTest(0x10500073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.WFI, rd=0, rs1=0, op=OpType.WFI),
+        InstrTest(0x10500073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.WFI, op=OpType.WFI),
     ]
     DECODER_TESTS_ZIFENCEI = [
         InstrTest(0x0000100F, Opcode.MISC_MEM, Funct3.FENCEI, rd=0, rs1=0, imm=0, op=OpType.FENCEI),
@@ -126,6 +126,7 @@ class TestDecoder(TestCaseWithSimulator):
     DECODER_TESTS_ILLEGAL = [
         InstrTest(0xFFFFFFFF, Opcode.OP_IMM, illegal=1),
         InstrTest(0x003160FF, Opcode.OP, Funct3.OR, Funct7.OR, rd=1, rs1=2, rs2=3, op=OpType.LOGIC, illegal=1),
+        InstrTest(0x000000F3, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, op=OpType.ECALL, illegal=1),
     ]
     DECODER_TESTS_M = [
         InstrTest(0x02310133, Opcode.OP, Funct3.MUL, Funct7.MULDIV, rd=2, rs1=2, rs2=3, op=OpType.MUL),
@@ -154,14 +155,14 @@ class TestDecoder(TestCaseWithSimulator):
 
             self.assertEqual((yield self.decoder.opcode), test.opcode)
 
-            self.assertEqual((yield self.decoder.funct3), test.funct3 if test.funct3 is not None else 0)
-            self.assertEqual((yield self.decoder.funct3_v), test.funct3 is not None)
+            if test.funct3 is not None:
+                self.assertEqual((yield self.decoder.funct3), test.funct3)
 
-            self.assertEqual((yield self.decoder.funct7), test.funct7 if test.funct7 is not None else 0)
-            self.assertEqual((yield self.decoder.funct7_v), test.funct7 is not None)
+            if test.funct7 is not None:
+                self.assertEqual((yield self.decoder.funct7), test.funct7)
 
-            self.assertEqual((yield self.decoder.funct12), test.funct12 if test.funct12 is not None else 0)
-            self.assertEqual((yield self.decoder.funct12_v), test.funct12 is not None)
+            if test.funct12 is not None:
+                self.assertEqual((yield self.decoder.funct12), test.funct12)
 
             if test.rd is not None:
                 self.assertEqual((yield self.decoder.rd), test.rd)
@@ -190,7 +191,7 @@ class TestDecoder(TestCaseWithSimulator):
             if test.csr is not None:
                 self.assertEqual((yield self.decoder.csr), test.csr)
 
-            self.assertEqual((yield self.decoder.op), test.op)
+            self.assertEqual((yield self.decoder.optype), test.op)
 
         with self.run_simulation(self.decoder) as sim:
             sim.add_process(process)


### PR DESCRIPTION
Sorry, but I become so frustrated with decoder today (trying to add sfence.vma) and seeing the bug from #369, I had to do it.
 
##  The Problem (skip this section if not interested)
Previous decoder was designed with assumption that `InstrType` from RISCV can be always determined from only `Opcode` and rest of the main decoding happened based on that `InstrType`.
And that's *almost always* true. *almost*. RISCV is not that nice with those exceptions

Problem starts to appear for example with `Opcode=SYSTEM,Funct3=Priv`. These instruction uses Funct12, which is not specified in InstrType in specifaction, resulting in special logic in decoder - `self.funct12_v.eq((opcode == Opcode.SYSTEM) & (self.funct3 == Funct3.PRIV))` (and that's also true for ZBB instructions, which need to be added with all of appropiate opcodes/functs there). Then those instruction also specifically state that rd=0 and rs1=0 - another logic (in match  `& ((self.rd == 0) & (self.rs1 == 0) if enc.opcode == Opcode.SYSTEM and enc.funct3 == Funct3.PRIV else 1)`), and similiar in rs1_v decoding. 
When adding new instructions all of those conditions need to updated or new workaround logic added.

And ultimate problem with `sfence.vma`. It's the instruction with `Opcode.SYSTEM` & `Funct3.PRIV`. But as the only one from that group  (for now), instead of using `I`-like format, uses `R`-like format with Funct7 instead of Funct12, rs2 valid, rs1 valid and rd=0=invalid. Decoding this needed so many workarounds that I gave up. If we want to check for that specific instruction we need to compare Funct7 and set funct7_v for it, but if it is not that instruction then funct7_v needs to be false again, and instructions decoded with Fuct12 instead (comb loop) + all the fun with r*_v overrides.

## What is changed

* Decoding begins with matching instruction to specific `Encoding`.
* Funct3/7/**12** validity is decoded from matched `Encoding`. 
  Usage in matching statements is determined by `enc.* is not None` and after successful match assigned to _v signals.
  This allows to cleanly specify instruction encoded by different Functs for the same Opcode and normal support of Funct12.
* Registers and immediate are decoded on `InstrType` like in the old decoder. For this use case it works very well.
* No more workaround logic for main decoding (yay!).
  All of non standard operations are now handled by setting extra args in `Encoding`. It allows to cleanly override `InstrType` for single `Encoding` (instruction) in `Optype` group (for that sfence and others in future) Options are also added to verify rd/rs1=0 and disable its validity (for ECALL/EBREAK...).
* From my perspective the logic is easier to understand now.