### PR TITLE
Vector frontend

### DIFF
--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -354,6 +354,8 @@ _instructions_by_optype = {
     OpType.V_CONTROL: [
         Encoding(Opcode.OP_V, Funct3.OPCFG),
     ],
+    OpType.V_MEMORY: [
+    ],
 }
 
 

--- a/coreblocks/frontend/decoder.py
+++ b/coreblocks/frontend/decoder.py
@@ -354,8 +354,7 @@ _instructions_by_optype = {
     OpType.V_CONTROL: [
         Encoding(Opcode.OP_V, Funct3.OPCFG),
     ],
-    OpType.V_MEMORY: [
-    ],
+    OpType.V_MEMORY: [],
 }
 
 

--- a/coreblocks/fu/vector_unit/utils.py
+++ b/coreblocks/fu/vector_unit/utils.py
@@ -5,7 +5,7 @@ from amaranth import *
 from coreblocks.params import VectorParameters, GenParams
 from coreblocks.utils._typing import ValueLike
 
-__all__ = ["SEW", "EEW", "EMUL", "LMUL", "eew_to_bits", "bits_to_eew", "eew_div_2", "get_vlmax"]
+__all__ = ["SEW", "EEW", "EMUL", "LMUL", "eew_to_bits", "bits_to_eew", "eew_div_2", "get_vlmax", "lmul_to_float"]
 
 
 class SEW(IntEnum):
@@ -123,5 +123,5 @@ def get_vlmax(m : TModule, sew : Value, lmul : Value, gen_params : GenParams, v_
         for s in SEW:
             for lm in LMUL:
                 with m.Case((s << log2_int(len(SEW))) | lm):
-                    m.d.comb += sig.eq(int(v_params.vlen//eew_to_bits(s)/lmul_to_float(lm)))
+                    m.d.comb += sig.eq(int(v_params.vlen//eew_to_bits(s)*lmul_to_float(lm)))
     return sig

--- a/coreblocks/fu/vector_unit/utils.py
+++ b/coreblocks/fu/vector_unit/utils.py
@@ -3,7 +3,7 @@ from enum import IntEnum, auto
 from amaranth.utils import *
 from amaranth import *
 from coreblocks.params import VectorParameters, GenParams
-from coreblocks.utils._typing import ValueLike
+from coreblocks.utils._typing import ValueLike, ModuleLike
 
 __all__ = ["SEW", "EEW", "EMUL", "LMUL", "eew_to_bits", "bits_to_eew", "eew_div_2", "get_vlmax", "lmul_to_float"]
 
@@ -101,6 +101,18 @@ def eew_div_2(eew: EEW) -> EEW:
     return bits_to_eew(eew_to_bits(eew) // 2)
 
 def lmul_to_float(lmul : LMUL) -> float:
+    """Converts LMUL to float
+
+    Parameters
+    ----------
+    lmul : LMUL
+        The lmul to convert.
+    
+    Returns
+    -------
+    float
+        The multiplier that is represented by `lmul`.
+    """
     match lmul:
         case LMUL.m1:
             return 1
@@ -117,7 +129,32 @@ def lmul_to_float(lmul : LMUL) -> float:
         case LMUL.mf8:
             return 0.125
 
-def get_vlmax(m : TModule, sew : Value, lmul : Value, gen_params : GenParams, v_params : VectorParameters) -> Signal:
+def get_vlmax(m : ModuleLike, sew : Value, lmul : Value, gen_params : GenParams, v_params : VectorParameters) -> Signal:
+    """ Generates circuit to calculate VLMAX
+
+    This function generates a circuit that computes in
+    combinational domain, a VLMAX based on the `sew` and
+    `lmul` signals, taking into account the `vlen` configured in
+    `v_params`.
+
+    Parameters
+    ----------
+    m : ModuleLike
+        Module to connect the generated circuit to.
+    sew : Value
+        SEW for which VLMAX should is to be calculated.
+    lmul : Value
+        LMUL for which VLMAX should is to be calculated.
+    gen_params : GenParams
+        Configuration of the core.
+    v_params : VectorParameters
+        Configuration of the vector extension.
+
+    Returns
+    -------
+    vlmax : Signal
+        Signal containing the calculated VLMAX.
+    """
     sig = Signal(gen_params.isa.xlen)
     with m.Switch((sew << len(lmul)) | lmul):
         for s in SEW:

--- a/coreblocks/fu/vector_unit/utils.py
+++ b/coreblocks/fu/vector_unit/utils.py
@@ -1,9 +1,8 @@
-from coreblocks.transactions import TModule
-from enum import IntEnum, auto
+from enum import IntEnum
 from amaranth.utils import *
 from amaranth import *
 from coreblocks.params import VectorParameters, GenParams
-from coreblocks.utils._typing import ValueLike, ModuleLike
+from coreblocks.utils._typing import ModuleLike
 
 __all__ = ["SEW", "EEW", "EMUL", "LMUL", "eew_to_bits", "bits_to_eew", "eew_div_2", "get_vlmax", "lmul_to_float"]
 
@@ -23,17 +22,23 @@ class SEW(IntEnum):
     w16 = 1
     w32 = 2
     w64 = 3
+
+
 EEW = SEW
+
 
 class LMUL(IntEnum):
     m1 = 0
     m2 = 1
     m4 = 2
     m8 = 3
-    mf2 = 7 # multiply fractional 2 --> LMUL=1/2
+    mf2 = 7  # multiply fractional 2 --> LMUL=1/2
     mf4 = 6
     mf8 = 5
+
+
 EMUL = LMUL
+
 
 def eew_to_bits(eew: EEW) -> int:
     """Convert EEW to number of bits
@@ -100,14 +105,15 @@ def eew_div_2(eew: EEW) -> EEW:
     """
     return bits_to_eew(eew_to_bits(eew) // 2)
 
-def lmul_to_float(lmul : LMUL) -> float:
+
+def lmul_to_float(lmul: LMUL) -> float:
     """Converts LMUL to float
 
     Parameters
     ----------
     lmul : LMUL
         The lmul to convert.
-    
+
     Returns
     -------
     float
@@ -129,8 +135,9 @@ def lmul_to_float(lmul : LMUL) -> float:
         case LMUL.mf8:
             return 0.125
 
-def get_vlmax(m : ModuleLike, sew : Value, lmul : Value, gen_params : GenParams, v_params : VectorParameters) -> Signal:
-    """ Generates circuit to calculate VLMAX
+
+def get_vlmax(m: ModuleLike, sew: Value, lmul: Value, gen_params: GenParams, v_params: VectorParameters) -> Signal:
+    """Generates circuit to calculate VLMAX
 
     This function generates a circuit that computes in
     combinational domain, a VLMAX based on the `sew` and
@@ -161,6 +168,6 @@ def get_vlmax(m : ModuleLike, sew : Value, lmul : Value, gen_params : GenParams,
             for lm in LMUL:
                 bits = (s << log2_int(len(LMUL), False)) | lm
                 with m.Case(bits):
-                    val = int(v_params.vlen//eew_to_bits(s)*lmul_to_float(lm))
+                    val = int(v_params.vlen // eew_to_bits(s) * lmul_to_float(lm))
                     m.d.comb += sig.eq(val)
     return sig

--- a/coreblocks/fu/vector_unit/utils.py
+++ b/coreblocks/fu/vector_unit/utils.py
@@ -1,24 +1,34 @@
 from enum import IntEnum, auto
 
-__all__ = ["EEW", "eew_to_bits", "bits_to_eew", "eew_div_2"]
+__all__ = ["SEW", "EEW", "EMUL", "LMUL", "eew_to_bits", "bits_to_eew", "eew_div_2"]
 
 
-class EEW(IntEnum):
-    """Representation of possible EEW
+class SEW(IntEnum):
+    """Representation of possible SEW
 
-    This enum represents EEWs as defined by the V extension, that
+    This enum represents SEWs as defined by the V extension, that
     we are able to support in our core.
 
     Possible values are represented by the small integer numbers to
     compress the representation as much as possible. So it dosn't
-    take much HW resources to represent an EEW.
+    take much HW resources to represent an SEW.
     """
 
-    w8 = auto()
-    w16 = auto()
-    w32 = auto()
-    w64 = auto()
+    w8 = 0
+    w16 = 1
+    w32 = 2
+    w64 = 3
+EEW = SEW
 
+class LMUL(IntEnum):
+    m1 = 0
+    m2 = 1
+    m4 = 2
+    m8 = 3
+    mf2 = 7 # multiply fractional 2 --> LMUL=1/2
+    mf4 = 6
+    mf8 = 5
+EMUL = LMUL
 
 def eew_to_bits(eew: EEW) -> int:
     """Convert EEW to number of bits
@@ -84,3 +94,5 @@ def eew_div_2(eew: EEW) -> EEW:
         EEW to be divided by 2.
     """
     return bits_to_eew(eew_to_bits(eew) // 2)
+
+

--- a/coreblocks/fu/vector_unit/utils.py
+++ b/coreblocks/fu/vector_unit/utils.py
@@ -119,9 +119,11 @@ def lmul_to_float(lmul : LMUL) -> float:
 
 def get_vlmax(m : TModule, sew : Value, lmul : Value, gen_params : GenParams, v_params : VectorParameters) -> Signal:
     sig = Signal(gen_params.isa.xlen)
-    with m.Switch((sew << len(sew)) | lmul):
+    with m.Switch((sew << len(lmul)) | lmul):
         for s in SEW:
             for lm in LMUL:
-                with m.Case((s << log2_int(len(SEW))) | lm):
-                    m.d.comb += sig.eq(int(v_params.vlen//eew_to_bits(s)*lmul_to_float(lm)))
+                bits = (s << log2_int(len(LMUL), False)) | lm
+                with m.Case(bits):
+                    val = int(v_params.vlen//eew_to_bits(s)*lmul_to_float(lm))
+                    m.d.comb += sig.eq(val)
     return sig

--- a/coreblocks/fu/vector_unit/v_input_verification.py
+++ b/coreblocks/fu/vector_unit/v_input_verification.py
@@ -6,9 +6,10 @@ from coreblocks.fu.vector_unit.utils import *
 from coreblocks.fu.vector_unit.v_layouts import *
 from coreblocks.utils.fifo import BasicFifo
 
+
 class VectorInputVerificator(Elaboratable):
-    """ Module to verify incoming vector instructions
-    
+    """Module to verify incoming vector instructions
+
     This module should check if incoming vector instructions are correct,
     if not, it raises an ILLEGAL_INSTRUCTION exception and immediately
     retire instruction. It currently checks:
@@ -29,7 +30,17 @@ class VectorInputVerificator(Elaboratable):
     clear : Method
         Clear internal state.
     """
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters, rob_block_interrupts : Method, put_instr : Method, get_vill : Method, get_vstart : Method, retire : Method):
+
+    def __init__(
+        self,
+        gen_params: GenParams,
+        v_params: VectorParameters,
+        rob_block_interrupts: Method,
+        put_instr: Method,
+        get_vill: Method,
+        get_vstart: Method,
+        retire: Method,
+    ):
         """
         Parameters
         ----------
@@ -69,7 +80,7 @@ class VectorInputVerificator(Elaboratable):
         self.issue = Method(i=self.layouts.verification_in)
         self.clear = Method()
 
-    def check_instr(self, m : TModule, instr) -> Value:
+    def check_instr(self, m: TModule, instr) -> Value:
         # TODO add checking if instruction is whole-register move, load or store (so they don't use vtype)
         illegal_because_vill = Signal()
         with m.If((self.vill == 1) & (instr.exec_fn.op_type != OpType.V_CONTROL)):
@@ -79,7 +90,7 @@ class VectorInputVerificator(Elaboratable):
         # as for now we assume that no instruction can be stopped inside of execution
         # (which is not true, because of load/stores)
         illegal_because_vstart = Signal()
-        with m.If(self.vstart !=0):
+        with m.If(self.vstart != 0):
             m.d.comb += illegal_because_vstart.eq(1)
 
         return illegal_because_vill | illegal_because_vstart
@@ -95,16 +106,16 @@ class VectorInputVerificator(Elaboratable):
         raise_illegal = Signal()
         m.d.top_comb += raise_illegal.eq(self.check_instr(m, fifo.head))
 
-        with Transaction(name = "verify").body(m):
+        with Transaction(name="verify").body(m):
             instr = fifo.read(m)
-            with condition(m, nonblocking = False) as branch:
+            with condition(m, nonblocking=False) as branch:
                 with branch(raise_illegal == 0):
                     self.put_instr(m, instr)
-                    self.rob_block_interrupts(m, rob_id = instr.rob_id)
+                    self.rob_block_interrupts(m, rob_id=instr.rob_id)
                 with branch(raise_illegal == 1):
-                    self.report(m, rob_id = instr.rob_id, cause = ExceptionCause.ILLEGAL_INSTRUCTION)
-                    self.retire(m, rob_id = instr.rob_id, exception = 1, rp_dst = instr.rp_dst, result = 0)
-        with Transaction(name = "getters").body(m):
+                    self.report(m, rob_id=instr.rob_id, cause=ExceptionCause.ILLEGAL_INSTRUCTION)
+                    self.retire(m, rob_id=instr.rob_id, exception=1, rp_dst=instr.rp_dst, result=0)
+        with Transaction(name="getters").body(m):
             m.d.comb += self.vstart.eq(self.get_vstart(m).vstart)
             m.d.comb += self.vill.eq(self.get_vill(m).vill)
 

--- a/coreblocks/fu/vector_unit/v_input_verification.py
+++ b/coreblocks/fu/vector_unit/v_input_verification.py
@@ -1,0 +1,93 @@
+# Zweryfikować czy wspieramy dane SEW i LMUL, czyli:
+#   - SEW < ELEN
+#   - LMUL >= 8/ELEN
+# Jeśli nie to ustawić vill
+
+# Jeśli wykonujemy instrukcję i `vill` jest ustawiony, to zgłaszamy wyjątek `illegal instruction`
+#   - dotyczy tylko instrukcji używających vtype, czyli wszystkich poza vsetvl, loadami storami i movami
+#
+# Jeśli vill jest 1, to wszystkie pozostałe bity z rejestru powinny być 0
+#
+# - Każda instrukcja resetuje vstart
+# - vstart jest zapisywany przede wszystkim przez HW podczas przerwania/wyjątku
+# - vstart is not modi ed by vector instructions that raise illegal-instruction exceptions.
+# - The vstart CSR is writable by unprivileged code, but non-zero vstart values may cause vector instructions to run
+#   substantially slower on some implementations, so vstart should not be used by application programmers
+# - Implementations are permitted to raise illegal instruction exceptions when attempting to execute a vector instruction with a
+#   value of vstart that the implementation can never produce when executing that same instruction with the same vtype
+#   setting.
+#
+# It is recommended that at reset, vtype.vill is set, the remaining bits in vtype are zero, and vl is set to zero.
+#
+# Jeśli mamy grupę rejestrów to powinna być ona odpowiednio wyrównana - zarezerwowane
+# poszerzanie dla LMUL8 i zwężanie dla minimalnego LMUL są zarezerowowane
+#
+# podniesienie wyjątku powinno blokować dalsze przetwarzanie?
+#
+# When vstart ≥ vl, there are no body elements, and no elements are updated in any destination vector register group,
+# including that no tail elements are updated with agnostic values. - trzeba zrobić tylko renaming
+
+from amaranth import *
+from coreblocks.transactions import *
+from coreblocks.transactions.lib import *
+from coreblocks.params import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.utils.fifo import BasicFifo
+
+class VectorInputVerificator(Elaboratable):
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters, rob_block_interrupts : Method, put_instr : Method, get_vill : Method, get_vstart : Method):
+        self.gen_params = gen_params
+        self.v_params = v_params
+        self.rob_block_interrupts = rob_block_interrupts
+        self.put_instr = put_instr
+        self.get_vill = get_vill
+        self.get_vstart = get_vstart
+
+        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.vill = Signal()
+        self.vstart = Signal(self.v_params.vstart_bits)
+        self.dependency_manager = self.gen_params.get(DependencyManager)
+        self.report = self.dependency_manager.get_dependency(ExceptionReportKey())
+
+        self.issue = Method(i=self.layouts.verification_in)
+
+    def check_instr(self, m : TModule, instr) -> Value:
+        # TODO add checking if instruction is whole-register move, load or store (don't use vtype)
+        illegal_because_vill = Signal()
+        with m.If(self.vill == 1 & (instr.exec_fn.op_type != OpType.V_CONTROL)):
+            m.d.comb += illegal_because_vill.eq(1)
+
+        # TODO add checking for specific instructions if me support not zero start for them
+        # as for now we assume that no instruction can be stoppedn inside of execution
+        # (which is not true, because of load/stores)
+        illegal_because_vstart = Signal()
+        with m.If(self.vstart !=0):
+            m.d.comb += illegal_because_vstart.eq(1)
+
+        return illegal_because_vill | illegal_because_vstart
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        fifo = BasicFifo(self.layouts.verification_in, 2)
+        m.submodules.fifo = fifo
+
+        self.issue.proxy(m, fifo.write)
+
+        raise_illegal = Signal()
+        m.d.top_comb += raise_illegal.eq(self.check_instr(m, fifo.head))
+
+        with Transaction(name = "verify").body(m):
+            instr = fifo.read(m)
+            with condition(m, nonblocking = False) as branch:
+                with branch(raise_illegal == 0):
+                    self.put_instr(m, instr)
+                    self.rob_block_interrupts(m, rob_id = instr.rob_id)
+                with branch(raise_illegal == 1):
+                    self.report(m, rob_id = instr.rob_id, cuse = ExceptionCause.ILLEGAL_INSTRUCTION)
+
+        with Transaction(name = "vstart_getter").body(m):
+            m.d.comb += self.vstart.eq(self.get_vstart(m).vstart)
+        with Transaction(name = "vill_getter").body(m):
+            m.d.comb += self.vill.eq(self.get_vill(m).vill)

--- a/coreblocks/fu/vector_unit/v_input_verification.py
+++ b/coreblocks/fu/vector_unit/v_input_verification.py
@@ -98,3 +98,5 @@ class VectorInputVerificator(Elaboratable):
         @def_method(m, self.clear)
         def _():
             fifo.clear(m)
+
+        return m

--- a/coreblocks/fu/vector_unit/v_input_verification.py
+++ b/coreblocks/fu/vector_unit/v_input_verification.py
@@ -1,32 +1,3 @@
-# Zweryfikować czy wspieramy dane SEW i LMUL, czyli:
-#   - SEW <= ELEN
-#   - LMUL >= 8/ELEN
-# Jeśli nie to ustawić vill
-
-# Jeśli wykonujemy instrukcję i `vill` jest ustawiony, to zgłaszamy wyjątek `illegal instruction`
-#   - dotyczy tylko instrukcji używających vtype, czyli wszystkich poza vsetvl, loadami storami i movami
-#
-# Jeśli vill jest 1, to wszystkie pozostałe bity z rejestru powinny być 0
-#
-# - Każda instrukcja resetuje vstart
-# - vstart jest zapisywany przede wszystkim przez HW podczas przerwania/wyjątku
-# - vstart is not modi ed by vector instructions that raise illegal-instruction exceptions.
-# - The vstart CSR is writable by unprivileged code, but non-zero vstart values may cause vector instructions to run
-#   substantially slower on some implementations, so vstart should not be used by application programmers
-# - Implementations are permitted to raise illegal instruction exceptions when attempting to execute a vector instruction with a
-#   value of vstart that the implementation can never produce when executing that same instruction with the same vtype
-#   setting.
-#
-# It is recommended that at reset, vtype.vill is set, the remaining bits in vtype are zero, and vl is set to zero.
-#
-# Jeśli mamy grupę rejestrów to powinna być ona odpowiednio wyrównana - zarezerwowane
-# poszerzanie dla LMUL8 i zwężanie dla minimalnego LMUL są zarezerowowane
-#
-# podniesienie wyjątku powinno blokować dalsze przetwarzanie?
-#
-# When vstart ≥ vl, there are no body elements, and no elements are updated in any destination vector register group,
-# including that no tail elements are updated with agnostic values. - trzeba zrobić tylko renaming
-
 from amaranth import *
 from coreblocks.transactions import *
 from coreblocks.transactions.lib import *
@@ -36,7 +7,51 @@ from coreblocks.fu.vector_unit.v_layouts import *
 from coreblocks.utils.fifo import BasicFifo
 
 class VectorInputVerificator(Elaboratable):
+    """ Module to verify incoming vector instructions
+    
+    This module should check if incoming vector instructions are correct,
+    if not, it raises an ILLEGAL_INSTRUCTION exception and immediately
+    retire instruction. It currently checks:
+    - if vtype dependent instruction doesn't come when `vill` is set
+    - if vstart has a supported value (currently only vstart=0 is supported)
+    Retiring illegal instructions immediately skips all steps in the middle of the
+    vector pipeline. Notably, such instructions aren't passed to VectorStatusUnit
+    so vstart isn't updated. This is a behaviour as required by the specification.
+
+    There are no checks if instruction is being reserved and the behaviour is
+    unspecified (as RISC-V allows).
+
+    Attributes
+    ----------
+    issue : Method
+        Called to insert a new instruction to process.
+        Layout: VectorFrontendLayouts.verification_in
+    clear : Method
+        Clear internal state.
+    """
     def __init__(self, gen_params : GenParams, v_params : VectorParameters, rob_block_interrupts : Method, put_instr : Method, get_vill : Method, get_vstart : Method, retire : Method):
+        """
+        Parameters
+        ----------
+        gen_params : GenParams
+            Core configuration.
+        v_params : VectorParameters
+            Vector unit configuration
+        rob_block_interrupts : Method
+            Method to be called to block interrupts on the given rob_id.
+        put_instr : Method
+            Method used to pass vector instructions that operate on data to the next pipeline stage.
+            Layout: VectorFrontendLayouts.verification_out
+        get_vill : Method
+            Method used to get the current (in terms of programme order) vill. Care
+            should be taken to avoid introducing erroneous latency.
+        get_vstart : Method
+            Method used to get the current (in terms of programme order) vstart. Care
+            should be taken to avoid introducing erroneuos latency.
+        retire : Method
+            Method used to inform about the retirement of vset{i}vl{i} instructions.
+            Layout: FuncUnitLayouts.accept
+        """
         self.gen_params = gen_params
         self.v_params = v_params
         self.rob_block_interrupts = rob_block_interrupts

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -86,3 +86,12 @@ class VectorFrontendLayouts:
 
         self.get_vill = [("vill",1)]
         self.get_vstart = [("vstart", v_params.vstart_bits)]
+
+class VRATLayouts:
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters):
+        self.translate = [
+            ("s1_l", gen_params.isa.reg_cnt_log),
+            ("s2_l", gen_params.isa.reg_cnt_log),
+            ("dst_l", gen_params.isa.reg_cnt_log),
+            ("dst_p", gen_params.isa.reg_cnt_log),
+        ]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -59,3 +59,18 @@ class VectorXRSLayout(RSLayouts):
 
         self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
         self.take_out: LayoutLike = self.data_layout
+
+class VectorFrontendLayouts:
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters):
+        common = gen_params.get(CommonLayouts)
+        self.verification_in = self.verification_out = [
+            ("rp_s1", common.p_register_entry),
+            ("rp_s2", common.p_register_entry),
+            ("rp_dst", common.p_register_entry),
+            ("rob_id", gen_params.rob_entries_bits),
+            ("exec_fn", common.exec_fn),
+            ("s1_val", gen_params.isa.xlen),
+            ("s2_val", gen_params.isa.xlen),
+            ("imm", gen_params.isa.xlen),
+            ("imm2", gen_params.imm2_width),
+        ]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -60,16 +60,11 @@ class VectorXRSLayout(RSLayouts):
         self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
         self.take_out: LayoutLike = self.data_layout
 
+
 class VectorFrontendLayouts:
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters):
+    def __init__(self, gen_params: GenParams, v_params: VectorParameters):
         common = gen_params.get(CommonLayouts)
-        self.vtype = [
-            ("lmul", LMUL),
-            ("sew", SEW),
-            ("ta", 1),
-            ("ma", 1),
-            ("vl", gen_params.isa.xlen)
-        ]
+        self.vtype = [("lmul", LMUL), ("sew", SEW), ("ta", 1), ("ma", 1), ("vl", gen_params.isa.xlen)]
 
         self.verification_in = self.verification_out = self.status_in = [
             ("rp_s1", common.p_register_entry),
@@ -83,7 +78,7 @@ class VectorFrontendLayouts:
             ("imm2", gen_params.imm2_width),
         ]
 
-        self.status_out = layout_difference(self.status_in, fields = {"imm2"}) + [("vtype", self.vtype)]
+        self.status_out = layout_difference(self.status_in, fields={"imm2"}) + [("vtype", self.vtype)]
 
-        self.get_vill = [("vill",1)]
+        self.get_vill = [("vill", 1)]
         self.get_vstart = [("vstart", v_params.vstart_bits)]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -1,9 +1,9 @@
 from amaranth.utils import *
 from coreblocks.params import *
 from coreblocks.params.vector_params import VectorParameters
-from coreblocks.fu.vector_unit.utils import EEW
+from coreblocks.fu.vector_unit.utils import SEW, LMUL, EEW
 from coreblocks.utils._typing import LayoutLike
-from coreblocks.utils import layout_subset
+from coreblocks.utils import layout_subset, layout_difference
 
 
 class VectorRegisterBankLayouts:
@@ -63,7 +63,14 @@ class VectorXRSLayout(RSLayouts):
 class VectorFrontendLayouts:
     def __init__(self, gen_params : GenParams, v_params : VectorParameters):
         common = gen_params.get(CommonLayouts)
-        self.verification_in = self.verification_out = [
+        self.vtype = [
+            ("lmul", LMUL),
+            ("sew", SEW),
+            ("ta", 1),
+            ("ma", 1),
+        ]
+
+        self.verification_in = self.verification_out = self.status_in = [
             ("rp_s1", common.p_register_entry),
             ("rp_s2", common.p_register_entry),
             ("rp_dst", common.p_register_entry),
@@ -74,3 +81,8 @@ class VectorFrontendLayouts:
             ("imm", gen_params.isa.xlen),
             ("imm2", gen_params.imm2_width),
         ]
+
+        self.status_out = layout_difference(self.status_in, fields = {"imm2"}) + [("vtype", self.vtype)]
+
+        self.get_vill = [("vill",1)]
+        self.get_vstart = [("vstart", v_params.vstart_bits)]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -86,12 +86,3 @@ class VectorFrontendLayouts:
 
         self.get_vill = [("vill",1)]
         self.get_vstart = [("vstart", v_params.vstart_bits)]
-
-class VRATLayouts:
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters):
-        self.translate = [
-            ("s1_l", gen_params.isa.reg_cnt_log),
-            ("s2_l", gen_params.isa.reg_cnt_log),
-            ("dst_l", gen_params.isa.reg_cnt_log),
-            ("dst_p", gen_params.isa.reg_cnt_log),
-        ]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -68,6 +68,7 @@ class VectorFrontendLayouts:
             ("sew", SEW),
             ("ta", 1),
             ("ma", 1),
+            ("vl", gen_params.isa.xlen)
         ]
 
         self.verification_in = self.verification_out = self.status_in = [

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -1,15 +1,80 @@
+from typing import Optional
 from amaranth import *
 from coreblocks.transactions import *
+from coreblocks.transactions.lib import *
 from coreblocks.params import *
 from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.utils.fifo import BasicFifo
 
 
 class VectorStatusUnit(Elaboratable):
-    def __init__(self, gen_params: GenParams, v_params: VectorParameters):
+    def __init__(self, gen_params: GenParams, v_params: VectorParameters, retire : Method, put_instr : Method):
         self.gen_params = gen_params
         self.v_params = v_params
+        self.retire = retire
+        self.put_instr = put_instr
+
+        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.get_vill = Method(o = self.layouts.get_vill, nonexclusive=True)
+        self.get_vstart = Method(o = self.layouts.get_vstart, nonexclusive = True)
+        self.clear = Method()
+        self.issue = Method(i = self.layouts.status_in)
+
+        self.vtype = Signal(self.gen_params.isa.xlen, reset = 1<<31)
+        self.vstart = Signal(self.v_params.vstart_bits)
+        self.vl = Signal(self.gen_params.isa.xlen)
+
+    def extract_vill(self) -> Value:
+        return self.vtype[31]
+
+    def extract_vma(self) -> Value:
+        return self.vtype[7]
+
+    def extract_vta(self) -> Value:
+        return self.vtype[6]
+
+    def extract_vlmul(self) -> Value:
+        return self.vtype[0:3]
+
+    def extract_vsew(self, val : Optional[Value] = None) -> Value:
+        if val is not None:
+            return val[3:6]
+        return self.vtype[3:6]
+
+    def process_vsetvl(self, m, instr):
+        new_vtype = Signal(8)
+        avl = Signal().like(self.vl)
+        ill = Signal()
+        with m.Switch(instr.imm2[-2:]):
+            with m.Case(0,1):
+                m.d.comb += new_vtype.eq(instr.imm2[:8])
+                m.d.comb += avl.eq(instr.s1_val)
+            with m.Case(2):
+                m.d.comb += new_vtype.eq(instr.s2_val[:8])
+                m.d.comb += avl.eq(instr.s1_val)
+            with m.Case(3):
+                m.d.comb += new_vtype.eq(instr.imm2[:8])
+                m.d.comb += avl.eq(instr.imm[:5])
+        with m.If(self.extract_vsew(new_vtype) > bits_to_eew(self.v_params.elen)):
+            m.d.comb += ill.eq(1)
+        #TODO VLMAX i ograniczanie i zwracanie
+
 
     def elaborate(self, platform):
         m = TModule()
+
+        fifo = BasicFifo(self.layouts.status_in, 2)
+        m.submodules.fifo = fifo
+
+        self.issue.proxy(m, fifo.write)
+
+        with Transaction(name = "status_handler").body(m):
+            instr = fifo.read(m)
+            with condition(m, nonblocking = False) as branch:
+                with branch(fifo.head.exec_fn.op_type == OpType.V_CONTROL):
+                    pass
+                with branch():
+                    pass
 
         return m

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -49,6 +49,8 @@ class VectorStatusUnit(Elaboratable):
         new_vtype = Signal(8)
         avl = Signal().like(self.vl)
         vlmax = Signal().like(self.vl)
+        m.d.comb += vlmax.eq(get_vlmax(m, new_vtype[3:6], new_vtype[:3], self.gen_params, self.v_params))
+        m.d.comb += avl.eq(vlmax)
         ill = Signal()
         valid_rs1 = Signal()
         with m.Switch(instr.imm2[-2:]):
@@ -64,8 +66,6 @@ class VectorStatusUnit(Elaboratable):
         with m.If(self.extract_vsew(new_vtype) > bits_to_eew(self.v_params.elen)):
             m.d.comb += ill.eq(1)
 
-        m.d.comb += vlmax.eq(get_vlmax(m, new_vtype[3:6], new_vtype[:3], self.gen_params, self.v_params))
-        m.d.comb += avl.eq(vlmax)
 
         with m.If(ill):
             m.d.sync += self.vtype.eq(1<<31)
@@ -76,7 +76,7 @@ class VectorStatusUnit(Elaboratable):
             m.d.comb += avl.eq(instr.s1_val)
 
         with m.If(instr.rp_dst.id.bool() | instr.rp_s1.id.bool()):
-                m.d.sync += self.vl.eq(avl)
+            m.d.sync += self.vl.eq(avl)
 
         self.retire(m, rob_id = instr.rob_id, exception = 0, result = avl, rp_dst = instr.rp_dst)
 

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -10,7 +10,49 @@ from coreblocks.utils.fifo import BasicFifo
 
 
 class VectorStatusUnit(Elaboratable):
+    """ Module to process vector CSR values
+
+    This module holds vector CSR registers values:
+    - vtype
+    - vstart
+    - vl
+    Each vector instruction passed to the vector unit, is associated with a copy of these registers,
+    with values from the moment of it is processing. This guarantees
+    that any instruction executed out-of-order in vector unit, will see
+    the csr registers as they were defined in programme order.
+
+    This unit is also a sink for `vset{i}vl{i}` instructions. These
+    update the apropriate registers and are immediately retired.
+
+    Attributes
+    ----------
+    issue : Method(one_caller = True)
+        Method that has only one caller, used to pass new instructions to be processed.
+        Layout: `VectorFrontendLayouts.status_in`
+    get_vill : Method
+        Nonexclusive method used to get the current value of `vill`.
+        Layout: `VectorFrontendLayouts.get_vill`
+    get_vstart : Method
+        Nonexclusive method used to get the current value of `vstart`.
+        Layout: `VectorFrontendLayouts.get_vstart`
+    clear : Method
+        Clear the internal state.
+    """
     def __init__(self, gen_params: GenParams, v_params: VectorParameters, put_instr : Method, retire : Method):
+        """
+        Parameters
+        ----------
+        gen_params : GenParams
+            Core configuration.
+        v_params : VectorParameters
+            Vector unit configuration
+        put_instr : Method
+            Method used to pass vector instructions that operate on data to the next pipeline stage.
+            Layout: VectorFrontendLayouts.status_out
+        retire : Method
+            Method used to inform about the retirement of vset{i}vl{i} instructions.
+            Layout: FuncUnitLayouts.accept
+        """
         self.gen_params = gen_params
         self.v_params = v_params
         self.retire = retire
@@ -117,4 +159,3 @@ class VectorStatusUnit(Elaboratable):
         @def_method(m, self.get_vstart)
         def _():
             return {"vstart": self.vstart}
-        return m

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -108,7 +108,7 @@ class VectorStatusUnit(Elaboratable):
                 with branch():
                     self.process_normal_instr(m, instr)
             m.d.sync += self.vstart.eq(0)
-            with condition(m) as branch:
+            with condition(m, nonblocking= False) as branch:
                 with branch(self.vstart != 0):
                     self.report(m, rob_id = instr.rob_id, cause = ExceptionCause.ILLEGAL_INSTRUCTION)
                     self.retire(m, rob_id = instr.rob_id, exception = 1)

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -23,6 +23,10 @@ class VectorStatusUnit(Elaboratable):
 
     This unit is also a sink for `vset{i}vl{i}` instructions. These
     update the apropriate registers and are immediately retired.
+    If the requested parameters aren't valid, `vill` is set. Current checks:
+    - SEW < ELEN
+
+    This unit is responsible for resetting vstart to 0 after each instruction.
 
     Attributes
     ----------

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -2,6 +2,7 @@ from typing import Optional
 from amaranth import *
 from coreblocks.transactions import *
 from coreblocks.transactions.lib import *
+from coreblocks.utils import *
 from coreblocks.params import *
 from coreblocks.fu.vector_unit.utils import *
 from coreblocks.fu.vector_unit.v_layouts import *
@@ -16,6 +17,8 @@ class VectorStatusUnit(Elaboratable):
         self.put_instr = put_instr
 
         self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.dependency_manager = self.gen_params.get(DependencyManager)
+        self.report = self.dependency_manager.get_dependency(ExceptionReportKey())
         self.get_vill = Method(o = self.layouts.get_vill, nonexclusive=True)
         self.get_vstart = Method(o = self.layouts.get_vstart, nonexclusive = True)
         self.clear = Method()
@@ -34,7 +37,9 @@ class VectorStatusUnit(Elaboratable):
     def extract_vta(self) -> Value:
         return self.vtype[6]
 
-    def extract_vlmul(self) -> Value:
+    def extract_vlmul(self, val : Optional[Value] = None) -> Value:
+        if val is not None:
+            return val[0:3]
         return self.vtype[0:3]
 
     def extract_vsew(self, val : Optional[Value] = None) -> Value:
@@ -46,20 +51,44 @@ class VectorStatusUnit(Elaboratable):
         new_vtype = Signal(8)
         avl = Signal().like(self.vl)
         ill = Signal()
+        valid_rs1 = Signal()
+        m.d.top_comb = avl.eq(get_vlmax(m, self.extract_vsew(new_vtype), self.extract_vlmul(new_vtype), self.gen_params, self.v_params))
         with m.Switch(instr.imm2[-2:]):
             with m.Case(0,1):
                 m.d.comb += new_vtype.eq(instr.imm2[:8])
-                m.d.comb += avl.eq(instr.s1_val)
+                m.d.comb += valid_rs1.eq(1)
             with m.Case(2):
                 m.d.comb += new_vtype.eq(instr.s2_val[:8])
-                m.d.comb += avl.eq(instr.s1_val)
+                m.d.comb += valid_rs1.eq(1)
             with m.Case(3):
                 m.d.comb += new_vtype.eq(instr.imm2[:8])
                 m.d.comb += avl.eq(instr.imm[:5])
         with m.If(self.extract_vsew(new_vtype) > bits_to_eew(self.v_params.elen)):
             m.d.comb += ill.eq(1)
-        #TODO VLMAX i ograniczanie i zwracanie
 
+        with m.If(ill):
+            m.d.sync += self.vtype.eq(1<<31)
+        with m.Else():
+            m.d.sync += self.vtype.eq(new_vtype)
+
+        with m.If(valid_rs1 & instr.rp_s1.id.bool()):
+            m.d.comb += avl.eq(instr.s1_val)
+
+        with m.If(instr.rp_dst.id.bool() | instr.rp_s1.id.bool()):
+                m.d.sync += self.vl.eq(avl)
+
+        self.retire(m, rob_id = instr.rob_id, exception = 0, result = avl, rp_dst = instr.rp_dst)
+
+    def process_normal_instr(self, m : TModule, instr):
+        output = Record(self.layouts.status_out)
+        m.d.top_comb += assign(output, instr, fields=AssignType.COMMON)
+        m.d.top_comb += [
+                output.vtype.sew.eq(self.extract_vsew()),
+                output.vtype.lmul.eq(self.extract_vlmul()),
+                output.vtype.ma.eq(self.extract_vma()),
+                output.vtype.ta.eq(self.extract_vta()),
+                ]
+        self.put_instr(m, output)
 
     def elaborate(self, platform):
         m = TModule()
@@ -69,12 +98,19 @@ class VectorStatusUnit(Elaboratable):
 
         self.issue.proxy(m, fifo.write)
 
-        with Transaction(name = "status_handler").body(m):
+        status_handler = Transaction(name = "status_handler")
+
+        with status_handler.body(m):
             instr = fifo.read(m)
             with condition(m, nonblocking = False) as branch:
                 with branch(fifo.head.exec_fn.op_type == OpType.V_CONTROL):
-                    pass
+                    self.process_vsetvl(m, instr)
                 with branch():
-                    pass
+                    self.process_normal_instr(m, instr)
+            m.d.sync += self.vstart.eq(0)
+            with condition(m) as branch:
+                with branch(self.vstart != 0):
+                    self.report(m, rob_id = instr.rob_id, cause = ExceptionCause.ILLEGAL_INSTRUCTION)
+                    self.retire(m, rob_id = instr.rob_id, exception = 1)
 
         return m

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -133,18 +133,17 @@ class RATLayouts:
         self.rat_commit_in = [("rl_dst", gen_params.isa.reg_cnt_log), ("rp_dst", gen_params.phys_regs_bits)]
         self.rat_commit_out = [("old_rp_dst", gen_params.phys_regs_bits)]
 
+
 class SuperscalarFreeRFLayouts:
-    def __init__(self, entries_count : int, outputs_count : int):
+    def __init__(self, entries_count: int, outputs_count: int):
         self.allocate_in = [
             ("reg_count", bits_for(outputs_count)),
         ]
 
-        self.allocate_out = [
-            (f"reg{i}", log2_int(entries_count, False)) for i in range(outputs_count)
-        ]
+        self.allocate_out = [(f"reg{i}", log2_int(entries_count, False)) for i in range(outputs_count)]
 
         self.deallocate_in = [
-            (f"reg", log2_int(entries_count, False)),
+            ("reg", log2_int(entries_count, False)),
         ]
 
 

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -20,6 +20,7 @@ __all__ = [
     "CSRLayouts",
     "ICacheLayouts",
     "SuperscalarFreeRFLayouts",
+    "ExceptionRegisterLayouts",
 ]
 
 

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -1,3 +1,4 @@
+from amaranth.utils import log2_int
 from coreblocks.params import GenParams, OpType, Funct7, Funct3, Opcode, RegisterType
 from coreblocks.params.isa import ExceptionCause
 from coreblocks.utils.utils import layout_subset
@@ -18,6 +19,7 @@ __all__ = [
     "LSULayouts",
     "CSRLayouts",
     "ICacheLayouts",
+    "SuperscalarFreeRFLayouts",
 ]
 
 
@@ -129,6 +131,20 @@ class RATLayouts:
 
         self.rat_commit_in = [("rl_dst", gen_params.isa.reg_cnt_log), ("rp_dst", gen_params.phys_regs_bits)]
         self.rat_commit_out = [("old_rp_dst", gen_params.phys_regs_bits)]
+
+class SuperscalarFreeRFLayouts:
+    def __init__(self, entries_count : int, outputs_count : int):
+        self.allocate_in = [
+            ("reg_count", log2_int(outputs_count)),
+        ]
+
+        self.allocate_out = [
+            (f"reg{i}", log2_int(entries_count)) for i in range(outputs_count)
+        ]
+
+        self.deallocate_in = [
+            (f"reg", log2_int(entries_count)),
+        ]
 
 
 class ROBLayouts:

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -1,4 +1,4 @@
-from amaranth.utils import log2_int
+from amaranth.utils import *
 from coreblocks.params import GenParams, OpType, Funct7, Funct3, Opcode, RegisterType
 from coreblocks.params.isa import ExceptionCause
 from coreblocks.utils.utils import layout_subset
@@ -135,15 +135,15 @@ class RATLayouts:
 class SuperscalarFreeRFLayouts:
     def __init__(self, entries_count : int, outputs_count : int):
         self.allocate_in = [
-            ("reg_count", log2_int(outputs_count)),
+            ("reg_count", bits_for(outputs_count)),
         ]
 
         self.allocate_out = [
-            (f"reg{i}", log2_int(entries_count)) for i in range(outputs_count)
+            (f"reg{i}", log2_int(entries_count, False)) for i in range(outputs_count)
         ]
 
         self.deallocate_in = [
-            (f"reg", log2_int(entries_count)),
+            (f"reg", log2_int(entries_count, False)),
         ]
 
 

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -147,6 +147,7 @@ class ROBLayouts:
             ("rob_data", self.data_layout),
             ("done", 1),
             ("exception", 1),
+            ("block_interrupts", 1),
         ]
 
         self.mark_done_layout = [
@@ -161,6 +162,8 @@ class ROBLayouts:
         ]
 
         self.get_indices = [("start", gen_params.rob_entries_bits), ("end", gen_params.rob_entries_bits)]
+
+        self.block_interrupts = [("rob_id", gen_params.rob_entries_bits)]
 
 
 class RSInterfaceLayouts:

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -56,6 +56,7 @@ class OpType(IntEnum):
     V_PERMUTATION_SCALAR = auto()
     V_CONTROL = auto()
     V_REDUCTION = auto()
+    V_MEMORY = auto()
 
 
 #
@@ -129,6 +130,7 @@ optypes_by_extensions = {
         OpType.V_PERMUTATION_SCALAR,
         OpType.V_CONTROL,
         OpType.V_REDUCTION,
+        OpType.V_MEMORY,
     ],
 }
 

--- a/coreblocks/params/vector_params.py
+++ b/coreblocks/params/vector_params.py
@@ -28,3 +28,6 @@ class VectorParameters:
 
         self.elems_in_bank = self.elems_in_vlen // self.register_bank_count
         self.elems_in_bank_bits = log2_int(self.elems_in_bank)
+        # vstart have to have enough bits to hold all indicies for minimum SEW and maximum LMUL
+        # minimum SEW is 1 byte and maximum LMUL is 8
+        self.vstart_bits = log2_int(self.bytes_in_vlen * 8) 

--- a/coreblocks/params/vector_params.py
+++ b/coreblocks/params/vector_params.py
@@ -30,4 +30,4 @@ class VectorParameters:
         self.elems_in_bank_bits = log2_int(self.elems_in_bank, False)
         # vstart have to have enough bits to hold all indicies for minimum SEW and maximum LMUL
         # minimum SEW is 1 byte and maximum LMUL is 8
-        self.vstart_bits = log2_int(self.bytes_in_vlen * 8, False) 
+        self.vstart_bits = log2_int(self.bytes_in_vlen * 8, False)

--- a/coreblocks/params/vector_params.py
+++ b/coreblocks/params/vector_params.py
@@ -8,7 +8,7 @@ class VectorParameters:
         self.elen = elen
         self.vlen = vlen
         self.vrp_count = vrp_count
-        self.vrp_count_bits = log2_int(self.vrp_count)
+        self.vrp_count_bits = log2_int(self.vrp_count, False)
         self.register_bank_count = register_bank_count
 
         self.bytes_in_vlen = self.vlen // 8
@@ -27,7 +27,7 @@ class VectorParameters:
             raise ValueError("Number of elements in vector register not divisable by number of banks.")
 
         self.elems_in_bank = self.elems_in_vlen // self.register_bank_count
-        self.elems_in_bank_bits = log2_int(self.elems_in_bank)
+        self.elems_in_bank_bits = log2_int(self.elems_in_bank, False)
         # vstart have to have enough bits to hold all indicies for minimum SEW and maximum LMUL
         # minimum SEW is 1 byte and maximum LMUL is 8
-        self.vstart_bits = log2_int(self.bytes_in_vlen * 8) 
+        self.vstart_bits = log2_int(self.bytes_in_vlen * 8, False) 

--- a/coreblocks/structs_common/rat.py
+++ b/coreblocks/structs_common/rat.py
@@ -6,7 +6,34 @@ __all__ = ["FRAT", "RRAT"]
 
 
 class FRAT(Elaboratable):
+    """ Frontend Register Alias Table
+
+    Module to store the translation from logical register
+    id's to physical register id's. It can handle up to
+    `superscalarity` requests simultaneously.
+
+    Attributes
+    ----------
+    rename : Method
+        Alias to rename_list[0] for backward compatibility.
+    rename_list : list[Method], len(rename_list) == `superscalarity`
+        List with the `superscalarity` rename methods. Each method can handle
+        one renaime request. Each request consists of two
+        source registers to be renamed and a pair of logical and
+        physical destination registers ids. This pair represents a
+        mapping to be added to RAT. There are no checks for conflicts
+        between mappings inserted by different methods simultaneusly.
+        Layout: RATLayouts.rat_rename_*
+    """
     def __init__(self, *, gen_params: GenParams, superscalarity : int = 1):
+        """
+        Parameters
+        ----------
+        gen_params : GenParams
+            Core configuration.
+        superscalarity : int
+            Number of the rename methods to create.
+        """
         self.gen_params = gen_params
         self.superscalarity = superscalarity
         layouts = gen_params.get(RATLayouts)
@@ -33,10 +60,33 @@ class FRAT(Elaboratable):
 
 
 class RRAT(Elaboratable):
-    """
-    Assumption about uniques
+    """ Retirement Register Alias Table
+
+    Register alias table of committed instructions. It represents the state of
+    the CPU as seen by the programmer. It can handle up to `superscalarity` commits
+    recuests in a cycle as long as the logical registers ids passed to the methods
+    are different. There are no checks to catch the situation, where two methods
+    try to update the same register simultaneusly.
+
+    Attributes
+    ----------
+    commit : Method
+        Alias to commit_list[0] for backward compatibility.
+    commit_list : list[Method]
+        List with the `superscalarity` commit methods. Each of them takes
+        `rp_dst` and `rl_dst` and update mapping hold in RAT returning
+        `old_rp_dst` which was previously mapped to `rl_dst`.
+        Layout: RATLayouts.rat_commit_*
     """
     def __init__(self, *, gen_params: GenParams, superscalarity : int = 1):
+        """
+        Parameters
+        ----------
+        gen_params : GenParams
+            Core configuration.
+        superscalarity : int
+            Number of `commit` methods to create.
+        """
         self.gen_params = gen_params
         self.superscalarity = superscalarity
         layouts = gen_params.get(RATLayouts)

--- a/coreblocks/structs_common/rat.py
+++ b/coreblocks/structs_common/rat.py
@@ -1,12 +1,12 @@
 from amaranth import *
-from coreblocks.transactions import Method, def_method, TModule, loop_def_method
+from coreblocks.transactions import Method, TModule, loop_def_method
 from coreblocks.params import RATLayouts, GenParams
 
 __all__ = ["FRAT", "RRAT"]
 
 
 class FRAT(Elaboratable):
-    """ Frontend Register Alias Table
+    """Frontend Register Alias Table
 
     Module to store the translation from logical register
     id's to physical register id's. It can handle up to
@@ -25,7 +25,8 @@ class FRAT(Elaboratable):
         between mappings inserted by different methods simultaneusly.
         Layout: RATLayouts.rat_rename_*
     """
-    def __init__(self, *, gen_params: GenParams, superscalarity : int = 1):
+
+    def __init__(self, *, gen_params: GenParams, superscalarity: int = 1):
         """
         Parameters
         ----------
@@ -42,9 +43,11 @@ class FRAT(Elaboratable):
 
         self.entries = Array(Signal(self.gen_params.phys_regs_bits) for _ in range(self.gen_params.isa.reg_cnt))
 
-        if self.superscalarity<1:
+        if self.superscalarity < 1:
             raise ValueError(f"FRAT should have minimum one method, so superscalarity>=1, got: {self.superscalarity}")
-        self.rename_list = [Method(i=self.rename_input_layout, o=self.rename_output_layout) for _ in range(self.superscalarity)]
+        self.rename_list = [
+            Method(i=self.rename_input_layout, o=self.rename_output_layout) for _ in range(self.superscalarity)
+        ]
         # for backward compatibility
         self.rename = self.rename_list[0]
 
@@ -60,7 +63,7 @@ class FRAT(Elaboratable):
 
 
 class RRAT(Elaboratable):
-    """ Retirement Register Alias Table
+    """Retirement Register Alias Table
 
     Register alias table of committed instructions. It represents the state of
     the CPU as seen by the programmer. It can handle up to `superscalarity` commits
@@ -78,7 +81,8 @@ class RRAT(Elaboratable):
         `old_rp_dst` which was previously mapped to `rl_dst`.
         Layout: RATLayouts.rat_commit_*
     """
-    def __init__(self, *, gen_params: GenParams, superscalarity : int = 1):
+
+    def __init__(self, *, gen_params: GenParams, superscalarity: int = 1):
         """
         Parameters
         ----------
@@ -95,9 +99,11 @@ class RRAT(Elaboratable):
 
         self.entries = Array(Signal(self.gen_params.phys_regs_bits) for _ in range(self.gen_params.isa.reg_cnt))
 
-        if self.superscalarity<1:
+        if self.superscalarity < 1:
             raise ValueError(f"FRAT should have minimum one method, so superscalarity>=1, got: {self.superscalarity}")
-        self.commit_list = [Method(i=self.commit_input_layout, o=self.commit_output_layout) for _ in range(self.superscalarity)]
+        self.commit_list = [
+            Method(i=self.commit_input_layout, o=self.commit_output_layout) for _ in range(self.superscalarity)
+        ]
         # for backward compatibility
         self.commit = self.commit_list[0]
 

--- a/coreblocks/structs_common/rat.py
+++ b/coreblocks/structs_common/rat.py
@@ -33,6 +33,9 @@ class FRAT(Elaboratable):
 
 
 class RRAT(Elaboratable):
+    """
+    Assumption about uniques
+    """
     def __init__(self, *, gen_params: GenParams, superscalarity : int = 1):
         self.gen_params = gen_params
         self.superscalarity = superscalarity

--- a/coreblocks/structs_common/rat.py
+++ b/coreblocks/structs_common/rat.py
@@ -1,26 +1,31 @@
 from amaranth import *
-from coreblocks.transactions import Method, def_method, TModule
+from coreblocks.transactions import Method, def_method, TModule, loop_def_method
 from coreblocks.params import RATLayouts, GenParams
 
 __all__ = ["FRAT", "RRAT"]
 
 
 class FRAT(Elaboratable):
-    def __init__(self, *, gen_params: GenParams):
+    def __init__(self, *, gen_params: GenParams, superscalarity : int = 1):
         self.gen_params = gen_params
+        self.superscalarity = superscalarity
         layouts = gen_params.get(RATLayouts)
         self.rename_input_layout = layouts.rat_rename_in
         self.rename_output_layout = layouts.rat_rename_out
 
         self.entries = Array(Signal(self.gen_params.phys_regs_bits) for _ in range(self.gen_params.isa.reg_cnt))
 
-        self.rename = Method(i=self.rename_input_layout, o=self.rename_output_layout)
+        if self.superscalarity<1:
+            raise ValueError(f"FRAT should have minimum one method, so superscalarity>=1, got: {self.superscalarity}")
+        self.rename_list = [Method(i=self.rename_input_layout, o=self.rename_output_layout) for _ in range(self.superscalarity)]
+        # for backward compatibility
+        self.rename = self.rename_list[0]
 
     def elaborate(self, platform):
         m = TModule()
 
-        @def_method(m, self.rename)
-        def _(rp_dst: Value, rl_dst: Value, rl_s1: Value, rl_s2: Value):
+        @loop_def_method(m, self.rename_list)
+        def _(_, rp_dst: Value, rl_dst: Value, rl_s1: Value, rl_s2: Value):
             m.d.sync += self.entries[rl_dst].eq(rp_dst)
             return {"rp_s1": self.entries[rl_s1], "rp_s2": self.entries[rl_s2]}
 
@@ -28,21 +33,26 @@ class FRAT(Elaboratable):
 
 
 class RRAT(Elaboratable):
-    def __init__(self, *, gen_params: GenParams):
+    def __init__(self, *, gen_params: GenParams, superscalarity : int = 1):
         self.gen_params = gen_params
+        self.superscalarity = superscalarity
         layouts = gen_params.get(RATLayouts)
         self.commit_input_layout = layouts.rat_commit_in
         self.commit_output_layout = layouts.rat_commit_out
 
         self.entries = Array(Signal(self.gen_params.phys_regs_bits) for _ in range(self.gen_params.isa.reg_cnt))
 
-        self.commit = Method(i=self.commit_input_layout, o=self.commit_output_layout)
+        if self.superscalarity<1:
+            raise ValueError(f"FRAT should have minimum one method, so superscalarity>=1, got: {self.superscalarity}")
+        self.commit_list = [Method(i=self.commit_input_layout, o=self.commit_output_layout) for _ in range(self.superscalarity)]
+        # for backward compatibility
+        self.commit = self.commit_list[0]
 
     def elaborate(self, platform):
         m = TModule()
 
-        @def_method(m, self.commit)
-        def _(rp_dst: Value, rl_dst: Value):
+        @loop_def_method(m, self.commit_list)
+        def _(_, rp_dst: Value, rl_dst: Value):
             m.d.sync += self.entries[rl_dst].eq(rp_dst)
             return {"old_rp_dst": self.entries[rl_dst]}
 

--- a/coreblocks/structs_common/rob.py
+++ b/coreblocks/structs_common/rob.py
@@ -13,8 +13,10 @@ class ReorderBuffer(Elaboratable):
         self.mark_done = Method(i=layouts.mark_done_layout)
         self.peek = Method(o=layouts.peek_layout, nonexclusive=True)
         self.retire = Method(o=layouts.retire_layout)
-        self.data = Array(Record(layouts.internal_layout) for _ in range(2**gen_params.rob_entries_bits))
         self.get_indices = Method(o=layouts.get_indices, nonexclusive=True)
+        self.block_interrupts = Method(i=layouts.block_interrupts)
+
+        self.data = Array(Record(layouts.internal_layout) for _ in range(2**gen_params.rob_entries_bits))
 
     def elaborate(self, platform):
         m = TModule()
@@ -63,5 +65,9 @@ class ReorderBuffer(Elaboratable):
         @def_method(m, self.get_indices)
         def _():
             return {"start": start_idx, "end": end_idx}
+
+        @def_method(m, self.block_interrupts)
+        def _(rob_id):
+            m.d.sync += self.data[rob_id].block_interrupts.eq(1)
 
         return m

--- a/coreblocks/structs_common/superscalar_freerf.py
+++ b/coreblocks/structs_common/superscalar_freerf.py
@@ -1,0 +1,52 @@
+from typing import Optional
+from amaranth import *
+from coreblocks.transactions import *
+from coreblocks.transactions.lib import *
+from coreblocks.utils import *
+from coreblocks.params import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_layouts import *
+
+
+class SuperscalarFreeRF(Elaboratable):
+    def __init__(self, entries_count : int, outputs_count : int):
+        self.entries_count = entries_count
+        self.outputs_count = outputs_count
+
+        self.layouts = SuperscalarFreeRFLayouts(self.entries_count, self.outputs_count)
+        self.allocate = Method(i=self.layouts.allocate_in, o=self.layouts.allocate_out)
+        self.deallocates = [Method(i=self.layouts.deallocate_in) for _ in range(self.outputs_count)]
+
+    def elaborate(self, platform) -> TModule:
+        m = TModule()
+
+        self.used = Signal(self.entries_count)
+
+        m.submodules.priority_encoder = encoder = MultiPriorityEncoder(self.entries_count, self.outputs_count)
+        m.d.top_comb += encoder.input.eq(self.used)
+
+        free_count = Signal(log2_int(self.entries_count))
+        m.d.top_comb += free_count.eq(count_trailing_zeros(~Cat(encoder.valids)))
+
+        regs = [Signal.like(encoder.outputs[j]) for j in range(self.outputs_count)]
+
+        # ONE CALLER!
+        @def_method(m, self.allocate)
+        def _(reg_count):
+            with condition(m, nonblocking = False) as branch:
+                with branch(reg_count <= free_count):
+                    mask = (2 << reg_count) - 1
+                    for j in range(self.outputs_count):
+                        used_bit = Signal()
+                        m.d.comb += used_bit.eq(self.used.bit_select(encoder.outputs[j], 1))
+                        m.d.sync += self.used.bit_select(encoder.outputs[j], 1).eq(used_bit & (~mask[j]))
+                        m.d.comb += regs[j].eq(encoder.outputs[j])
+            return {f"reg{i}":regs[i] for i in range(self.outputs_count)}
+
+
+        @loop_def_method(m, self.deallocates)
+        def _(_, reg):
+            m.d.sync += self.used.bit_select(reg, 1).eq(1)
+
+
+        return m

--- a/coreblocks/structs_common/superscalar_freerf.py
+++ b/coreblocks/structs_common/superscalar_freerf.py
@@ -10,7 +10,32 @@ from coreblocks.fu.vector_unit.v_layouts import *
 __all__ = ["SuperscalarFreeRF"]
 
 class SuperscalarFreeRF(Elaboratable):
+    """ Superscalar structure for holding free registers
+
+    This module is intended to hold information about physical
+    registers that aren't currently in use, and to provide superscalar
+    selection of free registers ids.
+
+    Attributes
+    ----------
+    allocate : Method(one_caller=True)
+        Method to get `reg_count` free registers. If the requested
+        registers number of registers is greater than the actual number of free registers
+        no registers are being allocated and the method is inactive.
+    deallocates : list[Method]
+        List with `outputs_count` methods. Each of them allows to deallocate
+        one register in one cycle.
+    """
     def __init__(self, entries_count : int, outputs_count : int):
+        """
+        Parameters
+        ----------
+        entries_count : int
+            The total number of registers that should be available in the core.
+        outputs_count : int
+            Number of the deallocate methods that should be created to allow for
+            superscalar freeing of registers.
+        """
         self.entries_count = entries_count
         self.outputs_count = outputs_count
 
@@ -31,7 +56,7 @@ class SuperscalarFreeRF(Elaboratable):
 
         regs = [Signal.like(encoder.outputs[j]) for j in range(self.outputs_count)]
 
-        # ONE CALLER!
+        # one caller!
         @def_method(m, self.allocate)
         def _(reg_count):
             with condition(m, nonblocking = False) as branch:

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -27,7 +27,6 @@ __all__ = [
 ]
 
 
-
 def mod_incr(sig: Value, mod: int) -> Value:
     """
     Perform `(sig+1) % mod` operation.
@@ -347,6 +346,7 @@ def count_trailing_zeros(s: Value) -> Value:
 def layout_subset(layout: LayoutList, *, fields: set[str]) -> LayoutList:
     return [item for item in layout if item[0] in fields]
 
+
 def layout_difference(layout: LayoutList, *, fields: set[str]) -> LayoutList:
     return [item for item in layout if item[0] not in fields]
 
@@ -438,8 +438,8 @@ def silence_mustuse(elaboratable: Elaboratable):
 
 
 class MultiPriorityEncoder(Elaboratable):
-    """ Priority encoder with more outputs
-    
+    """Priority encoder with more outputs
+
     This is an extension of the `PriorityEncoder` from amaranth, that supports
     generating more than one output from an input signal.
 
@@ -458,7 +458,8 @@ class MultiPriorityEncoder(Elaboratable):
     valids : list[Signals], out
         One bit for each output signal, indicating whether the output is valid or not.
     """
-    def __init__(self, input_width : int, outputs_count : int):
+
+    def __init__(self, input_width: int, outputs_count: int):
         self.input_width = input_width
         self.outputs_count = outputs_count
 
@@ -477,9 +478,9 @@ class MultiPriorityEncoder(Elaboratable):
             with m.If(self.input[j]):
                 m.d.comb += new_current_outputs[0].eq(j)
                 m.d.comb += new_current_valids[0].eq(1)
-                for k in range(self.outputs_count-1):
-                    m.d.comb += new_current_outputs[k+1].eq(current_outputs[k])
-                    m.d.comb += new_current_valids[k+1].eq(current_valids[k])
+                for k in range(self.outputs_count - 1):
+                    m.d.comb += new_current_outputs[k + 1].eq(current_outputs[k])
+                    m.d.comb += new_current_valids[k + 1].eq(current_valids[k])
             with m.Else():
                 for k in range(self.outputs_count):
                     m.d.comb += new_current_outputs[k].eq(current_outputs[k])

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -16,6 +16,7 @@ __all__ = [
     "align_to_power_of_two",
     "bits_from_int",
     "layout_subset",
+    "layout_difference",
     "ModuleConnector",
     "silence_mustuse",
     "popcount",
@@ -343,6 +344,9 @@ def count_trailing_zeros(s: Value) -> Value:
 
 def layout_subset(layout: LayoutList, *, fields: set[str]) -> LayoutList:
     return [item for item in layout if item[0] in fields]
+
+def layout_difference(layout: LayoutList, *, fields: set[str]) -> LayoutList:
+    return [item for item in layout if item[0] not in fields]
 
 
 def flatten_signals(signals: SignalBundle) -> Iterable[Signal]:

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -26,6 +26,7 @@ __all__ = [
 ]
 
 
+
 def mod_incr(sig: Value, mod: int) -> Value:
     """
     Perform `(sig+1) % mod` operation.

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -438,36 +438,56 @@ def silence_mustuse(elaboratable: Elaboratable):
 
 
 class MultiPriorityEncoder(Elaboratable):
-    def __init__(self, input_width : int, output_count : int):
+    """ Priority encoder with more outputs
+    
+    This is an extension of the `PriorityEncoder` from amaranth, that supports
+    generating more than one output from an input signal.
+
+    Attributes
+    ----------
+    input_width : int
+        Width of the input signal
+    outputs_count : int
+        Number of outputs to generate at once.
+    input : Signal, in
+        Signal with 1 on `i`-th bit if `i` can be selected by encoder
+    outputs : list[Signal], out
+        Signals with selected indicies, they are sorted in ascending order,
+        if the number of ready signals is less than `outputs_count`,
+        then valid signals are at the beginning of the list.
+    valids : list[Signals], out
+        One bit for each output signal, indicating whether the output is valid or not.
+    """
+    def __init__(self, input_width : int, outputs_count : int):
         self.input_width = input_width
-        self.output_count = output_count
+        self.outputs_count = outputs_count
 
         self.input = Signal(self.input_width)
-        self.outputs = [Signal(range(self.input_width)) for _ in range(self.output_count)]
-        self.valids = [Signal() for _ in range(self.output_count)]
+        self.outputs = [Signal(range(self.input_width)) for _ in range(self.outputs_count)]
+        self.valids = [Signal() for _ in range(self.outputs_count)]
 
     def elaborate(self, platform):
         m = Module()
 
-        current_outputs = [Signal(range(self.input_width)) for _ in range(self.output_count)]
-        current_valids = [Signal() for _ in range(self.output_count)]
+        current_outputs = [Signal(range(self.input_width)) for _ in range(self.outputs_count)]
+        current_valids = [Signal() for _ in range(self.outputs_count)]
         for j in reversed(range(self.input_width)):
-            new_current_outputs = [Signal(range(self.input_width)) for _ in range(self.output_count)]
-            new_current_valids = [Signal() for _ in range(self.output_count)]
+            new_current_outputs = [Signal(range(self.input_width)) for _ in range(self.outputs_count)]
+            new_current_valids = [Signal() for _ in range(self.outputs_count)]
             with m.If(self.input[j]):
                 m.d.comb += new_current_outputs[0].eq(j)
                 m.d.comb += new_current_valids[0].eq(1)
-                for k in range(self.output_count-1):
+                for k in range(self.outputs_count-1):
                     m.d.comb += new_current_outputs[k+1].eq(current_outputs[k])
                     m.d.comb += new_current_valids[k+1].eq(current_valids[k])
             with m.Else():
-                for k in range(self.output_count):
+                for k in range(self.outputs_count):
                     m.d.comb += new_current_outputs[k].eq(current_outputs[k])
                     m.d.comb += new_current_valids[k].eq(current_valids[k])
             current_outputs = new_current_outputs
             current_valids = new_current_valids
 
-        for k in range(self.output_count):
+        for k in range(self.outputs_count):
             m.d.comb += self.outputs[k].eq(current_outputs[k])
             m.d.comb += self.valids[k].eq(current_valids[k])
 

--- a/test/common.py
+++ b/test/common.py
@@ -46,7 +46,7 @@ U = TypeVar("U")
 RecordValueDict = Mapping[str, Union[ValueLike, "RecordValueDict"]]
 RecordIntDict = Mapping[str, Union[int, "RecordIntDict"]]
 RecordIntDictRet = Mapping[str, Any]  # full typing hard to work with
-TestGen = Generator[Union[Command , Value , Statement , None , "CoreblockCommand"], Any, T]
+TestGen = Generator[Union[Command, Value, Statement, None, "CoreblockCommand"], Any, T]
 _T_nested_collection = T | list["_T_nested_collection[T]"] | dict[str, "_T_nested_collection[T]"]
 SimpleLayout = list[Tuple[str, Union[int, "SimpleLayout"]]]
 
@@ -62,15 +62,19 @@ def set_inputs(values: RecordValueDict, field: Record) -> TestGen[None]:
         else:
             yield getattr(field, name).eq(value)
 
+
 def get_unique_generator():
     history = defaultdict(set)
+
     def f(cycle, generator):
         data = generator()
         while data in history[cycle]:
             data = generator()
         history[cycle].add(data)
         return data
+
     return f
+
 
 def generate_based_on_layout(layout: SimpleLayout, *, max_bits: Optional[int] = None):
     d = {}
@@ -85,14 +89,16 @@ def generate_based_on_layout(layout: SimpleLayout, *, max_bits: Optional[int] = 
             d[elem[0]] = generate_based_on_layout(elem[1])
     return d
 
-def generate_phys_register_id(*, gen_params : Optional[GenParams] = None, max_bits : Optional[int] = None):
+
+def generate_phys_register_id(*, gen_params: Optional[GenParams] = None, max_bits: Optional[int] = None):
     if max_bits is not None:
         return random.randrange(max_bits)
     if gen_params is not None:
         return random.randrange(2**gen_params.phys_regs_bits)
     raise ValueError("gen_params and max_bits can not be both None")
 
-def generate_l_register_id(*, gen_params : Optional[GenParams] = None, max_bits : Optional[int] = None):
+
+def generate_l_register_id(*, gen_params: Optional[GenParams] = None, max_bits: Optional[int] = None):
     if max_bits is not None:
         return random.randrange(max_bits)
     if gen_params is not None:
@@ -195,7 +201,8 @@ def generate_instr(
 def get_dict_subset(base: Mapping[T, U], keys: Iterable[T]) -> dict[T, U]:
     return {k: base[k] for k in keys}
 
-def get_dict_without(base: Mapping[T,U], keys_to_delete: Iterable[T]) -> dict[T,U]:
+
+def get_dict_without(base: Mapping[T, U], keys_to_delete: Iterable[T]) -> dict[T, U]:
     return {k: base[k] for k in base.keys() if k not in keys_to_delete}
 
 
@@ -347,12 +354,14 @@ class TestModule(Elaboratable):
 
         return m
 
+
 class CoreblockCommand:
     pass
 
 
 class Now(CoreblockCommand):
     pass
+
 
 class SyncProcessWrapper:
     def __init__(self, f):
@@ -370,7 +379,7 @@ class SyncProcessWrapper:
                 if command is None:
                     self.current_cycle += 1
                     # forward to amaranth
-                    yield 
+                    yield
                 elif isinstance(command, Now):
                     response = self.current_cycle
                 # Pass everything else to amaranth simulator without modifications
@@ -378,6 +387,7 @@ class SyncProcessWrapper:
                     response = yield command
         except StopIteration:
             pass
+
 
 class PysimSimulator(Simulator):
     def __init__(self, module: HasElaborate, max_cycles: float = 10e4, add_transaction_module=True, traces_file=None):
@@ -570,12 +580,13 @@ class TestbenchIO(Elaboratable):
     def debug_signals(self) -> SignalBundle:
         return self.adapter.debug_signals()
 
-def wrap_with_now(func : Callable):
+
+def wrap_with_now(func: Callable):
     parameters = signature(func).parameters
-    kw_parameters = set( n for n, p in parameters.items() if p.kind in {Parameter.KEYWORD_ONLY})
-    if ( "_now" in parameters):
+    kw_parameters = set(n for n, p in parameters.items() if p.kind in {Parameter.KEYWORD_ONLY})
+    if "_now" in kw_parameters:
         _now = yield Now()
-        return lambda *args, **kwargs: func(*args, _now = _now, **kwargs)
+        return lambda *args, **kwargs: func(*args, _now=_now, **kwargs)
     else:
         return func
 

--- a/test/common.py
+++ b/test/common.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import functools
 from contextlib import contextmanager, nullcontext
+from collections import defaultdict
 from typing import (
     Callable,
     Generic,
@@ -60,6 +61,15 @@ def set_inputs(values: RecordValueDict, field: Record) -> TestGen[None]:
         else:
             yield getattr(field, name).eq(value)
 
+def get_unique_generator():
+    history = defaultdict(set)
+    def f(cycle, generator):
+        data = generator()
+        while data in history[cycle]:
+            data = generator()
+        history[cycle].add(data)
+        return data
+    return f
 
 def generate_based_on_layout(layout: SimpleLayout, *, max_bits: Optional[int] = None):
     d = {}

--- a/test/common.py
+++ b/test/common.py
@@ -195,6 +195,9 @@ def generate_instr(
 def get_dict_subset(base: Mapping[T, U], keys: Iterable[T]) -> dict[T, U]:
     return {k: base[k] for k in keys}
 
+def get_dict_without(base: Mapping[T,U], keys_to_delete: Iterable[T]) -> dict[T,U]:
+    return {k: base[k] for k in base.keys() if k not in keys_to_delete}
+
 
 def get_outputs(field: Record) -> TestGen[RecordIntDict]:
     # return dict of all signal values in a record because amaranth's simulator can't read all

--- a/test/fu/vector_unit/test_v_instruction_verification.py
+++ b/test/fu/vector_unit/test_v_instruction_verification.py
@@ -1,0 +1,162 @@
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from amaranth.utils import bits_for
+from coreblocks.fu.vector_unit.v_input_verification import *
+from collections import deque, defaultdict
+
+
+class TestVInstructionVerification(TestCaseWithSimulator):
+
+    def setUp(self):
+        random.seed(14)
+        self.gen_params = GenParams(test_core_config)
+        self.test_number = 100
+        self.v_params = VectorParameters(vlen=1024, elen = 32)
+
+        self.vf_layout = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.rob_block_interrupts = TestbenchIO(Adapter(i=ROBLayouts(self.gen_params).block_interrupts))
+        self.put_instr = TestbenchIO(Adapter(i= self.vf_layout.verification_out))
+        self.get_vill = TestbenchIO(Adapter(o=self.vf_layout.get_vill))
+        self.get_vstart = TestbenchIO(Adapter(o=self.vf_layout.get_vstart))
+        self.retire = TestbenchIO(Adapter(i=FuncUnitLayouts(self.gen_params).accept))
+        self.exception_report = TestbenchIO( Adapter(i=self.gen_params.get(ExceptionRegisterLayouts).report))
+        self.gen_params.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
+
+        self.circ = SimpleTestCircuit(
+                VectorInputVerificator(self.gen_params, self.v_params, self.rob_block_interrupts.adapter.iface, self.put_instr.adapter.iface, self.get_vill.adapter.iface, self.get_vstart.adapter.iface, self.retire.adapter.iface)
+                )
+
+        self.m = ModuleConnector(circ = self.circ, rob_block_interrupts = self.rob_block_interrupts, put_instr = self.put_instr, get_vill = self.get_vill, get_vstart = self.get_vstart, retire = self.retire,
+                                 report = self.exception_report)
+
+    def check_ok(self, data, rbi, put):
+        self.assertEqual(len(data), len(rbi))
+        self.assertEqual(len(data), len(put))
+
+        for orginal, rbi, put in zip(data, rbi, put):
+            self.assertDictEqual(orginal, put)
+            self.assertEqual(orginal["rob_id"], rbi)
+
+    def test_passing(self):
+        data_q = deque()
+        rbi_q  = deque()
+        put_q = deque()
+        def create_mocks():
+            @def_method_mock(lambda: self.rob_block_interrupts)
+            def rbi(rob_id):
+                rbi_q.append(rob_id)
+
+            @def_method_mock(lambda: self.put_instr)
+            def put_instr(arg):
+                put_q.append(arg)
+
+            @def_method_mock(lambda: self.get_vill)
+            def get_vill():
+                return {"vill" : 0}
+
+            @def_method_mock(lambda: self.get_vstart)
+            def get_vstart():
+                return {"vstart" : 0}
+
+            @def_method_mock(lambda: self.retire)
+            def retire(rob_id, result, rp_dst, exception):
+                self.assertTrue(False)
+
+            @def_method_mock(lambda: self.exception_report)
+            def report(rob_id, cause):
+                self.assertTrue(False)
+            return rbi, put_instr, get_vill, get_vstart, retire, report
+
+        def process():
+            for _ in range(self.test_number):
+                data = generate_instr(self.gen_params, self.vf_layout.verification_in, support_vector=True)
+                yield from self.circ.issue.call(data)
+                data_q.append(data)
+            # wait few cycles to be sure that all mocks were called
+            for _ in range(2):
+                yield
+            self.check_ok(data_q, rbi_q, put_q)
+
+        with self.run_simulation(self.m) as sim:
+            for mock in create_mocks():
+                sim.add_sync_process(mock)
+            sim.add_sync_process(process)
+
+    def test_failing(self):
+        data_q_fail = deque()
+        data_q_pass = deque()
+        retire_q = deque()
+        report_q = deque()
+        vill_q = defaultdict(int)
+        vstart_q = defaultdict(int)
+        rbi_q  = deque()
+        put_q = deque()
+        def create_mocks():
+            @def_method_mock(lambda: self.rob_block_interrupts)
+            def rbi(rob_id):
+                rbi_q.append(rob_id)
+
+            @def_method_mock(lambda: self.put_instr)
+            def put_instr(arg):
+                put_q.append(arg)
+
+            @def_method_mock(lambda: self.get_vill)
+            def get_vill(*, _now):
+                ret = {"vill" : vill_q[_now]}
+                return ret
+
+            @def_method_mock(lambda: self.get_vstart)
+            def get_vstart(*, _now):
+                ret = {"vstart" : vstart_q[_now]}
+                return ret
+
+            @def_method_mock(lambda: self.retire)
+            def retire(arg):
+                retire_q.append(arg)
+
+            @def_method_mock(lambda: self.exception_report)
+            def report(arg):
+                report_q.append(arg)
+            return rbi, put_instr, get_vill, get_vstart, retire, report
+
+        def process():
+            for _ in range(self.test_number):
+                data = generate_instr(self.gen_params, self.vf_layout.verification_in, support_vector=True)
+                now = yield Now() 
+                if vill := random.randrange(2):
+                    vstart_q[now] = 0
+                else:
+                    vstart_q[now] = 1
+                vill_q[now]=vill
+
+                yield from self.circ.issue.call(data)
+                if (data["exec_fn"]["op_type"] == OpType.V_CONTROL) and vill:
+                    data_q_pass.append(data)
+                else:
+                    data_q_fail.append(data)
+                self.tick(random.randrange(4))
+
+            # wait few cycles to be sure that all mocks were called
+            for _ in range(2):
+                yield
+
+            self.assertEqual(len(data_q_fail), len(retire_q))
+            self.assertEqual(len(data_q_fail), len(report_q))
+
+            for orginal, retire_data, report_data in zip(data_q_fail, retire_q, report_q):
+                for field in ["rp_dst", "rob_id"]:
+                    self.assertEqual(orginal[field], retire_data[field])
+                self.assertEqual(1, retire_data["exception"])
+                self.assertEqual(orginal["rob_id"], report_data["rob_id"])
+                self.assertEqual(ExceptionCause.ILLEGAL_INSTRUCTION, report_data["cause"])
+
+            self.check_ok(data_q_pass, rbi_q, put_q)
+
+        with self.run_simulation(self.m) as sim:
+            for mock in create_mocks():
+                sim.add_sync_process(mock)
+            sim.add_sync_process(process)

--- a/test/fu/vector_unit/test_v_status.py
+++ b/test/fu/vector_unit/test_v_status.py
@@ -1,0 +1,122 @@
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.fu.vector_unit.utils import *
+from amaranth.utils import bits_for
+from coreblocks.fu.vector_unit.v_status import *
+from collections import deque, defaultdict
+
+def generate_vsetvl_imm():
+    sew = random.choice(list(SEW))
+    lmul = random.choice(list(LMUL))
+    ta = random.randrange(2)
+    ma = random.randrange(2)
+    imm = ma << 7 | ta << 6 | sew << 3 | lmul
+    return imm,{
+        "sew" : sew,
+        "lmul" : lmul,
+        "ta" : ta,
+        "ma" : ma,
+        }
+
+def generate_vsetvl(gen_params : GenParams, v_params : VectorParameters, layout : LayoutLike):
+    instr = generate_instr(gen_params, layout)
+    imm2, vtype = generate_vsetvl_imm()
+    vsetvl_type = random.randrange(4)
+    if vsetvl_type == 2:
+        instr = overwrite_dict_values(instr, {"s2_val" : imm2})
+    imm2 |= (vsetvl_type << 10)
+    instr = overwrite_dict_values(instr, {"imm2" : imm2, "exec_fn": {"op_type" : OpType.V_CONTROL, "funct3" : Funct3.OPCFG}})
+
+    vlmax = int(v_params.vlen // eew_to_bits(vtype["sew"]) * lmul_to_float(vtype["lmul"]))
+
+    print("vlmax",vlmax)
+    
+    if vsetvl_type==3:
+        vtype |= {"vl" : instr["rp_s1"]}
+    else:
+        if instr["rp_s1"]["id"] == 0:
+            vtype |= {"vl" : vlmax}
+        else:
+            vtype |= {"vl" : instr["s1_val"]}
+
+    print(vtype)
+    return instr, vtype
+
+class TestVInstructionVerification(TestCaseWithSimulator):
+
+    def setUp(self):
+        random.seed(14)
+        self.gen_params = GenParams(test_core_config)
+        self.test_number = 6
+        self.v_params = VectorParameters(vlen=1024, elen = 32)
+
+        self.vf_layout = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.put_instr = TestbenchIO(Adapter(i= self.vf_layout.status_out))
+        self.retire = TestbenchIO(Adapter(i=FuncUnitLayouts(self.gen_params).accept))
+
+        self.circ = SimpleTestCircuit( VectorStatusUnit(self.gen_params, self.v_params,  self.put_instr.adapter.iface, self.retire.adapter.iface))
+
+        self.m = ModuleConnector(circ = self.circ, put_instr = self.put_instr, retire = self.retire)
+
+    def test_passing(self):
+        data_normal_q = deque()
+        data_vsetvl_q = deque()
+        put_q = deque()
+        retire_q = deque()
+        def create_mocks():
+            @def_method_mock(lambda: self.put_instr)
+            def put_instr(arg):
+                print("---", arg)
+                put_q.append(arg)
+
+            @def_method_mock(lambda: self.retire)
+            def retire(arg):
+                retire_q.append(arg)
+
+            return put_instr, retire
+
+        def process():
+            print()
+            self.assertEqual((yield from self.circ.get_vill.call())["vill"], 1)
+            instr, vtype = generate_vsetvl(self.gen_params, self.v_params, self.vf_layout.status_in)
+            data_vsetvl_q.append((instr, vtype))
+            yield from self.circ.issue.call(instr)
+            print(instr)
+            current_vtype = vtype
+            for _ in range(self.test_number):
+                if random.randrange(2):
+                    while data := generate_instr(self.gen_params, self.vf_layout.verification_in, support_vector=True):
+                        if data["exec_fn"]["op_type"] != OpType.V_CONTROL:
+                            break
+                    data_normal_q.append((data, current_vtype))
+                else:
+                    data, current_vtype = generate_vsetvl(self.gen_params, self.v_params, self.vf_layout.verification_in)
+                    data_vsetvl_q.append((data, current_vtype))
+                print("+++", data)
+                yield from self.circ.issue.call(data)
+            # wait few cycles to be sure that all mocks were called
+            for _ in range(2):
+                yield
+
+            self.assertEqual(len(data_normal_q), len(put_q))
+            self.assertEqual(len(data_vsetvl_q), len(retire_q))
+
+            for (org_data, org_vtype), resp in zip(data_normal_q, put_q):
+                self.assertDictContainsSubset(get_dict_without(org_data, ["imm2"]), resp)
+                self.assertDictContainsSubset({"vtype" : org_vtype}, resp)
+
+            for (org_data, org_vtype), retire_data in zip(data_vsetvl_q, retire_q):
+                self.assertEqual(retire_data["exception"], 0)
+                for field in ["rp_dst", "rob_id"]:
+                    self.assertEqual(org_data[field], retire_data[field])
+                print(org_data["rp_dst"])
+                self.assertEqual(org_vtype["vl"], retire_data["result"])
+
+        with self.run_simulation(self.m) as sim:
+            for mock in create_mocks():
+                sim.add_sync_process(mock)
+            sim.add_sync_process(process)

--- a/test/fu/vector_unit/test_v_status.py
+++ b/test/fu/vector_unit/test_v_status.py
@@ -5,9 +5,9 @@ from coreblocks.params import *
 from coreblocks.params.configurations import *
 from coreblocks.fu.vector_unit.v_layouts import *
 from coreblocks.fu.vector_unit.utils import *
-from amaranth.utils import bits_for
 from coreblocks.fu.vector_unit.v_status import *
-from collections import deque, defaultdict
+from collections import deque
+
 
 def generate_vsetvl_imm():
     sew = random.choice(list(SEW))
@@ -15,63 +15,69 @@ def generate_vsetvl_imm():
     ta = random.randrange(2)
     ma = random.randrange(2)
     imm = ma << 7 | ta << 6 | sew << 3 | lmul
-    return imm,{
-        "sew" : sew,
-        "lmul" : lmul,
-        "ta" : ta,
-        "ma" : ma,
-        }
+    return imm, {
+        "sew": sew,
+        "lmul": lmul,
+        "ta": ta,
+        "ma": ma,
+    }
 
-def generate_vsetvl(gen_params : GenParams, v_params : VectorParameters, layout : LayoutLike, last_vl : int):
+
+def generate_vsetvl(gen_params: GenParams, v_params: VectorParameters, layout: LayoutLike, last_vl: int):
     instr = generate_instr(gen_params, layout)
     imm2, vtype = generate_vsetvl_imm()
-    if eew_to_bits(vtype["sew"])> v_params.elen:
-        imm2=0
-        vtype = { "sew" : EEW(0), "lmul" : LMUL(0), "ta" : 0, "ma" : 0}
+    if eew_to_bits(vtype["sew"]) > v_params.elen:
+        imm2 = 0
+        vtype = {"sew": EEW(0), "lmul": LMUL(0), "ta": 0, "ma": 0}
     vsetvl_type = random.randrange(4)
     if vsetvl_type == 2:
-        instr = overwrite_dict_values(instr, {"s2_val" : imm2})
+        instr = overwrite_dict_values(instr, {"s2_val": imm2})
     if vsetvl_type == 3:
-        instr = overwrite_dict_values(instr, {"imm" : instr["rp_s1"]["id"]})
-    imm2 |= (vsetvl_type << 10)
-    instr = overwrite_dict_values(instr, {"imm2" : imm2, "exec_fn": {"op_type" : OpType.V_CONTROL, "funct3" : Funct3.OPCFG}})
+        instr = overwrite_dict_values(instr, {"imm": instr["rp_s1"]["id"]})
+    imm2 |= vsetvl_type << 10
+    instr = overwrite_dict_values(
+        instr, {"imm2": imm2, "exec_fn": {"op_type": OpType.V_CONTROL, "funct3": Funct3.OPCFG}}
+    )
 
     vlmax = int(v_params.vlen // eew_to_bits(vtype["sew"]) * lmul_to_float(vtype["lmul"]))
 
-    if vsetvl_type==3:
-        vtype |= {"vl" : instr["rp_s1"]["id"]}
+    if vsetvl_type == 3:
+        vtype |= {"vl": instr["rp_s1"]["id"]}
     else:
         if instr["rp_s1"]["id"] == 0:
-            vtype |= {"vl" : vlmax}
+            vtype |= {"vl": vlmax}
         else:
-            vtype |= {"vl" : instr["s1_val"]}
+            vtype |= {"vl": instr["s1_val"]}
 
     if instr["rp_s1"]["id"] == 0 and instr["rp_dst"]["id"] == 0:
-        vtype |= {"vl" : last_vl}
+        vtype |= {"vl": last_vl}
 
     return instr, vtype
 
-class TestVInstructionVerification(TestCaseWithSimulator):
 
+class TestVectorStatusUnit(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
         self.gen_params = GenParams(test_core_config)
         self.test_number = 700
-        self.v_params = VectorParameters(vlen=1024, elen = 32)
+        self.v_params = VectorParameters(vlen=1024, elen=32)
 
         self.vf_layout = VectorFrontendLayouts(self.gen_params, self.v_params)
-        self.put_instr = TestbenchIO(Adapter(i= self.vf_layout.status_out))
+        self.put_instr = TestbenchIO(Adapter(i=self.vf_layout.status_out))
         self.retire = TestbenchIO(Adapter(i=FuncUnitLayouts(self.gen_params).accept))
 
-        self.circ = SimpleTestCircuit( VectorStatusUnit(self.gen_params, self.v_params,  self.put_instr.adapter.iface, self.retire.adapter.iface))
+        self.circ = SimpleTestCircuit(
+            VectorStatusUnit(self.gen_params, self.v_params, self.put_instr.adapter.iface, self.retire.adapter.iface)
+        )
 
-        self.m = ModuleConnector(circ = self.circ, put_instr = self.put_instr, retire = self.retire)
+        self.m = ModuleConnector(circ=self.circ, put_instr=self.put_instr, retire=self.retire)
 
     def test_passing(self):
         data_normal_q = deque()
         data_vsetvl_q = deque()
         put_q = deque()
         retire_q = deque()
+
         def create_mocks():
             @def_method_mock(lambda: self.put_instr)
             def put_instr(arg):
@@ -96,7 +102,9 @@ class TestVInstructionVerification(TestCaseWithSimulator):
                             break
                     data_normal_q.append((data, current_vtype))
                 else:
-                    data, current_vtype = generate_vsetvl(self.gen_params, self.v_params, self.vf_layout.verification_in, current_vtype["vl"])
+                    data, current_vtype = generate_vsetvl(
+                        self.gen_params, self.v_params, self.vf_layout.verification_in, current_vtype["vl"]
+                    )
                     data_vsetvl_q.append((data, current_vtype))
                 yield from self.circ.issue.call(data)
             # wait few cycles to be sure that all mocks were called
@@ -108,13 +116,13 @@ class TestVInstructionVerification(TestCaseWithSimulator):
 
             for (org_data, org_vtype), resp in zip(data_normal_q, put_q):
                 self.assertDictContainsSubset(get_dict_without(org_data, ["imm2"]), resp)
-                self.assertDictContainsSubset({"vtype" : org_vtype}, resp)
+                self.assertDictContainsSubset({"vtype": org_vtype}, resp)
 
             for (org_data, org_vtype), retire_data in zip(data_vsetvl_q, retire_q):
                 self.assertEqual(retire_data["exception"], 0)
                 for field in ["rp_dst", "rob_id"]:
                     self.assertEqual(org_data[field], retire_data[field])
-                if org_data["rp_dst"]["id"]!=0:
+                if org_data["rp_dst"]["id"] != 0:
                     self.assertEqual(org_vtype["vl"], retire_data["result"])
 
         with self.run_simulation(self.m) as sim:

--- a/test/structs_common/test_rat.py
+++ b/test/structs_common/test_rat.py
@@ -9,33 +9,20 @@ from coreblocks.structs_common.rat import *
 from collections import deque, defaultdict
 
 
-def get_unique_generator():
-    history = defaultdict(set)
-    def f(cycle, generator):
-        data = generator()
-        while data in history[cycle]:
-            data = generator()
-        history[cycle].add(data)
-        return data
-    return f
-
-
 
 class TestFRAT(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
-        self.test_cycles = 50
+        self.test_number = 50
         self.superscalarity = 3
         self.gen_params = GenParams(test_core_config)
 
         self.virtual_rat = {}
-        self.generated_dst = defaultdict(set)
         self.unique_rl_dst_generator = get_unique_generator()
-
 
     def create_process(self, k):
         def f():
-            for _ in range(self.test_cycles):
+            for _ in range(self.test_number):
                 rl_s1 = generate_l_register_id(gen_params = self.gen_params)
                 rl_s2 = generate_l_register_id(gen_params = self.gen_params)
                 rp_dst = generate_phys_register_id(gen_params = self.gen_params)
@@ -66,9 +53,35 @@ class TestFRAT(TestCaseWithSimulator):
 class TestRRAT(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
-        self.test_cycles = 50
+        self.test_number = 50
         self.superscalarity = 3
         self.gen_params = GenParams(test_core_config)
 
-        self.virtual_rat = {}
-        self.generated_dst = defaultdict(set)
+        self.virtual_rat = {id : 0 for id in range(self.gen_params.isa.reg_cnt)}
+        self.unique_rl_dst_generator = get_unique_generator()
+
+    
+    def create_process(self, k):
+        def f():
+            for _ in range(self.test_number):
+                rp_dst = generate_phys_register_id(gen_params = self.gen_params)
+                cycle = yield Now()
+                rl_dst = self.unique_rl_dst_generator(cycle, lambda : generate_l_register_id(gen_params=self.gen_params))
+                req = {"rl_dst":rl_dst, "rp_dst": rp_dst} 
+
+                resp = yield from self.circ.commit_list[k].call(req)
+                self.assertIsNotNone(resp)
+
+                self.assertEqual(resp["old_rp_dst"], self.virtual_rat[rl_dst])
+                #defer to end of cycle
+                yield Settle()
+                self.virtual_rat[rl_dst]=rp_dst
+
+                self.tick(random.randrange(2))
+        return f
+
+    def test_random(self):
+        self.circ = SimpleTestCircuit(RRAT(gen_params=self.gen_params, superscalarity = self.superscalarity))
+        with self.run_simulation(self.circ) as sim:
+            for k in range(self.superscalarity):
+                sim.add_sync_process(self.create_process(k))

--- a/test/structs_common/test_rat.py
+++ b/test/structs_common/test_rat.py
@@ -3,11 +3,7 @@ from test.common import *
 from coreblocks.fu.vector_unit.vrs import *
 from coreblocks.params import *
 from coreblocks.params.configurations import *
-from coreblocks.fu.vector_unit.v_layouts import VectorXRSLayout
-from amaranth.utils import bits_for
 from coreblocks.structs_common.rat import *
-from collections import deque, defaultdict
-
 
 
 class TestFRAT(TestCaseWithSimulator):
@@ -23,12 +19,12 @@ class TestFRAT(TestCaseWithSimulator):
     def create_process(self, k):
         def f():
             for _ in range(self.test_number):
-                rl_s1 = generate_l_register_id(gen_params = self.gen_params)
-                rl_s2 = generate_l_register_id(gen_params = self.gen_params)
-                rp_dst = generate_phys_register_id(gen_params = self.gen_params)
+                rl_s1 = generate_l_register_id(gen_params=self.gen_params)
+                rl_s2 = generate_l_register_id(gen_params=self.gen_params)
+                rp_dst = generate_phys_register_id(gen_params=self.gen_params)
                 cycle = yield Now()
-                rl_dst = self.unique_rl_dst_generator(cycle, lambda : generate_l_register_id(gen_params=self.gen_params))
-                req = {"rl_s1" : rl_s1, "rl_s2" : rl_s2, "rl_dst":rl_dst, "rp_dst": rp_dst} 
+                rl_dst = self.unique_rl_dst_generator(cycle, lambda: generate_l_register_id(gen_params=self.gen_params))
+                req = {"rl_s1": rl_s1, "rl_s2": rl_s2, "rl_dst": rl_dst, "rp_dst": rp_dst}
 
                 resp = yield from self.circ.rename_list[k].call(req)
                 self.assertIsNotNone(resp)
@@ -37,18 +33,20 @@ class TestFRAT(TestCaseWithSimulator):
                     self.assertEqual(resp["rp_s1"], self.virtual_rat[rl_s1])
                 if rl_s2 in self.virtual_rat:
                     self.assertEqual(resp["rp_s2"], self.virtual_rat[rl_s2])
-                #defer to end of cycle
+                # defer to end of cycle
                 yield Settle()
-                self.virtual_rat[rl_dst]=rp_dst
+                self.virtual_rat[rl_dst] = rp_dst
 
                 self.tick(random.randrange(2))
+
         return f
 
     def test_random(self):
-        self.circ = SimpleTestCircuit(FRAT(gen_params=self.gen_params, superscalarity = self.superscalarity))
+        self.circ = SimpleTestCircuit(FRAT(gen_params=self.gen_params, superscalarity=self.superscalarity))
         with self.run_simulation(self.circ) as sim:
             for k in range(self.superscalarity):
                 sim.add_sync_process(self.create_process(k))
+
 
 class TestRRAT(TestCaseWithSimulator):
     def setUp(self):
@@ -57,31 +55,31 @@ class TestRRAT(TestCaseWithSimulator):
         self.superscalarity = 3
         self.gen_params = GenParams(test_core_config)
 
-        self.virtual_rat = {id : 0 for id in range(self.gen_params.isa.reg_cnt)}
+        self.virtual_rat = {id: 0 for id in range(self.gen_params.isa.reg_cnt)}
         self.unique_rl_dst_generator = get_unique_generator()
 
-    
     def create_process(self, k):
         def f():
             for _ in range(self.test_number):
-                rp_dst = generate_phys_register_id(gen_params = self.gen_params)
+                rp_dst = generate_phys_register_id(gen_params=self.gen_params)
                 cycle = yield Now()
-                rl_dst = self.unique_rl_dst_generator(cycle, lambda : generate_l_register_id(gen_params=self.gen_params))
-                req = {"rl_dst":rl_dst, "rp_dst": rp_dst} 
+                rl_dst = self.unique_rl_dst_generator(cycle, lambda: generate_l_register_id(gen_params=self.gen_params))
+                req = {"rl_dst": rl_dst, "rp_dst": rp_dst}
 
                 resp = yield from self.circ.commit_list[k].call(req)
                 self.assertIsNotNone(resp)
 
                 self.assertEqual(resp["old_rp_dst"], self.virtual_rat[rl_dst])
-                #defer to end of cycle
+                # defer to end of cycle
                 yield Settle()
-                self.virtual_rat[rl_dst]=rp_dst
+                self.virtual_rat[rl_dst] = rp_dst
 
                 self.tick(random.randrange(2))
+
         return f
 
     def test_random(self):
-        self.circ = SimpleTestCircuit(RRAT(gen_params=self.gen_params, superscalarity = self.superscalarity))
+        self.circ = SimpleTestCircuit(RRAT(gen_params=self.gen_params, superscalarity=self.superscalarity))
         with self.run_simulation(self.circ) as sim:
             for k in range(self.superscalarity):
                 sim.add_sync_process(self.create_process(k))

--- a/test/structs_common/test_rat.py
+++ b/test/structs_common/test_rat.py
@@ -9,35 +9,41 @@ from coreblocks.structs_common.rat import *
 from collections import deque, defaultdict
 
 
+def get_unique_generator():
+    history = defaultdict(set)
+    def f(cycle, generator):
+        data = generator()
+        while data in history[cycle]:
+            data = generator()
+        history[cycle].add(data)
+        return data
+    return f
+
+
+
 class TestFRAT(TestCaseWithSimulator):
     def setUp(self):
-        random.seed(15)
-        self.test_cycles = 4000
-        self.superscalarity = 5
+        random.seed(14)
+        self.test_cycles = 50
+        self.superscalarity = 3
         self.gen_params = GenParams(test_core_config)
 
-        self.circ = SimpleTestCircuit(FRAT(gen_params=self.gen_params, superscalarity = self.superscalarity))
         self.virtual_rat = {}
         self.generated_dst = defaultdict(set)
+        self.unique_rl_dst_generator = get_unique_generator()
 
-    def generate_dst(self, cycle):
-        rl_dst = random.randrange(self.gen_params.isa.reg_cnt)
-        rp_dst = random.randrange(2**self.gen_params.phys_regs_bits)
-        while rl_dst in self.generated_dst[cycle]:
-            rl_dst += 1
-            rl_dst %= self.gen_params.isa.reg_cnt
-        self.generated_dst[cycle].add(rl_dst)
-        return rl_dst, rp_dst
 
     def create_process(self, k):
         def f():
-            for cycle in range(self.test_cycles):
-                rl_s1 = random.randrange(self.gen_params.isa.reg_cnt)
-                rl_s2 = random.randrange(self.gen_params.isa.reg_cnt)
-                rl_dst, rp_dst = self.generate_dst(cycle)
+            for _ in range(self.test_cycles):
+                rl_s1 = generate_l_register_id(gen_params = self.gen_params)
+                rl_s2 = generate_l_register_id(gen_params = self.gen_params)
+                rp_dst = generate_phys_register_id(gen_params = self.gen_params)
+                cycle = yield Now()
+                rl_dst = self.unique_rl_dst_generator(cycle, lambda : generate_l_register_id(gen_params=self.gen_params))
                 req = {"rl_s1" : rl_s1, "rl_s2" : rl_s2, "rl_dst":rl_dst, "rp_dst": rp_dst} 
 
-                resp = yield from self.circ.rename_list[k].call_try(req)
+                resp = yield from self.circ.rename_list[k].call(req)
                 self.assertIsNotNone(resp)
 
                 if rl_s1 in self.virtual_rat:
@@ -47,9 +53,22 @@ class TestFRAT(TestCaseWithSimulator):
                 #defer to end of cycle
                 yield Settle()
                 self.virtual_rat[rl_dst]=rp_dst
+
+                self.tick(random.randrange(2))
         return f
 
     def test_random(self):
+        self.circ = SimpleTestCircuit(FRAT(gen_params=self.gen_params, superscalarity = self.superscalarity))
         with self.run_simulation(self.circ) as sim:
             for k in range(self.superscalarity):
                 sim.add_sync_process(self.create_process(k))
+
+class TestRRAT(TestCaseWithSimulator):
+    def setUp(self):
+        random.seed(14)
+        self.test_cycles = 50
+        self.superscalarity = 3
+        self.gen_params = GenParams(test_core_config)
+
+        self.virtual_rat = {}
+        self.generated_dst = defaultdict(set)

--- a/test/structs_common/test_rat.py
+++ b/test/structs_common/test_rat.py
@@ -1,0 +1,55 @@
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import VectorXRSLayout
+from amaranth.utils import bits_for
+from coreblocks.structs_common.rat import *
+from collections import deque, defaultdict
+
+
+class TestFRAT(TestCaseWithSimulator):
+    def setUp(self):
+        random.seed(15)
+        self.test_cycles = 4000
+        self.superscalarity = 5
+        self.gen_params = GenParams(test_core_config)
+
+        self.circ = SimpleTestCircuit(FRAT(gen_params=self.gen_params, superscalarity = self.superscalarity))
+        self.virtual_rat = {}
+        self.generated_dst = defaultdict(set)
+
+    def generate_dst(self, cycle):
+        rl_dst = random.randrange(self.gen_params.isa.reg_cnt)
+        rp_dst = random.randrange(2**self.gen_params.phys_regs_bits)
+        while rl_dst in self.generated_dst[cycle]:
+            rl_dst += 1
+            rl_dst %= self.gen_params.isa.reg_cnt
+        self.generated_dst[cycle].add(rl_dst)
+        return rl_dst, rp_dst
+
+    def create_process(self, k):
+        def f():
+            for cycle in range(self.test_cycles):
+                rl_s1 = random.randrange(self.gen_params.isa.reg_cnt)
+                rl_s2 = random.randrange(self.gen_params.isa.reg_cnt)
+                rl_dst, rp_dst = self.generate_dst(cycle)
+                req = {"rl_s1" : rl_s1, "rl_s2" : rl_s2, "rl_dst":rl_dst, "rp_dst": rp_dst} 
+
+                resp = yield from self.circ.rename_list[k].call_try(req)
+                self.assertIsNotNone(resp)
+
+                if rl_s1 in self.virtual_rat:
+                    self.assertEqual(resp["rp_s1"], self.virtual_rat[rl_s1])
+                if rl_s2 in self.virtual_rat:
+                    self.assertEqual(resp["rp_s2"], self.virtual_rat[rl_s2])
+                #defer to end of cycle
+                yield Settle()
+                self.virtual_rat[rl_dst]=rp_dst
+        return f
+
+    def test_random(self):
+        with self.run_simulation(self.circ) as sim:
+            for k in range(self.superscalarity):
+                sim.add_sync_process(self.create_process(k))

--- a/test/structs_common/test_superscalar_freerf.py
+++ b/test/structs_common/test_superscalar_freerf.py
@@ -3,8 +3,6 @@ from test.common import *
 from coreblocks.fu.vector_unit.vrs import *
 from coreblocks.params import *
 from coreblocks.params.configurations import *
-from coreblocks.fu.vector_unit.v_layouts import VectorXRSLayout
-from amaranth.utils import bits_for
 from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
 from collections import deque
 
@@ -19,24 +17,24 @@ class TestSuperscalarFreeRF(TestCaseWithSimulator):
         self.circ = SimpleTestCircuit(SuperscalarFreeRF(self.entries_count, self.outputs_count))
 
         self.mirroring_freerf = {i for i in range(self.entries_count)}
-        self.to_dealocate= deque()
+        self.to_dealocate = deque()
 
         self.allocator_end = False
         self.deallocators_end = [False for i in range(self.outputs_count)]
 
     def allocator(self):
         for _ in range(self.test_cycles):
-            reg_count = random.randrange(self.outputs_count)+1
-            regs = yield from self.circ.allocate.call(reg_count = reg_count)
+            reg_count = random.randrange(self.outputs_count) + 1
+            regs = yield from self.circ.allocate.call(reg_count=reg_count)
             yield Settle()
             for i in range(reg_count):
                 reg_id = regs[f"reg{i}"]
                 self.assertIn(reg_id, self.mirroring_freerf)
                 self.mirroring_freerf.remove(reg_id)
                 self.to_dealocate.append(reg_id)
-        self.allocator_end=True
+        self.allocator_end = True
 
-    def dealocator(self, k : int):
+    def dealocator(self, k: int):
         def f():
             while True:
                 if not self.to_dealocate:
@@ -47,7 +45,8 @@ class TestSuperscalarFreeRF(TestCaseWithSimulator):
                 reg_id = self.to_dealocate.popleft()
                 yield from self.circ.deallocates[k].call(reg=reg_id)
                 self.mirroring_freerf.add(reg_id)
-            self.deallocators_end[k]=True
+            self.deallocators_end[k] = True
+
         return f
 
     def checker(self):

--- a/test/structs_common/test_superscalar_freerf.py
+++ b/test/structs_common/test_superscalar_freerf.py
@@ -1,0 +1,65 @@
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import VectorXRSLayout
+from amaranth.utils import bits_for
+from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
+from collections import deque
+
+
+class TestSuperscalarFreeRF(TestCaseWithSimulator):
+    def setUp(self):
+        random.seed(14)
+        self.entries_count = 21
+        self.outputs_count = 4
+        self.test_cycles = 50
+
+        self.circ = SimpleTestCircuit(SuperscalarFreeRF(self.entries_count, self.outputs_count))
+
+        self.mirroring_freerf = {i for i in range(self.entries_count)}
+        self.to_dealocate= deque()
+
+        self.allocator_end = False
+        self.deallocators_end = [False for i in range(self.outputs_count)]
+
+    def allocator(self):
+        for _ in range(self.test_cycles):
+            reg_count = random.randrange(self.outputs_count)+1
+            regs = yield from self.circ.allocate.call(reg_count = reg_count)
+            yield Settle()
+            for i in range(reg_count):
+                reg_id = regs[f"reg{i}"]
+                self.assertIn(reg_id, self.mirroring_freerf)
+                self.mirroring_freerf.remove(reg_id)
+                self.to_dealocate.append(reg_id)
+        self.allocator_end=True
+
+    def dealocator(self, k : int):
+        def f():
+            while True:
+                if not self.to_dealocate:
+                    if self.allocator_end:
+                        break
+                    yield
+                    continue
+                reg_id = self.to_dealocate.popleft()
+                yield from self.circ.deallocates[k].call(reg=reg_id)
+                self.mirroring_freerf.add(reg_id)
+            self.deallocators_end[k]=True
+        return f
+
+    def checker(self):
+        while not (self.allocator_end and all(self.deallocators_end)):
+            yield
+
+        for i in range(self.entries_count):
+            self.assertIn(i, self.mirroring_freerf)
+
+    def test_random(self):
+        with self.run_simulation(self.circ, 4000) as sim:
+            sim.add_sync_process(self.checker)
+            sim.add_sync_process(self.allocator)
+            for i in range(self.outputs_count):
+                sim.add_sync_process(self.dealocator(i))

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -3,7 +3,13 @@ import random
 
 from amaranth import *
 from test.common import *
-from coreblocks.utils import align_to_power_of_two, popcount, count_leading_zeros, count_trailing_zeros, MultiPriorityEncoder
+from coreblocks.utils import (
+    align_to_power_of_two,
+    popcount,
+    count_leading_zeros,
+    count_trailing_zeros,
+    MultiPriorityEncoder,
+)
 from parameterized import parameterized_class
 
 
@@ -174,7 +180,6 @@ class TestCountTrailingZeros(TestCaseWithSimulator):
 
 
 class TestMultiPriorityEncoder(TestCaseWithSimulator):
-
     def setUp(self):
         random.seed(14)
         self.test_number = 50
@@ -192,7 +197,6 @@ class TestMultiPriorityEncoder(TestCaseWithSimulator):
         places += [None] * self.output_count
         return places
 
-
     def process(self):
         for _ in range(self.test_number):
             input = random.randrange(2**self.input_width)
@@ -207,5 +211,5 @@ class TestMultiPriorityEncoder(TestCaseWithSimulator):
                     self.assertEqual((yield real), ex)
 
     def test_random(self):
-        with self.run_simulation(self.circ, max_cycles = 100) as sim:
+        with self.run_simulation(self.circ, max_cycles=100) as sim:
             sim.add_process(self.process)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -3,7 +3,7 @@ import random
 
 from amaranth import *
 from test.common import *
-from coreblocks.utils import align_to_power_of_two, popcount, count_leading_zeros, count_trailing_zeros
+from coreblocks.utils import align_to_power_of_two, popcount, count_leading_zeros, count_trailing_zeros, MultiPriorityEncoder
 from parameterized import parameterized_class
 
 
@@ -170,4 +170,42 @@ class TestCountTrailingZeros(TestCaseWithSimulator):
 
     def test_count_trailing_zeros(self):
         with self.run_simulation(self.m) as sim:
+            sim.add_process(self.process)
+
+
+class TestMultiPriorityEncoder(TestCaseWithSimulator):
+
+    def setUp(self):
+        random.seed(14)
+        self.test_number = 50
+        self.input_width = 16
+        self.output_count = 4
+
+        self.circ = MultiPriorityEncoder(self.input_width, self.output_count)
+
+    def get_expected(self, input):
+        places = []
+        for i in range(self.input_width):
+            if input % 2:
+                places.append(i)
+            input //= 2
+        places += [None] * self.output_count
+        return places
+
+
+    def process(self):
+        for _ in range(self.test_number):
+            input = random.randrange(2**self.input_width)
+            yield self.circ.input.eq(input)
+            yield Settle()
+            expected_output = self.get_expected(input)
+            for ex, real, valid in zip(expected_output, self.circ.outputs, self.circ.valids):
+                if ex is None:
+                    self.assertEqual((yield valid), 0)
+                else:
+                    self.assertEqual((yield valid), 1)
+                    self.assertEqual((yield real), ex)
+
+    def test_random(self):
+        with self.run_simulation(self.circ, max_cycles = 100) as sim:
             sim.add_process(self.process)


### PR DESCRIPTION
This PR will be introducing frontend blocks for vector unit. By default they will be part of vector functional block, so they will be active after vector instruction pass scalar RS.

Added:
- VectorInputVerificator (to check if incoming instruction is correct, or we should raise an exception)
- VectorStatus (which handles changes in vector CSRs and add CSR snapshot to each instruction passed through it)
- SuperscalarFreeRF (support allocating and deallocating more registers at once)
- MultiPriorityEncoder (extension of priority encoder from amaranth to get more outputs in one cycle)
- SuperscalarRATs

Other features:
- added `Now()` command to simulation to get current cycle
- added special argument `_now` to get current time in method mock