### PR TITLE
Use Zbc and Zbs in full core

### DIFF
--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -11,6 +11,8 @@ from coreblocks.fu.shift_unit import ShiftUnitComponent
 from coreblocks.fu.jumpbranch import JumpComponent
 from coreblocks.fu.mul_unit import MulComponent, MulType
 from coreblocks.fu.div_unit import DivComponent
+from coreblocks.fu.zbc import ZbcComponent
+from coreblocks.fu.zbs import ZbsComponent
 from coreblocks.fu.exception import ExceptionUnitComponent
 from coreblocks.lsu.dummyLsu import LSUBlockComponent
 from coreblocks.structs_common.csr import CSRBlockComponent
@@ -101,6 +103,8 @@ full_core_config = CoreConfiguration(
             [
                 ALUComponent(zba_enable=True, zbb_enable=True),
                 ShiftUnitComponent(zbb_enable=True),
+                ZbcComponent(),
+                ZbsComponent(),
                 JumpComponent(),
                 ExceptionUnitComponent(),
             ],

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -17,7 +17,12 @@ class TestConfigurationsISAString(TestCase):
 
     TEST_CASES = [
         ISAStrTest(basic_core_config, "rv32i", "rv32", "rv32i"),
-        ISAStrTest(full_core_config, "rv32imzicsr_zba_zbb", "rv32mzicsr_zba_zbb", "rv32imczicsr_zba_zbb"),
+        ISAStrTest(
+            full_core_config,
+            "rv32imzicsr_zba_zbb_zbc_zbs",
+            "rv32mzicsr_zba_zbb_zbc_zbs",
+            "rv32imczicsr_zba_zbb_zbc_zbs",
+        ),
         ISAStrTest(tiny_core_config, "rv32i", "rv32", "rv32i"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),
     ]


### PR DESCRIPTION
Added Zbc and Zbs support to the full core configuration, it therefore now has full B extension support.

A problem with handling ISA strings was found - the B extension is not generated, even though it's fully supported.

Rationalizing core configurations is left for later.