### PR TITLE
[RFC] Controversial make dict

### DIFF
--- a/test/structs_common/test_exception.py
+++ b/test/structs_common/test_exception.py
@@ -74,8 +74,8 @@ class TestExceptionCauseRegister(TestCaseWithSimulator):
                 self.rob_id = random.randint(0, self.rob_max)
 
                 cause = random.choice(list(ExceptionCause))
-                report_rob = random.randint(0, self.rob_max)
-                report_arg = {"cause": cause, "rob_id": report_rob}
+                rob_id = random.randint(0, self.rob_max)
+                report_arg = make_dict(cause, rob_id)
 
                 yield from self.dut.report.call(report_arg)
 


### PR DESCRIPTION
I have recently observed that in many places in tests we have pattern:
`{"var1" : var1, "var2" : var2, "var3" : var3 }`
This cause a lot of boilerplate, so I started to think about reducing it. Here is a PoC, which allow to write:
`make_dict(var1, var2, var3)`
In interpreter it works, but after substituting in tests there is a fail (but I should be able to correct this).

So I would like to ask if there is a sense to invest time in it, taking into account that current solution is very hacky?(@Arusekk maybe you can do that better)

Other proposition which I have is to introduce a little bit more costly syntax:
`make_dict("var1", "var2", "var3")`
but such `make_dict` will be a lot easier to implement (get previous frame, iterate over `locals` and get requested values).

What do you think? Is second proposition better? Or maybe both are not acceptable hackery?