### PR TITLE
Vector frontend - part 2

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -107,7 +107,8 @@ class Core(Elaboratable):
         m.submodules.scheduler = Scheduler(
             get_instr=fifo_decode.read,
             get_free_reg=free_rf_fifo.read,
-            rat_rename=frat.rename,
+            rat_get_rename=frat.get_rename_list[0],
+            rat_set_rename=frat.set_rename_list[0],
             rob_put=rob.put,
             rf_read1=rf.read1,
             rf_read2=rf.read2,

--- a/coreblocks/fu/vector_unit/utils.py
+++ b/coreblocks/fu/vector_unit/utils.py
@@ -1,10 +1,11 @@
+import math
 from enum import IntEnum
 from amaranth.utils import *
 from amaranth import *
 from coreblocks.params import VectorParameters, GenParams
 from coreblocks.utils._typing import ModuleLike
 
-__all__ = ["SEW", "EEW", "EMUL", "LMUL", "eew_to_bits", "bits_to_eew", "eew_div_2", "get_vlmax", "lmul_to_float"]
+__all__ = ["SEW", "EEW", "EMUL", "LMUL", "eew_to_bits", "bits_to_eew", "eew_div_2", "get_vlmax", "lmul_to_float", "lmul_to_int"]
 
 
 class SEW(IntEnum):
@@ -171,3 +172,6 @@ def get_vlmax(m: ModuleLike, sew: Value, lmul: Value, gen_params: GenParams, v_p
                     val = int(v_params.vlen // eew_to_bits(s) * lmul_to_float(lm))
                     m.d.comb += sig.eq(val)
     return sig
+
+def lmul_to_int(lmul : LMUL) -> int:
+    return math.ceil(lmul_to_float(lmul))

--- a/coreblocks/fu/vector_unit/utils.py
+++ b/coreblocks/fu/vector_unit/utils.py
@@ -5,7 +5,18 @@ from amaranth import *
 from coreblocks.params import VectorParameters, GenParams
 from coreblocks.utils._typing import ModuleLike
 
-__all__ = ["SEW", "EEW", "EMUL", "LMUL", "eew_to_bits", "bits_to_eew", "eew_div_2", "get_vlmax", "lmul_to_float", "lmul_to_int"]
+__all__ = [
+    "SEW",
+    "EEW",
+    "EMUL",
+    "LMUL",
+    "eew_to_bits",
+    "bits_to_eew",
+    "eew_div_2",
+    "get_vlmax",
+    "lmul_to_float",
+    "lmul_to_int",
+]
 
 
 class SEW(IntEnum):
@@ -173,7 +184,8 @@ def get_vlmax(m: ModuleLike, sew: Value, lmul: Value, gen_params: GenParams, v_p
                     m.d.comb += sig.eq(val)
     return sig
 
-def lmul_to_int(lmul : LMUL) -> int:
+
+def lmul_to_int(lmul: LMUL) -> int:
     """Convert LMUL to int by rounding up.
 
     Parameters

--- a/coreblocks/fu/vector_unit/utils.py
+++ b/coreblocks/fu/vector_unit/utils.py
@@ -174,4 +174,11 @@ def get_vlmax(m: ModuleLike, sew: Value, lmul: Value, gen_params: GenParams, v_p
     return sig
 
 def lmul_to_int(lmul : LMUL) -> int:
+    """Convert LMUL to int by rounding up.
+
+    Parameters
+    ----------
+    lmul : LMUL
+        Value to convert.
+    """
     return math.ceil(lmul_to_float(lmul))

--- a/coreblocks/fu/vector_unit/v_alloc_rename.py
+++ b/coreblocks/fu/vector_unit/v_alloc_rename.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from amaranth import *
 from coreblocks.transactions import *
 from coreblocks.transactions.lib import *
@@ -8,12 +7,12 @@ from coreblocks.utils.fifo import *
 from coreblocks.scheduler.wakeup_select import *
 from coreblocks.fu.vector_unit.utils import *
 from coreblocks.fu.vector_unit.v_layouts import *
-from coreblocks.utils._typing import ValueLike
 
 __all__ = ["VectorAllocRename"]
 
+
 class VectorAllocRename(Elaboratable):
-    """ Allocate and rename vector registers
+    """Allocate and rename vector registers
 
     Module for allocating and renaming vector registers using the vector
     register alias table and vector FreeRF file.
@@ -24,7 +23,10 @@ class VectorAllocRename(Elaboratable):
         Method to send the instruction to be renamed. If `rp_dst` has `RegisterType.V` then a
         new physical vector register is allocated and VFRAT will be updated.
     """
-    def __init__(self, gen_params : GenParams,alloc : Method, get_rename1 : Method, get_rename2 : Method, set_rename : Method):
+
+    def __init__(
+        self, gen_params: GenParams, alloc: Method, get_rename1: Method, get_rename2: Method, set_rename: Method
+    ):
         """
         Parameters
         ----------
@@ -33,7 +35,7 @@ class VectorAllocRename(Elaboratable):
         alloc : Method(i=SuperscalarFreeRFLayouts.allocate_in)
             Method to allocate a register.
         get_rename1 : Method(i=RATLayouts.get_rename_in, o=RATLayouts.get_rename_out)
-            Method to get the renaming of registers. 
+            Method to get the renaming of registers.
         get_rename2 : Method
             The same as `get_rename1` but an another instance, to allow for renaming of 4
             registers at a time.
@@ -47,7 +49,7 @@ class VectorAllocRename(Elaboratable):
         self.set_rename = set_rename
 
         self.layouts = VectorFrontendLayouts(self.gen_params)
-        self.issue = Method(i = self.layouts.alloc_rename_in, o = self.layouts.alloc_rename_out)
+        self.issue = Method(i=self.layouts.alloc_rename_in, o=self.layouts.alloc_rename_out)
 
     def elaborate(self, platform) -> TModule:
         m = TModule()
@@ -78,6 +80,5 @@ class VectorAllocRename(Elaboratable):
             m.d.av_comb += rec.rp_s3.id.eq(rename_out2.rp_s1)
             m.d.av_comb += rec.rp_v0.id.eq(rename_out2.rp_s2)
             return rec
-
 
         return m

--- a/coreblocks/fu/vector_unit/v_alloc_rename.py
+++ b/coreblocks/fu/vector_unit/v_alloc_rename.py
@@ -13,7 +13,33 @@ from coreblocks.utils._typing import ValueLike
 __all__ = ["VectorAllocRename"]
 
 class VectorAllocRename(Elaboratable):
+    """ Allocate and rename vector registers
+
+    Module for allocating and renaming vector registers using the vector
+    register alias table and vector FreeRF file.
+
+    Attributes
+    ----------
+    issue : Method(i=VectorFrontendLayouts.alloc_rename_in, o= VectorFrontendLayouts.alloc_rename_out)
+        Method to send the instruction to be renamed. If `rp_dst` has `RegisterType.V` then a
+        new physical vector register is allocated and VFRAT will be updated.
+    """
     def __init__(self, gen_params : GenParams,alloc : Method, get_rename1 : Method, get_rename2 : Method, set_rename : Method):
+        """
+        Parameters
+        ----------
+        gen_params : GenParams
+            Core configuration.
+        alloc : Method(i=SuperscalarFreeRFLayouts.allocate_in)
+            Method to allocate a register.
+        get_rename1 : Method(i=RATLayouts.get_rename_in, o=RATLayouts.get_rename_out)
+            Method to get the renaming of registers. 
+        get_rename2 : Method
+            The same as `get_rename1` but an another instance, to allow for renaming of 4
+            registers at a time.
+        set_rename : Method
+            Method used to update the VFRAT.
+        """
         self.gen_params = gen_params
         self.alloc = NotMethod(alloc)
         self.get_rename1 = get_rename1

--- a/coreblocks/fu/vector_unit/v_alloc_rename.py
+++ b/coreblocks/fu/vector_unit/v_alloc_rename.py
@@ -12,17 +12,21 @@ from coreblocks.utils._typing import ValueLike
 
 __all__ = ["VectorAllocRename"]
 
+class NotMethod():
+    def __init__(self, method : Method):
+        self.method = method
+
 class VectorAllocRename(Elaboratable):
     def __init__(self, gen_params : GenParams, v_params : VectorParameters, alloc : Method, get_rename1 : Method, get_rename2 : Method, set_rename : Method):
         self.gen_params = gen_params
         self.v_params = v_params
-        self.alloc = alloc
+        self.alloc = NotMethod(alloc)
         self.get_rename1 = get_rename1
         self.get_rename2 = get_rename2
         self.set_rename = set_rename
 
         self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
-        self.issue = Method(i = self.layouts.translator_out)
+        self.issue = Method(i = self.layouts.alloc_rename_in, o = self.layouts.alloc_rename_out)
 
     def elaborate(self, platform) -> TModule:
         m = TModule()
@@ -32,11 +36,22 @@ class VectorAllocRename(Elaboratable):
             rec = Record(self.layouts.alloc_rename_in)
             m.d.av_comb += assign(rec, arg)
             with m.If(arg.rp_dst.type == RegisterType.V):
-                realy_rp_dst = self.alloc(m, reg_count=1)
-                self.set_rename(m, rl_dst = arg.rp_dst.id, rp_dst = realy_rp_dst)
+                realy_rp_dst = self.alloc.method(m, reg_count=1)
+                # we are downcasting back to reg_cnt_log, because it conatins
+                # real logical id, but was increased in size due to renaiming in X scheduler
+                rec_rename = Record(self.set_rename.data_in.layout)
+                m.d.top_comb += rec_rename.rl_dst.eq(arg.rp_dst.id)
+                m.d.top_comb += rec_rename.rp_dst.eq(realy_rp_dst)
+                self.set_rename(m, rec_rename)
                 m.d.av_comb += rec.rp_dst.id.eq(realy_rp_dst)
-            rename_out1 = self.get_rename1(m, rl_s1 = arg.rp_s1.id, rl_s2 = arg.rp_s2.id)
-            rename_out2 = self.get_rename1(m, rl_s1 = arg.rp_s3.id, rl_s2 = arg.rp_v0.id)
+            rec_get_1 = Record(self.get_rename1.data_in.layout)
+            rec_get_2 = Record(self.get_rename2.data_in.layout)
+            m.d.top_comb += rec_get_1.rl_s1.eq(arg.rp_s1.id)
+            m.d.top_comb += rec_get_1.rl_s1.eq(arg.rp_s2.id)
+            m.d.top_comb += rec_get_2.rl_s1.eq(arg.rp_s3.id)
+            m.d.top_comb += rec_get_2.rl_s1.eq(arg.rp_v0.id)
+            rename_out1 = self.get_rename1(m, rec_get_1)
+            rename_out2 = self.get_rename2(m, rec_get_2)
             m.d.av_comb += rec.rp_s1.id.eq(rename_out1.rp_s1)
             m.d.av_comb += rec.rp_s2.id.eq(rename_out1.rp_s2)
             m.d.av_comb += rec.rp_s3.id.eq(rename_out2.rp_s1)

--- a/coreblocks/fu/vector_unit/v_alloc_rename.py
+++ b/coreblocks/fu/vector_unit/v_alloc_rename.py
@@ -12,10 +12,6 @@ from coreblocks.utils._typing import ValueLike
 
 __all__ = ["VectorAllocRename"]
 
-class NotMethod():
-    def __init__(self, method : Method):
-        self.method = method
-
 class VectorAllocRename(Elaboratable):
     def __init__(self, gen_params : GenParams, v_params : VectorParameters, alloc : Method, get_rename1 : Method, get_rename2 : Method, set_rename : Method):
         self.gen_params = gen_params

--- a/coreblocks/fu/vector_unit/v_alloc_rename.py
+++ b/coreblocks/fu/vector_unit/v_alloc_rename.py
@@ -1,0 +1,47 @@
+from typing import Optional
+from amaranth import *
+from coreblocks.transactions import *
+from coreblocks.transactions.lib import *
+from coreblocks.utils import *
+from coreblocks.params import *
+from coreblocks.utils.fifo import *
+from coreblocks.scheduler.wakeup_select import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.utils._typing import ValueLike
+
+__all__ = ["VectorAllocRename"]
+
+class VectorAllocRename(Elaboratable):
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters, alloc : Method, get_rename1 : Method, get_rename2 : Method, set_rename : Method):
+        self.gen_params = gen_params
+        self.v_params = v_params
+        self.alloc = alloc
+        self.get_rename1 = get_rename1
+        self.get_rename2 = get_rename2
+        self.set_rename = set_rename
+
+        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.issue = Method(i = self.layouts.translator_out)
+
+    def elaborate(self, platform) -> TModule:
+        m = TModule()
+
+        @def_method(m, self.issue)
+        def _(arg):
+            rec = Record(self.layouts.alloc_rename_in)
+            m.d.av_comb += assign(rec, arg)
+            with m.If(arg.rp_dst.type == RegisterType.V):
+                realy_rp_dst = self.alloc(m, reg_count=1)
+                self.set_rename(m, rl_dst = arg.rp_dst.id, rp_dst = realy_rp_dst)
+                m.d.av_comb += rec.rp_dst.id.eq(realy_rp_dst)
+            rename_out1 = self.get_rename1(m, rl_s1 = arg.rp_s1.id, rl_s2 = arg.rp_s2.id)
+            rename_out2 = self.get_rename1(m, rl_s1 = arg.rp_s3.id, rl_s2 = arg.rp_v0.id)
+            m.d.av_comb += rec.rp_s1.id.eq(rename_out1.rp_s1)
+            m.d.av_comb += rec.rp_s2.id.eq(rename_out1.rp_s2)
+            m.d.av_comb += rec.rp_s3.id.eq(rename_out2.rp_s1)
+            m.d.av_comb += rec.rp_v0.id.eq(rename_out2.rp_s2)
+            return rec
+
+
+        return m

--- a/coreblocks/fu/vector_unit/v_alloc_rename.py
+++ b/coreblocks/fu/vector_unit/v_alloc_rename.py
@@ -13,15 +13,14 @@ from coreblocks.utils._typing import ValueLike
 __all__ = ["VectorAllocRename"]
 
 class VectorAllocRename(Elaboratable):
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters, alloc : Method, get_rename1 : Method, get_rename2 : Method, set_rename : Method):
+    def __init__(self, gen_params : GenParams,alloc : Method, get_rename1 : Method, get_rename2 : Method, set_rename : Method):
         self.gen_params = gen_params
-        self.v_params = v_params
         self.alloc = NotMethod(alloc)
         self.get_rename1 = get_rename1
         self.get_rename2 = get_rename2
         self.set_rename = set_rename
 
-        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.layouts = VectorFrontendLayouts(self.gen_params)
         self.issue = Method(i = self.layouts.alloc_rename_in, o = self.layouts.alloc_rename_out)
 
     def elaborate(self, platform) -> TModule:

--- a/coreblocks/fu/vector_unit/v_frontend.py
+++ b/coreblocks/fu/vector_unit/v_frontend.py
@@ -14,6 +14,7 @@ from coreblocks.fu.vector_unit.v_status import *
 from coreblocks.fu.vector_unit.v_translator import *
 from coreblocks.fu.vector_unit.v_alloc_rename import *
 
+__all__ = ["VectorFrontend"]
 
 class VectorMemoryVVRSSplitter(Elaboratable):
     def __init__(self, gen_params : GenParams, v_params : VectorParameters, put_to_mem : Method, put_to_vvrs : Method):
@@ -32,11 +33,11 @@ class VectorMemoryVVRSSplitter(Elaboratable):
         def _(arg):
             with m.If(arg.exec_fn.op_type == OpType.V_MEMORY):
                 rec_mem = Record(self.layouts.instr_to_mem)
-                m.d.top_comb = assign(rec_mem, arg, fields = AssignType.COMMON)
+                m.d.top_comb += assign(rec_mem, arg, fields = AssignType.COMMON)
                 self.put_to_mem(m, rec_mem)
             with m.Else():
                 rec_vvrs = Record(self.layouts.instr_to_vvrs)
-                m.d.top_comb = assign(rec_vvrs, arg, fields = AssignType.COMMON)
+                m.d.top_comb += assign(rec_vvrs, arg, fields = AssignType.COMMON)
                 self.put_to_vvrs(m, rec_vvrs)
         return m
 
@@ -76,7 +77,7 @@ class VectorFrontend(Elaboratable):
         self.insert.proxy(m, vxrs.insert)
         self.select.proxy(m, vxrs.select)
         self.update.proxy(m, vxrs.update)
-        m.submodules.wakeup_xrs = wakeup_xrs = WakeupSelect(gen_params = self.gen_params, get_ready = vxrs.get_ready_list[0],take_row = vxrs.take, issue= verificator.issue)
+        m.submodules.wakeup_xrs = wakeup_xrs = WakeupSelect(gen_params = self.gen_params, get_ready = vxrs.get_ready_list[0],take_row = vxrs.take, issue= verificator.issue, row_layout = self.layouts.verification_in)
 
         
         m.submodules.fifo_from_translator = fifo_from_translator = BasicFifo(self.layouts.translator_out, 2)

--- a/coreblocks/fu/vector_unit/v_frontend.py
+++ b/coreblocks/fu/vector_unit/v_frontend.py
@@ -53,7 +53,7 @@ class VectorFrontend(Elaboratable):
         #TODO Prepare more retire methods to use in different places
         self.retire = retire
         self.retire_mult = retire_mult
-        self.alloc_reg = alloc_reg
+        self.alloc_reg = NotMethod(alloc_reg)
         self.get_rename1_frat = get_rename1_frat
         self.get_rename2_frat = get_rename2_frat
         self.set_rename_frat = set_rename_frat
@@ -85,7 +85,7 @@ class VectorFrontend(Elaboratable):
 
         m.submodules.from_status_to_tranlator = ConnectTrans(fifo_from_v_status.read, translator.issue)
         
-        m.submodules.alloc_rename = alloc_rename = VectorAllocRename(self.gen_params, self.v_params, self.alloc_reg, self.get_rename1_frat, self.get_rename2_frat, self.set_rename_frat)
+        m.submodules.alloc_rename = alloc_rename = VectorAllocRename(self.gen_params, self.v_params, self.alloc_reg.method, self.get_rename1_frat, self.get_rename2_frat, self.set_rename_frat)
         m.submodules.splitter = splitter = VectorMemoryVVRSSplitter(self.gen_params, self.v_params, self.put_to_mem, self.put_to_vvrs)
         
         with Transaction(name="allocating").body(m):

--- a/coreblocks/fu/vector_unit/v_frontend.py
+++ b/coreblocks/fu/vector_unit/v_frontend.py
@@ -1,0 +1,96 @@
+from typing import Optional
+from amaranth import *
+from coreblocks.transactions import *
+from coreblocks.transactions.lib import *
+from coreblocks.utils import *
+from coreblocks.params import *
+from coreblocks.utils.fifo import *
+from coreblocks.scheduler.wakeup_select import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.fu.vector_unit.v_input_verification import *
+from coreblocks.fu.vector_unit.v_status import *
+from coreblocks.fu.vector_unit.v_translator import *
+from coreblocks.fu.vector_unit.v_alloc_rename import *
+
+
+class VectorMemoryVVRSSplitter(Elaboratable):
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters, put_to_mem : Method, put_to_vvrs : Method):
+        self.gen_params = gen_params
+        self.v_params = v_params
+        self.put_to_mem = put_to_mem
+        self.put_to_vvrs = put_to_vvrs
+
+        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.issue = Method(i = self.layouts.alloc_rename_out)
+
+    def elaborate(self, platform) -> TModule:
+        m = TModule()
+
+        @def_method(m, self.issue)
+        def _(arg):
+            with m.If(arg.exec_fn.op_type == OpType.V_MEMORY):
+                rec_mem = Record(self.layouts.instr_to_mem)
+                m.d.top_comb = assign(rec_mem, arg, fields = AssignType.COMMON)
+                self.put_to_mem(m, rec_mem)
+            with m.Else():
+                rec_vvrs = Record(self.layouts.instr_to_vvrs)
+                m.d.top_comb = assign(rec_vvrs, arg, fields = AssignType.COMMON)
+                self.put_to_vvrs(m, rec_vvrs)
+        return m
+
+
+class VectorFrontend(Elaboratable):
+
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters, rob_block_interrupts : Method, retire : Method, retire_mult : Method, alloc_reg : Method,
+                 get_rename1_frat : Method, get_rename2_frat : Method, set_rename_frat : Method, put_to_mem : Method, put_to_vvrs : Method):
+        self.gen_params = gen_params
+        self.v_params = v_params
+        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.rob_block_interrupts = rob_block_interrupts
+        #TODO Prepare more retire methods to use in different places
+        self.retire = retire
+        self.retire_mult = retire_mult
+        self.alloc_reg = alloc_reg
+        self.get_rename1_frat = get_rename1_frat
+        self.get_rename2_frat = get_rename2_frat
+        self.set_rename_frat = set_rename_frat
+        self.put_to_mem = put_to_mem
+        self.put_to_vvrs = put_to_vvrs
+
+        self.vxrs_layouts = VectorXRSLayout(self.gen_params, rs_entries_bits = log2_int(self.v_params.vxrs_entries, False))
+        self.insert = Method(i = self.vxrs_layouts.insert_in)
+        self.select = Method(o = self.vxrs_layouts.select_out)
+        self.update = Method(i = self.vxrs_layouts.update_in)
+
+    def elaborate(self, platform) -> TModule:
+        m = TModule()
+
+
+        m.submodules.fifo_from_v_status = fifo_from_v_status = BasicFifo(self.layouts.status_out, 2)
+        m.submodules.v_status = v_status = VectorStatusUnit(self.gen_params, self.v_params, fifo_from_v_status.write, self.retire)
+        m.submodules.verificator = verificator = VectorInputVerificator(self.gen_params, self.v_params, self.rob_block_interrupts, v_status.issue, v_status.get_vill, v_status.get_vstart, self.retire)
+
+        m.submodules.vxrs = vxrs = VXRS(self.gen_params, self.v_params.vxrs_entries)
+        self.insert.proxy(m, vxrs.insert)
+        self.select.proxy(m, vxrs.select)
+        self.update.proxy(m, vxrs.update)
+        m.submodules.wakeup_xrs = wakeup_xrs = WakeupSelect(gen_params = self.gen_params, get_ready = vxrs.get_ready_list[0],take_row = vxrs.take, issue= verificator.issue)
+
+        
+        m.submodules.fifo_from_translator = fifo_from_translator = BasicFifo(self.layouts.translator_out, 2)
+        m.submodules.translator = translator = VectorTranslator(self.gen_params, self.v_params, fifo_from_translator.write, self.retire_mult)
+
+        m.submodules.from_status_to_tranlator = ConnectTrans(fifo_from_v_status.read, translator.issue)
+        
+        m.submodules.alloc_rename = alloc_rename = VectorAllocRename(self.gen_params, self.v_params, self.alloc_reg, self.get_rename1_frat, self.get_rename2_frat, self.set_rename_frat)
+        m.submodules.splitter = splitter = VectorMemoryVVRSSplitter(self.gen_params, self.v_params, self.put_to_mem, self.put_to_vvrs)
+        
+        with Transaction(name="allocating").body(m):
+            instr = fifo_from_translator.read(m)
+            renamed = alloc_rename.issue(m, instr)
+            splitter.issue(m, renamed)
+
+
+        return m

--- a/coreblocks/fu/vector_unit/v_input_verification.py
+++ b/coreblocks/fu/vector_unit/v_input_verification.py
@@ -6,6 +6,8 @@ from coreblocks.fu.vector_unit.utils import *
 from coreblocks.fu.vector_unit.v_layouts import *
 from coreblocks.utils.fifo import BasicFifo
 
+__all__ = ["VectorInputVerificator"]
+
 
 class VectorInputVerificator(Elaboratable):
     """Module to verify incoming vector instructions

--- a/coreblocks/fu/vector_unit/v_input_verification.py
+++ b/coreblocks/fu/vector_unit/v_input_verification.py
@@ -36,7 +36,6 @@ class VectorInputVerificator(Elaboratable):
     def __init__(
         self,
         gen_params: GenParams,
-        v_params: VectorParameters,
         rob_block_interrupts: Method,
         put_instr: Method,
         get_vill: Method,
@@ -48,8 +47,6 @@ class VectorInputVerificator(Elaboratable):
         ----------
         gen_params : GenParams
             Core configuration.
-        v_params : VectorParameters
-            Vector unit configuration
         rob_block_interrupts : Method
             Method to be called to block interrupts on the given rob_id.
         put_instr : Method
@@ -66,14 +63,14 @@ class VectorInputVerificator(Elaboratable):
             Layout: FuncUnitLayouts.accept
         """
         self.gen_params = gen_params
-        self.v_params = v_params
+        self.v_params = self.gen_params.v_params
         self.rob_block_interrupts = rob_block_interrupts
         self.put_instr = put_instr
         self.get_vill = get_vill
         self.get_vstart = get_vstart
         self.retire = retire
 
-        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.layouts = VectorFrontendLayouts(self.gen_params)
         self.vill = Signal()
         self.vstart = Signal(self.v_params.vstart_bits)
         self.dependency_manager = self.gen_params.get(DependencyManager)

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -1,6 +1,5 @@
 from amaranth.utils import *
 from coreblocks.params import *
-from coreblocks.params.vector_params import VectorParameters
 from coreblocks.fu.vector_unit.utils import SEW, LMUL, EEW
 from coreblocks.utils._typing import LayoutLike
 from coreblocks.utils import layout_subset, layout_difference
@@ -62,15 +61,15 @@ class VectorXRSLayout(RSLayouts):
         self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
         self.take_out: LayoutLike = self.data_layout
 
+
 class VectorVRSLayout(RSLayouts):
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         super().__init__(gen_params, rs_entries_bits=rs_entries_bits)
         common = gen_params.get(CommonLayouts)
         common_vector = VectorCommonLayouts(gen_params)
-        rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
 
-        #TODO check if all bits are needed
-        #TODO add prechecking which registers are used and wait only on these
+        # TODO check if all bits are needed
+        # TODO add prechecking which registers are used and wait only on these
         self.data_layout: LayoutLike = [
             ("rp_s1", common.p_register_entry),
             ("rp_s2", common.p_register_entry),
@@ -85,7 +84,7 @@ class VectorVRSLayout(RSLayouts):
             ("rp_s2_rdy", 1),
             ("rp_s3_rdy", 1),
             ("rp_v0_rdy", 1),
-            ]
+        ]
 
         self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
         self.take_out: LayoutLike = self.data_layout
@@ -93,8 +92,8 @@ class VectorVRSLayout(RSLayouts):
 
 class VectorCommonLayouts:
     def __init__(self, gen_params: GenParams):
-        common = gen_params.get(CommonLayouts)
         self.vtype = [("lmul", LMUL), ("sew", SEW), ("ta", 1), ("ma", 1), ("vl", gen_params.isa.xlen)]
+
 
 class VectorFrontendLayouts:
     def __init__(self, gen_params: GenParams):
@@ -115,14 +114,18 @@ class VectorFrontendLayouts:
             ("imm2", gen_params.imm2_width),
         ]
 
-        self.status_out = self.translator_in =  layout_difference(self.status_in, fields={"imm2"}) + [("vtype", self.vtype)]
-        self.translator_inner = layout_difference(self.translator_in, fields= {"imm"})
-        self.translator_out = self.translator_inner + [("rp_s3", common.p_register_entry), ("rp_v0", [("id", gen_params.phys_regs_bits)])]
+        self.status_out = self.translator_in = layout_difference(self.status_in, fields={"imm2"}) + [
+            ("vtype", self.vtype)
+        ]
+        self.translator_inner = layout_difference(self.translator_in, fields={"imm"})
+        self.translator_out = self.translator_inner + [
+            ("rp_s3", common.p_register_entry),
+            ("rp_v0", [("id", gen_params.phys_regs_bits)]),
+        ]
         self.alloc_rename_out = self.alloc_rename_in = self.translator_out
         self.get_vill = [("vill", 1)]
         self.get_vstart = [("vstart", v_params.vstart_bits)]
         self.translator_report_multiplier = [("mult", 4)]
-
 
         self.instr_to_mem = [
             ("rp_s1", common.p_register_entry),
@@ -136,7 +139,7 @@ class VectorFrontendLayouts:
             ("vtype", self.vtype),
             ("rp_s3", common.p_register_entry),
             ("rp_v0", [("id", gen_params.phys_regs_bits)]),
-            ]
+        ]
 
         self.instr_to_vvrs = [
             ("rp_s1", common.p_register_entry),
@@ -148,14 +151,11 @@ class VectorFrontendLayouts:
             ("vtype", self.vtype),
             ("rp_s3", common.p_register_entry),
             ("rp_v0", [("id", gen_params.phys_regs_bits)]),
-                ]
+        ]
+
 
 class VectorBackendLayouts:
     def __init__(self, gen_params: GenParams):
-        v_params = gen_params.v_params
-        common = gen_params.get(CommonLayouts)
         frontend = VectorFrontendLayouts(gen_params)
-        common_vector = VectorCommonLayouts(gen_params)
 
         self.vvrs_in = frontend.instr_to_vvrs
-

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -105,7 +105,34 @@ class VectorFrontendLayouts:
         ]
 
         self.status_out = self.translator_in =  layout_difference(self.status_in, fields={"imm2"}) + [("vtype", self.vtype)]
-        self.translator_out = self.translator_in + [("rp_s3", common.p_register_entry), ("rp_v0", [("id", gen_params.phys_regs_bits)])]
+        self.translator_inner = layout_difference(self.translator_in, fields= {"imm"})
+        self.translator_out = self.translator_inner + [("rp_s3", common.p_register_entry), ("rp_v0", [("id", gen_params.phys_regs_bits)])]
+        self.alloc_rename_out = self.alloc_rename_in = self.translator_out
         self.get_vill = [("vill", 1)]
         self.get_vstart = [("vstart", v_params.vstart_bits)]
         self.translator_report_multiplier = [("mult", 4)]
+
+
+        self.instr_to_mem = [
+            ("rp_s1", common.p_register_entry),
+            ("rp_s2", common.p_register_entry),
+            ("rp_s3", common.p_register_entry),
+            ("rp_v0", [("id", gen_params.phys_regs_bits)]),
+            ("rp_dst", common.p_register_entry),
+            ("rob_id", gen_params.rob_entries_bits),
+            ("exec_fn", common.exec_fn),
+            ("s1_val", gen_params.isa.xlen),
+            ("s2_val", gen_params.isa.xlen),
+            ("imm2", gen_params.imm2_width),
+                ]
+
+        self.instr_to_vvrs = [
+            ("rp_s1", common.p_register_entry),
+            ("rp_s2", common.p_register_entry),
+            ("rp_s3", common.p_register_entry),
+            ("rp_v0", [("id", gen_params.phys_regs_bits)]),
+            ("rp_dst", common.p_register_entry),
+            ("rob_id", gen_params.rob_entries_bits),
+            ("exec_fn", common.exec_fn),
+            ("s1_val", gen_params.isa.xlen),
+                ]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -104,7 +104,7 @@ class VectorFrontendLayouts:
             ("imm2", gen_params.imm2_width),
         ]
 
-        self.status_out = layout_difference(self.status_in, fields={"imm2"}) + [("vtype", self.vtype)]
-
+        self.status_out = self.translator_in =  layout_difference(self.status_in, fields={"imm2"}) + [("vtype", self.vtype)]
+        self.translator_out = self.translator_in + [("rp_s3", common.p_register_entry)]
         self.get_vill = [("vill", 1)]
         self.get_vstart = [("vstart", v_params.vstart_bits)]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -108,3 +108,4 @@ class VectorFrontendLayouts:
         self.translator_out = self.translator_in + [("rp_s3", common.p_register_entry)]
         self.get_vill = [("vill", 1)]
         self.get_vstart = [("vstart", v_params.vstart_bits)]
+        self.translator_report_multiplier_in = [("mult", 4)]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -116,23 +116,25 @@ class VectorFrontendLayouts:
         self.instr_to_mem = [
             ("rp_s1", common.p_register_entry),
             ("rp_s2", common.p_register_entry),
-            ("rp_s3", common.p_register_entry),
-            ("rp_v0", [("id", gen_params.phys_regs_bits)]),
             ("rp_dst", common.p_register_entry),
             ("rob_id", gen_params.rob_entries_bits),
             ("exec_fn", common.exec_fn),
             ("s1_val", gen_params.isa.xlen),
             ("s2_val", gen_params.isa.xlen),
             ("imm2", gen_params.imm2_width),
-                ]
+            ("vtype", self.vtype),
+            ("rp_s3", common.p_register_entry),
+            ("rp_v0", [("id", gen_params.phys_regs_bits)]),
+            ]
 
         self.instr_to_vvrs = [
             ("rp_s1", common.p_register_entry),
             ("rp_s2", common.p_register_entry),
-            ("rp_s3", common.p_register_entry),
-            ("rp_v0", [("id", gen_params.phys_regs_bits)]),
             ("rp_dst", common.p_register_entry),
             ("rob_id", gen_params.rob_entries_bits),
             ("exec_fn", common.exec_fn),
             ("s1_val", gen_params.isa.xlen),
+            ("vtype", self.vtype),
+            ("rp_s3", common.p_register_entry),
+            ("rp_v0", [("id", gen_params.phys_regs_bits)]),
                 ]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -60,6 +60,32 @@ class VectorXRSLayout(RSLayouts):
         self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
         self.take_out: LayoutLike = self.data_layout
 
+class VectorVRSLayout(RSLayouts):
+    def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
+        super().__init__(gen_params, rs_entries_bits=rs_entries_bits)
+        common = gen_params.get(CommonLayouts)
+        rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
+
+        self.data_layout: LayoutLike = layout_subset(
+            rs_interface.data_layout,
+            fields={
+                "rp_s1",
+                "rp_s2",
+                "rp_dst",
+                "rob_id",
+                "exec_fn",
+                "imm",
+            },
+        ) + [
+                ("rp_s3", common.p_register_entry),
+                ("rp_s1_rdy", 1),
+                ("rp_s2_rdy", 1),
+                ("rp_s3_rdy", 1),
+             ]
+
+        self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
+        self.take_out: LayoutLike = self.data_layout
+
 
 class VectorFrontendLayouts:
     def __init__(self, gen_params: GenParams, v_params: VectorParameters):

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -105,7 +105,7 @@ class VectorFrontendLayouts:
         ]
 
         self.status_out = self.translator_in =  layout_difference(self.status_in, fields={"imm2"}) + [("vtype", self.vtype)]
-        self.translator_out = self.translator_in + [("rp_s3", common.p_register_entry)]
+        self.translator_out = self.translator_in + [("rp_s3", common.p_register_entry), ("rp_v0", [("id", gen_params.phys_regs_bits)])]
         self.get_vill = [("vill", 1)]
         self.get_vstart = [("vstart", v_params.vstart_bits)]
-        self.translator_report_multiplier_in = [("mult", 4)]
+        self.translator_report_multiplier = [("mult", 4)]

--- a/coreblocks/fu/vector_unit/v_layouts.py
+++ b/coreblocks/fu/vector_unit/v_layouts.py
@@ -7,7 +7,8 @@ from coreblocks.utils import layout_subset, layout_difference
 
 
 class VectorRegisterBankLayouts:
-    def __init__(self, gen_params: GenParams, v_params: VectorParameters):
+    def __init__(self, gen_params: GenParams):
+        v_params = gen_params.v_params
         self.read_resp = [("data", v_params.elen)]
 
         self.write = [
@@ -21,7 +22,8 @@ class VectorRegisterBankLayouts:
 
 
 class VRFFragmentLayouts:
-    def __init__(self, gen_params: GenParams, v_params: VectorParameters):
+    def __init__(self, gen_params: GenParams):
+        v_params = gen_params.v_params
         self.read_req = [("vrp_id", v_params.vrp_count_bits), ("addr", v_params.elems_in_bank_bits)]
 
         self.read_resp_i = [("vrp_id", v_params.vrp_count_bits)]
@@ -64,33 +66,42 @@ class VectorVRSLayout(RSLayouts):
     def __init__(self, gen_params: GenParams, *, rs_entries_bits: int):
         super().__init__(gen_params, rs_entries_bits=rs_entries_bits)
         common = gen_params.get(CommonLayouts)
+        common_vector = VectorCommonLayouts(gen_params)
         rs_interface = gen_params.get(RSInterfaceLayouts, rs_entries_bits=rs_entries_bits)
 
-        self.data_layout: LayoutLike = layout_subset(
-            rs_interface.data_layout,
-            fields={
-                "rp_s1",
-                "rp_s2",
-                "rp_dst",
-                "rob_id",
-                "exec_fn",
-                "imm",
-            },
-        ) + [
-                ("rp_s3", common.p_register_entry),
-                ("rp_s1_rdy", 1),
-                ("rp_s2_rdy", 1),
-                ("rp_s3_rdy", 1),
-             ]
+        #TODO check if all bits are needed
+        #TODO add prechecking which registers are used and wait only on these
+        self.data_layout: LayoutLike = [
+            ("rp_s1", common.p_register_entry),
+            ("rp_s2", common.p_register_entry),
+            ("rp_dst", common.p_register_entry),
+            ("rob_id", gen_params.rob_entries_bits),
+            ("exec_fn", common.exec_fn),
+            ("s1_val", gen_params.isa.xlen),
+            ("vtype", common_vector.vtype),
+            ("rp_s3", common.p_register_entry),
+            ("rp_v0", [("id", gen_params.phys_regs_bits)]),
+            ("rp_s1_rdy", 1),
+            ("rp_s2_rdy", 1),
+            ("rp_s3_rdy", 1),
+            ("rp_v0_rdy", 1),
+            ]
 
         self.insert_in: LayoutLike = [("rs_data", self.data_layout), ("rs_entry_id", rs_entries_bits)]
         self.take_out: LayoutLike = self.data_layout
 
 
-class VectorFrontendLayouts:
-    def __init__(self, gen_params: GenParams, v_params: VectorParameters):
+class VectorCommonLayouts:
+    def __init__(self, gen_params: GenParams):
         common = gen_params.get(CommonLayouts)
         self.vtype = [("lmul", LMUL), ("sew", SEW), ("ta", 1), ("ma", 1), ("vl", gen_params.isa.xlen)]
+
+class VectorFrontendLayouts:
+    def __init__(self, gen_params: GenParams):
+        v_params = gen_params.v_params
+        common = gen_params.get(CommonLayouts)
+        common_vector = VectorCommonLayouts(gen_params)
+        self.vtype = common_vector.vtype
 
         self.verification_in = self.verification_out = self.status_in = [
             ("rp_s1", common.p_register_entry),
@@ -138,3 +149,13 @@ class VectorFrontendLayouts:
             ("rp_s3", common.p_register_entry),
             ("rp_v0", [("id", gen_params.phys_regs_bits)]),
                 ]
+
+class VectorBackendLayouts:
+    def __init__(self, gen_params: GenParams):
+        v_params = gen_params.v_params
+        common = gen_params.get(CommonLayouts)
+        frontend = VectorFrontendLayouts(gen_params)
+        common_vector = VectorCommonLayouts(gen_params)
+
+        self.vvrs_in = frontend.instr_to_vvrs
+

--- a/coreblocks/fu/vector_unit/v_register.py
+++ b/coreblocks/fu/vector_unit/v_register.py
@@ -4,7 +4,6 @@ from coreblocks.transactions.core import *
 from coreblocks.transactions.lib import MemoryBank
 from coreblocks.params import *
 from coreblocks.utils.fifo import BasicFifo
-from coreblocks.params.vector_params import VectorParameters
 from coreblocks.fu.vector_unit.v_layouts import VectorRegisterBankLayouts
 from coreblocks.fu.vector_unit.utils import EEW
 

--- a/coreblocks/fu/vector_unit/v_register.py
+++ b/coreblocks/fu/vector_unit/v_register.py
@@ -39,11 +39,11 @@ class VectorRegisterBank(Elaboratable):
         Clear register and all internal buffers.
     """
 
-    def __init__(self, *, gen_params: GenParams, v_params: VectorParameters):
+    def __init__(self, *, gen_params: GenParams):
         self.gen_params = gen_params
-        self.v_params = v_params
+        self.v_params = self.gen_params.v_params
 
-        self.layouts = VectorRegisterBankLayouts(self.gen_params, self.v_params)
+        self.layouts = VectorRegisterBankLayouts(self.gen_params)
 
         self.bank = MemoryBank(
             data_layout=self.layouts.read_resp, elem_count=self.v_params.elems_in_bank, granularity=8

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -140,6 +140,8 @@ class VectorStatusUnit(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
+        #TODO Optimisation: Use Funct7+rs2 istead of imm2
+
         @def_method(m, self.issue)
         def _(arg):
             m.d.sync += self.vstart.eq(0)

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -42,14 +42,12 @@ class VectorStatusUnit(Elaboratable):
         Clear the internal state.
     """
 
-    def __init__(self, gen_params: GenParams, v_params: VectorParameters, put_instr: Method, retire: Method):
+    def __init__(self, gen_params: GenParams, put_instr: Method, retire: Method):
         """
         Parameters
         ----------
         gen_params : GenParams
             Core configuration.
-        v_params : VectorParameters
-            Vector unit configuration
         put_instr : Method
             Method used to pass vector instructions that operate on data to the next pipeline stage.
             Layout: VectorFrontendLayouts.status_out
@@ -58,11 +56,11 @@ class VectorStatusUnit(Elaboratable):
             Layout: FuncUnitLayouts.accept
         """
         self.gen_params = gen_params
-        self.v_params = v_params
+        self.v_params = self.gen_params.v_params
         self.retire = retire
         self.put_instr = put_instr
 
-        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.layouts = VectorFrontendLayouts(self.gen_params)
         self.get_vill = Method(o=self.layouts.get_vill, nonexclusive=True)
         self.get_vstart = Method(o=self.layouts.get_vstart, nonexclusive=True)
         self.clear = Method()

--- a/coreblocks/fu/vector_unit/v_status.py
+++ b/coreblocks/fu/vector_unit/v_status.py
@@ -138,7 +138,7 @@ class VectorStatusUnit(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        #TODO Optimisation: Use Funct7+rs2 istead of imm2
+        # TODO Optimisation: Use Funct7+rs2 istead of imm2
 
         @def_method(m, self.issue)
         def _(arg):

--- a/coreblocks/fu/vector_unit/v_translator.py
+++ b/coreblocks/fu/vector_unit/v_translator.py
@@ -19,11 +19,10 @@ class VectorTranslatorEEW(Elaboratable):
     instructions.
     As for now it uses internal instruction to narrow data, but there is ZEXT and SEXT
     """
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters, put_instr : Method, report_multiplicator : Method):
+    def __init__(self, gen_params : GenParams, put_instr : Method, report_multiplicator : Method):
        self.gen_params = gen_params
-       self.v_params = v_params
 
-       self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+       self.layouts = VectorFrontendLayouts(self.gen_params)
        self.issue = Method(i= self.layouts.translator_in)
        self.put_instr = put_instr
        self.report_multiplicator = report_multiplicator
@@ -129,11 +128,10 @@ class VectorTranslatorEEW(Elaboratable):
 
 
 class VectorTranslateLMUL(Elaboratable):
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters, put_instr : Method):
+    def __init__(self, gen_params : GenParams,put_instr : Method):
        self.gen_params = gen_params
-       self.v_params = v_params
 
-       self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+       self.layouts = VectorFrontendLayouts(self.gen_params)
        self.issue = Method(i= self.layouts.translator_inner, o=self.layouts.translator_report_multiplier)
        self.put_instr = put_instr
 
@@ -186,11 +184,10 @@ class VectorTranslateLMUL(Elaboratable):
         return m
 
 class VectorTranslateRS3(Elaboratable):
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters, put_instr : Method):
+    def __init__(self, gen_params : GenParams, put_instr : Method):
        self.gen_params = gen_params
-       self.v_params = v_params
 
-       self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+       self.layouts = VectorFrontendLayouts(self.gen_params)
        self.issue = Method(i= self.layouts.translator_inner)
        self.put_instr = put_instr
 
@@ -209,11 +206,10 @@ class VectorTranslateRS3(Elaboratable):
         return m
 
 class VectorTranslateRewirteImm(Elaboratable):
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters):
+    def __init__(self, gen_params : GenParams):
        self.gen_params = gen_params
-       self.v_params = v_params
 
-       self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+       self.layouts = VectorFrontendLayouts(self.gen_params)
        self.issue = Method(i= self.layouts.translator_in, o =self.layouts.translator_inner )
 
     def elaborate(self, platform) -> TModule:
@@ -230,21 +226,20 @@ class VectorTranslateRewirteImm(Elaboratable):
                 
 
 class VectorTranslator(Elaboratable):
-    def __init__(self, gen_params : GenParams, v_params : VectorParameters, put_instr : Method, retire_mult : Method):
+    def __init__(self, gen_params : GenParams,put_instr : Method, retire_mult : Method):
        self.gen_params = gen_params
-       self.v_params = v_params
        self.put_instr = put_instr
        self.retire_mult = retire_mult
 
-       self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+       self.layouts = VectorFrontendLayouts(self.gen_params)
        self.issue = Method(i= self.layouts.translator_in)
 
     def elaborate(self, platform) -> TModule:
         m = TModule()
 
-        m.submodules.transl_rp3 = transl_rp3 = VectorTranslateRS3(self.gen_params, self.v_params, self.put_instr)
-        m.submodules.transl_lmul = transl_lmul =VectorTranslateLMUL(self.gen_params, self.v_params, transl_rp3.issue)
-        m.submodules.transl_rewrite_imm = transl_rewrite_imm = VectorTranslateRewirteImm(self.gen_params, self.v_params)
+        m.submodules.transl_rp3 = transl_rp3 = VectorTranslateRS3(self.gen_params, self.put_instr)
+        m.submodules.transl_lmul = transl_lmul =VectorTranslateLMUL(self.gen_params, transl_rp3.issue)
+        m.submodules.transl_rewrite_imm = transl_rewrite_imm = VectorTranslateRewirteImm(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):

--- a/coreblocks/fu/vector_unit/v_translator.py
+++ b/coreblocks/fu/vector_unit/v_translator.py
@@ -128,6 +128,9 @@ class VectorTranslatorEEW(Elaboratable):
         return m
 
 
+class VectorTranslateLMUL(Elaboratable):
+    pass
+
 class VectorTranslator(Elaboratable):
     def __init__(self, gen_params : GenParams, v_params : VectorParameters):
        self.gen_params = gen_params

--- a/coreblocks/fu/vector_unit/v_translator.py
+++ b/coreblocks/fu/vector_unit/v_translator.py
@@ -13,6 +13,12 @@ from coreblocks.utils._typing import ValueLike
 __all__ = ["VectorTranslator"]
 
 class VectorTranslatorEEW(Elaboratable):
+    """
+    Not tested, may not work.
+    Probably there is a need to do mapping from widening/narrowing instructions to normal
+    instructions.
+    As for now it uses internal instruction to narrow data, but there is ZEXT and SEXT
+    """
     def __init__(self, gen_params : GenParams, v_params : VectorParameters, put_instr : Method, report_multiplicator : Method):
        self.gen_params = gen_params
        self.v_params = v_params

--- a/coreblocks/fu/vector_unit/v_translator.py
+++ b/coreblocks/fu/vector_unit/v_translator.py
@@ -1,0 +1,149 @@
+from typing import Optional
+from amaranth import *
+from coreblocks.transactions import *
+from coreblocks.transactions.lib import *
+from coreblocks.utils import *
+from coreblocks.params import *
+from coreblocks.utils.fifo import *
+from coreblocks.scheduler.wakeup_select import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.utils._typing import ValueLike
+
+__all__ = ["VectorTranslator"]
+
+class VectorTranslatorEEW(Elaboratable):
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters, put_instr : Method, report_multiplicator : Method):
+       self.gen_params = gen_params
+       self.v_params = v_params
+
+       self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+       self.issue = Method(i= self.layouts.translator_in)
+       self.put_instr = put_instr
+       self.report_multiplicator = report_multiplicator
+
+       self.shape_narrowing_optypes = [
+           OpType.V_ARITHMETIC_NARROWING,
+           OpType.V_ARITHMETIC_NARROWING_IMM,
+           OpType.V_ARITHMETIC_NARROWING_SCALAR,
+           ]
+       self.shape_widening_optypes = [
+           OpType.V_ARITHMETIC_WIDENING,
+           OpType.V_ARITHMETIC_WIDENING_IMM,
+           OpType.V_ARITHMETIC_WIDENING_SCALAR]
+
+
+    def generate_move_instr(self, m : TModule, org_instr, if_narrow : ValueLike, reg_id : ValueLike) -> Record:
+        rec = Record(self.layouts.translator_in)
+        d = {
+            "exec_fn" : {
+                "funct3" : Funct3.OPIVI,
+                "funct7" : Mux(if_narrow, Funct6._VNARROW, Funct6._VWIDEN) * 2 + 1,
+                "op_type" : OpType.V_CONTROL,
+                },
+            "vtype" : org_instr.vtype,
+            "rp_s1" : {
+                "id": reg_id,
+                "type" : RegisterType.V,
+                },
+            "rp_dst" : {
+                "id": reg_id,
+                "type" : RegisterType.V,
+                }
+        }
+        m.d.comb += assign(rec, d)
+        return rec
+
+    def eleborate(self, platform):
+        m = TModule()
+
+        reg1 = Record(self.layouts.translator_in)
+        reg2 = Record(self.layouts.translator_in)
+        reg_now = Record(self.layouts.translator_in)
+        counter = Signal(2)
+        multiplicator = Signal(2)
+
+        with Transaction(name="trans_put_instr_buff_1").body(m, request = counter == 1):
+            m.d.sync += counter.eq(0)
+            self.put_instr(m, reg1)
+
+        with Transaction(name="trans_put_instr_buff_2").body(m, request = counter == 2):
+            m.d.sync += counter.eq(1)
+            self.put_instr(m, reg2)
+
+        @def_method(m, self.issue, counter == 0)
+        def _(arg):
+            instr1_narrowing = Signal()
+            instr1_reg = Signal(self.gen_params.phys_regs_bits)
+            instr1_generated = self.generate_move_instr(m, arg, instr1_narrowing, instr1_reg)
+            instr2_narrowing = Signal()
+            instr2_reg = Signal(self.gen_params.phys_regs_bits)
+            instr2_generated =  self.generate_move_instr(m, arg, instr2_narrowing, instr2_reg)
+            is_narrowing = Cat(arg.exec_fn.op_type == op for op in self.shape_narrowing_optypes).any()
+            is_widening = Cat(arg.exec_fn.op_type == op for op in self.shape_widening_optypes).any()
+            with m.If(is_narrowing):
+                with m.If(Cat([arg.exec_fn.funct3 == funct for funct in [Funct3.OPIVV, Funct3.OPMVV, Funct3.OPFVV]]).any()):
+                    m.d.comb += [
+                            instr1_narrowing.eq(0),
+                            instr1_reg.eq(arg.rp_s1.id),
+                            instr2_narrowing.eq(1),
+                            instr2_reg.eq(arg.rp_dst.id),
+                            reg_now.re(instr1_generated),
+                            multiplicator.eq(3),
+                            ]
+                    m.d.sync += reg2.eq(arg)
+                    m.d.sync += reg1.eq(instr2_generated)
+                    m.d.sync += counter.eq(2)
+                with m.Else():
+                    m.d.comb += [
+                            reg_now.re(arg),
+                            multiplicator.eq(2),
+                            instr2_narrowing.eq(1),
+                            instr2_reg.eq(arg.rp_dst.id),]
+                    m.d.sync += reg1.eq(instr2_generated)
+                    m.d.sync += counter.eq(1)
+            with m.Elif(is_widening):
+                m.d.comb += [reg_now.re(instr1_generated),
+                             multiplicator.eq(3),
+                             instr1_narrowing.eq(0),
+                             instr1_reg.eq(arg.rp_s1.id),
+                             instr2_narrowing.eq(0),
+                             instr2_reg.eq(arg.rp_s2.id),
+                             ]
+                m.d.sync += reg2.eq(instr2_generated)
+                m.d.sync += reg1.eq(arg)
+                m.d.sync += counter.eq(2)
+            with m.Else():
+                m.d.comb += reg_now.re(arg)
+                m.d.comb += multiplicator.eq(1)
+            self.put_instr(m, reg_now)
+            self.report_multiplicator(m, multiplicator=multiplicator)
+
+        return m
+
+
+class VectorTranslator(Elaboratable):
+    def __init__(self, gen_params : GenParams, v_params : VectorParameters):
+       self.gen_params = gen_params
+       self.v_params = v_params
+
+       self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+       self.issue = Method(i= self.layouts.translator_in)
+       self.get_instr_list = [Method(o = self.layouts.translator_out) for _ in range(self.v_params.max_lmul)]
+
+
+    def elaborate(self, platform) -> TModule:
+        m = TModule()
+
+        pipe = RegisterPipe(self.layouts.translator_out, self.v_params.max_lmul)
+        m.submodules.pipe = pipe
+
+        for i in range(self.v_params.max_lmul):
+            self.get_instr_list[i].proxy(m, pipe.read_list[i])
+
+        @def_method(m, self.issue)
+        def _(arg):
+            pass
+
+
+        return m

--- a/coreblocks/fu/vector_unit/vrf.py
+++ b/coreblocks/fu/vector_unit/vrf.py
@@ -3,7 +3,6 @@ from coreblocks.transactions import *
 from coreblocks.transactions.lib import *
 from coreblocks.params import *
 from coreblocks.utils import *
-from coreblocks.params.vector_params import VectorParameters
 from coreblocks.fu.vector_unit.v_layouts import VRFFragmentLayouts
 from coreblocks.fu.vector_unit.v_register import VectorRegisterBank
 
@@ -46,10 +45,7 @@ class VRFFragment(Elaboratable):
         ]
         self.write = Method(i=self.layout.write)
 
-        self.regs = [
-            VectorRegisterBank(gen_params=self.gen_params)
-            for _ in range(self.v_params.vrp_count)
-        ]
+        self.regs = [VectorRegisterBank(gen_params=self.gen_params) for _ in range(self.v_params.vrp_count)]
 
         self.clear_module = MethodProduct([reg.clear for reg in self.regs])
         self.clear = self.clear_module.method

--- a/coreblocks/fu/vector_unit/vrf.py
+++ b/coreblocks/fu/vector_unit/vrf.py
@@ -33,11 +33,11 @@ class VRFFragment(Elaboratable):
         `read_resp[1]`.
     """
 
-    def __init__(self, *, gen_params: GenParams, v_params: VectorParameters):
+    def __init__(self, *, gen_params: GenParams):
         self.gen_params = gen_params
-        self.v_params = v_params
+        self.v_params = self.gen_params.v_params
 
-        self.layout = VRFFragmentLayouts(self.gen_params, self.v_params)
+        self.layout = VRFFragmentLayouts(self.gen_params)
 
         self.read_ports_count = 3
         self.read_req = [Method(i=self.layout.read_req) for _ in range(self.read_ports_count)]
@@ -47,7 +47,7 @@ class VRFFragment(Elaboratable):
         self.write = Method(i=self.layout.write)
 
         self.regs = [
-            VectorRegisterBank(gen_params=self.gen_params, v_params=self.v_params)
+            VectorRegisterBank(gen_params=self.gen_params)
             for _ in range(self.v_params.vrp_count)
         ]
 

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -1,7 +1,7 @@
 from amaranth import *
 from typing import Optional, Iterable
 from coreblocks.transactions import *
-from coreblocks.structs_common.rs import FifoRS
+from coreblocks.structs_common.rs import FifoRS, RS
 from coreblocks.params import *
 from coreblocks.fu.vector_unit.v_layouts import *
 
@@ -28,3 +28,35 @@ class VXRS(FifoRS):
             is_rs1_ready = (record.rs_data.rp_s1.type == RegisterType.X).implies(~record.rs_data.rp_s1.id.bool())
             is_rs2_ready = (record.rs_data.rp_s2.type == RegisterType.X).implies(~record.rs_data.rp_s2.id.bool())
             m.d.comb += record.rec_ready.eq(is_rs1_ready & is_rs2_ready & record.rec_full.bool())
+
+
+class VVRS(RS):
+    def __init__(self,
+        gen_params: GenParams,
+        rs_entries: int,
+        ready_for: Optional[Iterable[Iterable[OpType]]] = None,
+    ) -> None:
+        super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorVRSLayout, superscalarity = 8)
+
+    def generate_rec_ready_setters(self, m: TModule):
+        for record in self.data:
+            m.d.comb += record.rec_ready.eq(
+                    record.rs_data.rp_s1_rdy &
+                    record.rs_data.rp_s2_rdy &
+                    record.rs_data.rp_s3_rdy &
+                    record.rec_full.bool()
+                    )
+
+    def define_update_method(self, m: TModule):
+        @def_method(m, self.update)
+        def _(tag: Value, value: Value) -> None:
+            for record in self.data:
+                with m.If(record.rec_full.bool()):
+                    with m.If(record.rs_data.rp_s1 == tag):
+                        m.d.sync += record.rs_data.rp_s1_rdy.eq(1)
+
+                    with m.If(record.rs_data.rp_s2 == tag):
+                        m.d.sync += record.rs_data.rp_s2_rdy.eq(1)
+
+                    with m.If(record.rs_data.rp_s3 == tag):
+                        m.d.sync += record.rs_data.rp_s3_rdy.eq(1)

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -31,30 +31,32 @@ class VXRS(FifoRS):
 
 
 class VVRS(RS):
-    """ Extends RS with vector update and ready functionality.
+    """Extends RS with vector update and ready functionality.
 
     This module implements an RS, that waits untill all vector registers
     that can be used by a vector instruction are ready.
 
-    NOTE: At the moment there is no prechecking if all 4 registers 
+    NOTE: At the moment there is no prechecking if all 4 registers
     we are waiting on needed.
     """
-    def __init__(self,
+
+    def __init__(
+        self,
         gen_params: GenParams,
         rs_entries: int,
         ready_for: Optional[Iterable[Iterable[OpType]]] = None,
     ) -> None:
-        super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorVRSLayout, superscalarity = 8)
+        super().__init__(gen_params, rs_entries, ready_for, layout_class=VectorVRSLayout, superscalarity=8)
 
     def generate_rec_ready_setters(self, m: TModule):
         for record in self.data:
             m.d.comb += record.rec_ready.eq(
-                    record.rs_data.rp_s1_rdy &
-                    record.rs_data.rp_s2_rdy &
-                    record.rs_data.rp_s3_rdy &
-                    record.rs_data.rp_v0_rdy &
-                    record.rec_full.bool()
-                    )
+                record.rs_data.rp_s1_rdy
+                & record.rs_data.rp_s2_rdy
+                & record.rs_data.rp_s3_rdy
+                & record.rs_data.rp_v0_rdy
+                & record.rec_full.bool()
+            )
 
     def define_update_method(self, m: TModule):
         @def_method(m, self.update)

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -31,6 +31,14 @@ class VXRS(FifoRS):
 
 
 class VVRS(RS):
+    """ Extends RS with vector update and ready functionality.
+
+    This module implements an RS, that waits untill all vector registers
+    that can be used by a vector instruction are ready.
+
+    NOTE: At the moment there is no prechecking if all 4 registers 
+    we are waiting on needed.
+    """
     def __init__(self,
         gen_params: GenParams,
         rs_entries: int,
@@ -44,6 +52,7 @@ class VVRS(RS):
                     record.rs_data.rp_s1_rdy &
                     record.rs_data.rp_s2_rdy &
                     record.rs_data.rp_s3_rdy &
+                    record.rs_data.rp_v0_rdy &
                     record.rec_full.bool()
                     )
 

--- a/coreblocks/fu/vector_unit/vrs.py
+++ b/coreblocks/fu/vector_unit/vrs.py
@@ -5,7 +5,7 @@ from coreblocks.structs_common.rs import FifoRS, RS
 from coreblocks.params import *
 from coreblocks.fu.vector_unit.v_layouts import *
 
-__all__ = ["VXRS"]
+__all__ = ["VXRS", "VVRS"]
 
 
 class VXRS(FifoRS):
@@ -60,3 +60,6 @@ class VVRS(RS):
 
                     with m.If(record.rs_data.rp_s3 == tag):
                         m.d.sync += record.rs_data.rp_s3_rdy.eq(1)
+
+                    with m.If(record.rs_data.rp_v0 == tag):
+                        m.d.sync += record.rs_data.rp_v0_rdy.eq(1)

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -15,16 +15,25 @@ from coreblocks.fu.exception import ExceptionUnitComponent
 from coreblocks.lsu.dummyLsu import LSUBlockComponent
 from coreblocks.structs_common.csr import CSRBlockComponent
 
-__all__ = ["CoreConfiguration", "VectorUnitConfiguration", "basic_core_config", "tiny_core_config", "full_core_config", "test_core_config", "test_vector_core_config"]
+__all__ = [
+    "CoreConfiguration",
+    "VectorUnitConfiguration",
+    "basic_core_config",
+    "tiny_core_config",
+    "full_core_config",
+    "test_core_config",
+    "test_vector_core_config",
+]
 
 basic_configuration: tuple[fu_params.BlockComponentParams, ...] = (
     rs_func_block.RSBlockComponent([ALUComponent(), ShiftUnitComponent(), JumpComponent()], rs_entries=4),
     LSUBlockComponent(),
 )
 
+
 @dataclass(kw_only=True)
 class VectorUnitConfiguration:
-    """ Vector unit configuration parameters
+    """Vector unit configuration parameters
 
     Parameters
     ----------
@@ -42,12 +51,13 @@ class VectorUnitConfiguration:
     vvrs_entries : int
         Number of entries in VVRS (reservation station for vector registers).
     """
+
     vlen: int = 1024
     elen: int = 32
     vrp_count: int = 40
     register_bank_count: int = 4
-    vxrs_entries :int = 8
-    vvrs_entries :int = 8
+    vxrs_entries: int = 8
+    vvrs_entries: int = 8
 
 
 @dataclass(kw_only=True)
@@ -105,12 +115,13 @@ class CoreConfiguration:
 
     allow_partial_extensions: bool = True  # TODO: Change to False when I extension will be fully supported
 
-    vector_config : Optional[VectorUnitConfiguration] = None
+    vector_config: Optional[VectorUnitConfiguration] = None
 
     _implied_extensions: isa.Extension = isa.Extension(0)
 
     def replace(self, **kwargs):
         return dataclasses.replace(self, **kwargs)
+
 
 # Default core configuration
 basic_core_config = CoreConfiguration()
@@ -156,7 +167,7 @@ test_vector_core_config = CoreConfiguration(
     rob_entries_bits=7,
     phys_regs_bits=7,
     _implied_extensions=isa.Extension.I | isa.Extension.V,
-    vector_config = VectorUnitConfiguration()
+    vector_config=VectorUnitConfiguration(),
 )
 
 # Core configuration with vector extension

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -24,6 +24,24 @@ basic_configuration: tuple[fu_params.BlockComponentParams, ...] = (
 
 @dataclass(kw_only=True)
 class VectorUnitConfiguration:
+    """ Vector unit configuration parameters
+
+    Parameters
+    ----------
+    vlen : int
+        Length of one vector register in bits.
+    elen : int
+        Maximal supported element width by vector extension. It has to be
+        power of 2. Currently available values: {8,16,32,64}.
+    vrp_count : int
+        The number of physical vector registers.
+    register_bank_count : int
+        Number of banks to which an physical register should be split.
+    vxrs_entries : int
+        Number of entries in VXRS (reservation station for scalars).
+    vvrs_entries : int
+        Number of entries in VVRS (reservation station for vector registers).
+    """
     vlen: int = 1024
     elen: int = 32
     vrp_count: int = 40

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from collections.abc import Collection
 import dataclasses
 from dataclasses import dataclass
@@ -14,12 +15,21 @@ from coreblocks.fu.exception import ExceptionUnitComponent
 from coreblocks.lsu.dummyLsu import LSUBlockComponent
 from coreblocks.structs_common.csr import CSRBlockComponent
 
-__all__ = ["CoreConfiguration", "basic_core_config", "tiny_core_config", "full_core_config", "test_core_config"]
+__all__ = ["CoreConfiguration", "VectorUnitConfiguration", "basic_core_config", "tiny_core_config", "full_core_config", "test_core_config", "test_vector_core_config"]
 
 basic_configuration: tuple[fu_params.BlockComponentParams, ...] = (
     rs_func_block.RSBlockComponent([ALUComponent(), ShiftUnitComponent(), JumpComponent()], rs_entries=4),
     LSUBlockComponent(),
 )
+
+@dataclass(kw_only=True)
+class VectorUnitConfiguration:
+    vlen: int = 1024
+    elen: int = 32
+    vrp_count: int = 40
+    register_bank_count: int = 4
+    vxrs_entries :int = 8
+    vvrs_entries :int = 8
 
 
 @dataclass(kw_only=True)
@@ -54,6 +64,8 @@ class CoreConfiguration:
         Log of the cache line size (in bytes).
     allow_partial_extensions: bool
         Allow partial support of extensions.
+    vector_config: Optional[VectorUnitConfiguration]
+        Configuration of vector unit.
     _implied_extensions: Extenstion
         Bit flag specifing enabled extenstions that are not specified by func_units_config. Used in internal tests.
     """
@@ -75,11 +87,12 @@ class CoreConfiguration:
 
     allow_partial_extensions: bool = True  # TODO: Change to False when I extension will be fully supported
 
+    vector_config : Optional[VectorUnitConfiguration] = None
+
     _implied_extensions: isa.Extension = isa.Extension(0)
 
     def replace(self, **kwargs):
         return dataclasses.replace(self, **kwargs)
-
 
 # Default core configuration
 basic_core_config = CoreConfiguration()
@@ -117,6 +130,15 @@ test_core_config = CoreConfiguration(
     rob_entries_bits=7,
     phys_regs_bits=7,
     _implied_extensions=isa.Extension.I,
+)
+
+# Core configuration used in internal testbenches with vector extension
+test_vector_core_config = CoreConfiguration(
+    func_units_config=tuple(rs_func_block.RSBlockComponent([], rs_entries=4) for _ in range(2)),
+    rob_entries_bits=7,
+    phys_regs_bits=7,
+    _implied_extensions=isa.Extension.I | isa.Extension.V,
+    vector_config = VectorUnitConfiguration()
 )
 
 # Core configuration with vector extension

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -7,6 +7,7 @@ from .isa import ISA, gen_isa_string
 from .icache_params import ICacheParameters
 from .fu_params import extensions_supported
 from ..peripherals.wishbone import WishboneParameters
+from .vector_params import VectorParameters
 
 from typing import TYPE_CHECKING
 
@@ -105,5 +106,8 @@ class GenParams(DependentCache):
         self.max_rs_entries_bits = (self.max_rs_entries - 1).bit_length()
         self.start_pc = cfg.start_pc
         self.imm2_width = max(self.isa.csr_alen, self.isa.v_zimmlen)
+
+        if cfg.vector_config is not None:
+            self.v_params = VectorParameters(cfg.vector_config)
 
         self._toolchain_isa_str = gen_isa_string(extensions, cfg.xlen, skip_internal=True)

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -15,6 +15,7 @@ __all__ = [
     "FenceFm",
     "ISA",
     "RegisterType",
+    "funct6_to_funct7",
 ]
 
 
@@ -61,8 +62,8 @@ class Funct3(IntEnum, shape=3):
 
 
 class Funct6(IntEnum, shape=6):
-    VADD = 0b000000
-    VSUB = 0b000010
+    VADD = _VWIDEN = 0b000000
+    VSUB = _VNARROW = 0b000010
     VRSUB = 0b000011
     VMINU = 0b000100
     VMIN = 0b000101
@@ -117,6 +118,9 @@ class Funct7(IntEnum, shape=7):
     ROL = ROR = SEXTB = SEXTH = CPOP = CLZ = CTZ = 0b0110000
     ZEXTH = 0b0000100
     SFENCEVMA = 0b0001001
+
+def funct6_to_funct7(funct6 : Funct6, vm : bool | int) -> Funct7:
+    return Funct7(int(funct6)*2 + int(vm))
 
 
 class Funct12(IntEnum, shape=12):

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -105,13 +105,13 @@ class Funct6(IntEnum, shape=6):
     VWREDSUMU = 0b110000
     VWREDSUM = 0b110001
 
-v_narrowing_to_normal_map = {
-    Funct6.VNSRA : Funct6.VSRA,
-    Funct6.VNSRL : Funct6.VSRL,
-        }
 
-v_widening_to_normal_map = {
-    }
+v_narrowing_to_normal_map = {
+    Funct6.VNSRA: Funct6.VSRA,
+    Funct6.VNSRL: Funct6.VSRL,
+}
+
+v_widening_to_normal_map = {}
 
 
 class Funct7(IntEnum, shape=7):
@@ -127,8 +127,9 @@ class Funct7(IntEnum, shape=7):
     ZEXTH = 0b0000100
     SFENCEVMA = 0b0001001
 
-def funct6_to_funct7(funct6 : Funct6, vm : bool | int) -> Funct7:
-    return Funct7(int(funct6)*2 + int(vm))
+
+def funct6_to_funct7(funct6: Funct6, vm: bool | int) -> Funct7:
+    return Funct7(int(funct6) * 2 + int(vm))
 
 
 class Funct12(IntEnum, shape=12):

--- a/coreblocks/params/isa.py
+++ b/coreblocks/params/isa.py
@@ -105,6 +105,14 @@ class Funct6(IntEnum, shape=6):
     VWREDSUMU = 0b110000
     VWREDSUM = 0b110001
 
+v_narrowing_to_normal_map = {
+    Funct6.VNSRA : Funct6.VSRA,
+    Funct6.VNSRL : Funct6.VSRL,
+        }
+
+v_widening_to_normal_map = {
+    }
+
 
 class Funct7(IntEnum, shape=7):
     SL = SLT = ADD = XOR = OR = AND = 0b0000000

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -123,13 +123,15 @@ class RFLayouts:
 
 class RATLayouts:
     def __init__(self, gen_params: GenParams):
-        self.rat_rename_in = [
-            ("rl_s1", gen_params.isa.reg_cnt_log),
-            ("rl_s2", gen_params.isa.reg_cnt_log),
+        self.set_rename_in = [
             ("rl_dst", gen_params.isa.reg_cnt_log),
             ("rp_dst", gen_params.phys_regs_bits),
         ]
-        self.rat_rename_out = [("rp_s1", gen_params.phys_regs_bits), ("rp_s2", gen_params.phys_regs_bits)]
+        self.get_rename_in = [
+            ("rl_s1", gen_params.isa.reg_cnt_log),
+            ("rl_s2", gen_params.isa.reg_cnt_log),
+        ]
+        self.get_rename_out = [("rp_s1", gen_params.phys_regs_bits), ("rp_s2", gen_params.phys_regs_bits)]
 
         self.rat_commit_in = [("rl_dst", gen_params.isa.reg_cnt_log), ("rp_dst", gen_params.phys_regs_bits)]
         self.rat_commit_out = [("old_rp_dst", gen_params.phys_regs_bits)]

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -423,8 +423,9 @@ class ExceptionRegisterLayouts:
             ("rob_id", gen_params.rob_entries_bits),
         ]
 
+
 class ScoreboardLayouts:
-    def __init__(self, entries_number : int):
+    def __init__(self, entries_number: int):
         bits = log2_int(entries_number, False)
         self.set_dirty_in = [("id", bits), ("dirty", 1)]
         self.get_dirty_in = [("id", bits)]

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -21,6 +21,7 @@ __all__ = [
     "ICacheLayouts",
     "SuperscalarFreeRFLayouts",
     "ExceptionRegisterLayouts",
+    "ScoreboardLayouts",
 ]
 
 
@@ -419,3 +420,10 @@ class ExceptionRegisterLayouts:
             ("cause", ExceptionCause),
             ("rob_id", gen_params.rob_entries_bits),
         ]
+
+class ScoreboardLayouts:
+    def __init__(self, entries_number : int):
+        bits = log2_int(entries_number, False)
+        self.set_dirty_in = [("id", bits), ("dirty", 1)]
+        self.get_dirty_in = [("id", bits)]
+        self.get_dirty_out = [("dirty", 1)]

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -57,7 +57,7 @@ class OpType(IntEnum):
     V_PERMUTATION = auto()
     V_PERMUTATION_IMM = auto()
     V_PERMUTATION_SCALAR = auto()
-    V_CONTROL = auto() # optype used both for vsetvl and internal instructions
+    V_CONTROL = auto()  # optype used both for vsetvl and internal instructions
     V_REDUCTION = auto()
     V_MEMORY = auto()
 

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -51,10 +51,13 @@ class OpType(IntEnum):
     V_ARITHMETIC_NARROWING = auto()
     V_ARITHMETIC_NARROWING_IMM = auto()
     V_ARITHMETIC_NARROWING_SCALAR = auto()
+    V_ARITHMETIC_WIDENING = auto()
+    V_ARITHMETIC_WIDENING_IMM = auto()
+    V_ARITHMETIC_WIDENING_SCALAR = auto()
     V_PERMUTATION = auto()
     V_PERMUTATION_IMM = auto()
     V_PERMUTATION_SCALAR = auto()
-    V_CONTROL = auto()
+    V_CONTROL = auto() # optype used both for vsetvl and internal instructions
     V_REDUCTION = auto()
     V_MEMORY = auto()
 

--- a/coreblocks/params/vector_params.py
+++ b/coreblocks/params/vector_params.py
@@ -8,7 +8,7 @@ __all__ = ["VectorParameters"]
 
 
 class VectorParameters:
-    def __init__(self,  cfg : "VectorUnitConfiguration"):
+    def __init__(self, cfg: "VectorUnitConfiguration"):
         self.elen = cfg.elen
         self.vlen = cfg.vlen
         self.vrp_count = cfg.vrp_count

--- a/coreblocks/params/vector_params.py
+++ b/coreblocks/params/vector_params.py
@@ -4,12 +4,13 @@ __all__ = ["VectorParameters"]
 
 
 class VectorParameters:
-    def __init__(self, *, vlen: int, elen: int, vrp_count: int = 40, register_bank_count: int = 4):
+    def __init__(self, *, vlen: int, elen: int, vrp_count: int = 40, register_bank_count: int = 4, vxrs_entries = 8):
         self.elen = elen
         self.vlen = vlen
         self.vrp_count = vrp_count
         self.vrp_count_bits = log2_int(self.vrp_count, False)
         self.register_bank_count = register_bank_count
+        self.vxrs_entries = vxrs_entries
 
         self.bytes_in_vlen = self.vlen // 8
         self.bytes_in_elen = elen // 8

--- a/coreblocks/params/vector_params.py
+++ b/coreblocks/params/vector_params.py
@@ -32,3 +32,5 @@ class VectorParameters:
         # vstart have to have enough bits to hold all indicies for minimum SEW and maximum LMUL
         # minimum SEW is 1 byte and maximum LMUL is 8
         self.vstart_bits = log2_int(self.bytes_in_vlen * 8, False)
+
+        self.max_lmul = 8

--- a/coreblocks/params/vector_params.py
+++ b/coreblocks/params/vector_params.py
@@ -1,19 +1,24 @@
 from amaranth.utils import *
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from coreblocks.params.configurations import VectorUnitConfiguration
 
 __all__ = ["VectorParameters"]
 
 
 class VectorParameters:
-    def __init__(self, *, vlen: int, elen: int, vrp_count: int = 40, register_bank_count: int = 4, vxrs_entries = 8):
-        self.elen = elen
-        self.vlen = vlen
-        self.vrp_count = vrp_count
+    def __init__(self,  cfg : "VectorUnitConfiguration"):
+        self.elen = cfg.elen
+        self.vlen = cfg.vlen
+        self.vrp_count = cfg.vrp_count
         self.vrp_count_bits = log2_int(self.vrp_count, False)
-        self.register_bank_count = register_bank_count
-        self.vxrs_entries = vxrs_entries
+        self.register_bank_count = cfg.register_bank_count
+        self.vxrs_entries = cfg.vxrs_entries
+        self.vvrs_entries = cfg.vvrs_entries
 
         self.bytes_in_vlen = self.vlen // 8
-        self.bytes_in_elen = elen // 8
+        self.bytes_in_elen = self.elen // 8
 
         accepted_elens = {8, 16, 32, 64}
         if self.elen not in accepted_elens:
@@ -32,5 +37,6 @@ class VectorParameters:
         # vstart have to have enough bits to hold all indicies for minimum SEW and maximum LMUL
         # minimum SEW is 1 byte and maximum LMUL is 8
         self.vstart_bits = log2_int(self.bytes_in_vlen * 8, False)
+        self.vvrs_entries_bits = log2_int(self.vvrs_entries, False)
 
         self.max_lmul = 8

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -71,7 +71,7 @@ class Renaming(Elaboratable):
     the F-RAT with the translation from the logical destination register ID to the physical ID.
     """
 
-    def __init__(self, *, get_instr: Method, push_instr: Method, rename: Method, gen_params: GenParams):
+    def __init__(self, *, get_instr: Method, push_instr: Method, get_rename: Method, set_rename : Method, gen_params: GenParams):
         """
         Parameters
         ----------
@@ -79,9 +79,12 @@ class Renaming(Elaboratable):
             Method providing instructions with an allocated physical register. Uses `SchedulerLayouts.renaming_in`.
         push_instr: Method
             Method used for pushing the serviced instruction to the next step. Uses `SchedulerLayouts.renaming_out`.
-        rename: Method
-            Method used for renaming the source register in F-RAT. Uses
-            `RATLayouts.rename_input_layout` and `RATLayouts.rename_output_layout`.
+        get_rename: Method
+            Method used for reading the renaming of the source register from F-RAT.
+            Uses `RATLayouts.get_rename_in` and `RATLayouts.get_rename_out`.
+        set_rename: Method
+            Method used for updating the renaming of the source register in the F-RAT.
+            Uses `RATLayouts.set_rename_in`.
         gen_params: GenParams
             Core generation parameters.
         """
@@ -92,7 +95,8 @@ class Renaming(Elaboratable):
 
         self.get_instr = get_instr
         self.push_instr = push_instr
-        self.rename = rename
+        self.get_rename = get_rename
+        self.set_rename = set_rename
 
     def elaborate(self, platform):
         m = TModule()
@@ -102,21 +106,10 @@ class Renaming(Elaboratable):
         with Transaction().body(m):
             instr = self.get_instr(m)
 
-            rl_dst_to_rename = Signal().like(instr.regs_l.dst.id, reset=0)
-            rp_dst_to_rename = Signal().like(instr.regs_p.dst.id, reset=0)
             with m.If(instr.regs_l.dst.type == RegisterType.X):
-                m.d.comb += rl_dst_to_rename.eq(instr.regs_l.dst.id)
-                m.d.comb += rp_dst_to_rename.eq(instr.regs_p.dst.id)
+                self.set_rename(m, rl_dst = instr.regs_l.dst.id, rp_dst = instr.regs_p.dst.id)
 
-            renamed_regs = self.rename(
-                m,
-                {
-                    "rl_s1": instr.regs_l.s1.id,
-                    "rl_s2": instr.regs_l.s2.id,
-                    "rl_dst": rl_dst_to_rename,
-                    "rp_dst": rp_dst_to_rename,
-                },
-            )
+            renamed_regs = self.get_rename( m, rl_s1= instr.regs_l.s1.id, rl_s2= instr.regs_l.s2.id)
 
             m.d.comb += assign(data_out, instr, fields={"opcode", "illegal", "exec_fn", "imm", "imm2", "pc"})
             m.d.comb += assign(data_out.regs_l, instr.regs_l, fields=AssignType.COMMON)
@@ -381,7 +374,8 @@ class Scheduler(Elaboratable):
         *,
         get_instr: Method,
         get_free_reg: Method,
-        rat_rename: Method,
+        rat_get_rename: Method,
+        rat_set_rename: Method,
         rob_put: Method,
         rf_read1: Method,
         rf_read2: Method,
@@ -396,9 +390,12 @@ class Scheduler(Elaboratable):
             layout as described by `DecodeLayouts.decoded_instr`.
         get_free_reg: Method
             Method providing the ID of a currently free physical register.
-        rat_rename: Method
-            Method used for renaming the source register in F-RAT. Uses `RATLayouts.rat_rename_in`
-            and `RATLayouts.rat_rename_out`.
+        rat_get_rename: Method
+            Method used for reading the renaming of the source register from F-RAT.
+            Uses `RATLayouts.get_rename_in` and `RATLayouts.get_rename_out`.
+        rat_set_rename: Method
+            Method used for updating the renaming of the source register in the F-RAT.
+            Uses `RATLayouts.set_rename_in`.
         rob_put: Method
             Method used for getting a free entry in ROB. Uses `ROBLayouts.data_layout`.
         rf_read1: Method
@@ -416,7 +413,8 @@ class Scheduler(Elaboratable):
         self.layouts = self.gen_params.get(SchedulerLayouts)
         self.get_instr = get_instr
         self.get_free_reg = get_free_reg
-        self.rat_rename = rat_rename
+        self.get_rat_rename = rat_get_rename
+        self.set_rat_rename = rat_set_rename
         self.rob_put = rob_put
         self.rf_read1 = rf_read1
         self.rf_read2 = rf_read2
@@ -437,7 +435,8 @@ class Scheduler(Elaboratable):
         m.submodules.renaming = Renaming(
             get_instr=alloc_rename_buf.read,
             push_instr=rename_out_buf.write,
-            rename=self.rat_rename,
+            get_rename=self.get_rat_rename,
+            set_rename=self.set_rat_rename,
             gen_params=self.gen_params,
         )
 

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -71,7 +71,9 @@ class Renaming(Elaboratable):
     the F-RAT with the translation from the logical destination register ID to the physical ID.
     """
 
-    def __init__(self, *, get_instr: Method, push_instr: Method, get_rename: Method, set_rename : Method, gen_params: GenParams):
+    def __init__(
+        self, *, get_instr: Method, push_instr: Method, get_rename: Method, set_rename: Method, gen_params: GenParams
+    ):
         """
         Parameters
         ----------
@@ -107,9 +109,9 @@ class Renaming(Elaboratable):
             instr = self.get_instr(m)
 
             with m.If(instr.regs_l.dst.type == RegisterType.X):
-                self.set_rename(m, rl_dst = instr.regs_l.dst.id, rp_dst = instr.regs_p.dst.id)
+                self.set_rename(m, rl_dst=instr.regs_l.dst.id, rp_dst=instr.regs_p.dst.id)
 
-            renamed_regs = self.get_rename( m, rl_s1= instr.regs_l.s1.id, rl_s2= instr.regs_l.s2.id)
+            renamed_regs = self.get_rename(m, rl_s1=instr.regs_l.s1.id, rl_s2=instr.regs_l.s2.id)
 
             m.d.comb += assign(data_out, instr, fields={"opcode", "illegal", "exec_fn", "imm", "imm2", "pc"})
             m.d.comb += assign(data_out.regs_l, instr.regs_l, fields=AssignType.COMMON)

--- a/coreblocks/scheduler/wakeup_select.py
+++ b/coreblocks/scheduler/wakeup_select.py
@@ -1,7 +1,9 @@
+from typing import Optional
+
 from amaranth import *
 
 from coreblocks.params import GenParams, FuncUnitLayouts
-from coreblocks.utils import assign, AssignType
+from coreblocks.utils import assign, AssignType, LayoutLike
 from coreblocks.transactions.core import *
 
 __all__ = ["WakeupSelect"]
@@ -18,7 +20,7 @@ class WakeupSelect(Elaboratable):
 
     """
 
-    def __init__(self, *, gen_params: GenParams, get_ready: Method, take_row: Method, issue: Method):
+    def __init__(self, *, gen_params: GenParams, get_ready: Method, take_row: Method, issue: Method, row_layout : Optional[LayoutLike] = None):
         """
         Parameters
         ----------
@@ -35,6 +37,7 @@ class WakeupSelect(Elaboratable):
         self.get_ready = get_ready  # assumption: ready only if nonzero result
         self.take_row = take_row
         self.issue = issue
+        self.row_layout = row_layout if row_layout is not None else self.gen_params.get(FuncUnitLayouts).issue
 
     def elaborate(self, platform):
         m = TModule()
@@ -48,7 +51,7 @@ class WakeupSelect(Elaboratable):
                     m.d.comb += last.eq(i)
 
             row = self.take_row(m, last)
-            issue_rec = Record(self.gen_params.get(FuncUnitLayouts).issue)
+            issue_rec = Record(self.row_layout)
             m.d.comb += assign(issue_rec, row, fields=AssignType.ALL)
             self.issue(m, issue_rec)
 

--- a/coreblocks/scheduler/wakeup_select.py
+++ b/coreblocks/scheduler/wakeup_select.py
@@ -20,7 +20,15 @@ class WakeupSelect(Elaboratable):
 
     """
 
-    def __init__(self, *, gen_params: GenParams, get_ready: Method, take_row: Method, issue: Method, row_layout : Optional[LayoutLike] = None):
+    def __init__(
+        self,
+        *,
+        gen_params: GenParams,
+        get_ready: Method,
+        take_row: Method,
+        issue: Method,
+        row_layout: Optional[LayoutLike] = None
+    ):
         """
         Parameters
         ----------

--- a/coreblocks/structs_common/rat.py
+++ b/coreblocks/structs_common/rat.py
@@ -44,8 +44,10 @@ class FRAT(Elaboratable):
         if self.superscalarity < 1:
             raise ValueError(f"FRAT should have minimum one method, so superscalarity>=1, got: {self.superscalarity}")
 
-        self.set_rename_list = [ Method(i=self.layouts.set_rename_in) for _ in range(self.superscalarity) ]
-        self.get_rename_list = [ Method(i=self.layouts.get_rename_in, o=self.layouts.get_rename_out) for _ in range(self.superscalarity) ]
+        self.set_rename_list = [Method(i=self.layouts.set_rename_in) for _ in range(self.superscalarity)]
+        self.get_rename_list = [
+            Method(i=self.layouts.get_rename_in, o=self.layouts.get_rename_out) for _ in range(self.superscalarity)
+        ]
 
     def elaborate(self, platform):
         m = TModule()

--- a/coreblocks/structs_common/scoreboard.py
+++ b/coreblocks/structs_common/scoreboard.py
@@ -4,10 +4,10 @@ from coreblocks.transactions.lib import *
 from coreblocks.params import *
 from coreblocks.fu.vector_unit.utils import *
 from coreblocks.fu.vector_unit.v_layouts import *
-from coreblocks.utils.fifo import BasicFifo
 from coreblocks.utils.utils import PriorityUniqnessChecker
 
 __all__ = ["Scoreboard"]
+
 
 class Scoreboard(Elaboratable):
     """
@@ -25,28 +25,33 @@ class Scoreboard(Elaboratable):
         with the lowest index in list has a priority.
         Layout: ScoreboardLayouts.set_dirty_in
     """
-    def __init__(self, entries_number : int, superscalarity : int = 1):
+
+    def __init__(self, entries_number: int, superscalarity: int = 1):
         self.entries_number = entries_number
         self.superscalarity = superscalarity
-        
+
         self.layouts = ScoreboardLayouts(self.entries_number)
-        self.get_dirty_list = [Method(i=self.layouts.get_dirty_in, o=self.layouts.get_dirty_out) for _ in range(self.superscalarity)]
+        self.get_dirty_list = [
+            Method(i=self.layouts.get_dirty_in, o=self.layouts.get_dirty_out) for _ in range(self.superscalarity)
+        ]
         self.set_dirty_list = [Method(i=self.layouts.set_dirty_in) for _ in range(self.superscalarity)]
 
         for i in range(1, self.superscalarity):
-            self.set_dirty_list[i-1].schedule_before(self.set_dirty_list[i])
+            self.set_dirty_list[i - 1].schedule_before(self.set_dirty_list[i])
 
     def elaborate(self, platform) -> TModule:
         m = TModule()
 
         data = Signal(self.entries_number)
-        m.submodules.checker = checker = PriorityUniqnessChecker(self.superscalarity, len(Record(self.layouts.set_dirty_in).id))
+        m.submodules.checker = checker = PriorityUniqnessChecker(
+            self.superscalarity, len(Record(self.layouts.set_dirty_in).id)
+        )
 
         @loop_def_method(m, self.get_dirty_list)
         def _(_, id):
-            return {"dirty" : data.bit_select(id, 1)}
+            return {"dirty": data.bit_select(id, 1)}
 
-        @loop_def_method(m, self.set_dirty_list, ready_list = checker.valids)
+        @loop_def_method(m, self.set_dirty_list, ready_list=checker.valids)
         def _(i, id, dirty):
             m.d.top_comb += checker.inputs[i].eq(id)
             m.d.top_comb += checker.input_valids[i].eq(self.set_dirty_list[i].run)

--- a/coreblocks/structs_common/scoreboard.py
+++ b/coreblocks/structs_common/scoreboard.py
@@ -1,0 +1,40 @@
+from amaranth import *
+from coreblocks.transactions import *
+from coreblocks.transactions.lib import *
+from coreblocks.params import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.utils.fifo import BasicFifo
+from coreblocks.utils.utils import PriorityUniqnessChecker
+
+__all__ = ["Scoreboard"]
+
+class Scoreboard(Elaboratable):
+    def __init__(self, entries_number : int, superscalarity : int = 1):
+        self.entries_number = entries_number
+        self.superscalarity = superscalarity
+        
+        self.layouts = ScoreboardLayouts(self.entries_number)
+        self.get_dirty_list = [Method(i=self.layouts.get_dirty_in, o=self.layouts.get_dirty_out) for _ in range(self.superscalarity)]
+        self.set_dirty_list = [Method(i=self.layouts.set_dirty_in) for _ in range(self.superscalarity)]
+
+        for i in range(1, self.superscalarity):
+            self.set_dirty_list[i-1].schedule_before(self.set_dirty_list[i])
+
+    def elaborate(self, platform) -> TModule:
+        m = TModule()
+
+        data = Signal(self.entries_number)
+        m.submodules.checker = checker = PriorityUniqnessChecker(self.superscalarity, len(Record(self.layouts.set_dirty_in).id))
+
+        @loop_def_method(m, self.get_dirty_list)
+        def _(_, id):
+            return {"dirty" : data.bit_select(id, 1)}
+
+        @loop_def_method(m, self.set_dirty_list, ready_list = checker.valids)
+        def _(i, id, dirty):
+            m.d.top_comb += checker.inputs[i].eq(id)
+            m.d.top_comb += checker.input_valids[i].eq(self.set_dirty_list[i].run)
+            m.d.sync += data.bit_select(id, 1).eq(dirty)
+
+        return m

--- a/coreblocks/structs_common/scoreboard.py
+++ b/coreblocks/structs_common/scoreboard.py
@@ -10,6 +10,21 @@ from coreblocks.utils.utils import PriorityUniqnessChecker
 __all__ = ["Scoreboard"]
 
 class Scoreboard(Elaboratable):
+    """
+    This module implements a scoreboard. A simple structure that allows
+    to store a dirty bit for each of the indicies..
+
+    Attributes
+    ----------
+    get_dirty_list : list[Method]
+        Methods to get the dirty bit for the given index id.
+        Layout: ScoreboardLayouts.get_dirty_*
+    set_dirty_list : list[Method]
+        Methods to set the dirty bit for the given index id. If more than
+        one method try to write to the same index, the method
+        with the lowest index in list has a priority.
+        Layout: ScoreboardLayouts.set_dirty_in
+    """
     def __init__(self, entries_number : int, superscalarity : int = 1):
         self.entries_number = entries_number
         self.superscalarity = superscalarity

--- a/coreblocks/structs_common/superscalar_freerf.py
+++ b/coreblocks/structs_common/superscalar_freerf.py
@@ -61,7 +61,7 @@ class SuperscalarFreeRF(Elaboratable):
         @def_method(m, self.allocate)
         def _(reg_count):
             with condition(m, nonblocking=False) as branch:
-                branch_cond = Signal(name="moj_warunek")
+                branch_cond = Signal()
                 m.d.top_comb += branch_cond.eq((reg_count <= free_count) & (reg_count > 0))
                 with branch(branch_cond):
                     mask = (1 << reg_count) - 1

--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -1182,7 +1182,7 @@ def def_method(m: TModule, method: Method, ready: ValueLike = C(1)):
     return decorator
 
 
-def loop_def_method(m: TModule, methods_list: list[Method], ready_list: Optional[list[ValueLike] | Callable] = None):
+def loop_def_method(m: TModule, methods_list: list[Method], ready_list: Optional[Sequence[ValueLike] | Callable] = None):
     """Decorator for defining similar methods
 
     This decorator is a wrapper over `def_method`, which allows you to easily

--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -771,7 +771,7 @@ class TransactionBase(Owned):
     def get(cls) -> Self:
         ret = cls.peek()
         if ret is None:
-            raise RuntimeError("No current body")
+            raise RuntimeError("No transaction body have been found. Maybe you use method outside of transaction?")
         return ret
 
     @classmethod

--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -1182,7 +1182,9 @@ def def_method(m: TModule, method: Method, ready: ValueLike = C(1)):
     return decorator
 
 
-def loop_def_method(m: TModule, methods_list: list[Method], ready_list: Optional[Sequence[ValueLike] | Callable] = None):
+def loop_def_method(
+    m: TModule, methods_list: list[Method], ready_list: Optional[Sequence[ValueLike] | Callable] = None
+):
     """Decorator for defining similar methods
 
     This decorator is a wrapper over `def_method`, which allows you to easily

--- a/coreblocks/transactions/lib.py
+++ b/coreblocks/transactions/lib.py
@@ -1617,17 +1617,8 @@ class ShiftRegister(Elaboratable):
         regs = [Signal(len(Record(self.layout))) for _ in range(self.entries_number)]
         valids=[Signal() for _ in range(self.entries_number)]
         count = Signal(log2_int(self.entries_number, False))
-        ready = Signal(reset = 1, name="rrready")
-        start = Signal(name="ssstart")
-
-        @loop_def_method(m, self.write_list, lambda _: ready)
-        def _(i, arg):
-            m.d.comb += start.eq(1)
-            if self.first_transparent and i == 0 :
-                self.put(m, arg)
-            else:
-                m.d.sync += regs[ i ].eq(arg)
-                m.d.sync += valids[ i ].eq(1)
+        ready = Signal(reset = 1)
+        start = Signal()
 
         reg_now = Signal.like(regs[0])
         reg_now_v = Signal()
@@ -1657,5 +1648,14 @@ class ShiftRegister(Elaboratable):
 
         with execute_put.body(m, request = reg_now_v):
             self.put(m,reg_now)
+
+        @loop_def_method(m, self.write_list, lambda _: ready)
+        def _(i, arg):
+            m.d.comb += start.eq(1)
+            if self.first_transparent and i == 0 :
+                self.put(m, arg)
+            else:
+                m.d.sync += regs[ i ].eq(arg)
+                m.d.sync += valids[ i ].eq(1)
 
         return m

--- a/coreblocks/transactions/lib.py
+++ b/coreblocks/transactions/lib.py
@@ -39,6 +39,7 @@ __all__ = [
     "PriorityOrderingProxyTrans",
     "RegisterPipe",
     "ShiftRegister",
+    "MethodBrancherIn",
 ]
 
 # FIFOs
@@ -1659,3 +1660,17 @@ class ShiftRegister(Elaboratable):
                 m.d.sync += valids[ i ].eq(1)
 
         return m
+
+
+class MethodBrancherIn():
+    def __init__(self, m:TModule, method : Method):
+        self.m = m
+        self.method = method
+        self.rec_in = Record(method.data_in.layout)
+        self.valid_in = Signal()
+        with self.m.If(self.valid_in):
+            method(m, self.rec_in)
+
+    def __call__(self, args):
+        self.m.d.comb += self.rec_in.eq(args)
+        self.m.d.comb += self.valid_in.eq(1)

--- a/coreblocks/transactions/lib.py
+++ b/coreblocks/transactions/lib.py
@@ -40,6 +40,7 @@ __all__ = [
     "RegisterPipe",
     "ShiftRegister",
     "MethodBrancherIn",
+    "NotMethod",
 ]
 
 # FIFOs
@@ -1637,7 +1638,8 @@ class ShiftRegister(Elaboratable):
                 with m.State(f"{i}"):
                     m.d.comb += ready.eq(0)
                     if i+1 == self.entries_number:
-                        m.next = "start"
+                        with m.If(execute_put.grant):
+                            m.next = "start"
                     else:
                         with m.If(valids[i+1] & execute_put.grant):
                             m.next = f"{i+1}"
@@ -1674,3 +1676,7 @@ class MethodBrancherIn():
     def __call__(self, args):
         self.m.d.comb += self.rec_in.eq(args)
         self.m.d.comb += self.valid_in.eq(1)
+
+class NotMethod():
+    def __init__(self, method : Method):
+        self.method = method

--- a/coreblocks/transactions/lib.py
+++ b/coreblocks/transactions/lib.py
@@ -1654,7 +1654,8 @@ class ShiftRegister(Elaboratable):
 
         @loop_def_method(m, self.write_list, lambda _: ready)
         def _(i, arg):
-            m.d.comb += start.eq(1)
+            if i==0:
+                m.d.comb += start.eq(1)
             if self.first_transparent and i == 0 :
                 self.put(m, arg)
             else:

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -502,13 +502,14 @@ class PriorityUniqnessChecker(Elaboratable):
         self.inputs_count =inputs_count
 
         self.inputs = [Signal(self.input_width) for _ in range(self.inputs_count)]
+        self.input_valids = [Signal() for _ in range(self.inputs_count)]
         self.valids = [Signal(reset = 1) for _ in range(self.inputs_count)]
 
     def elaborate(self, platform):
         m = Module()
 
         for i in range(self.inputs_count):
-            cond = Cat([self.inputs[i] == self.inputs[j] for j in range(i)]).any()
+            cond = Cat([(self.inputs[i] == self.inputs[j]) & self.input_valids[j] for j in range(i)]).any()
             with m.If(cond):
                 m.d.comb += self.valids[i].eq(0)
 

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -24,6 +24,7 @@ __all__ = [
     "count_trailing_zeros",
     "mod_incr",
     "MultiPriorityEncoder",
+    "PriorityUniqnessChecker",
 ]
 
 
@@ -491,5 +492,24 @@ class MultiPriorityEncoder(Elaboratable):
         for k in range(self.outputs_count):
             m.d.comb += self.outputs[k].eq(current_outputs[k])
             m.d.comb += self.valids[k].eq(current_valids[k])
+
+        return m
+
+
+class PriorityUniqnessChecker(Elaboratable):
+    def __init__(self, inputs_count : int, input_width : int):
+        self.input_width = input_width
+        self.inputs_count =inputs_count
+
+        self.inputs = [Signal(self.input_width) for _ in range(self.inputs_count)]
+        self.valids = [Signal(reset = 1) for _ in range(self.inputs_count)]
+
+    def elaborate(self, platform):
+        m = Module()
+
+        for i in range(self.inputs_count):
+            cond = Cat([self.inputs[i] == self.inputs[j] for j in range(i)]).any()
+            with m.If(cond):
+                m.d.comb += self.valids[i].eq(0)
 
         return m

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -323,7 +323,7 @@ def count_leading_zeros(s: Value) -> Value:
         xlen_log = log2_int(len(s))
     except ValueError:
         xlen_log = log2_int(len(s), False)
-        s = Cat(Repl(1, (1<<xlen_log) - len(s)), s)
+        s = Cat(Repl(1, (1 << xlen_log) - len(s)), s)
 
     value = iter(s, xlen_log)
 
@@ -340,7 +340,7 @@ def count_trailing_zeros(s: Value) -> Value:
     try:
         log2_int(len(s))
     except ValueError:
-        s = Cat(s, Repl(1, (1<<log2_int(len(s), False)) - len(s)))
+        s = Cat(s, Repl(1, (1 << log2_int(len(s), False)) - len(s)))
 
     return count_leading_zeros(s[::-1])
 
@@ -498,7 +498,7 @@ class MultiPriorityEncoder(Elaboratable):
 
 
 class PriorityUniqnessChecker(Elaboratable):
-    """ Find every first occurrence of the argument.
+    """Find every first occurrence of the argument.
 
     This module takes `input_count` arguments and checks which are
     unique. The first occurrence of a unique value is valid, all others
@@ -515,7 +515,8 @@ class PriorityUniqnessChecker(Elaboratable):
         Result of the uniqueness check. Each first occurrence of value
         has 1 bit and all others have 0.
     """
-    def __init__(self, inputs_count : int, input_width : int):
+
+    def __init__(self, inputs_count: int, input_width: int):
         """
         Parameters
         ----------
@@ -525,11 +526,11 @@ class PriorityUniqnessChecker(Elaboratable):
             Number of inputs to create.
         """
         self.input_width = input_width
-        self.inputs_count =inputs_count
+        self.inputs_count = inputs_count
 
         self.inputs = [Signal(self.input_width) for _ in range(self.inputs_count)]
         self.input_valids = [Signal() for _ in range(self.inputs_count)]
-        self.valids = [Signal(reset = 1) for _ in range(self.inputs_count)]
+        self.valids = [Signal(reset=1) for _ in range(self.inputs_count)]
 
     def elaborate(self, platform):
         m = Module()

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -498,7 +498,32 @@ class MultiPriorityEncoder(Elaboratable):
 
 
 class PriorityUniqnessChecker(Elaboratable):
+    """ Find every first occurrence of the argument.
+
+    This module takes `input_count` arguments and checks which are
+    unique. The first occurrence of a unique value is valid, all others
+    are not.
+
+    Attributes
+    ----------
+    inputs : list[Signal], in
+        List of input signals to be compared for uniqueness. Each has
+        `input_width` bits.
+    inputs_valids : list[Signal], in
+        Marks valid inputs to compare.
+    valids : list[Signal], out
+        Result of the uniqueness check. Each first occurrence of value
+        has 1 bit and all others have 0.
+    """
     def __init__(self, inputs_count : int, input_width : int):
+        """
+        Parameters
+        ----------
+        input_width : int
+            Width of an input element in bits.
+        input_count : int
+            Number of inputs to create.
+        """
         self.input_width = input_width
         self.inputs_count =inputs_count
 

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -322,7 +322,8 @@ def count_leading_zeros(s: Value) -> Value:
     try:
         xlen_log = log2_int(len(s))
     except ValueError:
-        raise NotImplementedError("CountLeadingZeros - only sizes aligned to power of 2 are supperted")
+        xlen_log = log2_int(len(s), False)
+        s = Cat(Repl(1, (1<<xlen_log) - len(s)), s)
 
     value = iter(s, xlen_log)
 
@@ -339,7 +340,7 @@ def count_trailing_zeros(s: Value) -> Value:
     try:
         log2_int(len(s))
     except ValueError:
-        raise NotImplementedError("CountTrailingZeros - only sizes aligned to power of 2 are supperted")
+        s = Cat(s, Repl(1, (1<<log2_int(len(s), False)) - len(s)))
 
     return count_leading_zeros(s[::-1])
 

--- a/test/common.py
+++ b/test/common.py
@@ -148,10 +148,11 @@ def generate_exec_fn(optypes: Optional[Iterable[OpType]] = None):
 def overwrite_dict_values(base: dict, overwriting: Mapping) -> dict:
     copy = base
     for k, v in overwriting.items():
-        if k in copy and isinstance(v, Mapping):
-            overwrite_dict_values(copy[k], v)
-        else:
-            copy[k] = v
+        if k in copy:
+            if isinstance(v, Mapping):
+                overwrite_dict_values(copy[k], v)
+            else:
+                copy[k] = v
     return copy
 
 

--- a/test/common.py
+++ b/test/common.py
@@ -455,6 +455,9 @@ class TestCaseWithSimulator(unittest.TestCase):
         for _ in range(cycle_cnt):
             yield
 
+    def assertIterableEqual(self, it1, it2):
+        self.assertListEqual(list(it1), list(it2))
+
 
 class TestbenchIO(Elaboratable):
     def __init__(self, adapter: AdapterBase):

--- a/test/common.py
+++ b/test/common.py
@@ -51,8 +51,9 @@ TestGen = Generator[Union[Command, Value, Statement, None, "CoreblockCommand"], 
 _T_nested_collection = T | list["_T_nested_collection[T]"] | dict[str, "_T_nested_collection[T]"]
 SimpleLayout = list[Tuple[str, Union[int, "SimpleLayout"]]]
 
+
 class MethodMock(Elaboratable):
-    def __init__(self, i : MethodLayout = (), o : MethodLayout = ()):
+    def __init__(self, i: MethodLayout = (), o: MethodLayout = ()):
         self.tb = TestbenchIO(Adapter(i=i, o=o))
 
     def elaborate(self, platform):
@@ -64,7 +65,6 @@ class MethodMock(Elaboratable):
 
 def data_layout(val: int) -> LayoutLike:
     return [("data", val)]
-
 
 
 def set_inputs(values: RecordValueDict, field: Record) -> TestGen[None]:
@@ -161,7 +161,7 @@ def convert_vtype_to_imm(vtype) -> int:
     return imm
 
 
-def generate_vtype(gen_params : GenParams):
+def generate_vtype(gen_params: GenParams):
     sew = random.choice(list(SEW))
     lmul = random.choice(list(LMUL))
     ta = random.randrange(2)
@@ -172,7 +172,7 @@ def generate_vtype(gen_params : GenParams):
         "lmul": lmul,
         "ta": ta,
         "ma": ma,
-        "vl" : vl,
+        "vl": vl,
     }
 
 
@@ -231,7 +231,7 @@ def generate_instr(
         if "vtype" in field[0]:
             rec["vtype"] = generate_vtype(gen_params)
         if "rp_v0" in field[0]:
-            rec["rp_v0"] = {"id" : generate_phys_register_id(gen_params=gen_params)}
+            rec["rp_v0"] = {"id": generate_phys_register_id(gen_params=gen_params)}
     return overwrite_dict_values(rec, overwriting)
 
 
@@ -492,10 +492,10 @@ class TestCaseWithSimulator(unittest.TestCase):
         for _ in range(cycle_cnt):
             yield
 
-    def assertIterableEqual(self, it1, it2):
+    def assertIterableEqual(self, it1, it2):  # noqa: N802
         self.assertListEqual(list(it1), list(it2))
 
-    def assertFieldsEqual(self, dict1, dict2, fields : Iterable):
+    def assertFieldsEqual(self, dict1, dict2, fields: Iterable):  # noqa: N802
         for field in fields:
             self.assertEqual(dict1[field], dict2[field], field)
 
@@ -636,8 +636,12 @@ def wrap_with_now(func: Callable):
 
 
 def def_method_mock(
-    tb_getter: Callable[[], TestbenchIO] | Callable[[Any], TestbenchIO] | Callable[[], MethodMock] | Callable[[Any], MethodMock],
-    sched_prio: int = 0, **kwargs
+    tb_getter: Callable[[], TestbenchIO]
+    | Callable[[Any], TestbenchIO]
+    | Callable[[], MethodMock]
+    | Callable[[Any], MethodMock],
+    sched_prio: int = 0,
+    **kwargs,
 ) -> Callable[[Callable[..., Optional[RecordIntDict]]], Callable[[], TestGen[None]]]:
     """
     Decorator function to create method mock handlers. It should be applied on
@@ -706,7 +710,7 @@ def def_method_mock(
                     kw[k] = bind(func_self) if bind else v
             tb = getter()
             if isinstance(tb, MethodMock):
-                tb=tb.tb
+                tb = tb.tb
             assert isinstance(tb, TestbenchIO)
             yield from tb.method_handle_loop(f, extra_settle_count=sched_prio, **kw)
 

--- a/test/common.py
+++ b/test/common.py
@@ -494,6 +494,10 @@ class TestCaseWithSimulator(unittest.TestCase):
     def assertIterableEqual(self, it1, it2):
         self.assertListEqual(list(it1), list(it2))
 
+    def assertFieldsEqual(self, dict1, dict2, fields : Iterable):
+        for field in fields:
+            self.assertEqual(dict1[field], dict2[field], field)
+
 
 class TestbenchIO(Elaboratable):
     def __init__(self, adapter: AdapterBase):

--- a/test/common.py
+++ b/test/common.py
@@ -202,7 +202,7 @@ def generate_instr(
             rec["regs_l"] = generate_register_set(width, support_vector=support_vector)
         if "regs_p" in field[0]:
             rec["regs_p"] = generate_register_set(reg_phys_width, support_vector=support_vector)
-        for label in ["rp_dst", "rp_s1", "rp_s2"]:
+        for label in ["rp_dst", "rp_s1", "rp_s2", "rp_s3"]:
             if label in field[0]:
                 rec[label] = generate_register_entry(reg_phys_width, support_vector=support_vector)
         if "exec_fn" in field[0]:
@@ -229,6 +229,8 @@ def generate_instr(
             rec["s2_val"] = s2_val
         if "vtype" in field[0]:
             rec["vtype"] = generate_vtype(gen_params)
+        if "rp_v0" in field[0]:
+            rec["rp_v0"] = {"id" : generate_phys_register_id(gen_params=gen_params)}
     return overwrite_dict_values(rec, overwriting)
 
 

--- a/test/fu/vector_unit/common.py
+++ b/test/fu/vector_unit/common.py
@@ -45,7 +45,7 @@ def generate_vsetvl(gen_params: GenParams, v_params: VectorParameters, layout: L
 def get_vector_instr_generator():
     last_vtype = {"vl" :0, "ma" : 0, "ta" : 0, "sew":0, "lmul":0}
     first_instr = True
-    def f(gen_params: GenParams, v_params: VectorParameters, layout: LayoutLike, not_balanced_vsetvl = False):
+    def f(gen_params: GenParams, v_params: VectorParameters, layout: LayoutLike, not_balanced_vsetvl = False, vsetvl_different_rp_id : bool = False):
         nonlocal last_vtype
         nonlocal first_instr
         if first_instr:
@@ -56,5 +56,7 @@ def get_vector_instr_generator():
         instr = generate_instr(gen_params, layout, support_vector = True)
         if instr["exec_fn"]["op_type"]==OpType.V_CONTROL or (not_balanced_vsetvl and random.randrange(2)):
             instr, last_vtype = generate_vsetvl(gen_params, v_params, layout)
+            while vsetvl_different_rp_id and instr["rp_s1"]["id"] == instr["rp_s2"]["id"]:
+                instr, last_vtype = generate_vsetvl(gen_params, v_params, layout)
         return instr, last_vtype
     return f

--- a/test/fu/vector_unit/common.py
+++ b/test/fu/vector_unit/common.py
@@ -9,7 +9,8 @@ from coreblocks.fu.vector_unit.v_status import *
 from collections import deque
 
 
-def generate_vsetvl(gen_params: GenParams, v_params: VectorParameters, layout: LayoutLike, last_vl: int = 0, const_lmul : Optional[LMUL] = None, allow_illegal : bool = False):
+def generate_vsetvl(gen_params: GenParams, layout: LayoutLike, last_vl: int = 0, const_lmul : Optional[LMUL] = None, allow_illegal : bool = False):
+    v_params = gen_params.v_params
     instr = generate_instr(gen_params, layout)
     vtype = generate_vtype(gen_params)
     if const_lmul is not None:
@@ -49,18 +50,18 @@ def generate_vsetvl(gen_params: GenParams, v_params: VectorParameters, layout: L
 def get_vector_instr_generator():
     last_vtype = {"vl" :0, "ma" : 0, "ta" : 0, "sew":0, "lmul":0}
     first_instr = True
-    def f(gen_params: GenParams, v_params: VectorParameters, layout: LayoutLike, not_balanced_vsetvl = False, vsetvl_different_rp_id : bool = False, const_lmul : Optional[LMUL] = None):
+    def f(gen_params: GenParams, layout: LayoutLike, not_balanced_vsetvl = False, vsetvl_different_rp_id : bool = False, const_lmul : Optional[LMUL] = None):
         nonlocal last_vtype
         nonlocal first_instr
         if first_instr:
-            instr, last_vtype = generate_vsetvl(gen_params, v_params, layout, const_lmul = const_lmul)
+            instr, last_vtype = generate_vsetvl(gen_params,  layout, const_lmul = const_lmul)
             first_instr = False
             return instr, last_vtype
 
         instr = generate_instr(gen_params, layout, support_vector = True)
         if instr["exec_fn"]["op_type"]==OpType.V_CONTROL or (not_balanced_vsetvl and random.randrange(2)):
-            instr, last_vtype = generate_vsetvl(gen_params, v_params, layout, const_lmul = const_lmul)
+            instr, last_vtype = generate_vsetvl(gen_params,  layout, const_lmul = const_lmul)
             while vsetvl_different_rp_id and instr["rp_s1"]["id"] == instr["rp_s2"]["id"]:
-                instr, last_vtype = generate_vsetvl(gen_params, v_params, layout, const_lmul = const_lmul)
+                instr, last_vtype = generate_vsetvl(gen_params,  layout, const_lmul = const_lmul)
         return instr, last_vtype
     return f

--- a/test/fu/vector_unit/common.py
+++ b/test/fu/vector_unit/common.py
@@ -1,0 +1,49 @@
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_status import *
+from collections import deque
+
+
+def generate_vsetvl(gen_params: GenParams, v_params: VectorParameters, layout: LayoutLike, last_vl: int = 0):
+    instr = generate_instr(gen_params, layout)
+    vtype = generate_vtype(gen_params)
+    imm2 = convert_vtype_to_imm(vtype)
+    if eew_to_bits(vtype["sew"]) > v_params.elen:
+        imm2 = 0
+        vtype = {"sew": EEW(0), "lmul": LMUL(0), "ta": 0, "ma": 0}
+    vsetvl_type = random.randrange(4)
+    if vsetvl_type == 2:
+        instr = overwrite_dict_values(instr, {"s2_val": imm2})
+    if vsetvl_type == 3:
+        instr = overwrite_dict_values(instr, {"imm": instr["rp_s1"]["id"]})
+    imm2 |= vsetvl_type << 10
+    instr = overwrite_dict_values(
+        instr, {"imm2": imm2, "exec_fn": {"op_type": OpType.V_CONTROL, "funct3": Funct3.OPCFG}}
+    )
+
+    vlmax = int(v_params.vlen // eew_to_bits(vtype["sew"]) * lmul_to_float(vtype["lmul"]))
+
+    if vsetvl_type == 3:
+        vtype |= {"vl": instr["rp_s1"]["id"]}
+    else:
+        if instr["rp_s1"]["id"] == 0:
+            vtype |= {"vl": vlmax}
+        else:
+            vtype |= {"vl": instr["s1_val"]}
+
+    if instr["rp_s1"]["id"] == 0 and instr["rp_dst"]["id"] == 0:
+        vtype |= {"vl": last_vl}
+
+    return instr, vtype
+
+
+def generate_vector_instr(gen_params: GenParams, v_params: VectorParameters, layout: LayoutLike, not_balanced_vsetvl = False):
+    instr = generate_instr(gen_params, layout, support_vector = True)
+    if instr["exec_fn"]["op_type"]==OpType.V_CONTROL or (not_balanced_vsetvl and random.randrange(2)):
+        instr = get_dict_subset(generate_vsetvl(gen_params, v_params, layout)[0], [field[0] for field in layout])
+    return instr

--- a/test/fu/vector_unit/common.py
+++ b/test/fu/vector_unit/common.py
@@ -6,10 +6,15 @@ from coreblocks.params.configurations import *
 from coreblocks.fu.vector_unit.v_layouts import *
 from coreblocks.fu.vector_unit.utils import *
 from coreblocks.fu.vector_unit.v_status import *
-from collections import deque
 
 
-def generate_vsetvl(gen_params: GenParams, layout: LayoutLike, last_vl: int = 0, const_lmul : Optional[LMUL] = None, allow_illegal : bool = False):
+def generate_vsetvl(
+    gen_params: GenParams,
+    layout: LayoutLike,
+    last_vl: int = 0,
+    const_lmul: Optional[LMUL] = None,
+    allow_illegal: bool = False,
+):
     v_params = gen_params.v_params
     instr = generate_instr(gen_params, layout)
     vtype = generate_vtype(gen_params)
@@ -48,20 +53,28 @@ def generate_vsetvl(gen_params: GenParams, layout: LayoutLike, last_vl: int = 0,
 
 
 def get_vector_instr_generator():
-    last_vtype = {"vl" :0, "ma" : 0, "ta" : 0, "sew":0, "lmul":0}
+    last_vtype = {"vl": 0, "ma": 0, "ta": 0, "sew": 0, "lmul": 0}
     first_instr = True
-    def f(gen_params: GenParams, layout: LayoutLike, not_balanced_vsetvl = False, vsetvl_different_rp_id : bool = False, const_lmul : Optional[LMUL] = None):
+
+    def f(
+        gen_params: GenParams,
+        layout: LayoutLike,
+        not_balanced_vsetvl=False,
+        vsetvl_different_rp_id: bool = False,
+        const_lmul: Optional[LMUL] = None,
+    ):
         nonlocal last_vtype
         nonlocal first_instr
         if first_instr:
-            instr, last_vtype = generate_vsetvl(gen_params,  layout, const_lmul = const_lmul)
+            instr, last_vtype = generate_vsetvl(gen_params, layout, const_lmul=const_lmul)
             first_instr = False
             return instr, last_vtype
 
-        instr = generate_instr(gen_params, layout, support_vector = True)
-        if instr["exec_fn"]["op_type"]==OpType.V_CONTROL or (not_balanced_vsetvl and random.randrange(2)):
-            instr, last_vtype = generate_vsetvl(gen_params,  layout, const_lmul = const_lmul)
+        instr = generate_instr(gen_params, layout, support_vector=True)
+        if instr["exec_fn"]["op_type"] == OpType.V_CONTROL or (not_balanced_vsetvl and random.randrange(2)):
+            instr, last_vtype = generate_vsetvl(gen_params, layout, const_lmul=const_lmul)
             while vsetvl_different_rp_id and instr["rp_s1"]["id"] == instr["rp_s2"]["id"]:
-                instr, last_vtype = generate_vsetvl(gen_params,  layout, const_lmul = const_lmul)
+                instr, last_vtype = generate_vsetvl(gen_params, layout, const_lmul=const_lmul)
         return instr, last_vtype
+
     return f

--- a/test/fu/vector_unit/test_v_alloc_rename.py
+++ b/test/fu/vector_unit/test_v_alloc_rename.py
@@ -8,7 +8,6 @@ from coreblocks.fu.vector_unit.v_alloc_rename import *
 from coreblocks.transactions.lib import *
 from coreblocks.structs_common.rat import FRAT
 from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
-from collections import deque, defaultdict
 from test.fu.vector_unit.common import *
 
 
@@ -21,21 +20,21 @@ class TestVectorAllocRename(TestCaseWithSimulator):
 
         self.layout = VectorFrontendLayouts(self.gen_params)
 
-        self.frat = FRAT(gen_params = self.gen_params, superscalarity = 2)
+        self.frat = FRAT(gen_params=self.gen_params, superscalarity=2)
         self.freerf = SuperscalarFreeRF(self.v_params.vrp_count, 1)
         self.deallocate = TestbenchIO(AdapterTrans(self.freerf.deallocates[0]))
-        self.circ = SimpleTestCircuit(VectorAllocRename(self.gen_params,
-                                                     self.freerf.allocate,
-                                                     self.frat.get_rename_list[0], self.frat.get_rename_list[1], self.frat.set_rename_list[0]))
-        self.m = ModuleConnector(
-                circ = self.circ,
-                frat = self.frat,
-                freerf = self.freerf,
-                dealocate = self.deallocate
-                )
+        self.circ = SimpleTestCircuit(
+            VectorAllocRename(
+                self.gen_params,
+                self.freerf.allocate,
+                self.frat.get_rename_list[0],
+                self.frat.get_rename_list[1],
+                self.frat.set_rename_list[0],
+            )
+        )
+        self.m = ModuleConnector(circ=self.circ, frat=self.frat, freerf=self.freerf, dealocate=self.deallocate)
 
         self.generate_vector_instr = get_vector_instr_generator()
-
 
     def process(self):
         for _ in range(self.test_number):
@@ -43,7 +42,7 @@ class TestVectorAllocRename(TestCaseWithSimulator):
             out = yield from self.circ.issue.call(instr)
             for field_name in ["rob_id", "exec_fn", "vtype"]:
                 self.assertEqual(instr[field_name], out[field_name])
-            yield from self.deallocate.call(reg = out["rp_dst"]["id"])
+            yield from self.deallocate.call(reg=out["rp_dst"]["id"])
 
     def test_random(self):
         with self.run_simulation(self.m) as sim:

--- a/test/fu/vector_unit/test_v_alloc_rename.py
+++ b/test/fu/vector_unit/test_v_alloc_rename.py
@@ -34,10 +34,12 @@ class TestVectorAllocRename(TestCaseWithSimulator):
                 dealocate = self.deallocate
                 )
 
+        self.generate_vector_instr = get_vector_instr_generator()
+
 
     def process(self):
         for _ in range(self.test_number):
-            instr = generate_vector_instr(self.gen_params, self.v_params, self.layout.alloc_rename_in)
+            instr, _ = self.generate_vector_instr(self.gen_params, self.v_params, self.layout.alloc_rename_in)
             out = yield from self.circ.issue.call(instr)
             for field_name in ["rob_id", "exec_fn", "vtype"]:
                 self.assertEqual(instr[field_name], out[field_name])

--- a/test/fu/vector_unit/test_v_alloc_rename.py
+++ b/test/fu/vector_unit/test_v_alloc_rename.py
@@ -1,0 +1,48 @@
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.fu.vector_unit.v_alloc_rename import *
+from coreblocks.transactions.lib import *
+from coreblocks.structs_common.rat import FRAT
+from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
+from collections import deque, defaultdict
+from test.fu.vector_unit.common import *
+
+
+class TestVectorAllocRename(TestCaseWithSimulator):
+    def setUp(self):
+        random.seed(14)
+        self.gen_params = GenParams(test_core_config)
+        self.test_number = 100
+        self.v_params = VectorParameters(vlen=1024, elen=32)
+
+        self.layout = VectorFrontendLayouts(self.gen_params, self.v_params)
+
+        self.frat = FRAT(gen_params = self.gen_params, superscalarity = 2)
+        self.freerf = SuperscalarFreeRF(self.v_params.vrp_count, 1)
+        self.deallocate = TestbenchIO(AdapterTrans(self.freerf.deallocates[0]))
+        self.circ = SimpleTestCircuit(VectorAllocRename(self.gen_params, self.v_params,
+                                                     self.freerf.allocate,
+                                                     self.frat.get_rename_list[0], self.frat.get_rename_list[1], self.frat.set_rename_list[0]))
+        self.m = ModuleConnector(
+                circ = self.circ,
+                frat = self.frat,
+                freerf = self.freerf,
+                dealocate = self.deallocate
+                )
+
+
+    def process(self):
+        for _ in range(self.test_number):
+            instr = generate_vector_instr(self.gen_params, self.v_params, self.layout.alloc_rename_in)
+            out = yield from self.circ.issue.call(instr)
+            for field_name in ["rob_id", "exec_fn", "vtype"]:
+                self.assertEqual(instr[field_name], out[field_name])
+            yield from self.deallocate.call(reg = out["rp_dst"]["id"])
+
+    def test_random(self):
+        with self.run_simulation(self.m) as sim:
+            sim.add_sync_process(self.process)

--- a/test/fu/vector_unit/test_v_alloc_rename.py
+++ b/test/fu/vector_unit/test_v_alloc_rename.py
@@ -15,16 +15,16 @@ from test.fu.vector_unit.common import *
 class TestVectorAllocRename(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
-        self.gen_params = GenParams(test_core_config)
+        self.gen_params = GenParams(test_vector_core_config)
         self.test_number = 100
-        self.v_params = VectorParameters(vlen=1024, elen=32)
+        self.v_params = self.gen_params.v_params
 
-        self.layout = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.layout = VectorFrontendLayouts(self.gen_params)
 
         self.frat = FRAT(gen_params = self.gen_params, superscalarity = 2)
         self.freerf = SuperscalarFreeRF(self.v_params.vrp_count, 1)
         self.deallocate = TestbenchIO(AdapterTrans(self.freerf.deallocates[0]))
-        self.circ = SimpleTestCircuit(VectorAllocRename(self.gen_params, self.v_params,
+        self.circ = SimpleTestCircuit(VectorAllocRename(self.gen_params,
                                                      self.freerf.allocate,
                                                      self.frat.get_rename_list[0], self.frat.get_rename_list[1], self.frat.set_rename_list[0]))
         self.m = ModuleConnector(
@@ -39,7 +39,7 @@ class TestVectorAllocRename(TestCaseWithSimulator):
 
     def process(self):
         for _ in range(self.test_number):
-            instr, _ = self.generate_vector_instr(self.gen_params, self.v_params, self.layout.alloc_rename_in)
+            instr, _ = self.generate_vector_instr(self.gen_params, self.layout.alloc_rename_in)
             out = yield from self.circ.issue.call(instr)
             for field_name in ["rob_id", "exec_fn", "vtype"]:
                 self.assertEqual(instr[field_name], out[field_name])

--- a/test/fu/vector_unit/test_v_frontend.py
+++ b/test/fu/vector_unit/test_v_frontend.py
@@ -20,9 +20,9 @@ class TestVectorFrontend(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
         self.test_number = 50
-        self.gen_params = GenParams(test_core_config)
-        self.v_params = VectorParameters(vlen = 1024, elen = 32)
-        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.gen_params = GenParams(test_vector_core_config)
+        self.layouts = VectorFrontendLayouts(self.gen_params)
+        self.v_params = self.gen_params.v_params
 
         self.generate_vector_instr = get_vector_instr_generator()
 
@@ -36,7 +36,7 @@ class TestVectorFrontend(TestCaseWithSimulator):
         self.frat = FRAT(gen_params = self.gen_params, superscalarity = 2)
         self.freerf = SuperscalarFreeRF(self.v_params.vrp_count, 1)
         self.deallocate = TestbenchIO(AdapterTrans(self.freerf.deallocates[0]))
-        self.circ = SimpleTestCircuit(VectorFrontend(self.gen_params, self.v_params, self.rob_block_interrupt.get_method(),
+        self.circ = SimpleTestCircuit(VectorFrontend(self.gen_params,self.rob_block_interrupt.get_method(),
                                                      self.retire.get_method(), self.retire_mult.get_method(), self.freerf.allocate,
                                                      self.frat.get_rename_list[0], self.frat.get_rename_list[1], self.frat.set_rename_list[0],
                                                      self.put_mem.get_method(), self.put_vvrs.get_method()))
@@ -150,7 +150,7 @@ class TestVectorFrontend(TestCaseWithSimulator):
     def test_random(self):
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.checker)
-            sim.add_sync_process(self.input_process(lambda : self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in, vsetvl_different_rp_id = True)))
+            sim.add_sync_process(self.input_process(lambda : self.generate_vector_instr(self.gen_params,self.layouts.verification_in, vsetvl_different_rp_id = True)))
             sim.add_sync_process(self.put_vvrs_process)
             sim.add_sync_process(self.put_mem_process)
             sim.add_sync_process(self.rob_block_interrupt_process)
@@ -162,7 +162,7 @@ class TestVectorFrontend(TestCaseWithSimulator):
     def test_heavy_load(self):
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.checker)
-            sim.add_sync_process(self.input_process(lambda : self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in, vsetvl_different_rp_id = True, const_lmul = LMUL.m8)))
+            sim.add_sync_process(self.input_process(lambda : self.generate_vector_instr(self.gen_params, self.layouts.verification_in, vsetvl_different_rp_id = True, const_lmul = LMUL.m8)))
             sim.add_sync_process(self.put_vvrs_process)
             sim.add_sync_process(self.put_mem_process)
             sim.add_sync_process(self.rob_block_interrupt_process)

--- a/test/fu/vector_unit/test_v_frontend.py
+++ b/test/fu/vector_unit/test_v_frontend.py
@@ -1,0 +1,149 @@
+import math
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_status import *
+from coreblocks.fu.vector_unit.v_frontend import VectorFrontend
+from coreblocks.structs_common.rat import FRAT
+from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
+from test.fu.vector_unit.common import *
+from collections import deque
+import copy
+
+
+class TestVectorFrontend(TestCaseWithSimulator):
+    def setUp(self):
+        random.seed(15)
+        self.test_number = 200
+        self.gen_params = GenParams(test_core_config)
+        self.v_params = VectorParameters(vlen = 1024, elen = 32)
+        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+
+        self.generate_vector_instr = get_vector_instr_generator()
+
+        self.rob_block_interrupt = MethodMock(i= self.gen_params.get(ROBLayouts).block_interrupts)
+        self.put_mem = MethodMock(i=self.layouts.instr_to_mem)
+        self.put_vvrs = MethodMock(i=self.layouts.instr_to_vvrs)
+        self.retire = MethodMock(i=FuncUnitLayouts(self.gen_params).accept)
+        self.retire_mult = MethodMock(i=self.layouts.translator_report_multiplier)
+        self.exception_report = MethodMock(i=self.gen_params.get(ExceptionRegisterLayouts).report)
+        self.gen_params.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.get_method())
+        self.frat = FRAT(gen_params = self.gen_params, superscalarity = 2)
+        self.freerf = SuperscalarFreeRF(self.v_params.vrp_count, 1)
+        self.deallocate = TestbenchIO(AdapterTrans(self.freerf.deallocates[0]))
+        self.circ = SimpleTestCircuit(VectorFrontend(self.gen_params, self.v_params, self.rob_block_interrupt.get_method(),
+                                                     self.retire.get_method(), self.retire_mult.get_method(), self.freerf.allocate,
+                                                     self.frat.get_rename_list[0], self.frat.get_rename_list[1], self.frat.set_rename_list[0],
+                                                     self.put_mem.get_method(), self.put_vvrs.get_method()))
+        self.m = ModuleConnector(
+                circ = self.circ,
+                frat = self.frat,
+                freerf = self.freerf,
+                rob_block_interrupt = self.rob_block_interrupt,
+                put_mem = self.put_mem,
+                put_vvrs = self.put_vvrs,
+                retire = self.retire,
+                retire_mult = self.retire_mult,
+                exception_report = self.exception_report,
+                deallocate = self.deallocate,
+                )
+
+        self.orginal_instr = deque()
+        self.to_dealocate = deque()
+        self.received_instr=deque()
+        self.received_instr_mem=deque()
+        self.received_block_interrupt = deque()
+        self.received_retire = deque()
+        self.received_mult = deque()
+        
+
+    @def_method_mock(lambda self: self.exception_report)
+    def report_process(self, arg):
+        self.assertTrue(False)
+
+    @def_method_mock(lambda self: self.put_vvrs)
+    def put_vvrs_process(self, arg):
+        self.to_dealocate.append(arg["rp_dst"]["id"])
+        self.received_instr.append(arg)
+
+    @def_method_mock(lambda self: self.put_mem)
+    def put_mem_process(self, arg):
+        self.to_dealocate.append(arg["rp_dst"]["id"])
+        self.received_instr_mem.append(arg)
+
+    @def_method_mock(lambda self: self.rob_block_interrupt)
+    def rob_block_interrupt_process(self, arg):
+        self.received_block_interrupt.append(arg)
+
+    @def_method_mock(lambda self: self.retire)
+    def retire_process(self, arg):
+        self.received_retire.append(arg)
+
+    @def_method_mock(lambda self: self.retire_mult)
+    def mult_process(self, mult):
+        self.received_mult.append(mult)
+
+
+    def input_process(self):
+        for _ in range(self.test_number):
+            instr, vtype = self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in)
+            while instr["exec_fn"]["op_type"] == OpType.V_CONTROL and instr["rp_s1"]["id"] == instr["rp_s2"]["id"]:
+                instr, vtype = self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in)
+            self.orginal_instr.append((instr, vtype))
+            yield from self.circ.select.call()
+            yield from self.circ.insert.call(rs_entry_id=0, rs_data = instr)
+            yield from self.circ.update.call(tag = instr["rp_s1"], value = instr["s1_val"])
+            yield from self.circ.update.call(tag = instr["rp_s2"], value = instr["s2_val"])
+            yield from self.tick(random.randrange(3))
+
+    def checker(self):
+        while len(self.received_mult) + len(self.received_retire) < self.test_number:
+            yield
+        # be sure that there is no other instructions in pipeline
+        yield from self.tick(10)
+        self.assertEqual(len(self.received_mult) + len(self.received_retire), self.test_number)
+
+        def compare_fields(org_instr, vtype, list_to_pop):
+            lmul = lmul_to_int(vtype["lmul"])
+            for _ in range(lmul):
+                retired_instr = list_to_pop.popleft()
+                print(retired_instr)
+                self.assertFieldsEqual(org_instr, retired_instr, ["rob_id", "exec_fn"])
+
+        for org_instr, vtype in self.orginal_instr:
+            print("----------------")
+            print(org_instr, vtype)
+            if org_instr["exec_fn"]["op_type"]==OpType.V_CONTROL:
+                retired_instr = self.received_retire.popleft()
+                self.assertFieldsEqual(org_instr, retired_instr, ["rob_id", "rp_dst"])
+            elif org_instr["exec_fn"]["op_type"]==OpType.V_MEMORY:
+                compare_fields(org_instr, vtype, self.received_instr_mem)
+            else:
+                compare_fields(org_instr, vtype, self.received_instr)
+    
+    def deallocator_process(self):
+        yield Passive()
+        while True:
+            if self.to_dealocate:
+                reg = self.to_dealocate.popleft()
+                yield from self.deallocate.call(reg=reg)
+            yield
+            #yield from self.tick(random.randrange(3))
+
+    def test_random(self):
+        with self.run_simulation(self.m, 15000) as sim:
+            sim.add_sync_process(self.checker)
+            sim.add_sync_process(self.input_process)
+            sim.add_sync_process(self.put_vvrs_process)
+            sim.add_sync_process(self.put_mem_process)
+            sim.add_sync_process(self.rob_block_interrupt_process)
+            sim.add_sync_process(self.retire_process)
+            sim.add_sync_process(self.mult_process)
+            sim.add_sync_process(self.report_process)
+            sim.add_sync_process(self.deallocator_process)
+
+    #TODO test z stałym LMUL=8

--- a/test/fu/vector_unit/test_v_frontend.py
+++ b/test/fu/vector_unit/test_v_frontend.py
@@ -13,13 +13,13 @@ from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
 from test.fu.vector_unit.common import *
 from collections import deque
 import copy
-
+from parameterized import parameterized_class
+import itertools
 
 class TestVectorFrontend(TestCaseWithSimulator):
     def setUp(self):
-        random.seed(15)
-        #  216 - OK, 217 NOK
-        self.test_number = 217
+        random.seed(14)
+        self.test_number = 50
         self.gen_params = GenParams(test_core_config)
         self.v_params = VectorParameters(vlen = 1024, elen = 32)
         self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
@@ -71,7 +71,6 @@ class TestVectorFrontend(TestCaseWithSimulator):
     @def_method_mock(lambda self: self.put_vvrs)
     def put_vvrs_process(self, arg):
         self.to_dealocate.append(arg["rp_dst"]["id"])
-        #print("rob_id", arg["rob_id"])
         self._robs.append(arg["rob_id"])
         self.received_instr.append(arg)
 
@@ -96,21 +95,17 @@ class TestVectorFrontend(TestCaseWithSimulator):
 
     def input_process(self):
         for i in range(self.test_number):
-            instr, vtype = self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in)
-            while instr["exec_fn"]["op_type"] == OpType.V_CONTROL and instr["rp_s1"]["id"] == instr["rp_s2"]["id"]:
-                instr, vtype = self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in)
-            print(i)
-            print(instr)
-            print(vtype)
+            instr, vtype = self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in, vsetvl_different_rp_id = True)
             self.orginal_instr.append((instr, vtype))
             if instr["exec_fn"]["op_type"] != OpType.V_CONTROL:
                 self._org_robs.append(instr["rob_id"])
             yield from self.circ.select.call()
             yield from self.circ.insert.call(rs_entry_id=0, rs_data = instr)
-            yield from self.circ.update.call(tag = instr["rp_s1"], value = instr["s1_val"])
-            yield from self.circ.update.call(tag = instr["rp_s2"], value = instr["s2_val"])
+            if instr["rp_s1"]["id"]!=0:
+                yield from self.circ.update.call(tag = instr["rp_s1"], value = instr["s1_val"])
+            if instr["rp_s2"]["id"]!=0:
+                yield from self.circ.update.call(tag = instr["rp_s2"], value = instr["s2_val"])
             yield from self.tick(random.randrange(3))
-        print("KONIEC WEJSCIA")
 
     def remove_duplicates(self, lista):
         nowa =[lista[0]]
@@ -122,30 +117,18 @@ class TestVectorFrontend(TestCaseWithSimulator):
 
     def checker(self):
         while len(self.received_mult) + len(self.received_retire) < self.test_number:
-            if (yield Now())==4900:
-                print(len(self.received_mult) , len(self.received_retire))
-                print(len(self.received_instr), len(self.received_instr_mem))
-                print(self.received_mult)
-                print(sum(self.received_mult))
-                print(self._robs)
-                print(self.remove_duplicates(self._robs)[200:])
-                print(list(self._org_robs)[200:])
-                #self.assertIterableEqual(self.remove_duplicates(self._robs), self._org_robs)
             yield
         # be sure that there is no other instructions in pipeline
-        yield from self.tick(10)
+        yield from self.tick(30)
         self.assertEqual(len(self.received_mult) + len(self.received_retire), self.test_number)
 
         def compare_fields(org_instr, vtype, list_to_pop):
             lmul = lmul_to_int(vtype["lmul"])
             for _ in range(lmul):
                 retired_instr = list_to_pop.popleft()
-                print(retired_instr)
                 self.assertFieldsEqual(org_instr, retired_instr, ["rob_id", "exec_fn"])
 
         for org_instr, vtype in self.orginal_instr:
-            print("----------------")
-            print(org_instr, vtype)
             if org_instr["exec_fn"]["op_type"]==OpType.V_CONTROL:
                 retired_instr = self.received_retire.popleft()
                 self.assertFieldsEqual(org_instr, retired_instr, ["rob_id", "rp_dst"])
@@ -164,7 +147,7 @@ class TestVectorFrontend(TestCaseWithSimulator):
             #yield from self.tick(random.randrange(3))
 
     def test_random(self):
-        with self.run_simulation(self.m, 5000) as sim:
+        with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.checker)
             sim.add_sync_process(self.input_process)
             sim.add_sync_process(self.put_vvrs_process)

--- a/test/fu/vector_unit/test_v_frontend.py
+++ b/test/fu/vector_unit/test_v_frontend.py
@@ -1,4 +1,3 @@
-import math
 from amaranth import *
 from test.common import *
 from coreblocks.fu.vector_unit.vrs import *
@@ -12,9 +11,7 @@ from coreblocks.structs_common.rat import FRAT
 from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
 from test.fu.vector_unit.common import *
 from collections import deque
-import copy
-from parameterized import parameterized_class
-import itertools
+
 
 class TestVectorFrontend(TestCaseWithSimulator):
     def setUp(self):
@@ -26,43 +23,52 @@ class TestVectorFrontend(TestCaseWithSimulator):
 
         self.generate_vector_instr = get_vector_instr_generator()
 
-        self.rob_block_interrupt = MethodMock(i= self.gen_params.get(ROBLayouts).block_interrupts)
+        self.rob_block_interrupt = MethodMock(i=self.gen_params.get(ROBLayouts).block_interrupts)
         self.put_mem = MethodMock(i=self.layouts.instr_to_mem)
         self.put_vvrs = MethodMock(i=self.layouts.instr_to_vvrs)
         self.retire = MethodMock(i=FuncUnitLayouts(self.gen_params).accept)
         self.retire_mult = MethodMock(i=self.layouts.translator_report_multiplier)
         self.exception_report = MethodMock(i=self.gen_params.get(ExceptionRegisterLayouts).report)
         self.gen_params.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.get_method())
-        self.frat = FRAT(gen_params = self.gen_params, superscalarity = 2)
+        self.frat = FRAT(gen_params=self.gen_params, superscalarity=2)
         self.freerf = SuperscalarFreeRF(self.v_params.vrp_count, 1)
         self.deallocate = TestbenchIO(AdapterTrans(self.freerf.deallocates[0]))
-        self.circ = SimpleTestCircuit(VectorFrontend(self.gen_params,self.rob_block_interrupt.get_method(),
-                                                     self.retire.get_method(), self.retire_mult.get_method(), self.freerf.allocate,
-                                                     self.frat.get_rename_list[0], self.frat.get_rename_list[1], self.frat.set_rename_list[0],
-                                                     self.put_mem.get_method(), self.put_vvrs.get_method()))
+        self.circ = SimpleTestCircuit(
+            VectorFrontend(
+                self.gen_params,
+                self.rob_block_interrupt.get_method(),
+                self.retire.get_method(),
+                self.retire_mult.get_method(),
+                self.freerf.allocate,
+                self.frat.get_rename_list[0],
+                self.frat.get_rename_list[1],
+                self.frat.set_rename_list[0],
+                self.put_mem.get_method(),
+                self.put_vvrs.get_method(),
+            )
+        )
         self.m = ModuleConnector(
-                circ = self.circ,
-                frat = self.frat,
-                freerf = self.freerf,
-                rob_block_interrupt = self.rob_block_interrupt,
-                put_mem = self.put_mem,
-                put_vvrs = self.put_vvrs,
-                retire = self.retire,
-                retire_mult = self.retire_mult,
-                exception_report = self.exception_report,
-                deallocate = self.deallocate,
-                )
+            circ=self.circ,
+            frat=self.frat,
+            freerf=self.freerf,
+            rob_block_interrupt=self.rob_block_interrupt,
+            put_mem=self.put_mem,
+            put_vvrs=self.put_vvrs,
+            retire=self.retire,
+            retire_mult=self.retire_mult,
+            exception_report=self.exception_report,
+            deallocate=self.deallocate,
+        )
 
         self.orginal_instr = deque()
         self.to_dealocate = deque()
-        self.received_instr=deque()
-        self.received_instr_mem=deque()
+        self.received_instr = deque()
+        self.received_instr_mem = deque()
         self.received_block_interrupt = deque()
         self.received_retire = deque()
         self.received_mult = deque()
         self._robs = deque()
         self._org_robs = deque()
-        
 
     @def_method_mock(lambda self: self.exception_report)
     def report_process(self, arg):
@@ -92,7 +98,6 @@ class TestVectorFrontend(TestCaseWithSimulator):
     def mult_process(self, mult):
         self.received_mult.append(mult)
 
-
     def input_process(self, generator):
         def f():
             for i in range(self.test_number):
@@ -101,21 +106,21 @@ class TestVectorFrontend(TestCaseWithSimulator):
                 if instr["exec_fn"]["op_type"] != OpType.V_CONTROL:
                     self._org_robs.append(instr["rob_id"])
                 yield from self.circ.select.call()
-                yield from self.circ.insert.call(rs_entry_id=0, rs_data = instr)
-                if instr["rp_s1"]["id"]!=0:
-                    yield from self.circ.update.call(tag = instr["rp_s1"], value = instr["s1_val"])
-                if instr["rp_s2"]["id"]!=0:
-                    yield from self.circ.update.call(tag = instr["rp_s2"], value = instr["s2_val"])
+                yield from self.circ.insert.call(rs_entry_id=0, rs_data=instr)
+                if instr["rp_s1"]["id"] != 0:
+                    yield from self.circ.update.call(tag=instr["rp_s1"], value=instr["s1_val"])
+                if instr["rp_s2"]["id"] != 0:
+                    yield from self.circ.update.call(tag=instr["rp_s2"], value=instr["s2_val"])
                 yield from self.tick(random.randrange(3))
+
         return f
 
     def remove_duplicates(self, lista):
-        nowa =[lista[0]]
+        nowa = [lista[0]]
         for e in lista:
-            if nowa[-1]!=e:
+            if nowa[-1] != e:
                 nowa.append(e)
         return nowa
-
 
     def checker(self):
         while len(self.received_mult) + len(self.received_retire) < self.test_number:
@@ -131,14 +136,14 @@ class TestVectorFrontend(TestCaseWithSimulator):
                 self.assertFieldsEqual(org_instr, retired_instr, ["rob_id", "exec_fn"])
 
         for org_instr, vtype in self.orginal_instr:
-            if org_instr["exec_fn"]["op_type"]==OpType.V_CONTROL:
+            if org_instr["exec_fn"]["op_type"] == OpType.V_CONTROL:
                 retired_instr = self.received_retire.popleft()
                 self.assertFieldsEqual(org_instr, retired_instr, ["rob_id", "rp_dst"])
-            elif org_instr["exec_fn"]["op_type"]==OpType.V_MEMORY:
+            elif org_instr["exec_fn"]["op_type"] == OpType.V_MEMORY:
                 compare_fields(org_instr, vtype, self.received_instr_mem)
             else:
                 compare_fields(org_instr, vtype, self.received_instr)
-    
+
     def deallocator_process(self):
         yield Passive()
         while True:
@@ -150,7 +155,13 @@ class TestVectorFrontend(TestCaseWithSimulator):
     def test_random(self):
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.checker)
-            sim.add_sync_process(self.input_process(lambda : self.generate_vector_instr(self.gen_params,self.layouts.verification_in, vsetvl_different_rp_id = True)))
+            sim.add_sync_process(
+                self.input_process(
+                    lambda: self.generate_vector_instr(
+                        self.gen_params, self.layouts.verification_in, vsetvl_different_rp_id=True
+                    )
+                )
+            )
             sim.add_sync_process(self.put_vvrs_process)
             sim.add_sync_process(self.put_mem_process)
             sim.add_sync_process(self.rob_block_interrupt_process)
@@ -162,7 +173,13 @@ class TestVectorFrontend(TestCaseWithSimulator):
     def test_heavy_load(self):
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.checker)
-            sim.add_sync_process(self.input_process(lambda : self.generate_vector_instr(self.gen_params, self.layouts.verification_in, vsetvl_different_rp_id = True, const_lmul = LMUL.m8)))
+            sim.add_sync_process(
+                self.input_process(
+                    lambda: self.generate_vector_instr(
+                        self.gen_params, self.layouts.verification_in, vsetvl_different_rp_id=True, const_lmul=LMUL.m8
+                    )
+                )
+            )
             sim.add_sync_process(self.put_vvrs_process)
             sim.add_sync_process(self.put_mem_process)
             sim.add_sync_process(self.rob_block_interrupt_process)

--- a/test/fu/vector_unit/test_v_frontend.py
+++ b/test/fu/vector_unit/test_v_frontend.py
@@ -18,7 +18,8 @@ import copy
 class TestVectorFrontend(TestCaseWithSimulator):
     def setUp(self):
         random.seed(15)
-        self.test_number = 200
+        #  216 - OK, 217 NOK
+        self.test_number = 217
         self.gen_params = GenParams(test_core_config)
         self.v_params = VectorParameters(vlen = 1024, elen = 32)
         self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
@@ -59,6 +60,8 @@ class TestVectorFrontend(TestCaseWithSimulator):
         self.received_block_interrupt = deque()
         self.received_retire = deque()
         self.received_mult = deque()
+        self._robs = deque()
+        self._org_robs = deque()
         
 
     @def_method_mock(lambda self: self.exception_report)
@@ -68,11 +71,14 @@ class TestVectorFrontend(TestCaseWithSimulator):
     @def_method_mock(lambda self: self.put_vvrs)
     def put_vvrs_process(self, arg):
         self.to_dealocate.append(arg["rp_dst"]["id"])
+        #print("rob_id", arg["rob_id"])
+        self._robs.append(arg["rob_id"])
         self.received_instr.append(arg)
 
     @def_method_mock(lambda self: self.put_mem)
     def put_mem_process(self, arg):
         self.to_dealocate.append(arg["rp_dst"]["id"])
+        self._robs.append(arg["rob_id"])
         self.received_instr_mem.append(arg)
 
     @def_method_mock(lambda self: self.rob_block_interrupt)
@@ -89,19 +95,42 @@ class TestVectorFrontend(TestCaseWithSimulator):
 
 
     def input_process(self):
-        for _ in range(self.test_number):
+        for i in range(self.test_number):
             instr, vtype = self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in)
             while instr["exec_fn"]["op_type"] == OpType.V_CONTROL and instr["rp_s1"]["id"] == instr["rp_s2"]["id"]:
                 instr, vtype = self.generate_vector_instr(self.gen_params, self.v_params, self.layouts.verification_in)
+            print(i)
+            print(instr)
+            print(vtype)
             self.orginal_instr.append((instr, vtype))
+            if instr["exec_fn"]["op_type"] != OpType.V_CONTROL:
+                self._org_robs.append(instr["rob_id"])
             yield from self.circ.select.call()
             yield from self.circ.insert.call(rs_entry_id=0, rs_data = instr)
             yield from self.circ.update.call(tag = instr["rp_s1"], value = instr["s1_val"])
             yield from self.circ.update.call(tag = instr["rp_s2"], value = instr["s2_val"])
             yield from self.tick(random.randrange(3))
+        print("KONIEC WEJSCIA")
+
+    def remove_duplicates(self, lista):
+        nowa =[lista[0]]
+        for e in lista:
+            if nowa[-1]!=e:
+                nowa.append(e)
+        return nowa
+
 
     def checker(self):
         while len(self.received_mult) + len(self.received_retire) < self.test_number:
+            if (yield Now())==4900:
+                print(len(self.received_mult) , len(self.received_retire))
+                print(len(self.received_instr), len(self.received_instr_mem))
+                print(self.received_mult)
+                print(sum(self.received_mult))
+                print(self._robs)
+                print(self.remove_duplicates(self._robs)[200:])
+                print(list(self._org_robs)[200:])
+                #self.assertIterableEqual(self.remove_duplicates(self._robs), self._org_robs)
             yield
         # be sure that there is no other instructions in pipeline
         yield from self.tick(10)
@@ -135,7 +164,7 @@ class TestVectorFrontend(TestCaseWithSimulator):
             #yield from self.tick(random.randrange(3))
 
     def test_random(self):
-        with self.run_simulation(self.m, 15000) as sim:
+        with self.run_simulation(self.m, 5000) as sim:
             sim.add_sync_process(self.checker)
             sim.add_sync_process(self.input_process)
             sim.add_sync_process(self.put_vvrs_process)

--- a/test/fu/vector_unit/test_v_instruction_verification.py
+++ b/test/fu/vector_unit/test_v_instruction_verification.py
@@ -5,6 +5,7 @@ from coreblocks.params import *
 from coreblocks.params.configurations import *
 from coreblocks.fu.vector_unit.v_layouts import *
 from coreblocks.fu.vector_unit.v_input_verification import *
+from coreblocks.transactions.lib import *
 from collections import deque, defaultdict
 
 
@@ -155,7 +156,7 @@ class TestVInstructionVerification(TestCaseWithSimulator):
                     data_q_pass.append(data)
                 else:
                     data_q_fail.append(data)
-                self.tick(random.randrange(4))
+                yield from self.tick(random.randrange(4))
 
             # wait few cycles to be sure that all mocks were called
             for _ in range(2):

--- a/test/fu/vector_unit/test_v_instruction_verification.py
+++ b/test/fu/vector_unit/test_v_instruction_verification.py
@@ -12,11 +12,11 @@ from collections import deque, defaultdict
 class TestVInstructionVerification(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
-        self.gen_params = GenParams(test_core_config)
+        self.gen_params = GenParams(test_vector_core_config)
         self.test_number = 100
-        self.v_params = VectorParameters(vlen=1024, elen=32)
+        self.v_params = self.gen_params.v_params
 
-        self.vf_layout = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.vf_layout = VectorFrontendLayouts(self.gen_params)
         self.rob_block_interrupts = TestbenchIO(Adapter(i=ROBLayouts(self.gen_params).block_interrupts))
         self.put_instr = TestbenchIO(Adapter(i=self.vf_layout.verification_out))
         self.get_vill = TestbenchIO(Adapter(o=self.vf_layout.get_vill))
@@ -28,7 +28,6 @@ class TestVInstructionVerification(TestCaseWithSimulator):
         self.circ = SimpleTestCircuit(
             VectorInputVerificator(
                 self.gen_params,
-                self.v_params,
                 self.rob_block_interrupts.adapter.iface,
                 self.put_instr.adapter.iface,
                 self.get_vill.adapter.iface,

--- a/test/fu/vector_unit/test_v_status.py
+++ b/test/fu/vector_unit/test_v_status.py
@@ -8,24 +8,15 @@ from coreblocks.fu.vector_unit.utils import *
 from coreblocks.fu.vector_unit.v_status import *
 from collections import deque
 
-
-def generate_vsetvl_imm():
-    sew = random.choice(list(SEW))
-    lmul = random.choice(list(LMUL))
-    ta = random.randrange(2)
-    ma = random.randrange(2)
-    imm = ma << 7 | ta << 6 | sew << 3 | lmul
-    return imm, {
-        "sew": sew,
-        "lmul": lmul,
-        "ta": ta,
-        "ma": ma,
-    }
+def generate_vsetvl_imm(gen_params) -> tuple[int, dict]:
+    vtype = generate_vtype(gen_params)
+    imm = convert_vtype_to_imm(vtype)
+    return imm, get_dict_without(vtype, ["vl"])
 
 
 def generate_vsetvl(gen_params: GenParams, v_params: VectorParameters, layout: LayoutLike, last_vl: int):
     instr = generate_instr(gen_params, layout)
-    imm2, vtype = generate_vsetvl_imm()
+    imm2, vtype = generate_vsetvl_imm(gen_params)
     if eew_to_bits(vtype["sew"]) > v_params.elen:
         imm2 = 0
         vtype = {"sew": EEW(0), "lmul": LMUL(0), "ta": 0, "ma": 0}

--- a/test/fu/vector_unit/test_v_status.py
+++ b/test/fu/vector_unit/test_v_status.py
@@ -9,6 +9,7 @@ from coreblocks.fu.vector_unit.v_status import *
 from test.fu.vector_unit.common import *
 from collections import deque
 
+
 class TestVectorStatusUnit(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)

--- a/test/fu/vector_unit/test_v_status.py
+++ b/test/fu/vector_unit/test_v_status.py
@@ -12,16 +12,15 @@ from collections import deque
 class TestVectorStatusUnit(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
-        self.gen_params = GenParams(test_core_config)
+        self.gen_params = GenParams(test_vector_core_config)
         self.test_number = 700
-        self.v_params = VectorParameters(vlen=1024, elen=32)
 
-        self.vf_layout = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.vf_layout = VectorFrontendLayouts(self.gen_params)
         self.put_instr = TestbenchIO(Adapter(i=self.vf_layout.status_out))
         self.retire = TestbenchIO(Adapter(i=FuncUnitLayouts(self.gen_params).accept))
 
         self.circ = SimpleTestCircuit(
-            VectorStatusUnit(self.gen_params, self.v_params, self.put_instr.adapter.iface, self.retire.adapter.iface)
+            VectorStatusUnit(self.gen_params, self.put_instr.adapter.iface, self.retire.adapter.iface)
         )
 
         self.m = ModuleConnector(circ=self.circ, put_instr=self.put_instr, retire=self.retire)
@@ -45,7 +44,7 @@ class TestVectorStatusUnit(TestCaseWithSimulator):
 
         def process():
             self.assertEqual((yield from self.circ.get_vill.call())["vill"], 1)
-            instr, vtype = generate_vsetvl(self.gen_params, self.v_params, self.vf_layout.status_in, 0)
+            instr, vtype = generate_vsetvl(self.gen_params, self.vf_layout.status_in, 0)
             data_vsetvl_q.append((instr, vtype))
             yield from self.circ.issue.call(instr)
             current_vtype = vtype
@@ -57,7 +56,7 @@ class TestVectorStatusUnit(TestCaseWithSimulator):
                     data_normal_q.append((data, current_vtype))
                 else:
                     data, current_vtype = generate_vsetvl(
-                        self.gen_params, self.v_params, self.vf_layout.verification_in, current_vtype["vl"]
+                        self.gen_params, self.vf_layout.verification_in, current_vtype["vl"]
                     )
                     data_vsetvl_q.append((data, current_vtype))
                 yield from self.circ.issue.call(data)

--- a/test/fu/vector_unit/test_v_translator.py
+++ b/test/fu/vector_unit/test_v_translator.py
@@ -1,0 +1,72 @@
+import math
+from amaranth import *
+from test.common import *
+from coreblocks.fu.vector_unit.vrs import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from coreblocks.fu.vector_unit.v_layouts import *
+from coreblocks.fu.vector_unit.utils import *
+from coreblocks.fu.vector_unit.v_status import *
+from coreblocks.fu.vector_unit.v_translator import VectorTranslateLMUL
+from collections import deque
+import copy
+
+
+class TestLMULTranslator(TestCaseWithSimulator):
+    def setUp(self):
+        random.seed(14)
+        self.test_number = 50
+        self.gen_params = GenParams(test_core_config)
+        self.v_params = VectorParameters(vlen = 1024, elen = 32)
+        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.put = MethodMock(i=self.layouts.translator_in)
+        self.report_mult = MethodMock(i=self.layouts.translator_report_multiplier_in)
+        self.circ = SimpleTestCircuit(VectorTranslateLMUL(self.gen_params, self.v_params, self.put.get_method(), self.report_mult.get_method()))
+
+        self.m = ModuleConnector(circ = self.circ, put=self.put, report= self.report_mult)
+
+        self.received_instr=deque()
+        self.received_multiplier = deque()
+
+    @def_method_mock(lambda self: self.put, sched_prio = 1)
+    def put_process(self, arg):
+        self.received_instr.append(arg)
+
+    @def_method_mock(lambda self: self.report_mult, sched_prio = 1)
+    def report_mult_process(self, mult):
+        self.received_multiplier.append(mult)
+
+    def generate_expected_list(self, instr):
+        lmul = math.ceil(lmul_to_float(instr["vtype"]["lmul"]))
+        instr["rp_s1"]["id"] -= (instr["rp_s1"]["id"]%lmul)
+        instr["rp_s2"]["id"] -= (instr["rp_s2"]["id"]%lmul)
+        instr["rp_dst"]["id"] -= (instr["rp_dst"]["id"]%lmul)
+        instr["vtype"]["lmul"]=LMUL.m1 if lmul > 1 else instr["vtype"]["lmul"]
+        out = []
+        for i in range(lmul):
+            instr_new = copy.deepcopy(instr)
+            instr_new["rp_s1"]["id"] +=i
+            instr_new["rp_s2"]["id"] +=i
+            instr_new["rp_dst"]["id"] +=i
+            out.append(instr_new)
+        return out
+
+
+    def process(self):
+        for _ in range(self.test_number):
+            instr = generate_instr(self.gen_params, self.layouts.translator_in, support_vector=True)
+            yield from self.circ.issue.call(instr)
+            expected_mult = math.ceil(lmul_to_float(instr["vtype"]["lmul"]))
+            expected_list = self.generate_expected_list(instr)
+            yield from self.tick(expected_mult)
+            yield Settle()
+            self.assertEqual(expected_mult, self.received_multiplier[0])
+            self.assertIterableEqual(expected_list, self.received_instr)
+            self.received_instr.clear()
+            self.received_multiplier.clear()
+
+    def test_random(self):
+        with self.run_simulation(self.m) as sim:
+            sim.add_sync_process(self.process)
+            sim.add_sync_process(self.put_process)
+            sim.add_sync_process(self.report_mult_process)

--- a/test/fu/vector_unit/test_v_translator.py
+++ b/test/fu/vector_unit/test_v_translator.py
@@ -16,11 +16,10 @@ class TestLMULTranslator(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
         self.test_number = 50
-        self.gen_params = GenParams(test_core_config)
-        self.v_params = VectorParameters(vlen = 1024, elen = 32)
-        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.gen_params = GenParams(test_vector_core_config)
+        self.layouts = VectorFrontendLayouts(self.gen_params)
         self.put = MethodMock(i=self.layouts.translator_inner)
-        self.circ = SimpleTestCircuit(VectorTranslateLMUL(self.gen_params, self.v_params, self.put.get_method()))
+        self.circ = SimpleTestCircuit(VectorTranslateLMUL(self.gen_params, self.put.get_method()))
 
         self.m = ModuleConnector(circ = self.circ, put=self.put)
 
@@ -83,11 +82,10 @@ class TestVectorTranslateRS3(TestCaseWithSimulator):
     def setUp(self):
         random.seed(14)
         self.test_number = 50
-        self.gen_params = GenParams(test_core_config)
-        self.v_params = VectorParameters(vlen = 1024, elen = 32)
-        self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
+        self.gen_params = GenParams(test_vector_core_config)
+        self.layouts = VectorFrontendLayouts(self.gen_params)
         self.put = MethodMock(i=self.layouts.translator_out)
-        self.circ = SimpleTestCircuit(VectorTranslateRS3(self.gen_params, self.v_params, self.put.get_method()))
+        self.circ = SimpleTestCircuit(VectorTranslateRS3(self.gen_params, self.put.get_method()))
 
         self.m = ModuleConnector(circ = self.circ, put=self.put)
 

--- a/test/fu/vector_unit/test_v_translator.py
+++ b/test/fu/vector_unit/test_v_translator.py
@@ -19,7 +19,7 @@ class TestLMULTranslator(TestCaseWithSimulator):
         self.gen_params = GenParams(test_core_config)
         self.v_params = VectorParameters(vlen = 1024, elen = 32)
         self.layouts = VectorFrontendLayouts(self.gen_params, self.v_params)
-        self.put = MethodMock(i=self.layouts.translator_in)
+        self.put = MethodMock(i=self.layouts.translator_inner)
         self.circ = SimpleTestCircuit(VectorTranslateLMUL(self.gen_params, self.v_params, self.put.get_method()))
 
         self.m = ModuleConnector(circ = self.circ, put=self.put)
@@ -48,7 +48,7 @@ class TestLMULTranslator(TestCaseWithSimulator):
 
     def process(self):
         for _ in range(self.test_number):
-            instr = generate_instr(self.gen_params, self.layouts.translator_in, support_vector=True)
+            instr = generate_instr(self.gen_params, self.layouts.translator_inner, support_vector=True)
             received_mult = (yield from self.circ.issue.call(instr))["mult"]
             expected_mult = math.ceil(lmul_to_float(instr["vtype"]["lmul"]))
             expected_list = self.generate_expected_list(instr)
@@ -86,7 +86,7 @@ class TestVectorTranslateRS3(TestCaseWithSimulator):
 
     def process(self):
         for _ in range(self.test_number):
-            instr = generate_instr(self.gen_params, self.layouts.translator_in, support_vector=True)
+            instr = generate_instr(self.gen_params, self.layouts.translator_inner, support_vector=True)
             yield from self.circ.issue.call(instr)
             expected_instr = self.generate_expected_instr(instr)
             yield Settle()

--- a/test/fu/vector_unit/test_v_translator.py
+++ b/test/fu/vector_unit/test_v_translator.py
@@ -1,4 +1,3 @@
-import math
 from amaranth import *
 from test.common import *
 from coreblocks.fu.vector_unit.vrs import *
@@ -9,8 +8,8 @@ from coreblocks.fu.vector_unit.utils import *
 from coreblocks.fu.vector_unit.v_status import *
 from coreblocks.fu.vector_unit.v_translator import VectorTranslateLMUL, VectorTranslateRS3
 from collections import deque
-from parameterized import parameterized_class
 import copy
+
 
 class TestLMULTranslator(TestCaseWithSimulator):
     def setUp(self):
@@ -21,29 +20,28 @@ class TestLMULTranslator(TestCaseWithSimulator):
         self.put = MethodMock(i=self.layouts.translator_inner)
         self.circ = SimpleTestCircuit(VectorTranslateLMUL(self.gen_params, self.put.get_method()))
 
-        self.m = ModuleConnector(circ = self.circ, put=self.put)
+        self.m = ModuleConnector(circ=self.circ, put=self.put)
 
-        self.received_instr=deque()
+        self.received_instr = deque()
 
-    @def_method_mock(lambda self: self.put, sched_prio = 1, enable = lambda self: self.mock_enable())
+    @def_method_mock(lambda self: self.put, sched_prio=1, enable=lambda self: self.mock_enable())
     def put_process(self, arg):
         self.received_instr.append(arg)
 
     def generate_expected_list(self, instr):
         lmul = lmul_to_int(instr["vtype"]["lmul"])
-        instr["rp_s1"]["id"] -= (instr["rp_s1"]["id"]%lmul)
-        instr["rp_s2"]["id"] -= (instr["rp_s2"]["id"]%lmul)
-        instr["rp_dst"]["id"] -= (instr["rp_dst"]["id"]%lmul)
-        instr["vtype"]["lmul"]=LMUL.m1 if lmul > 1 else instr["vtype"]["lmul"]
+        instr["rp_s1"]["id"] -= instr["rp_s1"]["id"] % lmul
+        instr["rp_s2"]["id"] -= instr["rp_s2"]["id"] % lmul
+        instr["rp_dst"]["id"] -= instr["rp_dst"]["id"] % lmul
+        instr["vtype"]["lmul"] = LMUL.m1 if lmul > 1 else instr["vtype"]["lmul"]
         out = []
         for i in range(lmul):
             instr_new = copy.deepcopy(instr)
-            instr_new["rp_s1"]["id"] +=i
-            instr_new["rp_s2"]["id"] +=i
-            instr_new["rp_dst"]["id"] +=i
+            instr_new["rp_s1"]["id"] += i
+            instr_new["rp_s2"]["id"] += i
+            instr_new["rp_dst"]["id"] += i
             out.append(instr_new)
         return out
-
 
     def process(self, waiter):
         def f():
@@ -57,6 +55,7 @@ class TestLMULTranslator(TestCaseWithSimulator):
                 self.assertEqual(expected_mult, received_mult)
                 self.assertIterableEqual(expected_list, self.received_instr)
                 self.received_instr.clear()
+
         return f
 
     def waiter_in_pipeline(self, expected_mult):
@@ -73,10 +72,11 @@ class TestLMULTranslator(TestCaseWithSimulator):
             sim.add_sync_process(self.put_process)
 
     def test_random(self):
-        self.mock_enable = lambda : random.random()<0.1
+        self.mock_enable = lambda: random.random() < 0.1
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.process(self.waiter_in_random))
             sim.add_sync_process(self.put_process)
+
 
 class TestVectorTranslateRS3(TestCaseWithSimulator):
     def setUp(self):
@@ -87,16 +87,16 @@ class TestVectorTranslateRS3(TestCaseWithSimulator):
         self.put = MethodMock(i=self.layouts.translator_out)
         self.circ = SimpleTestCircuit(VectorTranslateRS3(self.gen_params, self.put.get_method()))
 
-        self.m = ModuleConnector(circ = self.circ, put=self.put)
+        self.m = ModuleConnector(circ=self.circ, put=self.put)
 
-        self.received_instr=deque()
+        self.received_instr = deque()
 
-    @def_method_mock(lambda self: self.put, sched_prio = 1)
+    @def_method_mock(lambda self: self.put, sched_prio=1)
     def put_process(self, arg):
         self.received_instr.append(arg)
 
     def generate_expected_instr(self, instr):
-        return instr | {"rp_s3" : instr["rp_dst"], "rp_v0" : {"id" : 0}}
+        return instr | {"rp_s3": instr["rp_dst"], "rp_v0": {"id": 0}}
 
     def process(self):
         for _ in range(self.test_number):

--- a/test/fu/vector_unit/test_vrf.py
+++ b/test/fu/vector_unit/test_vrf.py
@@ -38,7 +38,11 @@ class TestVRFFragment(TestCaseWithSimulator):
     wait_chance: float
 
     def setUp(self):
-        gp = GenParams(test_vector_core_config.replace(vector_config = VectorUnitConfiguration(vlen=128, elen=32, vrp_count=8, register_bank_count=1)))
+        gp = GenParams(
+            test_vector_core_config.replace(
+                vector_config=VectorUnitConfiguration(vlen=128, elen=32, vrp_count=8, register_bank_count=1)
+            )
+        )
         self.vp = gp.v_params
         self.circ = SimpleTestCircuit(VRFFragment(gen_params=gp))
         self.read_port_count = 3

--- a/test/fu/vector_unit/test_vrf.py
+++ b/test/fu/vector_unit/test_vrf.py
@@ -38,9 +38,9 @@ class TestVRFFragment(TestCaseWithSimulator):
     wait_chance: float
 
     def setUp(self):
-        gp = GenParams(test_core_config)
-        self.vp = VectorParameters(vlen=128, elen=32, vrp_count=8, register_bank_count=1)
-        self.circ = SimpleTestCircuit(VRFFragment(gen_params=gp, v_params=self.vp))
+        gp = GenParams(test_vector_core_config.replace(vector_config = VectorUnitConfiguration(vlen=128, elen=32, vrp_count=8, register_bank_count=1)))
+        self.vp = gp.v_params
+        self.circ = SimpleTestCircuit(VRFFragment(gen_params=gp))
         self.read_port_count = 3
 
         self.test_number = 100

--- a/test/fu/vector_unit/test_vrs.py
+++ b/test/fu/vector_unit/test_vrs.py
@@ -31,7 +31,7 @@ class TestVXRS(TestCaseWithSimulator):
 
     def generate_input(self):
         input = []
-        for i in range(self.rs_entries):
+        for i in range(self.rs_entries - 1):
             data = generate_instr(
                 self.gen_params,
                 VectorXRSLayout(self.gen_params, rs_entries_bits=bits_for(self.rs_entries - 1)).data_layout,
@@ -73,7 +73,7 @@ class TestVXRS(TestCaseWithSimulator):
     def process(self, input):
         def f():
             yield from self.insert_input(input)
-            for id in range(self.rs_entries):
+            for id in range(self.rs_entries - 1):
                 instr = input[id]
                 self.assertTrue((yield self.circ._dut.data[id].rec_full))
                 yield from self.assert_ready(self.circ._dut.data[id], instr)

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -87,7 +87,8 @@ class SchedulerTestCircuit(Elaboratable):
         m.submodules.scheduler = self.scheduler = Scheduler(
             get_instr=instr_fifo.read,
             get_free_reg=free_rf_fifo.read,
-            rat_rename=rat.rename,
+            rat_get_rename=rat.get_rename_list[0],
+            rat_set_rename=rat.set_rename_list[0],
             rob_put=self.rob.put,
             rf_read1=self.rf.read1,
             rf_read2=self.rf.read2,

--- a/test/structs_common/test_rat.py
+++ b/test/structs_common/test_rat.py
@@ -24,9 +24,16 @@ class TestFRAT(TestCaseWithSimulator):
                 rp_dst = generate_phys_register_id(gen_params=self.gen_params)
                 cycle = yield Now()
                 rl_dst = self.unique_rl_dst_generator(cycle, lambda: generate_l_register_id(gen_params=self.gen_params))
-                req = {"rl_s1": rl_s1, "rl_s2": rl_s2, "rl_dst": rl_dst, "rp_dst": rp_dst}
+                req_get = {"rl_s1": rl_s1, "rl_s2": rl_s2}
+                req_set = {"rl_dst": rl_dst, "rp_dst": rp_dst}
 
-                resp = yield from self.circ.rename_list[k].call(req)
+                yield from self.circ.get_rename_list[k].call_init(req_get)
+                yield from self.circ.set_rename_list[k].call_init(req_set)
+                yield
+                resp = yield from self.circ.get_rename_list[k].call_result()
+                yield from self.circ.get_rename_list[k].disable()
+                yield from self.circ.set_rename_list[k].disable()
+
                 self.assertIsNotNone(resp)
 
                 if rl_s1 in self.virtual_rat:

--- a/test/structs_common/test_rat.py
+++ b/test/structs_common/test_rat.py
@@ -37,7 +37,7 @@ class TestFRAT(TestCaseWithSimulator):
                 yield Settle()
                 self.virtual_rat[rl_dst] = rp_dst
 
-                self.tick(random.randrange(2))
+                yield from self.tick(random.randrange(2))
 
         return f
 
@@ -74,7 +74,7 @@ class TestRRAT(TestCaseWithSimulator):
                 yield Settle()
                 self.virtual_rat[rl_dst] = rp_dst
 
-                self.tick(random.randrange(2))
+                yield from self.tick(random.randrange(2))
 
         return f
 

--- a/test/structs_common/test_rs.py
+++ b/test/structs_common/test_rs.py
@@ -398,8 +398,9 @@ class TestLayout(RSLayoutProtocol):
 
 @parameterized_class(["wait_time_consumer", "wait_time_inserter"], itertools.product([1, 5], [1, 5]))
 class TestFifoRS(TestCaseWithSimulator):
-    wait_time_consumer : int
-    wait_time_inserter : int
+    wait_time_consumer: int
+    wait_time_inserter: int
+
     def rec_ready_setter(self):
         def f(self_dut: FifoRS, m: TModule):
             for record in self_dut.data:

--- a/test/structs_common/test_rs.py
+++ b/test/structs_common/test_rs.py
@@ -1,7 +1,9 @@
+import itertools
 from typing import Iterable, Optional
 from collections import deque
 from amaranth import Elaboratable, Module
 from amaranth.sim import Settle
+from parameterized import parameterized_class
 
 from coreblocks.transactions.lib import AdapterTrans
 from coreblocks.transactions import TModule
@@ -394,7 +396,10 @@ class TestLayout(RSLayoutProtocol):
         self.get_ready_list_out = [("ready_list", 8)]
 
 
+@parameterized_class(["wait_time_consumer", "wait_time_inserter"], itertools.product([1, 5], [1, 5]))
 class TestFifoRS(TestCaseWithSimulator):
+    wait_time_consumer : int
+    wait_time_inserter : int
     def rec_ready_setter(self):
         def f(self_dut: FifoRS, m: TModule):
             for record in self_dut.data:
@@ -417,12 +422,14 @@ class TestFifoRS(TestCaseWithSimulator):
             data = generate_based_on_layout(self.layouts.data_layout)
             yield from self.circ.insert.call(rs_data=data, rs_entry_id=0)
             self.data_queue.append(data)
+            yield from self.tick(random.randrange(self.wait_time_inserter))
 
     def consumer(self):
         for _ in range(self.test_number):
             data = yield from self.circ.take.call(rs_entry_id=0)
             data_expected = self.data_queue.popleft()
             self.assertEqual(data, data_expected)
+            yield from self.tick(random.randrange(self.wait_time_consumer))
 
     def test(self):
         with self.run_simulation(self.circ, 2000) as sim:

--- a/test/structs_common/test_scoreboard.py
+++ b/test/structs_common/test_scoreboard.py
@@ -2,8 +2,8 @@ from amaranth import *
 from test.common import *
 from coreblocks.params import *
 from coreblocks.params.configurations import *
-from collections import deque
 from coreblocks.structs_common.scoreboard import *
+
 
 class TestScoreboard(TestCaseWithSimulator):
     def setUp(self):
@@ -27,8 +27,8 @@ class TestScoreboard(TestCaseWithSimulator):
                 yield Settle()
                 self.virtual_scoreboard[id] = new_dirty
                 yield from self.tick(random.randrange(3))
-        return f
 
+        return f
 
     def test_random(self):
         with self.run_simulation(self.circ) as sim:
@@ -36,8 +36,8 @@ class TestScoreboard(TestCaseWithSimulator):
                 sim.add_sync_process(self.create_process(k))
 
     def conflict_process(self):
-        yield from self.circ.set_dirty_list[0].call_init(id=0, dirty = 0)
-        yield from self.circ.set_dirty_list[1].call_init(id=0, dirty = 0)
+        yield from self.circ.set_dirty_list[0].call_init(id=0, dirty=0)
+        yield from self.circ.set_dirty_list[1].call_init(id=0, dirty=0)
         yield Settle()
         yield
         self.assertEqual((yield from self.circ.set_dirty_list[0].done()), 1)

--- a/test/structs_common/test_scoreboard.py
+++ b/test/structs_common/test_scoreboard.py
@@ -26,7 +26,7 @@ class TestScoreboard(TestCaseWithSimulator):
                 yield from self.circ.set_dirty_list[k].call(id=id, dirty=new_dirty)
                 yield Settle()
                 self.virtual_scoreboard[id] = new_dirty
-                self.tick(random.randrange(3))
+                yield from self.tick(random.randrange(3))
         return f
 
 

--- a/test/structs_common/test_scoreboard.py
+++ b/test/structs_common/test_scoreboard.py
@@ -1,0 +1,48 @@
+from amaranth import *
+from test.common import *
+from coreblocks.params import *
+from coreblocks.params.configurations import *
+from collections import deque
+from coreblocks.structs_common.scoreboard import *
+
+class TestScoreboard(TestCaseWithSimulator):
+    def setUp(self):
+        random.seed(14)
+
+        self.test_number = 50
+        self.entries_count = 9
+        self.superscalarity = 4
+        self.circ = SimpleTestCircuit(Scoreboard(self.entries_count, self.superscalarity))
+
+        self.virtual_scoreboard = defaultdict(int)
+
+    def create_process(self, k):
+        def f():
+            for _ in range(self.test_number):
+                id = random.randrange(self.entries_count)
+                dirty = yield from self.circ.get_dirty_list[k].call(id=id)
+                self.assertEqual(dirty["dirty"], self.virtual_scoreboard[id])
+                new_dirty = random.randrange(2)
+                yield from self.circ.set_dirty_list[k].call(id=id, dirty=new_dirty)
+                yield Settle()
+                self.virtual_scoreboard[id] = new_dirty
+                self.tick(random.randrange(3))
+        return f
+
+
+    def test_random(self):
+        with self.run_simulation(self.circ) as sim:
+            for k in range(self.superscalarity):
+                sim.add_sync_process(self.create_process(k))
+
+    def conflict_process(self):
+        yield from self.circ.set_dirty_list[0].call_init(id=0, dirty = 0)
+        yield from self.circ.set_dirty_list[1].call_init(id=0, dirty = 0)
+        yield Settle()
+        yield
+        self.assertEqual((yield from self.circ.set_dirty_list[0].done()), 1)
+        self.assertEqual((yield from self.circ.set_dirty_list[1].done()), 0)
+
+    def test_conflict(self):
+        with self.run_simulation(self.circ) as sim:
+            sim.add_sync_process(self.conflict_process)

--- a/test/structs_common/test_superscalar_freerf.py
+++ b/test/structs_common/test_superscalar_freerf.py
@@ -7,9 +7,11 @@ from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
 from collections import deque
 from parameterized import parameterized_class
 
+
 @parameterized_class(["outputs_count"], [(1,), (2,), (3,), (4,), (5,)])
 class TestSuperscalarFreeRF(TestCaseWithSimulator):
-    outputs_count : int
+    outputs_count: int
+
     def setUp(self):
         random.seed(14)
         self.entries_count = 21

--- a/test/structs_common/test_superscalar_freerf.py
+++ b/test/structs_common/test_superscalar_freerf.py
@@ -5,13 +5,14 @@ from coreblocks.params import *
 from coreblocks.params.configurations import *
 from coreblocks.structs_common.superscalar_freerf import SuperscalarFreeRF
 from collections import deque
+from parameterized import parameterized_class
 
-
+@parameterized_class(["outputs_count"], [(1,), (2,), (3,), (4,), (5,)])
 class TestSuperscalarFreeRF(TestCaseWithSimulator):
+    outputs_count : int
     def setUp(self):
         random.seed(14)
         self.entries_count = 21
-        self.outputs_count = 4
         self.test_cycles = 50
 
         self.circ = SimpleTestCircuit(SuperscalarFreeRF(self.entries_count, self.outputs_count))

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -1000,9 +1000,12 @@ class TestRegisterPipe(TestCaseWithSimulator):
                 sim.add_sync_process(self.output_process(k))
 
 
-@parameterized_class("transparent", [(True,), (False,)])
+@parameterized_class(["transparent", "mock_enable"], 
+                     itertools.product([True, False], [lambda _: True, lambda _: random.random()<0.1])
+                     )
 class TestShiftRegister(TestCaseWithSimulator):
     transparent : bool
+    mock_enable : Callable
     def setUp(self):
         self.test_number = 50
         self.input_width = 8
@@ -1018,7 +1021,7 @@ class TestShiftRegister(TestCaseWithSimulator):
         self.received_data=deque()
         self.expected_data = deque()
 
-    @def_method_mock(lambda self: self.put)
+    @def_method_mock(lambda self: self.put, enable = lambda self: self.mock_enable())
     def put_process(self, data):
         self.received_data.append(data)
 

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -964,7 +964,6 @@ class TestRegisterPipe(TestCaseWithSimulator):
             for _ in range(self.test_number):
                 while True:
                     val = random.randrange(2**self.data_width)
-                    print(k, self.virtual_regs, (yield Now()))
                     yield Settle()
                     if all( (reg is None) or try_read for reg,try_read in zip(self.virtual_regs, self.try_read)):
                         ret = yield from self.circ.write_list[k].call_try(data=val)
@@ -992,11 +991,9 @@ class TestRegisterPipe(TestCaseWithSimulator):
                         break
                 self.try_read[k]=False
                 yield from self.tick(random.randrange(3))
-                print((yield Now()))
         return f
 
     def test_random(self):
-        print()
         with self.run_simulation(self.circ) as sim:
             for k in range(self.channels):
                 sim.add_sync_process(self.input_process(k))

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -97,7 +97,7 @@ class CLZTestCircuit(Elaboratable):
 
 @parameterized_class(
     ("name", "size"),
-    [("size" + str(s), s) for s in [1,2,4,8,16,32,3,5,13,42,111]],
+    [("size" + str(s), s) for s in [1, 2, 4, 8, 16, 32, 3, 5, 13, 42, 111]],
 )
 class TestCountLeadingZeros(TestCaseWithSimulator):
     size: int
@@ -142,7 +142,7 @@ class CTZTestCircuit(Elaboratable):
 
 @parameterized_class(
     ("name", "size"),
-    [("size" + str(s), s) for s in [1,2,4,8,16,32,3,5,13,42,111]],
+    [("size" + str(s), s) for s in [1, 2, 4, 8, 16, 32, 3, 5, 13, 42, 111]],
 )
 class TestCountTrailingZeros(TestCaseWithSimulator):
     size: int

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -224,26 +224,31 @@ class TestPriorityUniqnessChecker(TestCaseWithSimulator):
         self.input_count = 9
         self.circ = PriorityUniqnessChecker(self.input_count, self.input_width)
 
-    def generate_mask(self, vals):
+    def generate_mask(self, vals, inputs_valid):
         s = set()
         valids = []
-        for v in vals:
+        for v, in_valid in zip(vals, inputs_valid):
             valids.append(int(v not in s))
-            s.add(v)
+            if in_valid:
+                s.add(v)
         return valids
 
     def input_process(self):
         for _ in range(self.test_number):
             inputs = []
+            inputs_valid = []
             for k in range(self.input_count):
                 val = random.randrange(2**self.input_width)
+                in_valid = random.randrange(2)
                 inputs.append(val)
+                inputs_valid.append(in_valid)
                 yield self.circ.inputs[k].eq(val)
+                yield self.circ.input_valids[k].eq(in_valid)
             yield Settle()
             result = []
             for i in range(self.input_count):
                 result.append((yield self.circ.valids[i]))
-            self.assertListEqual(self.generate_mask(inputs), result)
+            self.assertListEqual(self.generate_mask(inputs, inputs_valid), result)
 
     def test_random(self):
         with self.run_simulation(self.circ) as sim:

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -80,10 +80,9 @@ class TestPopcount(TestCaseWithSimulator):
 
 
 class CLZTestCircuit(Elaboratable):
-    def __init__(self, xlen_log: int):
-        self.sig_in = Signal(1 << xlen_log)
-        self.sig_out = Signal(xlen_log + 1)
-        self.xlen_log = xlen_log
+    def __init__(self, xlen: int):
+        self.sig_in = Signal(xlen)
+        self.sig_out = Signal(xlen + 1)
 
     def elaborate(self, platform):
         m = Module()
@@ -98,7 +97,7 @@ class CLZTestCircuit(Elaboratable):
 
 @parameterized_class(
     ("name", "size"),
-    [("size" + str(s), s) for s in range(1, 7)],
+    [("size" + str(s), s) for s in [1,2,4,8,16,32,3,5,13,42,111]],
 )
 class TestCountLeadingZeros(TestCaseWithSimulator):
     size: int
@@ -112,7 +111,7 @@ class TestCountLeadingZeros(TestCaseWithSimulator):
         yield self.m.sig_in.eq(n)
         yield Settle()
         out_clz = yield self.m.sig_out
-        self.assertEqual(out_clz, (2**self.size) - n.bit_length(), f"{n:x}")
+        self.assertEqual(out_clz, self.size - n.bit_length(), f"{n:x}")
 
     def process(self):
         for i in range(self.test_number):
@@ -126,10 +125,9 @@ class TestCountLeadingZeros(TestCaseWithSimulator):
 
 
 class CTZTestCircuit(Elaboratable):
-    def __init__(self, xlen_log: int):
-        self.sig_in = Signal(1 << xlen_log)
-        self.sig_out = Signal(xlen_log + 1)
-        self.xlen_log = xlen_log
+    def __init__(self, xlen: int):
+        self.sig_in = Signal(xlen)
+        self.sig_out = Signal(xlen + 1)
 
     def elaborate(self, platform):
         m = Module()
@@ -144,7 +142,7 @@ class CTZTestCircuit(Elaboratable):
 
 @parameterized_class(
     ("name", "size"),
-    [("size" + str(s), s) for s in range(1, 7)],
+    [("size" + str(s), s) for s in [1,2,4,8,16,32,3,5,13,42,111]],
 )
 class TestCountTrailingZeros(TestCaseWithSimulator):
     size: int
@@ -161,7 +159,7 @@ class TestCountTrailingZeros(TestCaseWithSimulator):
 
         expected = 0
         if n == 0:
-            expected = 2**self.size
+            expected = self.size
         else:
             while (n & 1) == 0:
                 expected += 1


### PR DESCRIPTION
Here is a second part of vector frontend implementation where I take all modules implemented in #417 and connect them into one block similar to `Scheduler`. Data are now correctly delivered from integer scheduler to vector reservation station. Next step will be to prepare backend to which these instructions will be put and next executed.

Added:
- VectorAllocRename
- VectorFrontend
- VectorMemoryVVRSSpliter
- VectorTranslators (main block and EEW, LMUL, RP3, IMM)
- VVRS
- Scoreboard
- Register
- RegisterPipe
- ShiftRegister
- PriorityUniqnessChecker

Rework of vector configuration:
- Added VectorUnitConfiguration class
- added VectorParameters as field in GenParams

Miscellany:
- MethodBrancherIn (syntax sugar for calling methods under different branches of `m.If`)
- NotMethod (to workaround problems with single_caller and SimpleTestCircuit)
- MethodMock class (wrapper over `TestbenchIO(Adapter())`