### PR TITLE
Scheduler preparation for vector extension

### DIFF
--- a/coreblocks/frontend/decode.py
+++ b/coreblocks/frontend/decode.py
@@ -60,7 +60,7 @@ class Decode(Elaboratable):
                         "rl_s2_rf": Mux(instr_decoder.rs2_v, instr_decoder.rs2_rf, 0),
                     },
                     "imm": instr_decoder.imm,
-                    "csr": instr_decoder.csr,
+                    "imm2": instr_decoder.imm2,
                     "pc": raw.pc,
                 },
             )

--- a/coreblocks/frontend/decode.py
+++ b/coreblocks/frontend/decode.py
@@ -52,12 +52,18 @@ class Decode(Elaboratable):
                     },
                     "regs_l": {
                         # read/writes to phys reg 0 make no effect
-                        "rl_dst": Mux(instr_decoder.rd_v, instr_decoder.rd, 0),
-                        "rl_dst_rf": Mux(instr_decoder.rd_v, instr_decoder.rd_rf, 0),
-                        "rl_s1": Mux(instr_decoder.rs1_v, instr_decoder.rs1, 0),
-                        "rl_s1_rf": Mux(instr_decoder.rs1_v, instr_decoder.rs1_rf, 0),
-                        "rl_s2": Mux(instr_decoder.rs2_v, instr_decoder.rs2, 0),
-                        "rl_s2_rf": Mux(instr_decoder.rs2_v, instr_decoder.rs2_rf, 0),
+                        "dst": {
+                            "id": Mux(instr_decoder.rd_v, instr_decoder.rd, 0),
+                            "type": Mux(instr_decoder.rd_v, instr_decoder.rd_rf, 0),
+                        },
+                        "s1": {
+                            "id":Mux(instr_decoder.rs1_v, instr_decoder.rs1, 0),
+                            "type": Mux(instr_decoder.rs1_v, instr_decoder.rs1_rf, 0),
+                        },
+                        "s2": {
+                            "id":Mux(instr_decoder.rs2_v, instr_decoder.rs2, 0),
+                            "type": Mux(instr_decoder.rs2_v, instr_decoder.rs2_rf, 0),
+                        },
                     },
                     "imm": instr_decoder.imm,
                     "imm2": instr_decoder.imm2,

--- a/coreblocks/frontend/decode.py
+++ b/coreblocks/frontend/decode.py
@@ -57,11 +57,11 @@ class Decode(Elaboratable):
                             "type": Mux(instr_decoder.rd_v, instr_decoder.rd_rf, 0),
                         },
                         "s1": {
-                            "id":Mux(instr_decoder.rs1_v, instr_decoder.rs1, 0),
+                            "id": Mux(instr_decoder.rs1_v, instr_decoder.rs1, 0),
                             "type": Mux(instr_decoder.rs1_v, instr_decoder.rs1_rf, 0),
                         },
                         "s2": {
-                            "id":Mux(instr_decoder.rs2_v, instr_decoder.rs2, 0),
+                            "id": Mux(instr_decoder.rs2_v, instr_decoder.rs2, 0),
                             "type": Mux(instr_decoder.rs2_v, instr_decoder.rs2_rf, 0),
                         },
                     },

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -400,7 +400,7 @@ class InstrDecoder(Elaboratable):
         Predecessor for `FENCE` instructions.
     fm: Signal(FenceFm), out
         Fence mode for `FENCE` instructions.
-    csr: Signal(gen.isa.csr_alen), out
+    imm2: Signal(gen.imm2_width), out
         Address of Control and Source Register for `CSR` instructions.
     optype: Signal(OpType), out
         Operation type of instruction, used to define functional unit to perform this kind of instructions.
@@ -463,8 +463,8 @@ class InstrDecoder(Elaboratable):
         self.pred = Signal(FenceTarget)
         self.fm = Signal(FenceFm)
 
-        # CSR address
-        self.csr = Signal(gen.isa.csr_alen)
+        # CSR address or vtype for vector instruction
+        self.imm2 = Signal(gen.imm2_width)
 
         # Operation type
         self.optype = Signal(OpType)
@@ -647,7 +647,7 @@ class InstrDecoder(Elaboratable):
 
         # CSR address and constant for vector control instructions
 
-        m.d.comb += self._extract(20, self.csr)
+        m.d.comb += self._extract(20, self.imm2)
 
         # Register types
         with m.If((self.opcode == Opcode.OP_V)):

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -8,7 +8,7 @@ from coreblocks.fu.unsigned_multiplication.fast_recursive import RecursiveUnsign
 from coreblocks.fu.unsigned_multiplication.sequence import SequentialUnsignedMul
 from coreblocks.fu.unsigned_multiplication.shift import ShiftUnsignedMul
 from coreblocks.params.fu_params import FunctionalComponentParams
-from coreblocks.params import Funct3, GenParams, FuncUnitLayouts, OpType
+from coreblocks.params import Funct3, GenParams, FuncUnitLayouts, OpType, CommonLayouts
 from coreblocks.transactions import *
 from coreblocks.transactions.core import def_method
 from coreblocks.transactions.lib import *
@@ -113,7 +113,7 @@ class MulUnit(FuncUnit, Elaboratable):
         m.submodules.params_fifo = params_fifo = FIFO(
             [
                 ("rob_id", self.gen.rob_entries_bits),
-                ("rp_dst", self.gen.phys_regs_bits),
+                ("rp_dst", self.gen.get(CommonLayouts).p_register_entry),
                 ("negative_res", 1),
                 ("high_res", 1),
             ],

--- a/coreblocks/fu/vector_unit/__init__.py
+++ b/coreblocks/fu/vector_unit/__init__.py
@@ -1,6 +1,6 @@
-from coreblocks.fu.vector_unit.flexible_alu import *
-from coreblocks.fu.vector_unit.utils import *
-from coreblocks.fu.vector_unit.vrf import *
-from coreblocks.fu.vector_unit.v_layouts import *
-from coreblocks.fu.vector_unit.v_register import *
-from coreblocks.fu.vector_unit.v_status import *
+from coreblocks.fu.vector_unit.flexible_alu import *  # noqa: F401
+from coreblocks.fu.vector_unit.utils import *  # noqa: F401
+from coreblocks.fu.vector_unit.vrf import *  # noqa: F401
+from coreblocks.fu.vector_unit.v_layouts import *  # noqa: F401
+from coreblocks.fu.vector_unit.v_register import *  # noqa: F401
+from coreblocks.fu.vector_unit.v_status import *  # noqa: F401

--- a/coreblocks/fu/vector_unit/__init__.py
+++ b/coreblocks/fu/vector_unit/__init__.py
@@ -1,0 +1,6 @@
+from coreblocks.fu.vector_unit.flexible_alu import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.vrf import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.fu.vector_unit.v_register import *
+from coreblocks.fu.vector_unit.v_status import *

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -59,8 +59,3 @@ class VectorXRSLayout(RSLayouts):
 
         self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
         self.take_out: LayoutLike = self.data_layout
-
-
-class VectorStatusUnitLayouts:
-    def __init__(self, gen_params: GenParams):
-        self.issue = layout_subset

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -35,26 +35,12 @@ class VRFFragmentLayouts:
         ]
 
 
-class VectorRSLayout(RSLayouts):
+class VectorXRSLayout(RSLayouts):
+    """ Layout to describe scalar RS in vector func block """
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         super().__init__(gen_params, rs_entries_bits=rs_entries_bits)
         rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
 
-        #            ("rp_s1", gen_params.phys_regs_bits),
-        #            ("rp_s1_rf", RegisterType),
-        #            ("rp_s2", gen_params.phys_regs_bits),
-        #            ("rp_s2_rf", RegisterType),
-        #            ("rp_s1_reg", gen_params.phys_regs_bits),
-        #            ("rp_s2_reg", gen_params.phys_regs_bits),
-        #            ("rp_dst", gen_params.phys_regs_bits),
-        #            ("rp_dst_rf", RegisterType),
-        #            ("rob_id", gen_params.rob_entries_bits),
-        #            ("exec_fn", common.exec_fn),
-        #            ("s1_val", gen_params.isa.xlen),
-        #            ("s2_val", gen_params.isa.xlen),
-        #            ("imm", gen_params.isa.xlen),
-        #            ("imm2", gen_params.imm2_width),
-        #            ("pc", gen_params.isa.xlen),
         self.data_layout: LayoutLike = layout_subset(
             rs_interface.data_layout,
             fields={
@@ -67,22 +53,11 @@ class VectorRSLayout(RSLayouts):
                 "s2_val",
                 "imm",
                 "imm2",
-                "pc",
             },
         )
 
-        self.take_out: LayoutLike = layout_subset(
-            rs_interface.data_layout,
-            fields={
-                "s1_val",
-                "s2_val",
-                "rp_dst",
-                "rob_id",
-                "exec_fn",
-                "imm",
-                "pc",
-            },
-        )
+        self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
+        self.take_out: LayoutLike = self.data_layout
 
 
 class VectorStatusUnitLayouts:

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -39,6 +39,21 @@ class VectorRSLayout(RSLayouts):
         super().__init__(gen_params, rs_entries_bits=rs_entries_bits)
         rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
 
+#            ("rp_s1", gen_params.phys_regs_bits),
+#            ("rp_s1_rf", RegisterType),
+#            ("rp_s2", gen_params.phys_regs_bits),
+#            ("rp_s2_rf", RegisterType),
+#            ("rp_s1_reg", gen_params.phys_regs_bits),
+#            ("rp_s2_reg", gen_params.phys_regs_bits),
+#            ("rp_dst", gen_params.phys_regs_bits),
+#            ("rp_dst_rf", RegisterType),
+#            ("rob_id", gen_params.rob_entries_bits),
+#            ("exec_fn", common.exec_fn),
+#            ("s1_val", gen_params.isa.xlen),
+#            ("s2_val", gen_params.isa.xlen),
+#            ("imm", gen_params.isa.xlen),
+#            ("imm2", gen_params.imm2_width),
+#            ("pc", gen_params.isa.xlen),
         self.data_layout : LayoutLike = layout_subset(
             rs_interface.data_layout,
             fields={

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -2,6 +2,8 @@ from amaranth.utils import *
 from coreblocks.params import *
 from coreblocks.params.vector_params import VectorParameters
 from coreblocks.fu.vector_unit.utils import EEW
+from coreblocks.utils._typing import LayoutLike
+from coreblocks.utils import layout_subset
 
 
 class VectorRegisterBankLayouts:
@@ -31,3 +33,41 @@ class VRFFragmentLayouts:
             ("data", v_params.elen),
             ("mask", v_params.bytes_in_elen),
         ]
+
+class VectorRSLayout(RSLayouts):
+    def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
+        super().__init__(gen_params, rs_entries_bits=rs_entries_bits)
+        rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
+
+        self.data_layout : LayoutLike = layout_subset(
+            rs_interface.data_layout,
+            fields={
+                "rp_s1",
+                "rp_s2",
+                "rp_dst",
+                "rob_id",
+                "exec_fn",
+                "s1_val",
+                "s2_val",
+                "imm",
+                "imm2",
+                "pc",
+            },
+        )
+
+        self.take_out :LayoutLike = layout_subset(
+            rs_interface.data_layout,
+            fields={
+                "s1_val",
+                "s2_val",
+                "rp_dst",
+                "rob_id",
+                "exec_fn",
+                "imm",
+                "pc",
+            },
+        )
+
+class VectorStatusUnitLayouts:
+    def __init__(self, gen_params : GenParams):
+        self.issue = layout_subset

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -36,7 +36,8 @@ class VRFFragmentLayouts:
 
 
 class VectorXRSLayout(RSLayouts):
-    """ Layout to describe scalar RS in vector func block """
+    """Layout to describe scalar RS in vector func block"""
+
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         super().__init__(gen_params, rs_entries_bits=rs_entries_bits)
         rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -34,27 +34,28 @@ class VRFFragmentLayouts:
             ("mask", v_params.bytes_in_elen),
         ]
 
+
 class VectorRSLayout(RSLayouts):
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         super().__init__(gen_params, rs_entries_bits=rs_entries_bits)
         rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
 
-#            ("rp_s1", gen_params.phys_regs_bits),
-#            ("rp_s1_rf", RegisterType),
-#            ("rp_s2", gen_params.phys_regs_bits),
-#            ("rp_s2_rf", RegisterType),
-#            ("rp_s1_reg", gen_params.phys_regs_bits),
-#            ("rp_s2_reg", gen_params.phys_regs_bits),
-#            ("rp_dst", gen_params.phys_regs_bits),
-#            ("rp_dst_rf", RegisterType),
-#            ("rob_id", gen_params.rob_entries_bits),
-#            ("exec_fn", common.exec_fn),
-#            ("s1_val", gen_params.isa.xlen),
-#            ("s2_val", gen_params.isa.xlen),
-#            ("imm", gen_params.isa.xlen),
-#            ("imm2", gen_params.imm2_width),
-#            ("pc", gen_params.isa.xlen),
-        self.data_layout : LayoutLike = layout_subset(
+        #            ("rp_s1", gen_params.phys_regs_bits),
+        #            ("rp_s1_rf", RegisterType),
+        #            ("rp_s2", gen_params.phys_regs_bits),
+        #            ("rp_s2_rf", RegisterType),
+        #            ("rp_s1_reg", gen_params.phys_regs_bits),
+        #            ("rp_s2_reg", gen_params.phys_regs_bits),
+        #            ("rp_dst", gen_params.phys_regs_bits),
+        #            ("rp_dst_rf", RegisterType),
+        #            ("rob_id", gen_params.rob_entries_bits),
+        #            ("exec_fn", common.exec_fn),
+        #            ("s1_val", gen_params.isa.xlen),
+        #            ("s2_val", gen_params.isa.xlen),
+        #            ("imm", gen_params.isa.xlen),
+        #            ("imm2", gen_params.imm2_width),
+        #            ("pc", gen_params.isa.xlen),
+        self.data_layout: LayoutLike = layout_subset(
             rs_interface.data_layout,
             fields={
                 "rp_s1",
@@ -70,7 +71,7 @@ class VectorRSLayout(RSLayouts):
             },
         )
 
-        self.take_out :LayoutLike = layout_subset(
+        self.take_out: LayoutLike = layout_subset(
             rs_interface.data_layout,
             fields={
                 "s1_val",
@@ -83,6 +84,7 @@ class VectorRSLayout(RSLayouts):
             },
         )
 
+
 class VectorStatusUnitLayouts:
-    def __init__(self, gen_params : GenParams):
+    def __init__(self, gen_params: GenParams):
         self.issue = layout_subset

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -5,12 +5,11 @@ from coreblocks.fu.vector_unit.utils import *
 
 
 class VectorStatusUnit(Elaboratable):
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters):
+    def __init__(self, gen_params: GenParams, v_params: VectorParameters):
         self.gen_params = gen_params
         self.v_params = v_params
 
     def elaborate(self, platform):
         m = TModule()
-
 
         return m

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -1,0 +1,16 @@
+from amaranth import *
+from coreblocks.transactions import *
+from coreblocks.params import *
+from coreblocks.fu.vector_unit.utils import *
+
+
+class VectorStatusUnit(Elaboratable):
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters):
+        self.gen_params = gen_params
+        self.v_params = v_params
+
+    def elaborate(self, platform):
+        m = TModule()
+
+
+        return m

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -9,6 +9,11 @@ __all__ = ["VXRS"]
 
 
 class VXRS(FifoRS):
+    """ Vector extension RS to wait for scalars
+
+    This is a RS, which extends the FifoRS with `rec_ready` signals to
+    specialise it for the usage as RS that wait only for scalars values.
+    """
     def __init__(
         self,
         gen_params: GenParams,

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -5,6 +5,13 @@ from coreblocks.structs_common.rs import RS
 from coreblocks.params import *
 from coreblocks.fu.vector_unit.v_layouts import *
 
+
 class VRS(RS):
-    def __init__(self, gen_params: GenParams, rs_entries: int, insert_hook : Optional[Method] = None, ready_for: Optional[Iterable[Iterable[OpType]]] = None) -> None:
-        super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorRSLayout, insert_hook = insert_hook)
+    def __init__(
+        self,
+        gen_params: GenParams,
+        rs_entries: int,
+        insert_hook: Optional[Method] = None,
+        ready_for: Optional[Iterable[Iterable[OpType]]] = None,
+    ) -> None:
+        super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorRSLayout, insert_hook=insert_hook)

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -5,7 +5,8 @@ from coreblocks.structs_common.rs import FifoRS
 from coreblocks.params import *
 from coreblocks.fu.vector_unit.v_layouts import *
 
-__all__=["VXRS"]
+__all__ = ["VXRS"]
+
 
 class VXRS(FifoRS):
     def __init__(
@@ -16,8 +17,8 @@ class VXRS(FifoRS):
     ) -> None:
         super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorXRSLayout)
 
-    def generate_rec_ready_setters(self, m : TModule):
+    def generate_rec_ready_setters(self, m: TModule):
         for record in self.data:
             is_rs1_ready = (record.rs_data.rp_s1.type == RegisterType.X).implies(~record.rs_data.rp_s1.id.bool())
             is_rs2_ready = (record.rs_data.rp_s2.type == RegisterType.X).implies(~record.rs_data.rp_s2.id.bool())
-            m.d.comb += record.rec_ready.eq( is_rs1_ready & is_rs2_ready & record.rec_full.bool())
+            m.d.comb += record.rec_ready.eq(is_rs1_ready & is_rs2_ready & record.rec_full.bool())

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -9,11 +9,12 @@ __all__ = ["VXRS"]
 
 
 class VXRS(FifoRS):
-    """ Vector extension RS to wait for scalars
+    """Vector extension RS to wait for scalars
 
     This is a RS, which extends the FifoRS with `rec_ready` signals to
     specialise it for the usage as RS that wait only for scalars values.
     """
+
     def __init__(
         self,
         gen_params: GenParams,

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -1,17 +1,23 @@
 from amaranth import *
 from typing import Optional, Iterable
 from coreblocks.transactions import *
-from coreblocks.structs_common.rs import RS
+from coreblocks.structs_common.rs import FifoRS
 from coreblocks.params import *
 from coreblocks.fu.vector_unit.v_layouts import *
 
+__all__=["VXRS"]
 
-class VRS(RS):
+class VXRS(FifoRS):
     def __init__(
         self,
         gen_params: GenParams,
         rs_entries: int,
-        insert_hook: Optional[Method] = None,
         ready_for: Optional[Iterable[Iterable[OpType]]] = None,
     ) -> None:
-        super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorRSLayout, insert_hook=insert_hook)
+        super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorXRSLayout)
+
+    def generate_rec_ready_setters(self, m : TModule):
+        for record in self.data:
+            is_rs1_ready = (record.rs_data.rp_s1.type == RegisterType.X).implies(~record.rs_data.rp_s1.id.bool())
+            is_rs2_ready = (record.rs_data.rp_s2.type == RegisterType.X).implies(~record.rs_data.rp_s2.id.bool())
+            m.d.comb += record.rec_ready.eq( is_rs1_ready & is_rs2_ready & record.rec_full.bool())

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -1,0 +1,10 @@
+from amaranth import *
+from typing import Optional, Iterable
+from coreblocks.transactions import *
+from coreblocks.structs_common.rs import RS
+from coreblocks.params import *
+from coreblocks.fu.vector_unit.v_layouts import *
+
+class VRS(RS):
+    def __init__(self, gen_params: GenParams, rs_entries: int, insert_hook : Optional[Method] = None, ready_for: Optional[Iterable[Iterable[OpType]]] = None) -> None:
+        super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorRSLayout, insert_hook = insert_hook)

--- a/coreblocks/fu/zbc.py
+++ b/coreblocks/fu/zbc.py
@@ -11,6 +11,7 @@ from coreblocks.params import (
     GenParams,
     FuncUnitLayouts,
     FunctionalComponentParams,
+    CommonLayouts,
 )
 from coreblocks.transactions import Method, def_method, TModule
 from coreblocks.transactions.lib import FIFO
@@ -166,13 +167,13 @@ class ZbcUnit(Elaboratable):
     """
 
     def __init__(self, gen_params: GenParams, recursion_depth: int, zbc_fn: ZbcFn):
-        layouts = gen_params.get(FuncUnitLayouts)
+        self.layouts = gen_params.get(FuncUnitLayouts)
 
         self.zbc_fn = zbc_fn
         self.recursion_depth = recursion_depth
         self.gen_params = gen_params
-        self.issue = Method(i=layouts.issue)
-        self.accept = Method(o=layouts.accept)
+        self.issue = Method(i=self.layouts.issue)
+        self.accept = Method(o=self.layouts.accept)
 
     def elaborate(self, platform):
         m = TModule()
@@ -180,7 +181,7 @@ class ZbcUnit(Elaboratable):
         m.submodules.params_fifo = params_fifo = FIFO(
             [
                 ("rob_id", self.gen_params.rob_entries_bits),
-                ("rp_dst", self.gen_params.phys_regs_bits),
+                ("rp_dst", self.gen_params.get(CommonLayouts).p_register_entry),
                 ("high_res", 1),
                 ("rev_res", 1),
             ],

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -2,9 +2,9 @@ from collections.abc import Collection
 import dataclasses
 from dataclasses import dataclass
 
-from coreblocks.params.isa import Extension
-from coreblocks.params.fu_params import BlockComponentParams
-from coreblocks.stages.rs_func_block import RSBlockComponent
+import coreblocks.params.isa as isa
+import coreblocks.params.fu_params as fu_params
+import coreblocks.stages.rs_func_block as rs_func_block
 
 from coreblocks.fu.alu import ALUComponent
 from coreblocks.fu.shift_unit import ShiftUnitComponent
@@ -16,8 +16,8 @@ from coreblocks.structs_common.csr import CSRBlockComponent
 
 __all__ = ["CoreConfiguration", "basic_core_config", "tiny_core_config", "full_core_config", "test_core_config"]
 
-basic_configuration: tuple[BlockComponentParams, ...] = (
-    RSBlockComponent([ALUComponent(), ShiftUnitComponent(), JumpComponent()], rs_entries=4),
+basic_configuration: tuple[fu_params.BlockComponentParams, ...] = (
+    rs_func_block.RSBlockComponent([ALUComponent(), ShiftUnitComponent(), JumpComponent()], rs_entries=4),
     LSUBlockComponent(),
 )
 
@@ -59,7 +59,7 @@ class CoreConfiguration:
     """
 
     xlen: int = 32
-    func_units_config: Collection[BlockComponentParams] = basic_configuration
+    func_units_config: Collection[fu_params.BlockComponentParams] = basic_configuration
 
     compressed: bool = False
     embedded: bool = False
@@ -75,7 +75,7 @@ class CoreConfiguration:
 
     allow_partial_extensions: bool = True  # TODO: Change to False when I extension will be fully supported
 
-    _implied_extensions: Extension = Extension(0)
+    _implied_extensions: isa.Extension = isa.Extension(0)
 
     def replace(self, **kwargs):
         return dataclasses.replace(self, **kwargs)
@@ -87,7 +87,7 @@ basic_core_config = CoreConfiguration()
 # Minimal core configuration
 tiny_core_config = CoreConfiguration(
     func_units_config=(
-        RSBlockComponent([ALUComponent(), ShiftUnitComponent(), JumpComponent()], rs_entries=2),
+        rs_func_block.RSBlockComponent([ALUComponent(), ShiftUnitComponent(), JumpComponent()], rs_entries=2),
         LSUBlockComponent(),
     ),
     rob_entries_bits=6,
@@ -96,7 +96,7 @@ tiny_core_config = CoreConfiguration(
 # Core configuration with all supported components
 full_core_config = CoreConfiguration(
     func_units_config=(
-        RSBlockComponent(
+        rs_func_block.RSBlockComponent(
             [
                 ALUComponent(zba_enable=True, zbb_enable=True),
                 ShiftUnitComponent(zbb_enable=True),
@@ -105,7 +105,7 @@ full_core_config = CoreConfiguration(
             ],
             rs_entries=4,
         ),
-        RSBlockComponent([MulComponent(mul_unit_type=MulType.SEQUENCE_MUL)], rs_entries=2),
+        rs_func_block.RSBlockComponent([MulComponent(mul_unit_type=MulType.SEQUENCE_MUL)], rs_entries=2),
         LSUBlockComponent(),
         CSRBlockComponent(),
     ),
@@ -113,11 +113,11 @@ full_core_config = CoreConfiguration(
 
 # Core configuration used in internal testbenches
 test_core_config = CoreConfiguration(
-    func_units_config=tuple(RSBlockComponent([], rs_entries=4) for _ in range(2)),
+    func_units_config=tuple(rs_func_block.RSBlockComponent([], rs_entries=4) for _ in range(2)),
     rob_entries_bits=7,
     phys_regs_bits=7,
-    _implied_extensions=Extension.I,
+    _implied_extensions=isa.Extension.I,
 )
 
 # Core configuration with vector extension
-vector_core_config = CoreConfiguration(_implied_extensions=Extension.V)
+vector_core_config = CoreConfiguration(_implied_extensions=isa.Extension.V)

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -104,5 +104,6 @@ class GenParams(DependentCache):
         self.rob_entries_bits = cfg.rob_entries_bits
         self.max_rs_entries_bits = (self.max_rs_entries - 1).bit_length()
         self.start_pc = cfg.start_pc
+        self.imm2_width = max(self.isa.csr_alen, self.isa.v_zimmlen)
 
         self._toolchain_isa_str = gen_isa_string(extensions, cfg.xlen, skip_internal=True)

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -384,6 +384,12 @@ class ISA:
 
         self.csr_alen = 12
 
+        if self.extensions & Extension.V:
+            self.v_zimmlen = 11
+        else:
+            self.v_zimmlen = 0
+
+
 
 def gen_isa_string(extensions: Extension, isa_xlen: int, *, skip_internal: bool = False) -> str:
     isa_str = "rv"

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -390,7 +390,6 @@ class ISA:
             self.v_zimmlen = 0
 
 
-
 def gen_isa_string(extensions: Extension, isa_xlen: int, *, skip_internal: bool = False) -> str:
     isa_str = "rv"
 

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -1,6 +1,7 @@
 from coreblocks.params import GenParams, OpType, Funct7, Funct3, Opcode, RegisterType
 from coreblocks.params.isa import ExceptionCause
 from coreblocks.utils.utils import layout_subset
+from coreblocks.utils._typing import LayoutLike, LayoutList
 
 __all__ = [
     "SchedulerLayouts",
@@ -53,7 +54,7 @@ class SchedulerLayouts:
             ("exec_fn", common.exec_fn),
             ("regs_l", common.regs_l),
             ("imm", gen_params.isa.xlen),
-            ("csr", gen_params.isa.csr_alen),
+            ("imm2", gen_params.imm2_width),
             ("pc", gen_params.isa.xlen),
         ]
         self.reg_alloc_out = self.renaming_in = [
@@ -63,7 +64,7 @@ class SchedulerLayouts:
             ("regs_l", common.regs_l),
             ("regs_p", [("rp_dst", gen_params.phys_regs_bits)]),
             ("imm", gen_params.isa.xlen),
-            ("csr", gen_params.isa.csr_alen),
+            ("imm2", gen_params.imm2_width),
             ("pc", gen_params.isa.xlen),
         ]
         self.renaming_out = self.rob_allocate_in = [
@@ -79,7 +80,7 @@ class SchedulerLayouts:
             ),
             ("regs_p", common.regs_p),
             ("imm", gen_params.isa.xlen),
-            ("csr", gen_params.isa.csr_alen),
+            ("imm2", gen_params.imm2_width),
             ("pc", gen_params.isa.xlen),
         ]
         self.rob_allocate_out = self.rs_select_in = [
@@ -89,7 +90,7 @@ class SchedulerLayouts:
             ("regs_p", common.regs_p),
             ("rob_id", gen_params.rob_entries_bits),
             ("imm", gen_params.isa.xlen),
-            ("csr", gen_params.isa.csr_alen),
+            ("imm2", gen_params.imm2_width),
             ("pc", gen_params.isa.xlen),
         ]
         self.rs_select_out = self.rs_insert_in = [
@@ -101,7 +102,7 @@ class SchedulerLayouts:
             ("rs_selected", gen_params.rs_number_bits),
             ("rs_entry_id", gen_params.max_rs_entries_bits),
             ("imm", gen_params.isa.xlen),
-            ("csr", gen_params.isa.csr_alen),
+            ("imm2", gen_params.imm2_width),
             ("pc", gen_params.isa.xlen),
         ]
         self.free_rf_layout = [("reg_id", gen_params.phys_regs_bits)]
@@ -162,7 +163,7 @@ class ROBLayouts:
 class RSInterfaceLayouts:
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         common = gen_params.get(CommonLayouts)
-        self.data_layout = [
+        self.data_layout : LayoutList = [
             ("rp_s1", gen_params.phys_regs_bits),
             ("rp_s2", gen_params.phys_regs_bits),
             ("rp_s1_reg", gen_params.phys_regs_bits),
@@ -173,15 +174,15 @@ class RSInterfaceLayouts:
             ("s1_val", gen_params.isa.xlen),
             ("s2_val", gen_params.isa.xlen),
             ("imm", gen_params.isa.xlen),
-            ("csr", gen_params.isa.csr_alen),
+            ("imm2", gen_params.imm2_width),
             ("pc", gen_params.isa.xlen),
         ]
 
-        self.select_out = [("rs_entry_id", rs_entries_bits)]
+        self.select_out : LayoutLike = [("rs_entry_id", rs_entries_bits)]
 
-        self.insert_in = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
+        self.insert_in : LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
 
-        self.update_in = [("tag", gen_params.phys_regs_bits), ("value", gen_params.isa.xlen)]
+        self.update_in : LayoutLike = [("tag", gen_params.phys_regs_bits), ("value", gen_params.isa.xlen)]
 
 
 class RetirementLayouts:
@@ -195,7 +196,7 @@ class RSLayouts:
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
 
-        self.data_layout = layout_subset(
+        self.data_layout : LayoutLike = layout_subset(
             rs_interface.data_layout,
             fields={
                 "rp_s1",
@@ -210,15 +211,15 @@ class RSLayouts:
             },
         )
 
-        self.insert_in = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
+        self.insert_in : LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
 
-        self.select_out = rs_interface.select_out
+        self.select_out : LayoutLike = rs_interface.select_out
 
-        self.update_in = rs_interface.update_in
+        self.update_in : LayoutLike = rs_interface.update_in
 
-        self.take_in = [("rs_entry_id", rs_entries_bits)]
+        self.take_in : LayoutLike  = [("rs_entry_id", rs_entries_bits)]
 
-        self.take_out = layout_subset(
+        self.take_out :LayoutLike = layout_subset(
             rs_interface.data_layout,
             fields={
                 "s1_val",
@@ -231,7 +232,7 @@ class RSLayouts:
             },
         )
 
-        self.get_ready_list_out = [("ready_list", 2**rs_entries_bits)]
+        self.get_ready_list_out : LayoutLike = [("ready_list", 2**rs_entries_bits)]
 
 
 class ICacheLayouts:
@@ -279,7 +280,7 @@ class DecodeLayouts:
             ("exec_fn", common.exec_fn),
             ("regs_l", common.regs_l),
             ("imm", gen_params.isa.xlen),
-            ("csr", gen_params.isa.csr_alen),
+            ("imm2", gen_params.imm2_width),
             ("pc", gen_params.isa.xlen),
         ]
 
@@ -374,7 +375,7 @@ class CSRLayouts:
                 "exec_fn",
                 "s1_val",
                 "imm",
-                "csr",
+                "imm2",
                 "pc",
             },
         )

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -34,7 +34,7 @@ class CommonLayouts:
         self.regs_l = [
             ("s1", self.l_register_entry),
             ("s2", self.l_register_entry),
-            ("dst",self.l_register_entry),
+            ("dst", self.l_register_entry),
         ]
 
         self.regs_p = [
@@ -43,11 +43,8 @@ class CommonLayouts:
             ("dst", self.p_register_entry),
         ]
 
-    def get_reg_description_layout(self, width : int):
-        reg_desc = [
-            ("id", width),
-            ("type", RegisterType)
-        ]
+    def get_reg_description_layout(self, width: int):
+        reg_desc = [("id", width), ("type", RegisterType)]
         return reg_desc
 
 
@@ -139,7 +136,7 @@ class ROBLayouts:
         common = gen_params.get(CommonLayouts)
         self.data_layout = [
             ("rl_dst", common.l_register_entry),
-            ("rp_dst",common.p_register_entry),
+            ("rp_dst", common.p_register_entry),
         ]
 
         self.id_layout = [
@@ -169,7 +166,7 @@ class ROBLayouts:
 class RSInterfaceLayouts:
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         common = gen_params.get(CommonLayouts)
-        self.data_layout : LayoutList = [
+        self.data_layout: LayoutList = [
             ("rp_s1", common.p_register_entry),
             ("rp_s2", common.p_register_entry),
             ("rp_s1_reg", gen_params.phys_regs_bits),
@@ -184,11 +181,11 @@ class RSInterfaceLayouts:
             ("pc", gen_params.isa.xlen),
         ]
 
-        self.select_out : LayoutLike = [("rs_entry_id", rs_entries_bits)]
+        self.select_out: LayoutLike = [("rs_entry_id", rs_entries_bits)]
 
-        self.insert_in : LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
+        self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
 
-        self.update_in : LayoutLike = [("tag", common.p_register_entry), ("value", gen_params.isa.xlen)]
+        self.update_in: LayoutLike = [("tag", common.p_register_entry), ("value", gen_params.isa.xlen)]
 
 
 class RetirementLayouts:
@@ -202,7 +199,7 @@ class RSLayouts:
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
 
-        self.data_layout : LayoutLike = layout_subset(
+        self.data_layout: LayoutLike = layout_subset(
             rs_interface.data_layout,
             fields={
                 "rp_s1",
@@ -217,15 +214,15 @@ class RSLayouts:
             },
         )
 
-        self.insert_in : LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
+        self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
 
-        self.select_out : LayoutLike = rs_interface.select_out
+        self.select_out: LayoutLike = rs_interface.select_out
 
-        self.update_in : LayoutLike = rs_interface.update_in
+        self.update_in: LayoutLike = rs_interface.update_in
 
-        self.take_in : LayoutLike  = [("rs_entry_id", rs_entries_bits)]
+        self.take_in: LayoutLike = [("rs_entry_id", rs_entries_bits)]
 
-        self.take_out :LayoutLike = layout_subset(
+        self.take_out: LayoutLike = layout_subset(
             rs_interface.data_layout,
             fields={
                 "s1_val",
@@ -238,7 +235,7 @@ class RSLayouts:
             },
         )
 
-        self.get_ready_list_out : LayoutLike = [("ready_list", 2**rs_entries_bits)]
+        self.get_ready_list_out: LayoutLike = [("ready_list", 2**rs_entries_bits)]
 
 
 class ICacheLayouts:

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -188,7 +188,7 @@ class RSInterfaceLayouts:
 
         self.insert_in : LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
 
-        self.update_in : LayoutLike = [("tag", gen_params.phys_regs_bits), ("value", gen_params.isa.xlen)]
+        self.update_in : LayoutLike = [("tag", common.p_register_entry), ("value", gen_params.isa.xlen)]
 
 
 class RetirementLayouts:

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -28,21 +28,27 @@ class CommonLayouts:
             ("funct3", Funct3),
             ("funct7", Funct7),
         ]
+        self.l_register_entry = self.get_reg_description_layout(gen_params.isa.reg_cnt_log)
+        self.p_register_entry = self.get_reg_description_layout(gen_params.phys_regs_bits)
 
         self.regs_l = [
-            ("rl_s1", gen_params.isa.reg_cnt_log),
-            ("rl_s1_rf", RegisterType),
-            ("rl_s2", gen_params.isa.reg_cnt_log),
-            ("rl_s2_rf", RegisterType),
-            ("rl_dst", gen_params.isa.reg_cnt_log),
-            ("rl_dst_rf", RegisterType),
+            ("s1", self.l_register_entry),
+            ("s2", self.l_register_entry),
+            ("dst",self.l_register_entry),
         ]
 
         self.regs_p = [
-            ("rp_dst", gen_params.phys_regs_bits),
-            ("rp_s1", gen_params.phys_regs_bits),
-            ("rp_s2", gen_params.phys_regs_bits),
+            ("s1", self.p_register_entry),
+            ("s2", self.p_register_entry),
+            ("dst", self.p_register_entry),
         ]
+
+    def get_reg_description_layout(self, width : int):
+        reg_desc = [
+            ("id", width),
+            ("type", RegisterType)
+        ]
+        return reg_desc
 
 
 class SchedulerLayouts:
@@ -62,7 +68,7 @@ class SchedulerLayouts:
             ("illegal", 1),
             ("exec_fn", common.exec_fn),
             ("regs_l", common.regs_l),
-            ("regs_p", [("rp_dst", gen_params.phys_regs_bits)]),
+            ("regs_p", [("dst", common.p_register_entry)]),
             ("imm", gen_params.isa.xlen),
             ("imm2", gen_params.imm2_width),
             ("pc", gen_params.isa.xlen),
@@ -74,8 +80,7 @@ class SchedulerLayouts:
             (
                 "regs_l",
                 [
-                    ("rl_dst", gen_params.isa.reg_cnt_log),
-                    ("rl_dst_v", 1),
+                    ("dst", common.l_register_entry),
                 ],
             ),
             ("regs_p", common.regs_p),
@@ -131,9 +136,10 @@ class RATLayouts:
 
 class ROBLayouts:
     def __init__(self, gen_params: GenParams):
+        common = gen_params.get(CommonLayouts)
         self.data_layout = [
-            ("rl_dst", gen_params.isa.reg_cnt_log),
-            ("rp_dst", gen_params.phys_regs_bits),
+            ("rl_dst", common.l_register_entry),
+            ("rp_dst",common.p_register_entry),
         ]
 
         self.id_layout = [
@@ -164,11 +170,11 @@ class RSInterfaceLayouts:
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         common = gen_params.get(CommonLayouts)
         self.data_layout : LayoutList = [
-            ("rp_s1", gen_params.phys_regs_bits),
-            ("rp_s2", gen_params.phys_regs_bits),
+            ("rp_s1", common.p_register_entry),
+            ("rp_s2", common.p_register_entry),
             ("rp_s1_reg", gen_params.phys_regs_bits),
             ("rp_s2_reg", gen_params.phys_regs_bits),
-            ("rp_dst", gen_params.phys_regs_bits),
+            ("rp_dst", common.p_register_entry),
             ("rob_id", gen_params.rob_entries_bits),
             ("exec_fn", common.exec_fn),
             ("s1_val", gen_params.isa.xlen),
@@ -292,7 +298,7 @@ class FuncUnitLayouts:
         self.issue = [
             ("s1_val", gen_params.isa.xlen),
             ("s2_val", gen_params.isa.xlen),
-            ("rp_dst", gen_params.phys_regs_bits),
+            ("rp_dst", common.p_register_entry),
             ("rob_id", gen_params.rob_entries_bits),
             ("exec_fn", common.exec_fn),
             ("imm", gen_params.isa.xlen),
@@ -302,7 +308,7 @@ class FuncUnitLayouts:
         self.accept = [
             ("rob_id", gen_params.rob_entries_bits),
             ("result", gen_params.isa.xlen),
-            ("rp_dst", gen_params.phys_regs_bits),
+            ("rp_dst", common.p_register_entry),
             ("exception", 1),
         ]
 

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -49,7 +49,7 @@ class RegAllocation(Elaboratable):
 
         with Transaction().body(m):
             instr = self.get_instr(m)
-            with m.If((instr.regs_l.dst.id != 0) & (instr.regs_l.dst.type==RegisterType.X)):
+            with m.If((instr.regs_l.dst.id != 0) & (instr.regs_l.dst.type == RegisterType.X)):
                 reg_id = self.get_free_reg(m)
                 m.d.comb += free_reg.eq(reg_id)
             with m.Else():
@@ -102,9 +102,9 @@ class Renaming(Elaboratable):
         with Transaction().body(m):
             instr = self.get_instr(m)
 
-            rl_dst_to_rename = Signal().like(instr.regs_l.dst.id, reset = 0)
-            rp_dst_to_rename = Signal().like(instr.regs_p.dst.id, reset = 0)
-            with m.If(instr.regs_l.dst.type==RegisterType.X):
+            rl_dst_to_rename = Signal().like(instr.regs_l.dst.id, reset=0)
+            rp_dst_to_rename = Signal().like(instr.regs_p.dst.id, reset=0)
+            with m.If(instr.regs_l.dst.type == RegisterType.X):
                 m.d.comb += rl_dst_to_rename.eq(instr.regs_l.dst.id)
                 m.d.comb += rp_dst_to_rename.eq(instr.regs_p.dst.id)
 

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -4,7 +4,7 @@ from amaranth import *
 
 from coreblocks.transactions import Method, Transaction, TModule
 from coreblocks.transactions.lib import FIFO, Forwarder
-from coreblocks.params import SchedulerLayouts, GenParams, OpType
+from coreblocks.params import SchedulerLayouts, GenParams, OpType, RegisterType
 from coreblocks.utils import assign, AssignType
 from coreblocks.utils.protocols import FuncBlock
 
@@ -49,12 +49,13 @@ class RegAllocation(Elaboratable):
 
         with Transaction().body(m):
             instr = self.get_instr(m)
-            with m.If(instr.regs_l.rl_dst != 0):
+            with m.If(instr.regs_l.dst.id != 0):
                 reg_id = self.get_free_reg(m)
                 m.d.comb += free_reg.eq(reg_id)
 
             m.d.comb += assign(data_out, instr)
-            m.d.comb += data_out.regs_p.rp_dst.eq(free_reg)
+            m.d.comb += data_out.regs_p.dst.id.eq(free_reg)
+            m.d.comb += data_out.regs_p.dst.type.eq(RegisterType.X)
             self.push_instr(m, data_out)
 
         return m
@@ -100,18 +101,20 @@ class Renaming(Elaboratable):
             renamed_regs = self.rename(
                 m,
                 {
-                    "rl_s1": instr.regs_l.rl_s1,
-                    "rl_s2": instr.regs_l.rl_s2,
-                    "rl_dst": instr.regs_l.rl_dst,
-                    "rp_dst": instr.regs_p.rp_dst,
+                    "rl_s1": instr.regs_l.s1.id,
+                    "rl_s2": instr.regs_l.s2.id,
+                    "rl_dst": instr.regs_l.dst.id,
+                    "rp_dst": instr.regs_p.dst.id,
                 },
             )
 
             m.d.comb += assign(data_out, instr, fields={"opcode", "illegal", "exec_fn", "imm", "imm2", "pc"})
             m.d.comb += assign(data_out.regs_l, instr.regs_l, fields=AssignType.COMMON)
-            m.d.comb += data_out.regs_p.rp_dst.eq(instr.regs_p.rp_dst)
-            m.d.comb += data_out.regs_p.rp_s1.eq(renamed_regs.rp_s1)
-            m.d.comb += data_out.regs_p.rp_s2.eq(renamed_regs.rp_s2)
+            m.d.comb += data_out.regs_p.dst.eq(instr.regs_p.dst)
+            m.d.comb += data_out.regs_p.s1.id.eq(renamed_regs.rp_s1)
+            m.d.comb += data_out.regs_p.s1.type.eq(RegisterType.X)
+            m.d.comb += data_out.regs_p.s2.id.eq(renamed_regs.rp_s2)
+            m.d.comb += data_out.regs_p.s2.type.eq(RegisterType.X)
             self.push_instr(m, data_out)
 
         return m
@@ -158,8 +161,8 @@ class ROBAllocation(Elaboratable):
             rob_id = self.rob_put(
                 m,
                 {
-                    "rl_dst": instr.regs_l.rl_dst,
-                    "rp_dst": instr.regs_p.rp_dst,
+                    "rl_dst": instr.regs_l.dst,
+                    "rp_dst": instr.regs_p.dst,
                 },
             )
 
@@ -302,17 +305,17 @@ class RSInsertion(Elaboratable):
         # therefore we can use single transaction here.
         with Transaction().body(m):
             instr = self.get_instr(m)
-            source1 = self.rf_read1(m, {"reg_id": instr.regs_p.rp_s1})
-            source2 = self.rf_read2(m, {"reg_id": instr.regs_p.rp_s2})
+            source1 = self.rf_read1(m, {"reg_id": instr.regs_p.s1.id})
+            source2 = self.rf_read2(m, {"reg_id": instr.regs_p.s2.id})
 
             data = {
                 # when operand value is valid the convention is to set operand source to 0
                 "rs_data": {
-                    "rp_s1": Mux(source1.valid, 0, instr.regs_p.rp_s1),
-                    "rp_s2": Mux(source2.valid, 0, instr.regs_p.rp_s2),
-                    "rp_s1_reg": instr.regs_p.rp_s1,
-                    "rp_s2_reg": instr.regs_p.rp_s2,
-                    "rp_dst": instr.regs_p.rp_dst,
+                    "rp_s1": Mux(source1.valid, 0, instr.regs_p.s1),
+                    "rp_s2": Mux(source2.valid, 0, instr.regs_p.s2),
+                    "rp_s1_reg": instr.regs_p.s1.id,
+                    "rp_s2_reg": instr.regs_p.s2.id,
+                    "rp_dst": instr.regs_p.dst,
                     "rob_id": instr.rob_id,
                     "exec_fn": instr.exec_fn,
                     "s1_val": Mux(source1.valid, source1.reg_val, 0),

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -107,7 +107,7 @@ class Renaming(Elaboratable):
                 },
             )
 
-            m.d.comb += assign(data_out, instr, fields={"opcode", "illegal", "exec_fn", "imm", "csr", "pc"})
+            m.d.comb += assign(data_out, instr, fields={"opcode", "illegal", "exec_fn", "imm", "imm2", "pc"})
             m.d.comb += assign(data_out.regs_l, instr.regs_l, fields=AssignType.COMMON)
             m.d.comb += data_out.regs_p.rp_dst.eq(instr.regs_p.rp_dst)
             m.d.comb += data_out.regs_p.rp_s1.eq(renamed_regs.rp_s1)
@@ -318,7 +318,7 @@ class RSInsertion(Elaboratable):
                     "s1_val": Mux(source1.valid, source1.reg_val, 0),
                     "s2_val": Mux(source2.valid, source2.reg_val, 0),
                     "imm": instr.imm,
-                    "csr": instr.csr,
+                    "imm2": instr.imm2,
                     "pc": instr.pc,
                 }
             }

--- a/coreblocks/stages/backend.py
+++ b/coreblocks/stages/backend.py
@@ -60,7 +60,7 @@ class ResultAnnouncement(Elaboratable):
             self.m_rob_mark_done(m, rob_id=result.rob_id, exception=result.exception)
 
             with m.If(result.exception == 0):
-                self.m_rf_write_val(m, reg_id=result.rp_dst, reg_val=result.result)
+                self.m_rf_write_val(m, reg_id=result.rp_dst.id, reg_val=result.result)
                 with m.If(result.rp_dst != 0):
                     self.m_rs_write_val(m, tag=result.rp_dst, value=result.result)
 

--- a/coreblocks/stages/backend.py
+++ b/coreblocks/stages/backend.py
@@ -61,7 +61,7 @@ class ResultAnnouncement(Elaboratable):
 
             with m.If(result.exception == 0):
                 self.m_rf_write_val(m, reg_id=result.rp_dst.id, reg_val=result.result)
-                with m.If(result.rp_dst != 0):
+                with m.If(result.rp_dst.id != 0):
                     self.m_rs_write_val(m, tag=result.rp_dst, value=result.result)
 
         return m

--- a/coreblocks/stages/retirement.py
+++ b/coreblocks/stages/retirement.py
@@ -56,7 +56,7 @@ class Retirement(Elaboratable):
                 mcause.write(m, entry)
 
             # set rl_dst -> rp_dst in R-RAT
-            rat_out = self.r_rat_commit(m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rob_entry.rob_data.rp_dst)
+            rat_out = self.r_rat_commit(m, rl_dst=rob_entry.rob_data.rl_dst.id, rp_dst=rob_entry.rob_data.rp_dst.id)
 
             self.rf_free(m, rat_out.old_rp_dst)
 

--- a/coreblocks/structs_common/csr.py
+++ b/coreblocks/structs_common/csr.py
@@ -252,7 +252,7 @@ class CSRUnit(FuncBlock, Elaboratable):
 
         # Methods used within this Tranaction are CSRRegister internal _fu_(read|write) handlers which are always ready
         with Transaction().body(m, request=(ready_to_process & ~done)):
-            with m.Switch(instr.csr):
+            with m.Switch(instr.imm2):
                 for csr_number, methods in self.regfile.items():
                     read, write = methods
                     priv_level_required, read_only = csr_access_privilege(csr_number)

--- a/coreblocks/structs_common/rs.py
+++ b/coreblocks/structs_common/rs.py
@@ -1,19 +1,24 @@
-from typing import Iterable, Optional, Type, Generic, TypeVar
+from typing import Iterable, Optional, Type, Generic, TypeVar, Callable
+from typing_extensions import Self
 from amaranth import *
 from amaranth.lib.coding import PriorityEncoder
-from coreblocks.transactions import Method, def_method, TModule
+from coreblocks.transactions import Method, def_method, TModule, loop_def_method
 from coreblocks.params import RSLayouts, GenParams, OpType, RSInterfaceLayouts
 from coreblocks.transactions.core import RecordDict
 from coreblocks.utils.protocols import RSLayoutProtocol
+from coreblocks.utils.utils import mod_incr, assign, AssignType
 
-__all__ = ["RS"]
+__all__ = ["RS", "FifoRS"]
 
 
 T = TypeVar('T', bound=RSLayoutProtocol)
 class RS(Elaboratable, Generic[T]):
     def __init__(
-            self, gen_params: GenParams, rs_entries: int, ready_for: Optional[Iterable[Iterable[OpType]]] = None, layout_class : Type[T] = RSLayouts
+            self, gen_params: GenParams, rs_entries: int, ready_for: Optional[Iterable[Iterable[OpType]]] = None, *, layout_class : Type[T] = RSLayouts, insert_hook : Optional[Method] = None,
+            custom_rec_ready_setter : Optional[Callable[[Self, TModule], None]] = None
     ) -> None:
+        self.insert_hook = insert_hook
+        self.custom_rec_ready_setter = custom_rec_ready_setter
         ready_for = ready_for or ((op for op in OpType),)
         self.gen_params = gen_params
         self.rs_entries = rs_entries
@@ -36,15 +41,34 @@ class RS(Elaboratable, Generic[T]):
 
         self.data = Array(Record(self.internal_layout) for _ in range(self.rs_entries))
 
+    def define_update_method(self, m : TModule):
+        @def_method(m, self.update)
+        def _(tag: Value, value: Value) -> None:
+            for record in self.data:
+                with m.If(record.rec_full.bool()):
+                    with m.If(record.rs_data.rp_s1 == tag):
+                        m.d.sync += record.rs_data.rp_s1.eq(0)
+                        m.d.sync += record.rs_data.s1_val.eq(value)
+
+                    with m.If(record.rs_data.rp_s2 == tag):
+                        m.d.sync += record.rs_data.rp_s2.eq(0)
+                        m.d.sync += record.rs_data.s2_val.eq(value)
+
+    def generate_rec_ready_setters(self, m):
+        if self.custom_rec_ready_setter is not None:
+            self.custom_rec_ready_setter(self, m)
+        else:
+            for record in self.data:
+                m.d.comb += record.rec_ready.eq(
+                    ~record.rs_data.rp_s1.bool() & ~record.rs_data.rp_s2.bool() & record.rec_full.bool()
+                )
+
     def elaborate(self, platform):
         m = TModule()
 
         m.submodules.enc_select = PriorityEncoder(width=self.rs_entries)
 
-        for record in self.data:
-            m.d.comb += record.rec_ready.eq(
-                ~record.rs_data.rp_s1.bool() & ~record.rs_data.rp_s2.bool() & record.rec_full.bool()
-            )
+        self.generate_rec_ready_setters(m)
 
         select_vector = Cat(~record.rec_reserved for record in self.data)
         select_possible = select_vector.any()
@@ -69,18 +93,8 @@ class RS(Elaboratable, Generic[T]):
             m.d.sync += self.data[rs_entry_id].rs_data.eq(rs_data)
             m.d.sync += self.data[rs_entry_id].rec_full.eq(1)
             m.d.sync += self.data[rs_entry_id].rec_reserved.eq(1)
-
-        @def_method(m, self.update)
-        def _(tag: Value, value: Value) -> None:
-            for record in self.data:
-                with m.If(record.rec_full.bool()):
-                    with m.If(record.rs_data.rp_s1 == tag):
-                        m.d.sync += record.rs_data.rp_s1.eq(0)
-                        m.d.sync += record.rs_data.s1_val.eq(value)
-
-                    with m.If(record.rs_data.rp_s2 == tag):
-                        m.d.sync += record.rs_data.rp_s2.eq(0)
-                        m.d.sync += record.rs_data.s2_val.eq(value)
+            if self.insert_hook is not None:
+                self.insert_hook(m, rs_entry_id)
 
         @def_method(m, self.take, ready=take_possible)
         def _(rs_entry_id: Value) -> RecordDict:
@@ -97,14 +111,57 @@ class RS(Elaboratable, Generic[T]):
                 "pc": record.rs_data.pc,
             }
 
-        for get_ready_list, ready_list in zip(self.get_ready_list, ready_lists):
-
-            @def_method(m, get_ready_list, ready=ready_list.any())
-            def _() -> RecordDict:
-                return {"ready_list": ready_list}
+        @loop_def_method(m, self.get_ready_list, ready_list=lambda i: ready_lists[i].any())
+        def _(i) -> RecordDict:
+            return {"ready_list": ready_lists[i]}
 
         return m
 
+class FifoRS(RS[T]):
+    def __init__(
+            self, gen_params: GenParams, rs_entries: int, ready_for: Optional[Iterable[Iterable[OpType]]] = None, **kwargs
+    ) -> None:
+        super().__init__(gen_params, rs_entries, ready_for, **kwargs)
+        self.first_empty = Signal(self.rs_entries_bits)
+        self.oldest_full = Signal(self.rs_entries_bits)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        @def_method(m, self.select)
+        def _():
+            # ignore rs_entry_id because we always insert data to first empty slot
+            return 
+
+        @def_method(m, self.insert, ready= mod_incr(self.first_empty, self.rs_entries)!=self.oldest_full)
+        def _(rs_entry_id, rs_data):
+            m.d.sync += self.data[self.first_empty].rs_data.eq(rs_data)
+            m.d.sync += self.data[self.first_empty].rec_full.eq(1)
+            m.d.sync += self.first_empty.eq(mod_incr(self.first_empty, self.rs_entries))
+
+        self.define_update_method(m)
+        self.generate_rec_ready_setters(m)
+
+        @def_method(m, self.take, ready=self.data[self.oldest_full].rec_ready)
+        def _(rs_entry_id):
+            record = self.data[self.oldest_full]
+            m.d.sync += self.oldest_full.eq(mod_incr(self.oldest_full, self.rs_entries))
+            m.d.sync += record.rec_reserved.eq(0)
+            m.d.sync += record.rec_full.eq(0)
+            record_out = Record(self.layouts.take_out)
+            m.d.comb += assign(record_out, record, fields=AssignType.COMMON)
+            return record_out
+
+        ready_lists: list[Value] = []
+        for op_list in self.ready_for:
+            op_correct = Cat(self.data[self.oldest_full].rs_data.exec_fn.op_type == op for op in op_list).any()
+            ready_lists.append(self.data[self.oldest_full].rec_ready & self.data[self.oldest_full].rec_full & op_correct)
+
+        @loop_def_method(m, self.get_ready_list, ready_list=lambda i: ready_lists[i].any())
+        def _(i) -> RecordDict:
+            return {"ready_list": ready_lists[i]}
+
+        return m
 
 class RSStub(Elaboratable):
     def __init__(self, gen_params : GenParams, update : Method, instr_out : Method):

--- a/coreblocks/structs_common/rs.py
+++ b/coreblocks/structs_common/rs.py
@@ -3,7 +3,7 @@ from typing_extensions import Self
 from amaranth import *
 from amaranth.lib.coding import PriorityEncoder
 from coreblocks.transactions import Method, def_method, TModule, loop_def_method
-from coreblocks.params import RSLayouts, GenParams, OpType, RSInterfaceLayouts
+from coreblocks.params import RSLayouts, GenParams, OpType
 from coreblocks.transactions.core import RecordDict
 from coreblocks.utils.protocols import RSLayoutProtocol
 from coreblocks.utils.utils import mod_incr, assign, AssignType
@@ -123,12 +123,13 @@ class RS(Elaboratable, Generic[T]):
 
 
 class FifoRS(RS[T]):
-    """ Fifo RS
+    """Fifo RS
 
     Implementation of RS interface, which ignores `rs_entry_id` and instead of that
     operates as fifo, so new elements are added to the end of the RS, and an element
     can be take iff it is ready and is on the head.
     """
+
     # TODO: Instead of creating separate class maybe it will be enough to add proper
     # selection and taken logic to normal RS?
     def __init__(

--- a/coreblocks/utils/fifo.py
+++ b/coreblocks/utils/fifo.py
@@ -3,7 +3,7 @@ from coreblocks.transactions import Method, def_method, Priority, TModule, Trans
 from coreblocks.transactions._utils import MethodLayout
 import coreblocks.transactions.lib as tlib
 from coreblocks.utils._typing import ValueLike
-from coreblocks.utils.utils import popcount
+from coreblocks.utils.utils import popcount, mod_incr
 
 
 class BasicFifo(Elaboratable):
@@ -61,12 +61,6 @@ class BasicFifo(Elaboratable):
         self.write_methods = [self.write]
 
     def elaborate(self, platform):
-        def mod_incr(sig: Value, mod: int) -> Value:
-            # perform (sig+1)%mod operation
-            if mod == 2 ** len(sig):
-                return sig + 1
-            return Mux(sig == mod - 1, 0, sig + 1)
-
         m = TModule()
 
         m.submodules.buff_rdport = self.buff_rdport = self.buff.read_port(

--- a/coreblocks/utils/protocols.py
+++ b/coreblocks/utils/protocols.py
@@ -29,11 +29,12 @@ class RoutingBlock(HasElaborate, Protocol):
     send: list[Method]
     receive: list[Method]
 
+
 class RSLayoutProtocol(Protocol):
-    data_layout : LayoutLike
-    select_out : LayoutLike
-    insert_in : LayoutLike
-    update_in : LayoutLike
-    take_in : LayoutLike
-    take_out : LayoutLike
-    get_ready_list_out : LayoutLike
+    data_layout: LayoutLike
+    select_out: LayoutLike
+    insert_in: LayoutLike
+    update_in: LayoutLike
+    take_in: LayoutLike
+    take_out: LayoutLike
+    get_ready_list_out: LayoutLike

--- a/coreblocks/utils/protocols.py
+++ b/coreblocks/utils/protocols.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 from coreblocks.transactions import Method
-from ._typing import HasElaborate
+from ._typing import HasElaborate, LayoutLike
 
 
 __all__ = ["FuncUnit", "FuncBlock", "Unifier", "RoutingBlock"]
@@ -28,3 +28,12 @@ class FuncBlock(HasElaborate, Protocol):
 class RoutingBlock(HasElaborate, Protocol):
     send: list[Method]
     receive: list[Method]
+
+class RSLayoutProtocol(Protocol):
+    data_layout : LayoutLike
+    select_out : LayoutLike
+    insert_in : LayoutLike
+    update_in : LayoutLike
+    take_in : LayoutLike
+    take_out : LayoutLike
+    get_ready_list_out : LayoutLike

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -24,6 +24,7 @@ __all__ = [
     "mod_incr",
 ]
 
+
 def mod_incr(sig: Value, mod: int) -> Value:
     # perform (sig+1)%mod operation
     if mod == 2 ** len(sig):

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -21,7 +21,14 @@ __all__ = [
     "popcount",
     "count_leading_zeros",
     "count_trailing_zeros",
+    "mod_incr",
 ]
+
+def mod_incr(sig: Value, mod: int) -> Value:
+    # perform (sig+1)%mod operation
+    if mod == 2 ** len(sig):
+        return sig + 1
+    return Mux(sig == mod - 1, 0, sig + 1)
 
 
 @contextmanager

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -26,7 +26,9 @@ __all__ = [
 
 
 def mod_incr(sig: Value, mod: int) -> Value:
-    # perform (sig+1)%mod operation
+    """
+    Perform `(sig+1) % mod` operation.
+    """
     if mod == 2 ** len(sig):
         return sig + 1
     return Mux(sig == mod - 1, 0, sig + 1)

--- a/test/common.py
+++ b/test/common.py
@@ -3,7 +3,7 @@ import unittest
 import os
 import functools
 from contextlib import contextmanager, nullcontext
-from typing import Callable, Generic, Mapping, Union, Generator, TypeVar, Optional, Any, cast, Type, TypeGuard, Tuple
+from typing import Callable, Generic, Mapping, Union, Generator, TypeVar, Optional, Any, cast, Type, TypeGuard, Tuple, Iterable
 
 from amaranth import *
 from amaranth.hdl.ast import Statement
@@ -13,11 +13,13 @@ from amaranth.sim.core import Command
 from coreblocks.transactions.core import SignalBundle, Method, TransactionModule
 from coreblocks.transactions.lib import AdapterBase, AdapterTrans
 from coreblocks.transactions._utils import method_def_helper
+from coreblocks.params import RegisterType, Funct3, Funct7, OpType, GenParams, Opcode
 from coreblocks.utils import ValueLike, HasElaborate, HasDebugSignals, auto_debug_signals, LayoutLike, ModuleConnector, LayoutList
 from .gtkw_extension import write_vcd_ext
 
 
 T = TypeVar("T")
+U = TypeVar("U")
 RecordValueDict = Mapping[str, Union[ValueLike, "RecordValueDict"]]
 RecordIntDict = Mapping[str, Union[int, "RecordIntDict"]]
 RecordIntDictRet = Mapping[str, Any]  # full typing hard to work with
@@ -49,6 +51,86 @@ def generate_based_on_layout(layout : SimpleLayout, *, max_bits : Optional[int]=
         else:
             d[elem[0]] = generate_based_on_layout(elem[1])
     return d
+
+def generate_register_entry(max_bits : int, *, support_vector = False):
+    rp = random.randrange(max_bits)
+    if support_vector:
+        rp_rf = random.choice(list(RegisterType))
+    else:
+        rp_rf = RegisterType.X
+    return {"id" : rp,  "type" : rp_rf}
+
+def generate_register_set(max_bits : int,*, support_vector = False):
+    return {
+            "s1" : generate_register_entry(max_bits, support_vector= support_vector),
+            "s2" : generate_register_entry(max_bits, support_vector= support_vector),
+            "dst" : generate_register_entry(max_bits, support_vector= support_vector),
+            }
+def generate_exec_fn(optypes : Optional[Iterable[OpType]] = None):
+    if optypes is None:
+        optypes = list(OpType)
+    return {
+    "op_type" : random.choice(list(optypes)),
+    "funct3" : random.choice(list(Funct3)),
+    "funct7" : random.choice(list(Funct7)),
+    }
+
+def overwrite_dict_values(base : dict, overwriting : Mapping) -> dict:
+    copy = base
+    for k, v in overwriting.items():
+        if k in copy and isinstance(v, Mapping):
+                overwrite_dict_values(copy[k], v)
+        else:
+            copy[k]=v
+    return copy
+
+def generate_instr(gen_params : GenParams, layout : LayoutLike, *, max_bits : Optional[int]= None, support_vector=False, optypes : Optional[Iterable[OpType]] = None, max_imm : int=2**32,
+                   generate_illegal : bool = False, non_uniform_s2_val = True, overwriting :dict ={}):
+    rec = {}
+    if max_bits is None:
+        reg_phys_width = gen_params.phys_regs_bits
+    else:
+        reg_phys_width = max_bits
+
+    for field in layout:
+        if "regs_l" in field[0]:
+            if max_bits is None:
+                width = gen_params.isa.reg_cnt_log
+            else:
+                width = max_bits
+            rec ["regs_l"] = generate_register_set(width, support_vector= support_vector)
+        if "regs_p" in field[0]:
+            rec ["regs_p"] = generate_register_set(reg_phys_width, support_vector= support_vector)
+        for label in ["rp_dst", "rp_s1", "rp_s2"]:
+            if label in field[0]:
+                rec[label] = generate_register_entry(reg_phys_width, support_vector=support_vector)
+        if "exec_fn" in field[0]:
+            rec["exec_fn"] = generate_exec_fn(optypes)
+        if "opcode" in field[0]:
+            rec["opcode"] = random.choice(list(Opcode))
+        if "imm" in field[0]:
+            rec["imm"] = random.randrange(max_imm)
+        if "imm2" in field[0]:
+            rec["imm2"] = random.randrange(2**gen_params.imm2_width)
+        if "rob_id" in field[0]:
+            rec["rob_id"] = random.randrange(2**gen_params.rob_entries_bits)
+        if "pc" in field[0]:
+            rec["pc"] = random.randrange(2**32)
+        if "illegal" in field[0]:
+            rec["illegal"] = random.randrange(2) if generate_illegal else 0
+        if "s1_val" in field[0]:
+            rec["s1_val"] = random.randrange(2**gen_params.isa.xlen)
+        if "s2_val" in field[0]:
+            if non_uniform_s2_val and random.random()<0.5:
+                s2_val=0
+            else:
+                s2_val = random.randrange(2**gen_params.isa.xlen)
+            rec["s2_val"] = s2_val
+    return overwrite_dict_values(rec, overwriting)
+
+def get_dict_subset(base : Mapping[T,U], keys : Iterable[T]) -> dict[T,U]:
+    return {k:base[k] for k in keys}
+
 
 def get_outputs(field: Record) -> TestGen[RecordIntDict]:
     # return dict of all signal values in a record because amaranth's simulator can't read all

--- a/test/frontend/test_decode.py
+++ b/test/frontend/test_decode.py
@@ -48,9 +48,9 @@ class TestFetch(TestCaseWithSimulator):
         self.assertEqual(decoded["exec_fn"]["op_type"], OpType.ARITHMETIC)
         self.assertEqual(decoded["exec_fn"]["funct3"], Funct3.ADD)
         self.assertEqual(decoded["exec_fn"]["funct7"], 0)
-        self.assertEqual(decoded["regs_l"]["rl_dst"], 4)
-        self.assertEqual(decoded["regs_l"]["rl_s1"], 5)
-        self.assertEqual(decoded["regs_l"]["rl_s2"], 0)
+        self.assertEqual(decoded["regs_l"]["dst"]["id"], 4)
+        self.assertEqual(decoded["regs_l"]["s1"]["id"], 5)
+        self.assertEqual(decoded["regs_l"]["s2"]["id"], 0)
         self.assertEqual(decoded["imm"], 42)
 
         # testing an OP instruction (test copied from test_decoder.py)
@@ -62,9 +62,9 @@ class TestFetch(TestCaseWithSimulator):
         self.assertEqual(decoded["exec_fn"]["op_type"], OpType.ARITHMETIC)
         self.assertEqual(decoded["exec_fn"]["funct3"], Funct3.ADD)
         self.assertEqual(decoded["exec_fn"]["funct7"], Funct7.ADD)
-        self.assertEqual(decoded["regs_l"]["rl_dst"], 1)
-        self.assertEqual(decoded["regs_l"]["rl_s1"], 2)
-        self.assertEqual(decoded["regs_l"]["rl_s2"], 3)
+        self.assertEqual(decoded["regs_l"]["dst"]["id"], 1)
+        self.assertEqual(decoded["regs_l"]["s1"]["id"], 2)
+        self.assertEqual(decoded["regs_l"]["s2"]["id"], 3)
 
     def test(self):
         with self.run_simulation(self.test_module) as sim:

--- a/test/frontend/test_decoder.py
+++ b/test/frontend/test_decoder.py
@@ -28,7 +28,7 @@ class TestDecoder(TestCaseWithSimulator):
             succ=None,
             pred=None,
             fm=None,
-            csr=None,
+            imm2=None,
             op=None,
             illegal=0,
         ):
@@ -47,7 +47,7 @@ class TestDecoder(TestCaseWithSimulator):
             self.succ = succ
             self.pred = pred
             self.fm = fm
-            self.csr = csr
+            self.imm2 = imm2
             self.op = op
             self.illegal = illegal
 
@@ -120,12 +120,12 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x0000100F, Opcode.MISC_MEM, Funct3.FENCEI, rd=0, rs1=0, imm=0, op=OpType.FENCEI),
     ]
     DECODER_TESTS_ZICSR = [
-        InstrTest(0x001A9A73, Opcode.SYSTEM, Funct3.CSRRW, rd=20, rs1=21, csr=0x01, op=OpType.CSR_REG),
-        InstrTest(0x002B2AF3, Opcode.SYSTEM, Funct3.CSRRS, rd=21, rs1=22, csr=0x02, op=OpType.CSR_REG),
-        InstrTest(0x004BBB73, Opcode.SYSTEM, Funct3.CSRRC, rd=22, rs1=23, csr=0x04, op=OpType.CSR_REG),
-        InstrTest(0x001FDA73, Opcode.SYSTEM, Funct3.CSRRWI, rd=20, imm=0x1F, csr=0x01, op=OpType.CSR_IMM),
-        InstrTest(0x0027EAF3, Opcode.SYSTEM, Funct3.CSRRSI, rd=21, imm=0xF, csr=0x02, op=OpType.CSR_IMM),
-        InstrTest(0x00407B73, Opcode.SYSTEM, Funct3.CSRRCI, rd=22, imm=0x0, csr=0x04, op=OpType.CSR_IMM),
+        InstrTest(0x001A9A73, Opcode.SYSTEM, Funct3.CSRRW, rd=20, rs1=21, imm2=0x01, op=OpType.CSR_REG),
+        InstrTest(0x002B2AF3, Opcode.SYSTEM, Funct3.CSRRS, rd=21, rs1=22, imm2=0x02, op=OpType.CSR_REG),
+        InstrTest(0x004BBB73, Opcode.SYSTEM, Funct3.CSRRC, rd=22, rs1=23, imm2=0x04, op=OpType.CSR_REG),
+        InstrTest(0x001FDA73, Opcode.SYSTEM, Funct3.CSRRWI, rd=20, imm=0x1F, imm2=0x01, op=OpType.CSR_IMM),
+        InstrTest(0x0027EAF3, Opcode.SYSTEM, Funct3.CSRRSI, rd=21, imm=0xF, imm2=0x02, op=OpType.CSR_IMM),
+        InstrTest(0x00407B73, Opcode.SYSTEM, Funct3.CSRRCI, rd=22, imm=0x0, imm2=0x04, op=OpType.CSR_IMM),
     ]
     DECODER_TESTS_ILLEGAL = [
         InstrTest(0xFFFFFFFF, Opcode.OP_IMM, illegal=1),
@@ -1566,10 +1566,10 @@ class TestDecoder(TestCaseWithSimulator):
     DECODER_TESTS_V_CONTROL = [
         InstrTest(0x8020F057, Opcode.OP_V, Funct3.OPCFG, rd=0, rs1=1, rs2=2, op=OpType.V_CONTROL),  # vsetvl x0, x1, x2
         InstrTest(
-            0x0D307057, Opcode.OP_V, Funct3.OPCFG, rd=0, rs1=0, csr=0b11010011, op=OpType.V_CONTROL
+            0x0D307057, Opcode.OP_V, Funct3.OPCFG, rd=0, rs1=0, imm2=0b11010011, op=OpType.V_CONTROL
         ),  # vsetvli x0, x0, e32,m8,ta,ma
         InstrTest(
-            0xCD3470D7, Opcode.OP_V, Funct3.OPCFG, rd=1, imm=8, csr=0b110011010011, op=OpType.V_CONTROL
+            0xCD3470D7, Opcode.OP_V, Funct3.OPCFG, rd=1, imm=8, imm2=0b110011010011, op=OpType.V_CONTROL
         ),  # vsetivli x1, 8, e32,m8,ta,ma
     ]
 
@@ -1638,8 +1638,8 @@ class TestDecoder(TestCaseWithSimulator):
             if test.fm is not None:
                 self.assertEqual((yield self.decoder.fm), test.fm)
 
-            if test.csr is not None:
-                self.assertEqual((yield self.decoder.csr), test.csr)
+            if test.imm2 is not None:
+                self.assertEqual((yield self.decoder.imm2), test.imm2)
 
             self.assertEqual((yield self.decoder.optype), test.op)
 

--- a/test/fu/functional_common.py
+++ b/test/fu/functional_common.py
@@ -11,7 +11,7 @@ from coreblocks.params.fu_params import FunctionalComponentParams
 from coreblocks.params.keys import ExceptionReportKey
 from coreblocks.params.layouts import ExceptionRegisterLayouts
 from coreblocks.transactions.lib import AdapterTrans, Adapter
-from test.common import TestbenchIO, TestCaseWithSimulator
+from test.common import TestbenchIO, TestCaseWithSimulator, generate_register_entry
 
 
 class FunctionalTestCircuit(Elaboratable):
@@ -94,6 +94,7 @@ class GenericFunctionalTestUnit(TestCaseWithSimulator):
         self.gen = gen
 
     def setUp(self):
+        self.maxDiff = None
         self.m = FunctionalTestCircuit(self.gen, self.func_unit)
 
         random.seed(self.seed)
@@ -111,7 +112,7 @@ class GenericFunctionalTestUnit(TestCaseWithSimulator):
             data2_is_imm = random.randint(0, 1)
             op = random.choice(functions)
             rob_id = random.randint(0, 2**self.gen.rob_entries_bits - 1)
-            rp_dst = random.randint(0, 2**self.gen.phys_regs_bits - 1)
+            rp_dst = generate_register_entry(self.gen.phys_regs_bits)
             exec_fn = self.ops[op]
             pc = random.randint(0, max_int) & ~0b11
             results = self.expected(data1, data2, data_imm, pc, op, self.gen.isa.xlen)

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -14,7 +14,7 @@ from coreblocks.transactions import *
 from coreblocks.transactions.lib import *
 
 from ..common import TestCaseWithSimulator, TestbenchIO
-from test.common import signed_to_int
+from test.common import *
 
 
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: AluFn.Fn, xlen: int) -> dict[str, int]:
@@ -271,7 +271,7 @@ class TestAluFuncUnit(TestCaseWithSimulator):
             data2 = random.randint(0, max_int)
             data2_is_imm = random.randint(0, 1)
             rob_id = random.randint(0, 2**self.gen.rob_entries_bits - 1)
-            rp_dst = random.randint(0, 2**self.gen.phys_regs_bits - 1)
+            rp_dst = generate_register_entry(self.gen.phys_regs_bits)
             exec_fn = {"op_type": OpType.ARITHMETIC, "funct3": Funct3.ADD, "funct7": Funct7.ADD}
             result = (data1 + data2) & max_int
 

--- a/test/fu/test_zbc.py
+++ b/test/fu/test_zbc.py
@@ -60,7 +60,7 @@ class IterativeZbcUnitTest(GenericFunctionalTestUnit):
             ZbcComponent(recursion_depth=0),
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=400,
+            number_of_tests=200,
             seed=323262,
             method_name=method_name,
         )
@@ -76,7 +76,7 @@ class RecursiveZbcUnitTestDepth3(GenericFunctionalTestUnit):
             ZbcComponent(recursion_depth=3),
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=400,
+            number_of_tests=200,
             seed=323262,
             method_name=method_name,
         )
@@ -93,7 +93,7 @@ class RecursiveZbcUnitTestFullDepth(GenericFunctionalTestUnit):
             ZbcComponent(recursion_depth=gen.isa.xlen_log),
             compute_result,
             gen=gen,
-            number_of_tests=300,
+            number_of_tests=150,
             seed=323262,
             method_name=method_name,
         )

--- a/test/fu/vector_unit/test_vrs.py
+++ b/test/fu/vector_unit/test_vrs.py
@@ -1,0 +1,81 @@
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import VectorXRSLayout
+from amaranth.utils import bits_for
+import copy
+
+def get_reg_id(instr, name):
+    return instr["rs_data"][name]["id"]
+def get_reg_type(instr, name):
+    return instr["rs_data"][name]["type"]
+
+def set_reg_id(instr, name, new_id):
+    instr["rs_data"][name]["id"]=new_id
+
+def set_s_val(instr, val_name, val):
+    instr["rs_data"][val_name] = val
+
+class TestVXRS(TestCaseWithSimulator):
+
+    def setUp(self):
+        self.gen_params = GenParams(test_core_config)
+        self.rs_entries = 8
+        self.circ  = SimpleTestCircuit(VXRS(self.gen_params, self.rs_entries))
+
+    def generate_input(self):
+        input =[]
+        for i in range(self.rs_entries):
+            data = generate_instr(self.gen_params, VectorXRSLayout(self.gen_params, rs_entries_bits = bits_for(self.rs_entries-1)).data_layout,support_vector=True, overwriting={"rp_s1":{"id":i*2}, "rp_s2":{"id":i*2+1}})
+            instr={}
+            instr ["rs_data"] = data
+            instr ["rs_entry_id"] = i
+            input.append(instr)
+        return input
+
+    def insert_input(self, input):
+        for instr in input:
+            yield from self.circ.insert.call(instr)
+
+    def update_register(self, instr, name, val_name):
+        if get_reg_id(instr, name) == 0 or get_reg_type(instr, name) == RegisterType.V:
+            return 
+        val = random.randrange(2**32-1)
+        yield from self.circ.update.call(tag=instr["rs_data"][name], value=val)
+        set_reg_id(instr, name, 0)
+        set_s_val(instr, val_name, val)
+
+    def assert_ready(self, record, instr):
+        s1_id = get_reg_id(instr, "rp_s1")
+        s2_id = get_reg_id(instr, "rp_s2")
+        s1_type = get_reg_type(instr, "rp_s1")
+        s2_type = get_reg_type(instr, "rp_s2")
+        yield Settle()
+        if s1_type==RegisterType.X and s1_id !=0:
+            self.assertEqual((yield record.rec_ready), 0)
+            return
+        if s2_type==RegisterType.X and s2_id !=0:
+            self.assertEqual((yield record.rec_ready), 0)
+            return
+        self.assertEqual((yield record.rec_ready), 1)
+
+    def process(self, input):
+        def f():
+            yield from self.insert_input(input)
+            for id in range(self.rs_entries):
+                instr = input[id]
+                self.assertTrue((yield self.circ._dut.data[id].rec_full))
+                yield from self.assert_ready(self.circ._dut.data[id], instr)
+                yield from self.update_register(instr, "rp_s1", "s1_val")
+                yield from self.assert_ready(self.circ._dut.data[id], instr)
+                yield from self.update_register(instr, "rp_s2", "s2_val")
+                yield from self.assert_ready(self.circ._dut.data[id], instr)
+                yield from self.circ.take.call(rs_entry_id=0)
+        return f
+
+    def test_readiness(self):
+        input = self.generate_input()
+        with self.run_simulation(self.circ) as sim:
+            sim.add_sync_process(self.process(input))

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -9,7 +9,7 @@ from coreblocks.lsu.dummyLsu import LSUDummy
 from coreblocks.params.configurations import test_core_config
 from coreblocks.params.isa import *
 from coreblocks.peripherals.wishbone import *
-from test.common import TestbenchIO, TestCaseWithSimulator, int_to_signed, signed_to_int
+from test.common import TestbenchIO, TestCaseWithSimulator, int_to_signed, signed_to_int, generate_register_entry
 from test.peripherals.test_wishbone import WishboneInterfaceWrapper
 
 
@@ -121,7 +121,7 @@ class TestDummyLSULoads(TestCaseWithSimulator):
             mask = shift_mask_based_on_addr(mask, addr)
             addr = addr >> 2
 
-            rp_dst = random.randint(0, 2**self.gp.phys_regs_bits - 1)
+            rp_dst = generate_register_entry(self.gp.phys_regs_bits)
             rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
             instr = {
                 "rp_s1": rp_s1,
@@ -211,7 +211,7 @@ class TestDummyLSULoadsCycles(TestCaseWithSimulator):
     def generate_instr(self, max_reg_val, max_imm_val):
         s1_val = random.randint(0, max_reg_val // 4) * 4
         imm = random.randint(0, max_imm_val // 4) * 4
-        rp_dst = random.randint(0, 2**self.gp.phys_regs_bits - 1)
+        rp_dst = generate_register_entry(self.gp.phys_regs_bits)
         rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
 
         exec_fn = {"op_type": OpType.LOAD, "funct3": Funct3.W, "funct7": 0}
@@ -365,7 +365,7 @@ class TestDummyLSUStores(TestCaseWithSimulator):
             v = yield from self.test_module.get_result.call()
             rob_id = self.get_result_data.pop()
             self.assertEqual(v["rob_id"], rob_id)
-            self.assertEqual(v["rp_dst"], 0)
+            self.assertEqual(v["rp_dst"]["id"], 0)
             yield from self.random_wait()
 
     def precommiter(self):

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -4,7 +4,7 @@ import random
 from amaranth import *
 from amaranth.sim import Settle, Passive
 
-from coreblocks.params import GenParams, RSLayouts, SchedulerLayouts, OpType, Opcode, Funct3, Funct7, SchedulerLayouts
+from coreblocks.params import GenParams, RSLayouts, SchedulerLayouts, OpType
 from coreblocks.params.configurations import test_core_config
 from coreblocks.scheduler.scheduler import RSSelection
 from coreblocks.transactions.lib import FIFO, Adapter, AdapterTrans

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -73,7 +73,7 @@ class TestRSSelect(TestCaseWithSimulator):
 
                 rob_id = random.randrange(self.gen_params.rob_entries_bits)
                 pc = random.randrange(2**32)
-                csr = random.randrange(2**self.gen_params.isa.csr_alen)
+                imm2 = random.randrange(2**self.gen_params.imm2_width)
 
                 instr = {
                     "opcode": opcode,
@@ -90,7 +90,7 @@ class TestRSSelect(TestCaseWithSimulator):
                     },
                     "rob_id": rob_id,
                     "imm": immediate,
-                    "csr": csr,
+                    "imm2": imm2,
                     "pc": pc,
                 }
 

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -12,7 +12,7 @@ from coreblocks.transactions.lib import FIFO, AdapterTrans, Adapter
 from coreblocks.scheduler.scheduler import Scheduler
 from coreblocks.structs_common.rf import RegisterFile
 from coreblocks.structs_common.rat import FRAT
-from coreblocks.params import RSLayouts, DecodeLayouts, SchedulerLayouts, GenParams, Opcode, OpType, Funct3, Funct7
+from coreblocks.params import RSLayouts, DecodeLayouts, SchedulerLayouts, GenParams, OpType
 from coreblocks.params.configurations import test_core_config
 from coreblocks.structs_common.rob import ReorderBuffer
 from coreblocks.utils.protocols import FuncBlock
@@ -177,7 +177,7 @@ class TestScheduler(TestCaseWithSimulator):
         output_queues: Optional[Iterable[deque]] = None,
         check: Optional[Callable[[RecordIntDict, RecordIntDict], TestGen[None]]] = None,
         always_enable: bool = False,
-        name : str = ""
+        name: str = "",
     ):
         """Create queue gather-and-test process
 
@@ -259,11 +259,11 @@ class TestScheduler(TestCaseWithSimulator):
 
         return queue_process
 
-    def make_output_process(self, io: TestbenchIO, output_queues: Iterable[deque], name : str = ""):
+    def make_output_process(self, io: TestbenchIO, output_queues: Iterable[deque], name: str = ""):
         def check(got, expected):
             rl_dst_id = yield self.m.rob.data[got["rs_data"]["rob_id"]].rob_data.rl_dst.id
             rl_dst_type = yield self.m.rob.data[got["rs_data"]["rob_id"]].rob_data.rl_dst.type
-            rl_dst = {"id" : rl_dst_id, "type" : rl_dst_type}
+            rl_dst = {"id": rl_dst_id, "type": rl_dst_type}
             s1 = self.rf_state[expected["rp_s1_id"]]
             s2 = self.rf_state[expected["rp_s2_id"]]
 
@@ -301,13 +301,12 @@ class TestScheduler(TestCaseWithSimulator):
 
             scheduler_layouts = SchedulerLayouts(self.gen_params)
             for i in range(self.instr_count):
-
-                instr = generate_instr(self.gen_params,scheduler_layouts.reg_alloc_in, optypes = op_types_set)
+                instr = generate_instr(self.gen_params, scheduler_layouts.reg_alloc_in, optypes=op_types_set)
 
                 rp_s1_id = self.current_RAT[instr["regs_l"]["s1"]["id"]]
                 rp_s2_id = self.current_RAT[instr["regs_l"]["s2"]["id"]]
                 rl_dst = instr["regs_l"]["dst"]
-                rp_dst_id = self.expected_phys_reg_queue.popleft() if rl_dst["id"]!= 0 else 0
+                rp_dst_id = self.expected_phys_reg_queue.popleft() if rl_dst["id"] != 0 else 0
 
                 self.expected_rename_queue.append(
                     {
@@ -315,7 +314,8 @@ class TestScheduler(TestCaseWithSimulator):
                         "rp_s2_id": rp_s2_id,
                         "rl_dst": rl_dst,
                         "rp_dst_id": rp_dst_id,
-                    } | get_dict_subset(instr, ["opcode", "exec_fn"])
+                    }
+                    | get_dict_subset(instr, ["opcode", "exec_fn"])
                 )
                 self.current_RAT[rl_dst["id"]] = rp_dst_id
 
@@ -346,11 +346,15 @@ class TestScheduler(TestCaseWithSimulator):
         with self.run_simulation(self.m, max_cycles=1500) as sim:
             for i in range(self.rs_count):
                 sim.add_sync_process(
-                    self.make_output_process(io=self.m.rs_insert[i], output_queues=[self.expected_rs_entry_queue[i]], name=f"rs[{i}]")
+                    self.make_output_process(
+                        io=self.m.rs_insert[i], output_queues=[self.expected_rs_entry_queue[i]], name=f"rs[{i}]"
+                    )
                 )
                 sim.add_sync_process(rs_alloc_process(self.m.rs_alloc[i], i))
             sim.add_sync_process(
                 self.make_queue_process(io=self.m.rob_done, input_queues=[self.free_ROB_entries_queue], name="rob_done")
             )
-            sim.add_sync_process(self.make_queue_process(io=self.m.free_rf_inp, input_queues=[self.free_regs_queue], name="free_rf"))
+            sim.add_sync_process(
+                self.make_queue_process(io=self.m.free_rf_inp, input_queues=[self.free_regs_queue], name="free_rf")
+            )
             sim.add_sync_process(instr_input_process)

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -16,7 +16,7 @@ from coreblocks.params import RSLayouts, DecodeLayouts, SchedulerLayouts, GenPar
 from coreblocks.params.configurations import test_core_config
 from coreblocks.structs_common.rob import ReorderBuffer
 from coreblocks.utils.protocols import FuncBlock
-from ..common import RecordIntDict, TestCaseWithSimulator, TestGen, TestbenchIO, def_method_mock
+from ..common import *
 
 
 class SchedulerTestCircuit(Elaboratable):
@@ -101,7 +101,7 @@ class SchedulerTestCircuit(Elaboratable):
 @parameterized_class(
     ("name", "optype_sets", "instr_count"),
     [
-        ("One-RS", [set(OpType)], 100),
+        ("One-RS", [set(OpType)], 40),
         ("Two-RS", [{OpType.ARITHMETIC, OpType.COMPARE}, {OpType.MUL, OpType.COMPARE}], 500),
         (
             "Three-RS",
@@ -177,6 +177,7 @@ class TestScheduler(TestCaseWithSimulator):
         output_queues: Optional[Iterable[deque]] = None,
         check: Optional[Callable[[RecordIntDict, RecordIntDict], TestGen[None]]] = None,
         always_enable: bool = False,
+        name : str = ""
     ):
         """Create queue gather-and-test process
 
@@ -213,6 +214,8 @@ class TestScheduler(TestCaseWithSimulator):
             gathered from `output_queues`.
         always_enable: bool
             Makes `io` method always appear enabled.
+        name : str
+            Name of process to make potential debug prints more readable.
 
         Returns
         -------
@@ -256,16 +259,18 @@ class TestScheduler(TestCaseWithSimulator):
 
         return queue_process
 
-    def make_output_process(self, io: TestbenchIO, output_queues: Iterable[deque]):
+    def make_output_process(self, io: TestbenchIO, output_queues: Iterable[deque], name : str = ""):
         def check(got, expected):
-            rl_dst = yield self.m.rob.data[got["rs_data"]["rob_id"]].rob_data.rl_dst
-            s1 = self.rf_state[expected["rp_s1"]]
-            s2 = self.rf_state[expected["rp_s2"]]
+            rl_dst_id = yield self.m.rob.data[got["rs_data"]["rob_id"]].rob_data.rl_dst.id
+            rl_dst_type = yield self.m.rob.data[got["rs_data"]["rob_id"]].rob_data.rl_dst.type
+            rl_dst = {"id" : rl_dst_id, "type" : rl_dst_type}
+            s1 = self.rf_state[expected["rp_s1_id"]]
+            s2 = self.rf_state[expected["rp_s2_id"]]
 
             # if source operand register ids are 0 then we already have values
-            self.assertEqual(got["rs_data"]["rp_s1"], expected["rp_s1"] if not s1.valid else 0)
-            self.assertEqual(got["rs_data"]["rp_s2"], expected["rp_s2"] if not s2.valid else 0)
-            self.assertEqual(got["rs_data"]["rp_dst"], expected["rp_dst"])
+            self.assertEqual(got["rs_data"]["rp_s1"]["id"], expected["rp_s1_id"] if not s1.valid else 0)
+            self.assertEqual(got["rs_data"]["rp_s2"]["id"], expected["rp_s2_id"] if not s2.valid else 0)
+            self.assertEqual(got["rs_data"]["rp_dst"]["id"], expected["rp_dst_id"])
             self.assertEqual(got["rs_data"]["exec_fn"], expected["exec_fn"])
             self.assertEqual(got["rs_entry_id"], expected["rs_entry_id"])
             self.assertEqual(got["rs_data"]["s1_val"], s1.value if s1.valid else 0)
@@ -273,12 +278,12 @@ class TestScheduler(TestCaseWithSimulator):
             self.assertEqual(rl_dst, expected["rl_dst"])
 
             # recycle physical register number
-            if got["rs_data"]["rp_dst"] != 0:
-                self.free_phys_reg(got["rs_data"]["rp_dst"])
+            if got["rs_data"]["rp_dst"]["id"] != 0:
+                self.free_phys_reg(got["rs_data"]["rp_dst"]["id"])
             # recycle ROB entry
             self.free_ROB_entries_queue.append({"rob_id": got["rs_data"]["rob_id"]})
 
-        return self.make_queue_process(io=io, output_queues=output_queues, check=check, always_enable=True)
+        return self.make_queue_process(io=io, output_queues=output_queues, check=check, always_enable=True, name=name)
 
     def test_randomized(self):
         def instr_input_process():
@@ -294,53 +299,27 @@ class TestScheduler(TestCaseWithSimulator):
             for rs in self.optype_sets:
                 op_types_set = op_types_set.union(rs)
 
+            scheduler_layouts = SchedulerLayouts(self.gen_params)
             for i in range(self.instr_count):
-                rl_s1 = random.randrange(self.gen_params.isa.reg_cnt)
-                rl_s2 = random.randrange(self.gen_params.isa.reg_cnt)
-                rl_dst = random.randrange(self.gen_params.isa.reg_cnt)
 
-                opcode = random.choice(list(Opcode))
-                op_type = random.choice(list(op_types_set))
-                funct3 = random.choice(list(Funct3))
-                funct7 = random.choice(list(Funct7))
-                immediate = random.randrange(2**32)
-                rp_s1 = self.current_RAT[rl_s1]
-                rp_s2 = self.current_RAT[rl_s2]
-                rp_dst = self.expected_phys_reg_queue.popleft() if rl_dst != 0 else 0
+                instr = generate_instr(self.gen_params,scheduler_layouts.reg_alloc_in, optypes = op_types_set)
+
+                rp_s1_id = self.current_RAT[instr["regs_l"]["s1"]["id"]]
+                rp_s2_id = self.current_RAT[instr["regs_l"]["s2"]["id"]]
+                rl_dst = instr["regs_l"]["dst"]
+                rp_dst_id = self.expected_phys_reg_queue.popleft() if rl_dst["id"]!= 0 else 0
 
                 self.expected_rename_queue.append(
                     {
-                        "rp_s1": rp_s1,
-                        "rp_s2": rp_s2,
+                        "rp_s1_id": rp_s1_id,
+                        "rp_s2_id": rp_s2_id,
                         "rl_dst": rl_dst,
-                        "rp_dst": rp_dst,
-                        "opcode": opcode,
-                        "exec_fn": {
-                            "op_type": op_type,
-                            "funct3": funct3,
-                            "funct7": funct7,
-                        },
-                    }
+                        "rp_dst_id": rp_dst_id,
+                    } | get_dict_subset(instr, ["opcode", "exec_fn"])
                 )
-                self.current_RAT[rl_dst] = rp_dst
+                self.current_RAT[rl_dst["id"]] = rp_dst_id
 
-                yield from self.m.instr_inp.call(
-                    {
-                        "opcode": opcode,
-                        "illegal": 0,
-                        "exec_fn": {
-                            "op_type": op_type,
-                            "funct3": funct3,
-                            "funct7": funct7,
-                        },
-                        "regs_l": {
-                            "rl_s1": rl_s1,
-                            "rl_s2": rl_s2,
-                            "rl_dst": rl_dst,
-                        },
-                        "imm": immediate,
-                    }
-                )
+                yield from self.m.instr_inp.call(instr)
             # Terminate other processes
             self.expected_rename_queue.append(None)
             self.free_regs_queue.append(None)
@@ -367,11 +346,11 @@ class TestScheduler(TestCaseWithSimulator):
         with self.run_simulation(self.m, max_cycles=1500) as sim:
             for i in range(self.rs_count):
                 sim.add_sync_process(
-                    self.make_output_process(io=self.m.rs_insert[i], output_queues=[self.expected_rs_entry_queue[i]])
+                    self.make_output_process(io=self.m.rs_insert[i], output_queues=[self.expected_rs_entry_queue[i]], name=f"rs[{i}]")
                 )
                 sim.add_sync_process(rs_alloc_process(self.m.rs_alloc[i], i))
             sim.add_sync_process(
-                self.make_queue_process(io=self.m.rob_done, input_queues=[self.free_ROB_entries_queue])
+                self.make_queue_process(io=self.m.rob_done, input_queues=[self.free_ROB_entries_queue], name="rob_done")
             )
-            sim.add_sync_process(self.make_queue_process(io=self.m.free_rf_inp, input_queues=[self.free_regs_queue]))
+            sim.add_sync_process(self.make_queue_process(io=self.m.free_rf_inp, input_queues=[self.free_regs_queue], name="free_rf"))
             sim.add_sync_process(instr_input_process)

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -98,7 +98,7 @@ class TestCSRUnit(TestCaseWithSimulator):
                 "s1_val": exp["rs1"]["value"] if value_available and not imm_op else 0,
                 "rp_dst": rd,
                 "imm": imm,
-                "csr": csr,
+                "imm2": csr,
             },
             "exp": exp,
         }

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -79,7 +79,7 @@ class TestCSRUnit(TestCaseWithSimulator):
         op = random.choice(ops)
         imm_op = op == Funct3.CSRRWI or op == Funct3.CSRRCI or op == Funct3.CSRRSI
 
-        rd = random.randint(0, 15)
+        rd = generate_register_entry(4)
         rs1 = 0 if imm_op else random.randint(0, 15)
         imm = random.randint(0, 2**self.gp.isa.xlen - 1)
         rs1_val = random.randint(0, 2**self.gp.isa.xlen - 1) if rs1 else 0
@@ -130,7 +130,7 @@ class TestCSRUnit(TestCaseWithSimulator):
 
             self.assertTrue(self.dut.fetch_continue.done())
             self.assertEqual(res["rp_dst"], op["exp"]["exp_read"]["rp_dst"])
-            if op["exp"]["exp_read"]["rp_dst"]:
+            if op["exp"]["exp_read"]["rp_dst"]["id"]:
                 self.assertEqual(res["result"], op["exp"]["exp_read"]["result"])
             self.assertEqual((yield self.dut.csr[op["exp"]["exp_write"]["csr"]].value), op["exp"]["exp_write"]["value"])
 

--- a/test/structs_common/test_reorder_buffer.py
+++ b/test/structs_common/test_reorder_buffer.py
@@ -76,7 +76,7 @@ class TestReorderBuffer(TestCaseWithSimulator):
         self.executed_list = []
         self.retire_queue = deque()
         for i in range(2**gp.phys_regs_bits):
-            self.regs_left_queue.append({"id":i, "type":RegisterType.X})
+            self.regs_left_queue.append({"id": i, "type": RegisterType.X})
 
         self.log_regs_bits = gp.isa.reg_cnt_log
 
@@ -119,7 +119,7 @@ class TestFullDoneCase(TestCaseWithSimulator):
     def test_single(self):
         self.rand = Random(0)
 
-        self.gp = GenParams( test_core_config.replace(phys_regs_bits=4, rob_entries_bits=5))
+        self.gp = GenParams(test_core_config.replace(phys_regs_bits=4, rob_entries_bits=5))
         self.test_steps = 2**self.gp.rob_entries_bits
         self.m = SimpleTestCircuit(ReorderBuffer(self.gp))
         self.to_execute_list = []


### PR DESCRIPTION
In this PR I prepare scheduler for handling vector extension. I am not sure if this is the most optimal way, but relatively easy to implement and should be scalable over extension F. I extended register identifiers with a type which says in which register file we should look for that register. As for now there are two types "X" and "V". These tags are pushed throw whole scheduler.

Additionally there is added FifoRS and VXRS, so logically the first elements of vector block.

Changes:
- rename "csr" to "imm2" (will be used by both CSR and vectors)
- extend register with type
- add FifoRS
- move mod_incr to standalone utils function
- create generic generate test data functions

_Optimisation_ to be implemented under separate PR:
- standard X FU always send data to X registers so there is no need to pass dst reg type throw them