### PR TITLE
Fix isa string generation

### DIFF
--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -11,6 +11,8 @@ from coreblocks.fu.shift_unit import ShiftUnitComponent
 from coreblocks.fu.jumpbranch import JumpComponent
 from coreblocks.fu.mul_unit import MulComponent, MulType
 from coreblocks.fu.div_unit import DivComponent
+from coreblocks.fu.zbc import ZbcComponent
+from coreblocks.fu.zbs import ZbsComponent
 from coreblocks.fu.exception import ExceptionUnitComponent
 from coreblocks.lsu.dummyLsu import LSUBlockComponent
 from coreblocks.structs_common.csr import CSRBlockComponent
@@ -101,6 +103,8 @@ full_core_config = CoreConfiguration(
             [
                 ALUComponent(zba_enable=True, zbb_enable=True),
                 ShiftUnitComponent(zbb_enable=True),
+                ZbcComponent(),
+                ZbsComponent(),
                 JumpComponent(),
                 ExceptionUnitComponent(),
             ],

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -261,6 +261,11 @@ extension_implications = {
     Extension.B: Extension.ZBA | Extension.ZBB | Extension.ZBC | Extension.ZBS,
 }
 
+# Extensions (not aliases) that only imply other sub-extensions, but don't add any new OpTypes.
+extension_only_implies = {
+    Extension.B,
+}
+
 
 class ISA:
     """

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -1,7 +1,7 @@
 from enum import IntEnum, auto, unique
 
 from coreblocks.params import Extension
-from coreblocks.params.isa import extension_implications
+from coreblocks.params.isa import extension_implications, extension_only_implies
 
 
 @unique
@@ -117,7 +117,8 @@ def optypes_required_by_extensions(
         implied_extensions = Extension(0)
         for ext in Extension:
             if ext in extensions:
-                if ext in extension_implications and ext in optypes_by_extensions:
+                # check if extensions has implications, but skip if we don't have defined any optypes for it yet
+                if ext in extension_implications and (ext in optypes_by_extensions or ext in extension_only_implies):
                     implied_extensions |= extension_implications[ext]
         extensions |= implied_extensions
 

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -19,9 +19,9 @@ class TestConfigurationsISAString(TestCase):
         ISAStrTest(basic_core_config, "rv32i", "rv32", "rv32i"),
         ISAStrTest(
             full_core_config,
-            "rv32imzicsr_zba_zbb_zbc_zbs",
-            "rv32mzicsr_zba_zbb_zbc_zbs",
-            "rv32imczicsr_zba_zbb_zbc_zbs",
+            "rv32imcbzicsr",
+            "rv32mcbzicsr",
+            "rv32imcbzicsr",
         ),
         ISAStrTest(tiny_core_config, "rv32i", "rv32", "rv32i"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),
@@ -34,7 +34,9 @@ class TestConfigurationsISAString(TestCase):
 
     def test_isa_str_raw(self):
         for test in self.TEST_CASES:
-            partial, full = extensions_supported(test.core_config.func_units_config)
+            partial, full = extensions_supported(
+                test.core_config.func_units_config, test.core_config.embedded, test.core_config.compressed
+            )
 
             partial = gen_isa_string(partial, 32)
             full = gen_isa_string(full, 32)

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -17,7 +17,12 @@ class TestConfigurationsISAString(TestCase):
 
     TEST_CASES = [
         ISAStrTest(basic_core_config, "rv32i", "rv32", "rv32i"),
-        ISAStrTest(full_core_config, "rv32imzicsr_zba_zbb", "rv32mzicsr_zba_zbb", "rv32imczicsr_zba_zbb"),
+        ISAStrTest(
+            full_core_config,
+            "rv32imzicsr_zba_zbb_zbc_zbs",
+            "rv32mzicsr_zba_zbb_zbc_zbs",
+            "rv32imczicsr_zba_zbb_zbc_zbs",
+        ),
         ISAStrTest(tiny_core_config, "rv32i", "rv32", "rv32i"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),
     ]


### PR DESCRIPTION
Isa string was failing because I added check to prevent extensions that we don't defied optypes yet (like F) and that imply others from being assumed as fully supported extensions. 
It failed for B, because it was not defining any other new optypes and was treated as not specified extension.
Additionally fixed configuration test with `compressed` and `embedded` gp parameters. 