### PR TITLE
Use all available cores when compiling cocotb regression tests with verilator

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -54,7 +54,8 @@ def load_regression_tests() -> list[str]:
 
 
 def run_regressions_with_cocotb(tests: list[str], traces: bool) -> bool:
-    arglist = ["make", "-C", "test/regression/cocotb", "-f", "test.Makefile"]
+    cpu_count = len(os.sched_getaffinity(0))
+    arglist = ["make", "-C", "test/regression/cocotb", "-f", "test.Makefile", f"-j{cpu_count}"]
 
     test_cases = ",".join(tests)
     arglist += [f"TESTCASE={test_cases}"]


### PR DESCRIPTION
I had to run cocotb tests locally and this bugged me (as I am a spoiled 12-core cpu user). Not sure how many cores github CI runners have available but if it's more than one, then this should also help speed up the CI flow.