### PR TITLE
DummyLSU: Delay pushing store result until execution

### DIFF
--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -45,7 +45,6 @@ class LSUDummyInternals(Elaboratable):
         self.get_result_ack = Signal()
         self.result_ready = Signal()
         self.execute_store = Signal()
-        self.store_ready = Signal()
 
     def calculate_addr(self):
         """Calculate Load/Store address as defined by RiscV spec"""
@@ -120,10 +119,9 @@ class LSUDummyInternals(Elaboratable):
         with Transaction().body(m):
             fetched = self.bus.result(m)
             m.d.sync += op_initiated.eq(0)
-            if is_store:
-                m.d.sync += self.store_ready.eq(1)
-            else:
-                m.d.sync += self.result_ready.eq(1)
+            m.d.sync += self.result_ready.eq(1)
+
+            if not is_store:
                 with m.If(fetched.err == 0):
                     m.d.sync += self.loadedData.eq(self.postprocess_load_data(m, fetched.data, addr))
                 with m.Else():
@@ -154,7 +152,6 @@ class LSUDummyInternals(Elaboratable):
                     self.op_init(m, op_initiated, False)
                     m.next = "LoadInit"
                 with m.If(instr_ready & ~instr_is_load):
-                    m.d.sync += self.result_ready.eq(1)
                     m.next = "StoreWaitForExec"
             with m.State("LoadInit"):
                 with m.If(~op_initiated):
@@ -180,8 +177,8 @@ class LSUDummyInternals(Elaboratable):
                     m.next = "StoreEnd"
             with m.State("StoreEnd"):
                 self.op_end(m, op_initiated, True)
-                with m.If(self.store_ready):
-                    m.d.sync += self.store_ready.eq(0)
+                with m.If(self.get_result_ack):
+                    m.d.sync += self.result_ready.eq(0)
                     m.next = "Start"
         return m
 
@@ -193,8 +190,6 @@ class LSUDummy(FuncBlock, Elaboratable):
     address is in correct range. Addresses have to be aligned.
 
     It uses the same interface as RS.
-
-    We assume that store cannot return an error.
 
     Attributes
     ----------
@@ -265,9 +260,10 @@ class LSUDummy(FuncBlock, Elaboratable):
         @def_method(m, self.get_result, result_ready)
         def _():
             m.d.comb += internal.get_result_ack.eq(1)
-            with m.If(current_instr.exec_fn.op_type == OpType.LOAD):
-                m.d.sync += current_instr.eq(0)
-                m.d.sync += reserved.eq(0)
+
+            m.d.sync += current_instr.eq(0)
+            m.d.sync += reserved.eq(0)
+
             return {
                 "rob_id": current_instr.rob_id,
                 "rp_dst": current_instr.rp_dst,
@@ -279,12 +275,7 @@ class LSUDummy(FuncBlock, Elaboratable):
         def _(rob_id: Value):
             # TODO: I/O reads
             with m.If((current_instr.exec_fn.op_type == OpType.STORE) & (rob_id == current_instr.rob_id)):
-                m.d.sync += internal.execute_store.eq(1)
-
-        with m.If(internal.store_ready):
-            m.d.sync += internal.execute_store.eq(0)
-            m.d.sync += current_instr.eq(0)
-            m.d.sync += reserved.eq(0)
+                m.d.comb += internal.execute_store.eq(1)
 
         return m
 

--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -165,8 +165,6 @@ class LSUDummyInternals(Elaboratable):
                     m.d.sync += self.loadedData.eq(0)
                     m.next = "Start"
             with m.State("StoreWaitForExec"):
-                with m.If(self.get_result_ack):
-                    m.d.sync += self.result_ready.eq(0)
                 with m.If(self.execute_store):
                     self.op_init(m, op_initiated, True)
                     m.next = "StoreInit"

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -367,12 +367,14 @@ class TestDummyLSUStores(TestCaseWithSimulator):
             self.assertEqual(v["rob_id"], rob_id)
             self.assertEqual(v["rp_dst"], 0)
             yield from self.random_wait()
+            self.precommit_data.pop()  # retire
 
     def precommiter(self):
-        for i in range(self.tests_number):
+        yield Passive()
+        while True:
             while len(self.precommit_data) == 0:
                 yield
-            rob_id = self.precommit_data.pop()
+            rob_id = self.precommit_data[-1]  # precommit is called continously until instruction is retired
             yield from self.test_module.precommit.call(rob_id=rob_id)
 
     def test(self):


### PR DESCRIPTION
Small change, useful for implementing reporting exceptions on store in #394, exported as independent change for eventual discussion.
This PR unifies LOAD and STORE instruction result pushing/accepting to point where instruction in actually executed. It will be useful to be able to pass pipeline `exception` flags in STORE instructions. Additional benefit is slightly easier to understand logic and it *may* be helpful in implementing IO reads.
Downside - increased dealy on stores as we need to wait for result. Previously they were executing also after instruction was retired? But this is the only way to handle exceptions on stores - to wait until completion. (Additonal different delay between FU->RET is negligible). I don't think that's a big issue for now as dummyLSU will be replaced, but may be useful note for future. Maybe we could specify Exception-less memory regions, where STORES could execute 'detached'?