### PR TITLE
auto_debug_signals: drop useless empty objects

### DIFF
--- a/coreblocks/utils/debug_signals.py
+++ b/coreblocks/utils/debug_signals.py
@@ -22,7 +22,7 @@ def auto_debug_signals(thing) -> SignalBundle:
 
         # Check for reference cycles e.g. Amaranth's MustUse
         if id(thing) in _visited:
-            return []
+            return None
         _visited.add(id(thing))
 
         match thing:
@@ -55,7 +55,7 @@ def auto_debug_signals(thing) -> SignalBundle:
                 try:
                     vs = vars(thing)
                 except (KeyError, AttributeError, TypeError):
-                    return []
+                    return None
 
                 for v in vs:
                     a = getattr(thing, v)


### PR DESCRIPTION
It looks like some 'improvement' made auto_debug_signals create entries even for totally empty (or signal-less) objects.