### PR TITLE
Make synthesis timeouts bigger

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
         config: [basic, full]
     name: Synthesis benchmarks
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     container: ghcr.io/kuznia-rdzeni/amaranth-synth:ecp5
     steps:
       - uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
   run-perf-benchmarks:
     name: Run performance benchmarks
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008
     needs: build-perf-benchmarks
     steps:


### PR DESCRIPTION
I see that after extending core with additional units (#421) synthesis has timeouted, so here is a quick fix to increase timeouts.