### PR TITLE
Improve GenericFunctionalTestUnit

### DIFF
--- a/test/fu/functional_common.py
+++ b/test/fu/functional_common.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict, dataclass
 from itertools import product
 import random
 from collections import deque
@@ -10,8 +11,10 @@ from coreblocks.params import GenParams
 from coreblocks.params.configurations import test_core_config
 from coreblocks.params.dependencies import DependencyManager
 from coreblocks.params.fu_params import FunctionalComponentParams
+from coreblocks.params.isa import Funct3, Funct7
 from coreblocks.params.keys import ExceptionReportKey
 from coreblocks.params.layouts import ExceptionRegisterLayouts
+from coreblocks.params.optypes import OpType
 from coreblocks.transactions.lib import AdapterTrans, Adapter
 from test.common import RecordIntDict, RecordIntDictRet, TestbenchIO, TestCaseWithSimulator
 
@@ -49,6 +52,13 @@ class FunctionalTestCircuit(Elaboratable):
         return m
 
 
+@dataclass
+class ExecFn:
+    op_type: OpType
+    funct3: Funct3 = Funct3.ADD
+    funct7: Funct7 = Funct7.ADD
+
+
 _T = TypeVar("_T")
 
 
@@ -59,7 +69,7 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
 
     Attributes
     ----------
-    operations: dict[_T, dict]
+    operations: dict[_T, ExecFn]
         List of operations performed by this unit.
     func_unit: FunctionalComponentParams
         Unit parameters for the unit instantiated.
@@ -73,7 +83,7 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
         Core generation parameters.
     """
 
-    ops: dict[_T, RecordIntDict]
+    ops: dict[_T, ExecFn]
     func_unit: FunctionalComponentParams
     number_of_tests = 50
     seed = 40
@@ -130,7 +140,7 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
                     "s1_val": data1,
                     "s2_val": 0 if data2_is_imm and self.zero_imm else data2,
                     "rob_id": rob_id,
-                    "exec_fn": exec_fn,
+                    "exec_fn": asdict(exec_fn),
                     "rp_dst": rp_dst,
                     "imm": data_imm if not self.zero_imm else data2 if data2_is_imm else 0,
                     "pc": pc,

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -13,225 +13,221 @@ from amaranth.sim import *
 from coreblocks.transactions import *
 from coreblocks.transactions.lib import *
 
-from ..common import RecordIntDict, TestCaseWithSimulator, TestbenchIO
+from ..common import TestCaseWithSimulator, TestbenchIO
 from test.common import signed_to_int
-
-
-@staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: AluFn.Fn, xlen: int) -> dict[str, int]:
-    val2 = i_imm if i_imm else i2
-    mask = (1 << xlen) - 1
-
-    res = 0
-
-    match fn:
-        case AluFn.Fn.ADD:
-            res = i1 + val2
-        case AluFn.Fn.SUB:
-            res = i1 - val2
-        case AluFn.Fn.XOR:
-            res = i1 ^ val2
-        case AluFn.Fn.OR:
-            res = i1 | val2
-        case AluFn.Fn.AND:
-            res = i1 & val2
-        case AluFn.Fn.SLT:
-            res = signed_to_int(i1, xlen) < signed_to_int(val2, xlen)
-        case AluFn.Fn.SLTU:
-            res = i1 < val2
-        case AluFn.Fn.SH1ADD:
-            res = (i1 << 1) + val2
-        case AluFn.Fn.SH2ADD:
-            res = (i1 << 2) + val2
-        case AluFn.Fn.SH3ADD:
-            res = (i1 << 3) + val2
-        case AluFn.Fn.ANDN:
-            res = i1 & ~val2
-        case AluFn.Fn.XNOR:
-            res = ~(i1 ^ val2)
-        case AluFn.Fn.ORN:
-            res = i1 | ~val2
-        case AluFn.Fn.MAX:
-            res = max(signed_to_int(i1, xlen), signed_to_int(val2, xlen))
-        case AluFn.Fn.MAXU:
-            res = max(i1, val2)
-        case AluFn.Fn.MIN:
-            res = min(signed_to_int(i1, xlen), signed_to_int(val2, xlen))
-        case AluFn.Fn.MINU:
-            res = min(i1, val2)
-        case AluFn.Fn.CPOP:
-            res = i1.bit_count()
-        case AluFn.Fn.SEXTH:
-            bit = (i1 >> 15) & 1
-            if bit:
-                res = i1 | (mask ^ 0xFFFF)
-            else:
-                res = i1 & 0xFFFF
-        case AluFn.Fn.SEXTB:
-            bit = (i1 >> 7) & 1
-            if bit:
-                res = i1 | (mask ^ 0xFF)
-            else:
-                res = i1 & 0xFF
-        case AluFn.Fn.ZEXTH:
-            res = i1 & 0xFFFF
-        case AluFn.Fn.ORCB:
-            i1 |= i1 >> 1
-            i1 |= i1 >> 2
-            i1 |= i1 >> 4
-
-            i1 &= 0x010101010101010101
-
-            for i in range(8):
-                res |= i1 << i
-        case AluFn.Fn.REV8:
-            for i in range(xlen // 8):
-                res = (res << 8) | (i1 & 0xFF)
-                i1 >>= 8  # Haskell screams in pain
-        case AluFn.Fn.CLZ:
-            res = xlen - i1.bit_length()
-        case AluFn.Fn.CTZ:
-            if i1 == 0:
-                res = xlen.bit_length()
-            else:
-                while (i1 & 1) == 0:
-                    res += 1
-                    i1 >>= 1
-
-    return {"result": res & mask}
-
-
-ops: dict[AluFn.Fn, RecordIntDict] = {
-    AluFn.Fn.ADD: {
-        "op_type": OpType.ARITHMETIC,
-        "funct3": Funct3.ADD,
-        "funct7": Funct7.ADD,
-    },
-    AluFn.Fn.SUB: {
-        "op_type": OpType.ARITHMETIC,
-        "funct3": Funct3.ADD,
-        "funct7": Funct7.SUB,
-    },
-    AluFn.Fn.SLT: {
-        "op_type": OpType.COMPARE,
-        "funct3": Funct3.SLT,
-    },
-    AluFn.Fn.SLTU: {
-        "op_type": OpType.COMPARE,
-        "funct3": Funct3.SLTU,
-    },
-    AluFn.Fn.XOR: {
-        "op_type": OpType.LOGIC,
-        "funct3": Funct3.XOR,
-    },
-    AluFn.Fn.OR: {
-        "op_type": OpType.LOGIC,
-        "funct3": Funct3.OR,
-    },
-    AluFn.Fn.AND: {
-        "op_type": OpType.LOGIC,
-        "funct3": Funct3.AND,
-    },
-    AluFn.Fn.SH1ADD: {
-        "op_type": OpType.ADDRESS_GENERATION,
-        "funct3": Funct3.SH1ADD,
-        "funct7": Funct7.SH1ADD,
-    },
-    AluFn.Fn.SH2ADD: {
-        "op_type": OpType.ADDRESS_GENERATION,
-        "funct3": Funct3.SH2ADD,
-        "funct7": Funct7.SH2ADD,
-    },
-    AluFn.Fn.SH3ADD: {
-        "op_type": OpType.ADDRESS_GENERATION,
-        "funct3": Funct3.SH3ADD,
-        "funct7": Funct7.SH3ADD,
-    },
-    AluFn.Fn.ANDN: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.ANDN,
-        "funct7": Funct7.ANDN,
-    },
-    AluFn.Fn.XNOR: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.XNOR,
-        "funct7": Funct7.XNOR,
-    },
-    AluFn.Fn.ORN: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.ORN,
-        "funct7": Funct7.ORN,
-    },
-    AluFn.Fn.MAX: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.MAX,
-        "funct7": Funct7.MAX,
-    },
-    AluFn.Fn.MAXU: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.MAXU,
-        "funct7": Funct7.MAX,
-    },
-    AluFn.Fn.MIN: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.MIN,
-        "funct7": Funct7.MIN,
-    },
-    AluFn.Fn.MINU: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.MINU,
-        "funct7": Funct7.MIN,
-    },
-    AluFn.Fn.CPOP: {
-        "op_type": OpType.UNARY_BIT_MANIPULATION_5,
-        "funct3": Funct3.CPOP,
-        "funct7": Funct7.CPOP,
-    },
-    AluFn.Fn.SEXTB: {
-        "op_type": OpType.UNARY_BIT_MANIPULATION_1,
-        "funct3": Funct3.SEXTB,
-        "funct7": Funct7.SEXTB,
-    },
-    AluFn.Fn.ZEXTH: {
-        "op_type": OpType.UNARY_BIT_MANIPULATION_1,
-        "funct3": Funct3.ZEXTH,
-        "funct7": Funct7.ZEXTH,
-    },
-    AluFn.Fn.SEXTH: {
-        "op_type": OpType.UNARY_BIT_MANIPULATION_2,
-        "funct3": Funct3.SEXTH,
-        "funct7": Funct7.SEXTH,
-    },
-    AluFn.Fn.ORCB: {
-        "op_type": OpType.UNARY_BIT_MANIPULATION_1,
-        "funct3": Funct3.ORCB,
-        "funct7": Funct7.ORCB,
-    },
-    AluFn.Fn.REV8: {
-        "op_type": OpType.UNARY_BIT_MANIPULATION_1,
-        "funct3": Funct3.REV8,
-        "funct7": Funct7.REV8,
-    },
-    AluFn.Fn.CLZ: {
-        "op_type": OpType.UNARY_BIT_MANIPULATION_3,
-        "funct3": Funct3.CLZ,
-        "funct7": Funct7.CLZ,
-    },
-    AluFn.Fn.CTZ: {
-        "op_type": OpType.UNARY_BIT_MANIPULATION_4,
-        "funct3": Funct3.CTZ,
-        "funct7": Funct7.CTZ,
-    },
-}
 
 
 class AluUnitTest(FunctionalUnitTestCase[AluFn.Fn]):
     func_unit = ALUComponent(zba_enable=True, zbb_enable=True)
-    compute_result = compute_result
-    ops = ops
     zero_imm = False
 
-    def test_test(self):
+    ops = {
+        AluFn.Fn.ADD: {
+            "op_type": OpType.ARITHMETIC,
+            "funct3": Funct3.ADD,
+            "funct7": Funct7.ADD,
+        },
+        AluFn.Fn.SUB: {
+            "op_type": OpType.ARITHMETIC,
+            "funct3": Funct3.ADD,
+            "funct7": Funct7.SUB,
+        },
+        AluFn.Fn.SLT: {
+            "op_type": OpType.COMPARE,
+            "funct3": Funct3.SLT,
+        },
+        AluFn.Fn.SLTU: {
+            "op_type": OpType.COMPARE,
+            "funct3": Funct3.SLTU,
+        },
+        AluFn.Fn.XOR: {
+            "op_type": OpType.LOGIC,
+            "funct3": Funct3.XOR,
+        },
+        AluFn.Fn.OR: {
+            "op_type": OpType.LOGIC,
+            "funct3": Funct3.OR,
+        },
+        AluFn.Fn.AND: {
+            "op_type": OpType.LOGIC,
+            "funct3": Funct3.AND,
+        },
+        AluFn.Fn.SH1ADD: {
+            "op_type": OpType.ADDRESS_GENERATION,
+            "funct3": Funct3.SH1ADD,
+            "funct7": Funct7.SH1ADD,
+        },
+        AluFn.Fn.SH2ADD: {
+            "op_type": OpType.ADDRESS_GENERATION,
+            "funct3": Funct3.SH2ADD,
+            "funct7": Funct7.SH2ADD,
+        },
+        AluFn.Fn.SH3ADD: {
+            "op_type": OpType.ADDRESS_GENERATION,
+            "funct3": Funct3.SH3ADD,
+            "funct7": Funct7.SH3ADD,
+        },
+        AluFn.Fn.ANDN: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.ANDN,
+            "funct7": Funct7.ANDN,
+        },
+        AluFn.Fn.XNOR: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.XNOR,
+            "funct7": Funct7.XNOR,
+        },
+        AluFn.Fn.ORN: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.ORN,
+            "funct7": Funct7.ORN,
+        },
+        AluFn.Fn.MAX: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.MAX,
+            "funct7": Funct7.MAX,
+        },
+        AluFn.Fn.MAXU: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.MAXU,
+            "funct7": Funct7.MAX,
+        },
+        AluFn.Fn.MIN: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.MIN,
+            "funct7": Funct7.MIN,
+        },
+        AluFn.Fn.MINU: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.MINU,
+            "funct7": Funct7.MIN,
+        },
+        AluFn.Fn.CPOP: {
+            "op_type": OpType.UNARY_BIT_MANIPULATION_5,
+            "funct3": Funct3.CPOP,
+            "funct7": Funct7.CPOP,
+        },
+        AluFn.Fn.SEXTB: {
+            "op_type": OpType.UNARY_BIT_MANIPULATION_1,
+            "funct3": Funct3.SEXTB,
+            "funct7": Funct7.SEXTB,
+        },
+        AluFn.Fn.ZEXTH: {
+            "op_type": OpType.UNARY_BIT_MANIPULATION_1,
+            "funct3": Funct3.ZEXTH,
+            "funct7": Funct7.ZEXTH,
+        },
+        AluFn.Fn.SEXTH: {
+            "op_type": OpType.UNARY_BIT_MANIPULATION_2,
+            "funct3": Funct3.SEXTH,
+            "funct7": Funct7.SEXTH,
+        },
+        AluFn.Fn.ORCB: {
+            "op_type": OpType.UNARY_BIT_MANIPULATION_1,
+            "funct3": Funct3.ORCB,
+            "funct7": Funct7.ORCB,
+        },
+        AluFn.Fn.REV8: {
+            "op_type": OpType.UNARY_BIT_MANIPULATION_1,
+            "funct3": Funct3.REV8,
+            "funct7": Funct7.REV8,
+        },
+        AluFn.Fn.CLZ: {
+            "op_type": OpType.UNARY_BIT_MANIPULATION_3,
+            "funct3": Funct3.CLZ,
+            "funct7": Funct7.CLZ,
+        },
+        AluFn.Fn.CTZ: {
+            "op_type": OpType.UNARY_BIT_MANIPULATION_4,
+            "funct3": Funct3.CTZ,
+            "funct7": Funct7.CTZ,
+        },
+    }
+
+    @staticmethod
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: AluFn.Fn, xlen: int) -> dict[str, int]:
+        val2 = i_imm if i_imm else i2
+        mask = (1 << xlen) - 1
+
+        res = 0
+
+        match fn:
+            case AluFn.Fn.ADD:
+                res = i1 + val2
+            case AluFn.Fn.SUB:
+                res = i1 - val2
+            case AluFn.Fn.XOR:
+                res = i1 ^ val2
+            case AluFn.Fn.OR:
+                res = i1 | val2
+            case AluFn.Fn.AND:
+                res = i1 & val2
+            case AluFn.Fn.SLT:
+                res = signed_to_int(i1, xlen) < signed_to_int(val2, xlen)
+            case AluFn.Fn.SLTU:
+                res = i1 < val2
+            case AluFn.Fn.SH1ADD:
+                res = (i1 << 1) + val2
+            case AluFn.Fn.SH2ADD:
+                res = (i1 << 2) + val2
+            case AluFn.Fn.SH3ADD:
+                res = (i1 << 3) + val2
+            case AluFn.Fn.ANDN:
+                res = i1 & ~val2
+            case AluFn.Fn.XNOR:
+                res = ~(i1 ^ val2)
+            case AluFn.Fn.ORN:
+                res = i1 | ~val2
+            case AluFn.Fn.MAX:
+                res = max(signed_to_int(i1, xlen), signed_to_int(val2, xlen))
+            case AluFn.Fn.MAXU:
+                res = max(i1, val2)
+            case AluFn.Fn.MIN:
+                res = min(signed_to_int(i1, xlen), signed_to_int(val2, xlen))
+            case AluFn.Fn.MINU:
+                res = min(i1, val2)
+            case AluFn.Fn.CPOP:
+                res = i1.bit_count()
+            case AluFn.Fn.SEXTH:
+                bit = (i1 >> 15) & 1
+                if bit:
+                    res = i1 | (mask ^ 0xFFFF)
+                else:
+                    res = i1 & 0xFFFF
+            case AluFn.Fn.SEXTB:
+                bit = (i1 >> 7) & 1
+                if bit:
+                    res = i1 | (mask ^ 0xFF)
+                else:
+                    res = i1 & 0xFF
+            case AluFn.Fn.ZEXTH:
+                res = i1 & 0xFFFF
+            case AluFn.Fn.ORCB:
+                i1 |= i1 >> 1
+                i1 |= i1 >> 2
+                i1 |= i1 >> 4
+
+                i1 &= 0x010101010101010101
+
+                for i in range(8):
+                    res |= i1 << i
+            case AluFn.Fn.REV8:
+                for i in range(xlen // 8):
+                    res = (res << 8) | (i1 & 0xFF)
+                    i1 >>= 8  # Haskell screams in pain
+            case AluFn.Fn.CLZ:
+                res = xlen - i1.bit_length()
+            case AluFn.Fn.CTZ:
+                if i1 == 0:
+                    res = xlen.bit_length()
+                else:
+                    while (i1 & 1) == 0:
+                        res += 1
+                        i1 >>= 1
+
+        return {"result": res & mask}
+
+    def test_fu(self):
         self.run_fu_test()
 
 

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -217,7 +217,7 @@ class AluUnitTest(FunctionalUnitTestCase[AluFn.Fn]):
         return {"result": res & mask}
 
     def test_fu(self):
-        self.run_fu_test()
+        self.run_standard_fu_test()
 
     def test_pipeline(self):
-        self.run_fu_test(pipeline_test=True)
+        self.run_standard_fu_test(pipeline_test=True)

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -17,6 +17,7 @@ from ..common import RecordIntDict, TestCaseWithSimulator, TestbenchIO
 from test.common import signed_to_int
 
 
+@staticmethod
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: AluFn.Fn, xlen: int) -> dict[str, int]:
     val2 = i_imm if i_imm else i2
     mask = (1 << xlen) - 1
@@ -225,18 +226,13 @@ ops: dict[AluFn.Fn, RecordIntDict] = {
 
 
 class AluUnitTest(FunctionalUnitTestCase[AluFn.Fn]):
+    func_unit = ALUComponent(zba_enable=True, zbb_enable=True)
+    compute_result = compute_result
+    ops = ops
+    zero_imm = False
+
     def test_test(self):
         self.run_fu_test()
-
-    def __init__(self, method_name: str = "runTest"):
-        super().__init__(
-            ops,
-            ALUComponent(zba_enable=True, zbb_enable=True),
-            compute_result,
-            gen=GenParams(test_core_config),
-            method_name=method_name,
-            zero_imm=False,
-        )
 
 
 class AluFuncUnitTestCircuit(Elaboratable):

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -2,7 +2,7 @@ from coreblocks.params import Funct3, Funct7, GenParams, OpType
 from coreblocks.params.configurations import test_core_config
 from coreblocks.fu.alu import AluFn, ALUComponent, AluFuncUnit
 
-from test.fu.functional_common import GenericFunctionalTestUnit
+from test.fu.functional_common import FunctionalUnitTestCase
 
 import random
 from collections import deque
@@ -13,7 +13,7 @@ from amaranth.sim import *
 from coreblocks.transactions import *
 from coreblocks.transactions.lib import *
 
-from ..common import TestCaseWithSimulator, TestbenchIO
+from ..common import RecordIntDict, TestCaseWithSimulator, TestbenchIO
 from test.common import signed_to_int
 
 
@@ -100,7 +100,7 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: AluFn.Fn, xlen: in
     return {"result": res & mask}
 
 
-ops = {
+ops: dict[AluFn.Fn, RecordIntDict] = {
     AluFn.Fn.ADD: {
         "op_type": OpType.ARITHMETIC,
         "funct3": Funct3.ADD,
@@ -224,9 +224,9 @@ ops = {
 }
 
 
-class AluUnitTest(GenericFunctionalTestUnit):
+class AluUnitTest(FunctionalUnitTestCase[AluFn.Fn]):
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -234,8 +234,6 @@ class AluUnitTest(GenericFunctionalTestUnit):
             ALUComponent(zba_enable=True, zbb_enable=True),
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=1000,
-            seed=42,
             method_name=method_name,
             zero_imm=False,
         )

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -1,7 +1,7 @@
 from coreblocks.params import Funct3, Funct7, OpType
 from coreblocks.fu.alu import AluFn, ALUComponent
 
-from test.fu.functional_common import FunctionalUnitTestCase
+from test.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 from test.common import signed_to_int
 
@@ -11,126 +11,31 @@ class AluUnitTest(FunctionalUnitTestCase[AluFn.Fn]):
     zero_imm = False
 
     ops = {
-        AluFn.Fn.ADD: {
-            "op_type": OpType.ARITHMETIC,
-            "funct3": Funct3.ADD,
-            "funct7": Funct7.ADD,
-        },
-        AluFn.Fn.SUB: {
-            "op_type": OpType.ARITHMETIC,
-            "funct3": Funct3.ADD,
-            "funct7": Funct7.SUB,
-        },
-        AluFn.Fn.SLT: {
-            "op_type": OpType.COMPARE,
-            "funct3": Funct3.SLT,
-        },
-        AluFn.Fn.SLTU: {
-            "op_type": OpType.COMPARE,
-            "funct3": Funct3.SLTU,
-        },
-        AluFn.Fn.XOR: {
-            "op_type": OpType.LOGIC,
-            "funct3": Funct3.XOR,
-        },
-        AluFn.Fn.OR: {
-            "op_type": OpType.LOGIC,
-            "funct3": Funct3.OR,
-        },
-        AluFn.Fn.AND: {
-            "op_type": OpType.LOGIC,
-            "funct3": Funct3.AND,
-        },
-        AluFn.Fn.SH1ADD: {
-            "op_type": OpType.ADDRESS_GENERATION,
-            "funct3": Funct3.SH1ADD,
-            "funct7": Funct7.SH1ADD,
-        },
-        AluFn.Fn.SH2ADD: {
-            "op_type": OpType.ADDRESS_GENERATION,
-            "funct3": Funct3.SH2ADD,
-            "funct7": Funct7.SH2ADD,
-        },
-        AluFn.Fn.SH3ADD: {
-            "op_type": OpType.ADDRESS_GENERATION,
-            "funct3": Funct3.SH3ADD,
-            "funct7": Funct7.SH3ADD,
-        },
-        AluFn.Fn.ANDN: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.ANDN,
-            "funct7": Funct7.ANDN,
-        },
-        AluFn.Fn.XNOR: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.XNOR,
-            "funct7": Funct7.XNOR,
-        },
-        AluFn.Fn.ORN: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.ORN,
-            "funct7": Funct7.ORN,
-        },
-        AluFn.Fn.MAX: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.MAX,
-            "funct7": Funct7.MAX,
-        },
-        AluFn.Fn.MAXU: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.MAXU,
-            "funct7": Funct7.MAX,
-        },
-        AluFn.Fn.MIN: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.MIN,
-            "funct7": Funct7.MIN,
-        },
-        AluFn.Fn.MINU: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.MINU,
-            "funct7": Funct7.MIN,
-        },
-        AluFn.Fn.CPOP: {
-            "op_type": OpType.UNARY_BIT_MANIPULATION_5,
-            "funct3": Funct3.CPOP,
-            "funct7": Funct7.CPOP,
-        },
-        AluFn.Fn.SEXTB: {
-            "op_type": OpType.UNARY_BIT_MANIPULATION_1,
-            "funct3": Funct3.SEXTB,
-            "funct7": Funct7.SEXTB,
-        },
-        AluFn.Fn.ZEXTH: {
-            "op_type": OpType.UNARY_BIT_MANIPULATION_1,
-            "funct3": Funct3.ZEXTH,
-            "funct7": Funct7.ZEXTH,
-        },
-        AluFn.Fn.SEXTH: {
-            "op_type": OpType.UNARY_BIT_MANIPULATION_2,
-            "funct3": Funct3.SEXTH,
-            "funct7": Funct7.SEXTH,
-        },
-        AluFn.Fn.ORCB: {
-            "op_type": OpType.UNARY_BIT_MANIPULATION_1,
-            "funct3": Funct3.ORCB,
-            "funct7": Funct7.ORCB,
-        },
-        AluFn.Fn.REV8: {
-            "op_type": OpType.UNARY_BIT_MANIPULATION_1,
-            "funct3": Funct3.REV8,
-            "funct7": Funct7.REV8,
-        },
-        AluFn.Fn.CLZ: {
-            "op_type": OpType.UNARY_BIT_MANIPULATION_3,
-            "funct3": Funct3.CLZ,
-            "funct7": Funct7.CLZ,
-        },
-        AluFn.Fn.CTZ: {
-            "op_type": OpType.UNARY_BIT_MANIPULATION_4,
-            "funct3": Funct3.CTZ,
-            "funct7": Funct7.CTZ,
-        },
+        AluFn.Fn.ADD: ExecFn(OpType.ARITHMETIC, Funct3.ADD, Funct7.ADD),
+        AluFn.Fn.SUB: ExecFn(OpType.ARITHMETIC, Funct3.ADD, Funct7.SUB),
+        AluFn.Fn.SLT: ExecFn(OpType.COMPARE, Funct3.SLT),
+        AluFn.Fn.SLTU: ExecFn(OpType.COMPARE, Funct3.SLTU),
+        AluFn.Fn.XOR: ExecFn(OpType.LOGIC, Funct3.XOR),
+        AluFn.Fn.OR: ExecFn(OpType.LOGIC, Funct3.OR),
+        AluFn.Fn.AND: ExecFn(OpType.LOGIC, Funct3.AND),
+        AluFn.Fn.SH1ADD: ExecFn(OpType.ADDRESS_GENERATION, Funct3.SH1ADD, Funct7.SH1ADD),
+        AluFn.Fn.SH2ADD: ExecFn(OpType.ADDRESS_GENERATION, Funct3.SH2ADD, Funct7.SH2ADD),
+        AluFn.Fn.SH3ADD: ExecFn(OpType.ADDRESS_GENERATION, Funct3.SH3ADD, Funct7.SH3ADD),
+        AluFn.Fn.ANDN: ExecFn(OpType.BIT_MANIPULATION, Funct3.ANDN, Funct7.ANDN),
+        AluFn.Fn.XNOR: ExecFn(OpType.BIT_MANIPULATION, Funct3.XNOR, Funct7.XNOR),
+        AluFn.Fn.ORN: ExecFn(OpType.BIT_MANIPULATION, Funct3.ORN, Funct7.ORN),
+        AluFn.Fn.MAX: ExecFn(OpType.BIT_MANIPULATION, Funct3.MAX, Funct7.MAX),
+        AluFn.Fn.MAXU: ExecFn(OpType.BIT_MANIPULATION, Funct3.MAXU, Funct7.MAX),
+        AluFn.Fn.MIN: ExecFn(OpType.BIT_MANIPULATION, Funct3.MIN, Funct7.MIN),
+        AluFn.Fn.MINU: ExecFn(OpType.BIT_MANIPULATION, Funct3.MINU, Funct7.MIN),
+        AluFn.Fn.CPOP: ExecFn(OpType.UNARY_BIT_MANIPULATION_5, Funct3.CPOP, Funct7.CPOP),
+        AluFn.Fn.SEXTB: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.SEXTB, Funct7.SEXTB),
+        AluFn.Fn.ZEXTH: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.ZEXTH, Funct7.ZEXTH),
+        AluFn.Fn.SEXTH: ExecFn(OpType.UNARY_BIT_MANIPULATION_2, Funct3.SEXTH, Funct7.SEXTH),
+        AluFn.Fn.ORCB: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.ORCB, Funct7.ORCB),
+        AluFn.Fn.REV8: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.REV8, Funct7.REV8),
+        AluFn.Fn.CLZ: ExecFn(OpType.UNARY_BIT_MANIPULATION_3, Funct3.CLZ, Funct7.CLZ),
+        AluFn.Fn.CTZ: ExecFn(OpType.UNARY_BIT_MANIPULATION_4, Funct3.CTZ, Funct7.CTZ),
     }
 
     @staticmethod

--- a/test/fu/test_div_unit.py
+++ b/test/fu/test_div_unit.py
@@ -59,4 +59,4 @@ class DivisionUnitTest(FunctionalUnitTestCase[DivFn.Fn]):
         return {"result": res & mask}
 
     def test_fu(self):
-        self.run_fu_test()
+        self.run_standard_fu_test()

--- a/test/fu/test_div_unit.py
+++ b/test/fu/test_div_unit.py
@@ -8,60 +8,55 @@ from test.fu.functional_common import FunctionalUnitTestCase
 from test.common import RecordIntDict, signed_to_int, int_to_signed
 
 
-@staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: DivFn.Fn, xlen: int) -> dict[str, int]:
-    signed_i1 = signed_to_int(i1, xlen)
-    signed_i2 = signed_to_int(i2, xlen)
-
-    res = 0
-    mask = (1 << xlen) - 1
-
-    match fn:
-        case DivFn.Fn.DIVU:
-            if i2 == 0:
-                res = -1
-            else:
-                res = i1 // i2
-        case DivFn.Fn.DIV:
-            if signed_i2 == 0:
-                res = -1
-            else:
-                res = abs(signed_i1) // abs(signed_i2)
-                # if signs are different negate the result
-                if signed_i1 * signed_i2 < 0:
-                    res = int_to_signed(-res, xlen)
-        case DivFn.Fn.REMU:
-            if i2 == 0:
-                res = i1
-            else:
-                res = i1 % i2
-        case DivFn.Fn.REM:
-            if signed_i2 == 0:
-                res = i1
-            else:
-                res = abs(signed_i1) % abs(signed_i2)
-                # if divisor is negative negate the result
-                if signed_i1 < 0:
-                    res = int_to_signed(-res, xlen)
-
-    return {"result": res & mask}
-
-
-ops: dict[DivFn.Fn, RecordIntDict] = {
-    DivFn.Fn.DIVU: {"op_type": OpType.DIV_REM, "funct3": Funct3.DIVU, "funct7": Funct7.MULDIV},
-    DivFn.Fn.DIV: {"op_type": OpType.DIV_REM, "funct3": Funct3.DIV, "funct7": Funct7.MULDIV},
-    DivFn.Fn.REMU: {"op_type": OpType.DIV_REM, "funct3": Funct3.REMU, "funct7": Funct7.MULDIV},
-    DivFn.Fn.REM: {"op_type": OpType.DIV_REM, "funct3": Funct3.REM, "funct7": Funct7.MULDIV},
-}
-
-
 @parameterized_class(
     ("name", "func_unit"),
     [("ipc" + str(s), DivComponent(ipc=s)) for s in [3, 4, 5, 8]],
 )
 class DivisionUnitTest(FunctionalUnitTestCase[DivFn.Fn]):
-    ops = ops
-    compute_result = compute_result
+    ops: dict[DivFn.Fn, RecordIntDict] = {
+        DivFn.Fn.DIVU: {"op_type": OpType.DIV_REM, "funct3": Funct3.DIVU, "funct7": Funct7.MULDIV},
+        DivFn.Fn.DIV: {"op_type": OpType.DIV_REM, "funct3": Funct3.DIV, "funct7": Funct7.MULDIV},
+        DivFn.Fn.REMU: {"op_type": OpType.DIV_REM, "funct3": Funct3.REMU, "funct7": Funct7.MULDIV},
+        DivFn.Fn.REM: {"op_type": OpType.DIV_REM, "funct3": Funct3.REM, "funct7": Funct7.MULDIV},
+    }
 
-    def test_test(self):
+    @staticmethod
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: DivFn.Fn, xlen: int) -> dict[str, int]:
+        signed_i1 = signed_to_int(i1, xlen)
+        signed_i2 = signed_to_int(i2, xlen)
+
+        res = 0
+        mask = (1 << xlen) - 1
+
+        match fn:
+            case DivFn.Fn.DIVU:
+                if i2 == 0:
+                    res = -1
+                else:
+                    res = i1 // i2
+            case DivFn.Fn.DIV:
+                if signed_i2 == 0:
+                    res = -1
+                else:
+                    res = abs(signed_i1) // abs(signed_i2)
+                    # if signs are different negate the result
+                    if signed_i1 * signed_i2 < 0:
+                        res = int_to_signed(-res, xlen)
+            case DivFn.Fn.REMU:
+                if i2 == 0:
+                    res = i1
+                else:
+                    res = i1 % i2
+            case DivFn.Fn.REM:
+                if signed_i2 == 0:
+                    res = i1
+                else:
+                    res = abs(signed_i1) % abs(signed_i2)
+                    # if divisor is negative negate the result
+                    if signed_i1 < 0:
+                        res = int_to_signed(-res, xlen)
+
+        return {"result": res & mask}
+
+    def test_fu(self):
         self.run_fu_test()

--- a/test/fu/test_div_unit.py
+++ b/test/fu/test_div_unit.py
@@ -3,10 +3,10 @@ from parameterized import parameterized_class
 from coreblocks.params import Funct3, Funct7, OpType, GenParams
 from coreblocks.fu.div_unit import DivFn, DivComponent
 
-from test.fu.functional_common import GenericFunctionalTestUnit
+from test.fu.functional_common import FunctionalUnitTestCase
 from coreblocks.params.configurations import test_core_config
 
-from test.common import signed_to_int, int_to_signed
+from test.common import RecordIntDict, signed_to_int, int_to_signed
 
 
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: DivFn.Fn, xlen: int) -> dict[str, int]:
@@ -47,7 +47,7 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: DivFn.Fn, xlen: in
     return {"result": res & mask}
 
 
-ops = {
+ops: dict[DivFn.Fn, RecordIntDict] = {
     DivFn.Fn.DIVU: {"op_type": OpType.DIV_REM, "funct3": Funct3.DIVU, "funct7": Funct7.MULDIV},
     DivFn.Fn.DIV: {"op_type": OpType.DIV_REM, "funct3": Funct3.DIV, "funct7": Funct7.MULDIV},
     DivFn.Fn.REMU: {"op_type": OpType.DIV_REM, "funct3": Funct3.REMU, "funct7": Funct7.MULDIV},
@@ -59,11 +59,11 @@ ops = {
     ("name", "ipc"),
     [("ipc" + str(s), s) for s in [3, 4, 5, 8]],
 )
-class DivisionUnitTest(GenericFunctionalTestUnit):
+class DivisionUnitTest(FunctionalUnitTestCase[DivFn.Fn]):
     ipc: int
 
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -71,7 +71,5 @@ class DivisionUnitTest(GenericFunctionalTestUnit):
             DivComponent(ipc=self.ipc),
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=200,
-            seed=1,
             method_name=method_name,
         )

--- a/test/fu/test_div_unit.py
+++ b/test/fu/test_div_unit.py
@@ -1,14 +1,14 @@
 from parameterized import parameterized_class
 
-from coreblocks.params import Funct3, Funct7, OpType, GenParams
+from coreblocks.params import Funct3, Funct7, OpType
 from coreblocks.fu.div_unit import DivFn, DivComponent
 
 from test.fu.functional_common import FunctionalUnitTestCase
-from coreblocks.params.configurations import test_core_config
 
 from test.common import RecordIntDict, signed_to_int, int_to_signed
 
 
+@staticmethod
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: DivFn.Fn, xlen: int) -> dict[str, int]:
     signed_i1 = signed_to_int(i1, xlen)
     signed_i2 = signed_to_int(i2, xlen)
@@ -56,20 +56,12 @@ ops: dict[DivFn.Fn, RecordIntDict] = {
 
 
 @parameterized_class(
-    ("name", "ipc"),
-    [("ipc" + str(s), s) for s in [3, 4, 5, 8]],
+    ("name", "func_unit"),
+    [("ipc" + str(s), DivComponent(ipc=s)) for s in [3, 4, 5, 8]],
 )
 class DivisionUnitTest(FunctionalUnitTestCase[DivFn.Fn]):
-    ipc: int
+    ops = ops
+    compute_result = compute_result
 
     def test_test(self):
         self.run_fu_test()
-
-    def __init__(self, method_name: str = "runTest"):
-        super().__init__(
-            ops,
-            DivComponent(ipc=self.ipc),
-            compute_result,
-            gen=GenParams(test_core_config),
-            method_name=method_name,
-        )

--- a/test/fu/test_div_unit.py
+++ b/test/fu/test_div_unit.py
@@ -3,9 +3,9 @@ from parameterized import parameterized_class
 from coreblocks.params import Funct3, Funct7, OpType
 from coreblocks.fu.div_unit import DivFn, DivComponent
 
-from test.fu.functional_common import FunctionalUnitTestCase
+from test.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
-from test.common import RecordIntDict, signed_to_int, int_to_signed
+from test.common import signed_to_int, int_to_signed
 
 
 @parameterized_class(
@@ -13,11 +13,11 @@ from test.common import RecordIntDict, signed_to_int, int_to_signed
     [("ipc" + str(s), DivComponent(ipc=s)) for s in [3, 4, 5, 8]],
 )
 class DivisionUnitTest(FunctionalUnitTestCase[DivFn.Fn]):
-    ops: dict[DivFn.Fn, RecordIntDict] = {
-        DivFn.Fn.DIVU: {"op_type": OpType.DIV_REM, "funct3": Funct3.DIVU, "funct7": Funct7.MULDIV},
-        DivFn.Fn.DIV: {"op_type": OpType.DIV_REM, "funct3": Funct3.DIV, "funct7": Funct7.MULDIV},
-        DivFn.Fn.REMU: {"op_type": OpType.DIV_REM, "funct3": Funct3.REMU, "funct7": Funct7.MULDIV},
-        DivFn.Fn.REM: {"op_type": OpType.DIV_REM, "funct3": Funct3.REM, "funct7": Funct7.MULDIV},
+    ops = {
+        DivFn.Fn.DIVU: ExecFn(OpType.DIV_REM, Funct3.DIVU, Funct7.MULDIV),
+        DivFn.Fn.DIV: ExecFn(OpType.DIV_REM, Funct3.DIV, Funct7.MULDIV),
+        DivFn.Fn.REMU: ExecFn(OpType.DIV_REM, Funct3.REMU, Funct7.MULDIV),
+        DivFn.Fn.REM: ExecFn(OpType.DIV_REM, Funct3.REM, Funct7.MULDIV),
     }
 
     @staticmethod

--- a/test/fu/test_exception_unit.py
+++ b/test/fu/test_exception_unit.py
@@ -1,10 +1,8 @@
 from amaranth import *
-from typing import Dict, Callable, Any
 from parameterized import parameterized_class
 
 from coreblocks.params import *
 from coreblocks.fu.exception import ExceptionUnitFn, ExceptionUnitComponent
-from coreblocks.params.configurations import test_core_config
 from coreblocks.params.isa import ExceptionCause
 from test.common import RecordIntDict
 
@@ -12,7 +10,7 @@ from test.fu.functional_common import FunctionalUnitTestCase
 
 
 @staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ExceptionUnitFn.Fn, xlen: int) -> Dict[str, int]:
+def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ExceptionUnitFn.Fn, xlen: int) -> dict[str, int]:
     cause = None
     if fn == ExceptionUnitFn.Fn.EBREAK or fn == ExceptionUnitFn.Fn.BREAKPOINT:
         cause = ExceptionCause.BREAKPOINT
@@ -50,18 +48,8 @@ ops: dict[ExceptionUnitFn.Fn, RecordIntDict] = {
     ],
 )
 class ExceptionUnitTest(FunctionalUnitTestCase[ExceptionUnitFn.Fn]):
-    compute_result: Callable[[int, int, int, int, Any, int], Dict[str, int]]
+    number_of_tests = 1
+    zero_imm = False
 
     def test_test(self):
         self.run_fu_test()
-
-    def __init__(self, method_name: str = "runTest"):
-        super().__init__(
-            self.ops,
-            self.func_unit,
-            self.compute_result,
-            gen=GenParams(test_core_config),
-            number_of_tests=1,
-            zero_imm=False,
-            method_name=method_name,
-        )

--- a/test/fu/test_exception_unit.py
+++ b/test/fu/test_exception_unit.py
@@ -4,7 +4,7 @@ from coreblocks.params import *
 from coreblocks.fu.exception import ExceptionUnitFn, ExceptionUnitComponent
 from coreblocks.params.isa import ExceptionCause
 
-from test.fu.functional_common import FunctionalUnitTestCase
+from test.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
 class ExceptionUnitTest(FunctionalUnitTestCase[ExceptionUnitFn.Fn]):
@@ -13,12 +13,12 @@ class ExceptionUnitTest(FunctionalUnitTestCase[ExceptionUnitFn.Fn]):
     zero_imm = False
 
     ops = {
-        ExceptionUnitFn.Fn.EBREAK: {"op_type": OpType.EBREAK},
-        ExceptionUnitFn.Fn.ECALL: {"op_type": OpType.ECALL},
-        ExceptionUnitFn.Fn.INSTR_ACCESS_FAULT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EINSTRACCESSFAULT},
-        ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EILLEGALINSTR},
-        ExceptionUnitFn.Fn.BREAKPOINT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EBREAKPOINT},
-        ExceptionUnitFn.Fn.INSTR_PAGE_FAULT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EINSTRPAGEFAULT},
+        ExceptionUnitFn.Fn.EBREAK: ExecFn(OpType.EBREAK),
+        ExceptionUnitFn.Fn.ECALL: ExecFn(OpType.ECALL),
+        ExceptionUnitFn.Fn.INSTR_ACCESS_FAULT: ExecFn(OpType.EXCEPTION, Funct3._EINSTRACCESSFAULT),
+        ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION: ExecFn(OpType.EXCEPTION, Funct3._EILLEGALINSTR),
+        ExceptionUnitFn.Fn.BREAKPOINT: ExecFn(OpType.EXCEPTION, Funct3._EBREAKPOINT),
+        ExceptionUnitFn.Fn.INSTR_PAGE_FAULT: ExecFn(OpType.EXCEPTION, Funct3._EINSTRPAGEFAULT),
     }
 
     @staticmethod

--- a/test/fu/test_exception_unit.py
+++ b/test/fu/test_exception_unit.py
@@ -40,4 +40,4 @@ class ExceptionUnitTest(FunctionalUnitTestCase[ExceptionUnitFn.Fn]):
         return {"result": 0} | {"exception": cause} if cause is not None else {}
 
     def test_fu(self):
-        self.run_fu_test()
+        self.run_standard_fu_test()

--- a/test/fu/test_exception_unit.py
+++ b/test/fu/test_exception_unit.py
@@ -6,8 +6,9 @@ from coreblocks.params import *
 from coreblocks.fu.exception import ExceptionUnitFn, ExceptionUnitComponent
 from coreblocks.params.configurations import test_core_config
 from coreblocks.params.isa import ExceptionCause
+from test.common import RecordIntDict
 
-from test.fu.functional_common import GenericFunctionalTestUnit
+from test.fu.functional_common import FunctionalUnitTestCase
 
 
 @staticmethod
@@ -27,7 +28,7 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ExceptionUnitFn.Fn
     return {"result": 0} | {"exception": cause} if cause is not None else {}
 
 
-ops = {
+ops: dict[ExceptionUnitFn.Fn, RecordIntDict] = {
     ExceptionUnitFn.Fn.EBREAK: {"op_type": OpType.EBREAK},
     ExceptionUnitFn.Fn.ECALL: {"op_type": OpType.ECALL},
     ExceptionUnitFn.Fn.INSTR_ACCESS_FAULT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EINSTRACCESSFAULT},
@@ -48,11 +49,11 @@ ops = {
         )
     ],
 )
-class ExceptionUnitTest(GenericFunctionalTestUnit):
+class ExceptionUnitTest(FunctionalUnitTestCase[ExceptionUnitFn.Fn]):
     compute_result: Callable[[int, int, int, int, Any, int], Dict[str, int]]
 
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -60,8 +61,7 @@ class ExceptionUnitTest(GenericFunctionalTestUnit):
             self.func_unit,
             self.compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=10,
-            seed=32323,
+            number_of_tests=1,
             zero_imm=False,
             method_name=method_name,
         )

--- a/test/fu/test_exception_unit.py
+++ b/test/fu/test_exception_unit.py
@@ -1,55 +1,43 @@
 from amaranth import *
-from parameterized import parameterized_class
 
 from coreblocks.params import *
 from coreblocks.fu.exception import ExceptionUnitFn, ExceptionUnitComponent
 from coreblocks.params.isa import ExceptionCause
-from test.common import RecordIntDict
 
 from test.fu.functional_common import FunctionalUnitTestCase
 
 
-@staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ExceptionUnitFn.Fn, xlen: int) -> dict[str, int]:
-    cause = None
-    if fn == ExceptionUnitFn.Fn.EBREAK or fn == ExceptionUnitFn.Fn.BREAKPOINT:
-        cause = ExceptionCause.BREAKPOINT
-    if fn == ExceptionUnitFn.Fn.ECALL:
-        cause = ExceptionCause.ENVIRONMENT_CALL_FROM_M
-    if fn == ExceptionUnitFn.Fn.INSTR_ACCESS_FAULT:
-        cause = ExceptionCause.INSTRUCTION_ACCESS_FAULT
-    if fn == ExceptionUnitFn.Fn.INSTR_PAGE_FAULT:
-        cause = ExceptionCause.INSTRUCTION_PAGE_FAULT
-    if fn == ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION:
-        cause = ExceptionCause.ILLEGAL_INSTRUCTION
-
-    return {"result": 0} | {"exception": cause} if cause is not None else {}
-
-
-ops: dict[ExceptionUnitFn.Fn, RecordIntDict] = {
-    ExceptionUnitFn.Fn.EBREAK: {"op_type": OpType.EBREAK},
-    ExceptionUnitFn.Fn.ECALL: {"op_type": OpType.ECALL},
-    ExceptionUnitFn.Fn.INSTR_ACCESS_FAULT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EINSTRACCESSFAULT},
-    ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EILLEGALINSTR},
-    ExceptionUnitFn.Fn.BREAKPOINT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EBREAKPOINT},
-    ExceptionUnitFn.Fn.INSTR_PAGE_FAULT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EINSTRPAGEFAULT},
-}
-
-
-@parameterized_class(
-    ("name", "ops", "func_unit", "compute_result"),
-    [
-        (
-            "excpetions_fu",
-            ops,
-            ExceptionUnitComponent(),
-            compute_result,
-        )
-    ],
-)
 class ExceptionUnitTest(FunctionalUnitTestCase[ExceptionUnitFn.Fn]):
+    func_unit = ExceptionUnitComponent()
     number_of_tests = 1
     zero_imm = False
 
-    def test_test(self):
+    ops = {
+        ExceptionUnitFn.Fn.EBREAK: {"op_type": OpType.EBREAK},
+        ExceptionUnitFn.Fn.ECALL: {"op_type": OpType.ECALL},
+        ExceptionUnitFn.Fn.INSTR_ACCESS_FAULT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EINSTRACCESSFAULT},
+        ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EILLEGALINSTR},
+        ExceptionUnitFn.Fn.BREAKPOINT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EBREAKPOINT},
+        ExceptionUnitFn.Fn.INSTR_PAGE_FAULT: {"op_type": OpType.EXCEPTION, "funct3": Funct3._EINSTRPAGEFAULT},
+    }
+
+    @staticmethod
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ExceptionUnitFn.Fn, xlen: int) -> dict[str, int]:
+        cause = None
+
+        match fn:
+            case ExceptionUnitFn.Fn.EBREAK | ExceptionUnitFn.Fn.BREAKPOINT:
+                cause = ExceptionCause.BREAKPOINT
+            case ExceptionUnitFn.Fn.ECALL:
+                cause = ExceptionCause.ENVIRONMENT_CALL_FROM_M
+            case ExceptionUnitFn.Fn.INSTR_ACCESS_FAULT:
+                cause = ExceptionCause.INSTRUCTION_ACCESS_FAULT
+            case ExceptionUnitFn.Fn.INSTR_PAGE_FAULT:
+                cause = ExceptionCause.INSTRUCTION_PAGE_FAULT
+            case ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION:
+                cause = ExceptionCause.ILLEGAL_INSTRUCTION
+
+        return {"result": 0} | {"exception": cause} if cause is not None else {}
+
+    def test_fu(self):
         self.run_fu_test()

--- a/test/fu/test_jb_unit.py
+++ b/test/fu/test_jb_unit.py
@@ -54,23 +54,24 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn.Fn, x
     next_pc = 0
     res = pc + 4
 
-    if fn == JumpBranchFn.Fn.JAL:
-        next_pc = pc + signed_to_int(i_imm & 0x1FFFFF, 21)  # truncate to first 21 bits
-    if fn == JumpBranchFn.Fn.JALR:
-        # truncate to first 12 bits and set 0th bit to 0
-        next_pc = (i1 + signed_to_int(i_imm & 0xFFF, 12)) & ~0x1
-    if fn == JumpBranchFn.Fn.BEQ:
-        next_pc = branch_target if i1 == i2 else pc + 4
-    if fn == JumpBranchFn.Fn.BNE:
-        next_pc = branch_target if i1 != i2 else pc + 4
-    if fn == JumpBranchFn.Fn.BLT:
-        next_pc = branch_target if signed_to_int(i1, xlen) < signed_to_int(i2, xlen) else pc + 4
-    if fn == JumpBranchFn.Fn.BLTU:
-        next_pc = branch_target if i1 < i2 else pc + 4
-    if fn == JumpBranchFn.Fn.BGE:
-        next_pc = branch_target if signed_to_int(i1, xlen) >= signed_to_int(i2, xlen) else pc + 4
-    if fn == JumpBranchFn.Fn.BGEU:
-        next_pc = branch_target if i1 >= i2 else pc + 4
+    match fn:
+        case JumpBranchFn.Fn.JAL:
+            next_pc = pc + signed_to_int(i_imm & 0x1FFFFF, 21)  # truncate to first 21 bits
+        case JumpBranchFn.Fn.JALR:
+            # truncate to first 12 bits and set 0th bit to 0
+            next_pc = (i1 + signed_to_int(i_imm & 0xFFF, 12)) & ~0x1
+        case JumpBranchFn.Fn.BEQ:
+            next_pc = branch_target if i1 == i2 else pc + 4
+        case JumpBranchFn.Fn.BNE:
+            next_pc = branch_target if i1 != i2 else pc + 4
+        case JumpBranchFn.Fn.BLT:
+            next_pc = branch_target if signed_to_int(i1, xlen) < signed_to_int(i2, xlen) else pc + 4
+        case JumpBranchFn.Fn.BLTU:
+            next_pc = branch_target if i1 < i2 else pc + 4
+        case JumpBranchFn.Fn.BGE:
+            next_pc = branch_target if signed_to_int(i1, xlen) >= signed_to_int(i2, xlen) else pc + 4
+        case JumpBranchFn.Fn.BGEU:
+            next_pc = branch_target if i1 >= i2 else pc + 4
 
     next_pc &= max_int
     res &= max_int
@@ -134,5 +135,5 @@ class JumpBranchUnitTest(FunctionalUnitTestCase[JumpBranchFn.Fn]):
     compute_result = compute_result
     zero_imm = False
 
-    def test_test(self):
+    def test_fu(self):
         self.run_fu_test()

--- a/test/fu/test_jb_unit.py
+++ b/test/fu/test_jb_unit.py
@@ -4,7 +4,6 @@ from parameterized import parameterized_class
 from coreblocks.params import *
 from coreblocks.fu.jumpbranch import JumpBranchFuncUnit, JumpBranchFn, JumpComponent
 from coreblocks.transactions import Method, def_method, TModule
-from coreblocks.params.configurations import test_core_config
 from coreblocks.params.layouts import FuncUnitLayouts, FetchLayouts
 from coreblocks.utils.protocols import FuncUnit
 
@@ -132,15 +131,8 @@ ops_auipc = {
     ],
 )
 class JumpBranchUnitTest(FunctionalUnitTestCase[JumpBranchFn.Fn]):
+    compute_result = compute_result
+    zero_imm = False
+
     def test_test(self):
         self.run_fu_test()
-
-    def __init__(self, method_name: str = "runTest"):
-        super().__init__(
-            self.ops,
-            self.func_unit,
-            self.compute_result,
-            gen=GenParams(test_core_config),
-            zero_imm=False,
-            method_name=method_name,
-        )

--- a/test/fu/test_jb_unit.py
+++ b/test/fu/test_jb_unit.py
@@ -9,7 +9,7 @@ from coreblocks.utils.protocols import FuncUnit
 
 from test.common import signed_to_int
 
-from test.fu.functional_common import FunctionalUnitTestCase
+from test.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
 class JumpBranchWrapper(Elaboratable):
@@ -99,18 +99,18 @@ def compute_result_auipc(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn
 
 
 ops = {
-    JumpBranchFn.Fn.BEQ: {"op_type": OpType.BRANCH, "funct3": Funct3.BEQ, "funct7": 0},
-    JumpBranchFn.Fn.BNE: {"op_type": OpType.BRANCH, "funct3": Funct3.BNE, "funct7": 0},
-    JumpBranchFn.Fn.BLT: {"op_type": OpType.BRANCH, "funct3": Funct3.BLT, "funct7": 0},
-    JumpBranchFn.Fn.BLTU: {"op_type": OpType.BRANCH, "funct3": Funct3.BLTU, "funct7": 0},
-    JumpBranchFn.Fn.BGE: {"op_type": OpType.BRANCH, "funct3": Funct3.BGE, "funct7": 0},
-    JumpBranchFn.Fn.BGEU: {"op_type": OpType.BRANCH, "funct3": Funct3.BGEU, "funct7": 0},
-    JumpBranchFn.Fn.JAL: {"op_type": OpType.JAL, "funct3": 0, "funct7": 0},
-    JumpBranchFn.Fn.JALR: {"op_type": OpType.JALR, "funct3": Funct3.JALR, "funct7": 0},
+    JumpBranchFn.Fn.BEQ: ExecFn(OpType.BRANCH, Funct3.BEQ),
+    JumpBranchFn.Fn.BNE: ExecFn(OpType.BRANCH, Funct3.BNE),
+    JumpBranchFn.Fn.BLT: ExecFn(OpType.BRANCH, Funct3.BLT),
+    JumpBranchFn.Fn.BLTU: ExecFn(OpType.BRANCH, Funct3.BLTU),
+    JumpBranchFn.Fn.BGE: ExecFn(OpType.BRANCH, Funct3.BGE),
+    JumpBranchFn.Fn.BGEU: ExecFn(OpType.BRANCH, Funct3.BGEU),
+    JumpBranchFn.Fn.JAL: ExecFn(OpType.JAL),
+    JumpBranchFn.Fn.JALR: ExecFn(OpType.JALR),
 }
 
 ops_auipc = {
-    JumpBranchFn.Fn.AUIPC: {"op_type": OpType.AUIPC, "funct3": 0, "funct7": 0},
+    JumpBranchFn.Fn.AUIPC: ExecFn(OpType.AUIPC),
 }
 
 

--- a/test/fu/test_jb_unit.py
+++ b/test/fu/test_jb_unit.py
@@ -136,4 +136,4 @@ class JumpBranchUnitTest(FunctionalUnitTestCase[JumpBranchFn.Fn]):
     zero_imm = False
 
     def test_fu(self):
-        self.run_fu_test()
+        self.run_standard_fu_test()

--- a/test/fu/test_jb_unit.py
+++ b/test/fu/test_jb_unit.py
@@ -1,5 +1,4 @@
 from amaranth import *
-from typing import Dict, Callable, Any
 from parameterized import parameterized_class
 
 from coreblocks.params import *
@@ -11,7 +10,7 @@ from coreblocks.utils.protocols import FuncUnit
 
 from test.common import signed_to_int
 
-from test.fu.functional_common import GenericFunctionalTestUnit
+from test.fu.functional_common import FunctionalUnitTestCase
 
 
 class JumpBranchWrapper(Elaboratable):
@@ -50,7 +49,7 @@ class JumpBranchWrapperComponent(FunctionalComponentParams):
 
 
 @staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn.Fn, xlen: int) -> Dict[str, int]:
+def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn.Fn, xlen: int) -> dict[str, int]:
     max_int = 2**xlen - 1
     branch_target = pc + signed_to_int(i_imm & 0x1FFF, 13)
     next_pc = 0
@@ -87,7 +86,7 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn.Fn, x
 
 
 @staticmethod
-def compute_result_auipc(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn.Fn, xlen: int) -> Dict[str, int]:
+def compute_result_auipc(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn.Fn, xlen: int) -> dict[str, int]:
     max_int = 2**xlen - 1
     res = pc + 4
 
@@ -132,11 +131,9 @@ ops_auipc = {
         ),
     ],
 )
-class JumpBranchUnitTest(GenericFunctionalTestUnit):
-    compute_result: Callable[[int, int, int, int, Any, int], Dict[str, int]]
-
+class JumpBranchUnitTest(FunctionalUnitTestCase[JumpBranchFn.Fn]):
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -144,8 +141,6 @@ class JumpBranchUnitTest(GenericFunctionalTestUnit):
             self.func_unit,
             self.compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=300,
-            seed=32323,
             zero_imm=False,
             method_name=method_name,
         )

--- a/test/fu/test_mul_unit.py
+++ b/test/fu/test_mul_unit.py
@@ -6,9 +6,9 @@ from coreblocks.fu.mul_unit import MulFn, MulComponent, MulType
 from coreblocks.params.configurations import test_core_config
 from coreblocks.params.fu_params import FunctionalComponentParams
 
-from test.common import signed_to_int, int_to_signed
+from test.common import RecordIntDict, signed_to_int, int_to_signed
 
-from test.fu.functional_common import GenericFunctionalTestUnit
+from test.fu.functional_common import FunctionalUnitTestCase
 
 
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: MulFn.Fn, xlen: int) -> Dict[str, int]:
@@ -28,7 +28,7 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: MulFn.Fn, xlen: in
         return {"result": int_to_signed(signed_half_i1 * signed_half_i2, xlen)}
 
 
-ops = {
+ops: dict[MulFn.Fn, RecordIntDict] = {
     MulFn.Fn.MUL: {"op_type": OpType.MUL, "funct3": Funct3.MUL, "funct7": Funct7.MULDIV},
     MulFn.Fn.MULH: {"op_type": OpType.MUL, "funct3": Funct3.MULH, "funct7": Funct7.MULDIV},
     MulFn.Fn.MULHU: {"op_type": OpType.MUL, "funct3": Funct3.MULHU, "funct7": Funct7.MULDIV},
@@ -56,11 +56,11 @@ ops = {
         ),
     ],
 )
-class MultiplierUnitTest(GenericFunctionalTestUnit):
+class MultiplierUnitTest(FunctionalUnitTestCase[MulFn.Fn]):
     mul_unit: FunctionalComponentParams
 
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -68,7 +68,5 @@ class MultiplierUnitTest(GenericFunctionalTestUnit):
             self.mul_unit,
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=600,
-            seed=32323,
             method_name=method_name,
         )

--- a/test/fu/test_mul_unit.py
+++ b/test/fu/test_mul_unit.py
@@ -3,38 +3,9 @@ from parameterized import parameterized_class
 from coreblocks.params import *
 from coreblocks.fu.mul_unit import MulFn, MulComponent, MulType
 
-from test.common import RecordIntDict, signed_to_int, int_to_signed
+from test.common import signed_to_int, int_to_signed
 
 from test.fu.functional_common import FunctionalUnitTestCase
-
-
-@staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: MulFn.Fn, xlen: int) -> dict[str, int]:
-    signed_i1 = signed_to_int(i1, xlen)
-    signed_i2 = signed_to_int(i2, xlen)
-    if fn == MulFn.Fn.MUL:
-        return {"result": (i1 * i2) % (2**xlen)}
-    elif fn == MulFn.Fn.MULH:
-        return {"result": int_to_signed(signed_i1 * signed_i2, 2 * xlen) // (2**xlen)}
-    elif fn == MulFn.Fn.MULHU:
-        return {"result": i1 * i2 // (2**xlen)}
-    elif fn == MulFn.Fn.MULHSU:
-        return {"result": int_to_signed(signed_i1 * i2, 2 * xlen) // (2**xlen)}
-    else:
-        signed_half_i1 = signed_to_int(i1 % (2 ** (xlen // 2)), xlen // 2)
-        signed_half_i2 = signed_to_int(i2 % (2 ** (xlen // 2)), xlen // 2)
-        return {"result": int_to_signed(signed_half_i1 * signed_half_i2, xlen)}
-
-
-ops: dict[MulFn.Fn, RecordIntDict] = {
-    MulFn.Fn.MUL: {"op_type": OpType.MUL, "funct3": Funct3.MUL, "funct7": Funct7.MULDIV},
-    MulFn.Fn.MULH: {"op_type": OpType.MUL, "funct3": Funct3.MULH, "funct7": Funct7.MULDIV},
-    MulFn.Fn.MULHU: {"op_type": OpType.MUL, "funct3": Funct3.MULHU, "funct7": Funct7.MULDIV},
-    MulFn.Fn.MULHSU: {"op_type": OpType.MUL, "funct3": Funct3.MULHSU, "funct7": Funct7.MULDIV},
-    #  Prepared for RV64
-    #
-    #  MulFn.Fn.MULW: {"op_type": OpType.ARITHMETIC_W, "funct3": Funct3.MULW, "funct7": Funct7.MULDIV},
-}
 
 
 @parameterized_class(
@@ -55,8 +26,34 @@ ops: dict[MulFn.Fn, RecordIntDict] = {
     ],
 )
 class MultiplierUnitTest(FunctionalUnitTestCase[MulFn.Fn]):
-    ops = ops
-    compute_result = compute_result
+    ops = {
+        MulFn.Fn.MUL: {"op_type": OpType.MUL, "funct3": Funct3.MUL, "funct7": Funct7.MULDIV},
+        MulFn.Fn.MULH: {"op_type": OpType.MUL, "funct3": Funct3.MULH, "funct7": Funct7.MULDIV},
+        MulFn.Fn.MULHU: {"op_type": OpType.MUL, "funct3": Funct3.MULHU, "funct7": Funct7.MULDIV},
+        MulFn.Fn.MULHSU: {"op_type": OpType.MUL, "funct3": Funct3.MULHSU, "funct7": Funct7.MULDIV},
+        #  Prepared for RV64
+        #
+        #  MulFn.Fn.MULW: {"op_type": OpType.ARITHMETIC_W, "funct3": Funct3.MULW, "funct7": Funct7.MULDIV},
+    }
 
-    def test_test(self):
+    @staticmethod
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: MulFn.Fn, xlen: int) -> dict[str, int]:
+        signed_i1 = signed_to_int(i1, xlen)
+        signed_i2 = signed_to_int(i2, xlen)
+
+        match fn:
+            case MulFn.Fn.MUL:
+                return {"result": (i1 * i2) % (2**xlen)}
+            case MulFn.Fn.MULH:
+                return {"result": int_to_signed(signed_i1 * signed_i2, 2 * xlen) // (2**xlen)}
+            case MulFn.Fn.MULHU:
+                return {"result": i1 * i2 // (2**xlen)}
+            case MulFn.Fn.MULHSU:
+                return {"result": int_to_signed(signed_i1 * i2, 2 * xlen) // (2**xlen)}
+            case _:
+                signed_half_i1 = signed_to_int(i1 % (2 ** (xlen // 2)), xlen // 2)
+                signed_half_i2 = signed_to_int(i2 % (2 ** (xlen // 2)), xlen // 2)
+                return {"result": int_to_signed(signed_half_i1 * signed_half_i2, xlen)}
+
+    def test_fu(self):
         self.run_fu_test()

--- a/test/fu/test_mul_unit.py
+++ b/test/fu/test_mul_unit.py
@@ -5,7 +5,7 @@ from coreblocks.fu.mul_unit import MulFn, MulComponent, MulType
 
 from test.common import signed_to_int, int_to_signed
 
-from test.fu.functional_common import FunctionalUnitTestCase
+from test.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
 @parameterized_class(
@@ -27,13 +27,13 @@ from test.fu.functional_common import FunctionalUnitTestCase
 )
 class MultiplierUnitTest(FunctionalUnitTestCase[MulFn.Fn]):
     ops = {
-        MulFn.Fn.MUL: {"op_type": OpType.MUL, "funct3": Funct3.MUL, "funct7": Funct7.MULDIV},
-        MulFn.Fn.MULH: {"op_type": OpType.MUL, "funct3": Funct3.MULH, "funct7": Funct7.MULDIV},
-        MulFn.Fn.MULHU: {"op_type": OpType.MUL, "funct3": Funct3.MULHU, "funct7": Funct7.MULDIV},
-        MulFn.Fn.MULHSU: {"op_type": OpType.MUL, "funct3": Funct3.MULHSU, "funct7": Funct7.MULDIV},
+        MulFn.Fn.MUL: ExecFn(OpType.MUL, Funct3.MUL, Funct7.MULDIV),
+        MulFn.Fn.MULH: ExecFn(OpType.MUL, Funct3.MULH, Funct7.MULDIV),
+        MulFn.Fn.MULHU: ExecFn(OpType.MUL, Funct3.MULHU, Funct7.MULDIV),
+        MulFn.Fn.MULHSU: ExecFn(OpType.MUL, Funct3.MULHSU, Funct7.MULDIV),
         #  Prepared for RV64
         #
-        #  MulFn.Fn.MULW: {"op_type": OpType.ARITHMETIC_W, "funct3": Funct3.MULW, "funct7": Funct7.MULDIV},
+        #  MulFn.Fn.MULW: ExecFn(OpType.ARITHMETIC_W, Funct3.MULW, Funct7.MULDIV),
     }
 
     @staticmethod

--- a/test/fu/test_mul_unit.py
+++ b/test/fu/test_mul_unit.py
@@ -1,17 +1,15 @@
 from parameterized import parameterized_class
-from typing import Dict
 
 from coreblocks.params import *
 from coreblocks.fu.mul_unit import MulFn, MulComponent, MulType
-from coreblocks.params.configurations import test_core_config
-from coreblocks.params.fu_params import FunctionalComponentParams
 
 from test.common import RecordIntDict, signed_to_int, int_to_signed
 
 from test.fu.functional_common import FunctionalUnitTestCase
 
 
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: MulFn.Fn, xlen: int) -> Dict[str, int]:
+@staticmethod
+def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: MulFn.Fn, xlen: int) -> dict[str, int]:
     signed_i1 = signed_to_int(i1, xlen)
     signed_i2 = signed_to_int(i2, xlen)
     if fn == MulFn.Fn.MUL:
@@ -40,7 +38,7 @@ ops: dict[MulFn.Fn, RecordIntDict] = {
 
 
 @parameterized_class(
-    ("name", "mul_unit"),
+    ("name", "func_unit"),
     [
         (
             "recursive_multiplier",
@@ -57,16 +55,8 @@ ops: dict[MulFn.Fn, RecordIntDict] = {
     ],
 )
 class MultiplierUnitTest(FunctionalUnitTestCase[MulFn.Fn]):
-    mul_unit: FunctionalComponentParams
+    ops = ops
+    compute_result = compute_result
 
     def test_test(self):
         self.run_fu_test()
-
-    def __init__(self, method_name: str = "runTest"):
-        super().__init__(
-            ops,
-            self.mul_unit,
-            compute_result,
-            gen=GenParams(test_core_config),
-            method_name=method_name,
-        )

--- a/test/fu/test_mul_unit.py
+++ b/test/fu/test_mul_unit.py
@@ -56,4 +56,4 @@ class MultiplierUnitTest(FunctionalUnitTestCase[MulFn.Fn]):
                 return {"result": int_to_signed(signed_half_i1 * signed_half_i2, xlen)}
 
     def test_fu(self):
-        self.run_fu_test()
+        self.run_standard_fu_test()

--- a/test/fu/test_shift_unit.py
+++ b/test/fu/test_shift_unit.py
@@ -1,11 +1,11 @@
-from coreblocks.params import Funct3, Funct7, OpType, GenParams
-from coreblocks.params.configurations import test_core_config
+from coreblocks.params import Funct3, Funct7, OpType
 from coreblocks.fu.shift_unit import ShiftUnitFn, ShiftUnitComponent
 from test.common import RecordIntDict
 
 from test.fu.functional_common import FunctionalUnitTestCase
 
 
+@staticmethod
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ShiftUnitFn.Fn, xlen: int) -> dict[str, int]:
     val2 = i_imm if i_imm else i2
 
@@ -59,15 +59,10 @@ ops: dict[ShiftUnitFn.Fn, RecordIntDict] = {
 
 
 class ShiftUnitTest(FunctionalUnitTestCase[ShiftUnitFn.Fn]):
+    ops = ops
+    func_unit = ShiftUnitComponent(zbb_enable=True)
+    compute_result = compute_result
+    zero_imm = False
+
     def test_test(self):
         self.run_fu_test()
-
-    def __init__(self, method_name: str = "runTest"):
-        super().__init__(
-            ops,
-            ShiftUnitComponent(zbb_enable=True),
-            compute_result,
-            gen=GenParams(test_core_config),
-            method_name=method_name,
-            zero_imm=False,
-        )

--- a/test/fu/test_shift_unit.py
+++ b/test/fu/test_shift_unit.py
@@ -60,7 +60,7 @@ class ShiftUnitTest(FunctionalUnitTestCase[ShiftUnitFn.Fn]):
         return {"result": res & mask}
 
     def test_fu(self):
-        self.run_fu_test()
+        self.run_standard_fu_test()
 
     def test_pipeline(self):
-        self.run_fu_test(pipeline_test=True)
+        self.run_standard_fu_test(pipeline_test=True)

--- a/test/fu/test_shift_unit.py
+++ b/test/fu/test_shift_unit.py
@@ -1,68 +1,63 @@
 from coreblocks.params import Funct3, Funct7, OpType
 from coreblocks.fu.shift_unit import ShiftUnitFn, ShiftUnitComponent
-from test.common import RecordIntDict
 
 from test.fu.functional_common import FunctionalUnitTestCase
 
 
-@staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ShiftUnitFn.Fn, xlen: int) -> dict[str, int]:
-    val2 = i_imm if i_imm else i2
-
-    mask = (1 << xlen) - 1
-    res = 0
-    shamt = val2 & (xlen - 1)
-
-    match fn:
-        case ShiftUnitFn.Fn.SLL:
-            res = i1 << shamt
-        case ShiftUnitFn.Fn.SRA:
-            if i1 & 2 ** (xlen - 1) != 0:
-                res = (((1 << xlen) - 1) << xlen | i1) >> shamt
-            else:
-                res = i1 >> shamt
-        case ShiftUnitFn.Fn.SRL:
-            res = i1 >> shamt
-        case ShiftUnitFn.Fn.ROR:
-            res = (i1 >> shamt) | (i1 << (xlen - shamt))
-        case ShiftUnitFn.Fn.ROL:
-            res = (i1 << shamt) | (i1 >> (xlen - shamt))
-    return {"result": res & mask}
-
-
-ops: dict[ShiftUnitFn.Fn, RecordIntDict] = {
-    ShiftUnitFn.Fn.SLL: {
-        "op_type": OpType.SHIFT,
-        "funct3": Funct3.SLL,
-    },
-    ShiftUnitFn.Fn.SRL: {
-        "op_type": OpType.SHIFT,
-        "funct3": Funct3.SR,
-        "funct7": Funct7.SL,
-    },
-    ShiftUnitFn.Fn.SRA: {
-        "op_type": OpType.SHIFT,
-        "funct3": Funct3.SR,
-        "funct7": Funct7.SA,
-    },
-    ShiftUnitFn.Fn.ROL: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.ROL,
-        "funct7": Funct7.ROL,
-    },
-    ShiftUnitFn.Fn.ROR: {
-        "op_type": OpType.BIT_MANIPULATION,
-        "funct3": Funct3.ROR,
-        "funct7": Funct7.ROR,
-    },
-}
-
-
 class ShiftUnitTest(FunctionalUnitTestCase[ShiftUnitFn.Fn]):
-    ops = ops
     func_unit = ShiftUnitComponent(zbb_enable=True)
-    compute_result = compute_result
     zero_imm = False
 
-    def test_test(self):
+    ops = {
+        ShiftUnitFn.Fn.SLL: {
+            "op_type": OpType.SHIFT,
+            "funct3": Funct3.SLL,
+        },
+        ShiftUnitFn.Fn.SRL: {
+            "op_type": OpType.SHIFT,
+            "funct3": Funct3.SR,
+            "funct7": Funct7.SL,
+        },
+        ShiftUnitFn.Fn.SRA: {
+            "op_type": OpType.SHIFT,
+            "funct3": Funct3.SR,
+            "funct7": Funct7.SA,
+        },
+        ShiftUnitFn.Fn.ROL: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.ROL,
+            "funct7": Funct7.ROL,
+        },
+        ShiftUnitFn.Fn.ROR: {
+            "op_type": OpType.BIT_MANIPULATION,
+            "funct3": Funct3.ROR,
+            "funct7": Funct7.ROR,
+        },
+    }
+
+    @staticmethod
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ShiftUnitFn.Fn, xlen: int) -> dict[str, int]:
+        val2 = i_imm if i_imm else i2
+
+        mask = (1 << xlen) - 1
+        res = 0
+        shamt = val2 & (xlen - 1)
+
+        match fn:
+            case ShiftUnitFn.Fn.SLL:
+                res = i1 << shamt
+            case ShiftUnitFn.Fn.SRA:
+                if i1 & 2 ** (xlen - 1) != 0:
+                    res = (((1 << xlen) - 1) << xlen | i1) >> shamt
+                else:
+                    res = i1 >> shamt
+            case ShiftUnitFn.Fn.SRL:
+                res = i1 >> shamt
+            case ShiftUnitFn.Fn.ROR:
+                res = (i1 >> shamt) | (i1 << (xlen - shamt))
+            case ShiftUnitFn.Fn.ROL:
+                res = (i1 << shamt) | (i1 >> (xlen - shamt))
+        return {"result": res & mask}
+
+    def test_fu(self):
         self.run_fu_test()

--- a/test/fu/test_shift_unit.py
+++ b/test/fu/test_shift_unit.py
@@ -1,8 +1,9 @@
 from coreblocks.params import Funct3, Funct7, OpType, GenParams
 from coreblocks.params.configurations import test_core_config
 from coreblocks.fu.shift_unit import ShiftUnitFn, ShiftUnitComponent
+from test.common import RecordIntDict
 
-from test.fu.functional_common import GenericFunctionalTestUnit
+from test.fu.functional_common import FunctionalUnitTestCase
 
 
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ShiftUnitFn.Fn, xlen: int) -> dict[str, int]:
@@ -29,7 +30,7 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ShiftUnitFn.Fn, xl
     return {"result": res & mask}
 
 
-ops = {
+ops: dict[ShiftUnitFn.Fn, RecordIntDict] = {
     ShiftUnitFn.Fn.SLL: {
         "op_type": OpType.SHIFT,
         "funct3": Funct3.SLL,
@@ -57,9 +58,9 @@ ops = {
 }
 
 
-class ShiftUnitTest(GenericFunctionalTestUnit):
+class ShiftUnitTest(FunctionalUnitTestCase[ShiftUnitFn.Fn]):
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -67,8 +68,6 @@ class ShiftUnitTest(GenericFunctionalTestUnit):
             ShiftUnitComponent(zbb_enable=True),
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=200,
-            seed=42,
             method_name=method_name,
             zero_imm=False,
         )

--- a/test/fu/test_shift_unit.py
+++ b/test/fu/test_shift_unit.py
@@ -61,3 +61,6 @@ class ShiftUnitTest(FunctionalUnitTestCase[ShiftUnitFn.Fn]):
 
     def test_fu(self):
         self.run_fu_test()
+
+    def test_pipeline(self):
+        self.run_fu_test(pipeline_test=True)

--- a/test/fu/test_shift_unit.py
+++ b/test/fu/test_shift_unit.py
@@ -1,7 +1,7 @@
 from coreblocks.params import Funct3, Funct7, OpType
 from coreblocks.fu.shift_unit import ShiftUnitFn, ShiftUnitComponent
 
-from test.fu.functional_common import FunctionalUnitTestCase
+from test.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
 class ShiftUnitTest(FunctionalUnitTestCase[ShiftUnitFn.Fn]):
@@ -9,30 +9,11 @@ class ShiftUnitTest(FunctionalUnitTestCase[ShiftUnitFn.Fn]):
     zero_imm = False
 
     ops = {
-        ShiftUnitFn.Fn.SLL: {
-            "op_type": OpType.SHIFT,
-            "funct3": Funct3.SLL,
-        },
-        ShiftUnitFn.Fn.SRL: {
-            "op_type": OpType.SHIFT,
-            "funct3": Funct3.SR,
-            "funct7": Funct7.SL,
-        },
-        ShiftUnitFn.Fn.SRA: {
-            "op_type": OpType.SHIFT,
-            "funct3": Funct3.SR,
-            "funct7": Funct7.SA,
-        },
-        ShiftUnitFn.Fn.ROL: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.ROL,
-            "funct7": Funct7.ROL,
-        },
-        ShiftUnitFn.Fn.ROR: {
-            "op_type": OpType.BIT_MANIPULATION,
-            "funct3": Funct3.ROR,
-            "funct7": Funct7.ROR,
-        },
+        ShiftUnitFn.Fn.SLL: ExecFn(OpType.SHIFT, Funct3.SLL),
+        ShiftUnitFn.Fn.SRL: ExecFn(OpType.SHIFT, Funct3.SR, Funct7.SL),
+        ShiftUnitFn.Fn.SRA: ExecFn(OpType.SHIFT, Funct3.SR, Funct7.SA),
+        ShiftUnitFn.Fn.ROL: ExecFn(OpType.BIT_MANIPULATION, Funct3.ROL, Funct7.ROL),
+        ShiftUnitFn.Fn.ROR: ExecFn(OpType.BIT_MANIPULATION, Funct3.ROR, Funct7.ROR),
     }
 
     @staticmethod

--- a/test/fu/test_zbc.py
+++ b/test/fu/test_zbc.py
@@ -4,7 +4,7 @@ from coreblocks.fu.zbc import ZbcFn, ZbcComponent
 from coreblocks.params import *
 from coreblocks.params.configurations import test_core_config
 
-from test.fu.functional_common import FunctionalUnitTestCase
+from test.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
 # Instruction semantics are based on pseudocode from the spec
@@ -52,9 +52,9 @@ def clmulr(i1: int, i2: int, xlen: int) -> int:
 )
 class ZbcUnitTest(FunctionalUnitTestCase[ZbcFn.Fn]):
     ops = {
-        ZbcFn.Fn.CLMUL: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMUL, "funct7": Funct7.CLMUL},
-        ZbcFn.Fn.CLMULH: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMULH, "funct7": Funct7.CLMUL},
-        ZbcFn.Fn.CLMULR: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMULR, "funct7": Funct7.CLMUL},
+        ZbcFn.Fn.CLMUL: ExecFn(OpType.CLMUL, Funct3.CLMUL, Funct7.CLMUL),
+        ZbcFn.Fn.CLMULH: ExecFn(OpType.CLMUL, Funct3.CLMULH, Funct7.CLMUL),
+        ZbcFn.Fn.CLMULR: ExecFn(OpType.CLMUL, Funct3.CLMULR, Funct7.CLMUL),
     }
 
     @staticmethod

--- a/test/fu/test_zbc.py
+++ b/test/fu/test_zbc.py
@@ -3,7 +3,6 @@ from parameterized import parameterized_class
 from coreblocks.fu.zbc import ZbcFn, ZbcComponent
 from coreblocks.params import *
 from coreblocks.params.configurations import test_core_config
-from test.common import RecordIntDict
 
 from test.fu.functional_common import FunctionalUnitTestCase
 
@@ -34,24 +33,6 @@ def clmulr(i1: int, i2: int, xlen: int) -> int:
     return output % (2**xlen)
 
 
-@staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbcFn.Fn, xlen: int) -> dict[str, int]:
-    match fn:
-        case ZbcFn.Fn.CLMUL:
-            return {"result": clmul(i1, i2, xlen)}
-        case ZbcFn.Fn.CLMULH:
-            return {"result": clmulh(i1, i2, xlen)}
-        case ZbcFn.Fn.CLMULR:
-            return {"result": clmulr(i1, i2, xlen)}
-
-
-ops: dict[ZbcFn.Fn, RecordIntDict] = {
-    ZbcFn.Fn.CLMUL: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMUL, "funct7": Funct7.CLMUL},
-    ZbcFn.Fn.CLMULH: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMULH, "funct7": Funct7.CLMUL},
-    ZbcFn.Fn.CLMULR: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMULR, "funct7": Funct7.CLMUL},
-}
-
-
 @parameterized_class(
     ("name", "func_unit"),
     [
@@ -70,8 +51,21 @@ ops: dict[ZbcFn.Fn, RecordIntDict] = {
     ],
 )
 class ZbcUnitTest(FunctionalUnitTestCase[ZbcFn.Fn]):
-    ops = ops
-    compute_result = compute_result
+    ops = {
+        ZbcFn.Fn.CLMUL: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMUL, "funct7": Funct7.CLMUL},
+        ZbcFn.Fn.CLMULH: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMULH, "funct7": Funct7.CLMUL},
+        ZbcFn.Fn.CLMULR: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMULR, "funct7": Funct7.CLMUL},
+    }
 
-    def test_test(self):
+    @staticmethod
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbcFn.Fn, xlen: int) -> dict[str, int]:
+        match fn:
+            case ZbcFn.Fn.CLMUL:
+                return {"result": clmul(i1, i2, xlen)}
+            case ZbcFn.Fn.CLMULH:
+                return {"result": clmulh(i1, i2, xlen)}
+            case ZbcFn.Fn.CLMULR:
+                return {"result": clmulr(i1, i2, xlen)}
+
+    def test_fu(self):
         self.run_fu_test()

--- a/test/fu/test_zbc.py
+++ b/test/fu/test_zbc.py
@@ -68,4 +68,4 @@ class ZbcUnitTest(FunctionalUnitTestCase[ZbcFn.Fn]):
                 return {"result": clmulr(i1, i2, xlen)}
 
     def test_fu(self):
-        self.run_fu_test()
+        self.run_standard_fu_test()

--- a/test/fu/test_zbc.py
+++ b/test/fu/test_zbc.py
@@ -3,8 +3,9 @@ from typing import Dict
 from coreblocks.fu.zbc import ZbcFn, ZbcComponent
 from coreblocks.params import *
 from coreblocks.params.configurations import test_core_config
+from test.common import RecordIntDict
 
-from test.fu.functional_common import GenericFunctionalTestUnit
+from test.fu.functional_common import FunctionalUnitTestCase
 
 
 # Instruction semantics are based on pseudocode from the spec
@@ -43,16 +44,16 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbcFn.Fn, xlen: in
             return {"result": clmulr(i1, i2, xlen)}
 
 
-ops = {
+ops: dict[ZbcFn.Fn, RecordIntDict] = {
     ZbcFn.Fn.CLMUL: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMUL, "funct7": Funct7.CLMUL},
     ZbcFn.Fn.CLMULH: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMULH, "funct7": Funct7.CLMUL},
     ZbcFn.Fn.CLMULR: {"op_type": OpType.CLMUL, "funct3": Funct3.CLMULR, "funct7": Funct7.CLMUL},
 }
 
 
-class IterativeZbcUnitTest(GenericFunctionalTestUnit):
+class IterativeZbcUnitTest(FunctionalUnitTestCase[ZbcFn.Fn]):
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -60,15 +61,13 @@ class IterativeZbcUnitTest(GenericFunctionalTestUnit):
             ZbcComponent(recursion_depth=0),
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=400,
-            seed=323262,
             method_name=method_name,
         )
 
 
-class RecursiveZbcUnitTestDepth3(GenericFunctionalTestUnit):
+class RecursiveZbcUnitTestDepth3(FunctionalUnitTestCase[ZbcFn.Fn]):
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -76,15 +75,13 @@ class RecursiveZbcUnitTestDepth3(GenericFunctionalTestUnit):
             ZbcComponent(recursion_depth=3),
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=400,
-            seed=323262,
             method_name=method_name,
         )
 
 
-class RecursiveZbcUnitTestFullDepth(GenericFunctionalTestUnit):
+class RecursiveZbcUnitTestFullDepth(FunctionalUnitTestCase[ZbcFn.Fn]):
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         gen = GenParams(test_core_config)
@@ -93,7 +90,5 @@ class RecursiveZbcUnitTestFullDepth(GenericFunctionalTestUnit):
             ZbcComponent(recursion_depth=gen.isa.xlen_log),
             compute_result,
             gen=gen,
-            number_of_tests=300,
-            seed=323262,
             method_name=method_name,
         )

--- a/test/fu/test_zbs.py
+++ b/test/fu/test_zbs.py
@@ -1,7 +1,8 @@
 from coreblocks.params import Funct3, Funct7
 from coreblocks.fu.zbs import ZbsFunction, ZbsComponent
+from coreblocks.params.optypes import OpType
 
-from test.fu.functional_common import FunctionalUnitTestCase
+from test.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
 class ZbsUnitTest(FunctionalUnitTestCase[ZbsFunction.Fn]):
@@ -9,22 +10,10 @@ class ZbsUnitTest(FunctionalUnitTestCase[ZbsFunction.Fn]):
     zero_imm = False
 
     ops = {
-        ZbsFunction.Fn.BCLR: {
-            "funct3": Funct3.BCLR,
-            "funct7": Funct7.BCLR,
-        },
-        ZbsFunction.Fn.BEXT: {
-            "funct3": Funct3.BEXT,
-            "funct7": Funct7.BEXT,
-        },
-        ZbsFunction.Fn.BINV: {
-            "funct3": Funct3.BINV,
-            "funct7": Funct7.BINV,
-        },
-        ZbsFunction.Fn.BSET: {
-            "funct3": Funct3.BSET,
-            "funct7": Funct7.BSET,
-        },
+        ZbsFunction.Fn.BCLR: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BCLR, Funct7.BCLR),
+        ZbsFunction.Fn.BEXT: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BEXT, Funct7.BEXT),
+        ZbsFunction.Fn.BINV: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BINV, Funct7.BINV),
+        ZbsFunction.Fn.BSET: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BSET, Funct7.BSET),
     }
 
     @staticmethod

--- a/test/fu/test_zbs.py
+++ b/test/fu/test_zbs.py
@@ -47,3 +47,6 @@ class ZbsUnitTest(FunctionalUnitTestCase[ZbsFunction.Fn]):
 
     def test_fu(self):
         self.run_fu_test()
+
+    def test_pipeline(self):
+        self.run_fu_test(pipeline_test=True)

--- a/test/fu/test_zbs.py
+++ b/test/fu/test_zbs.py
@@ -1,11 +1,11 @@
-from coreblocks.params import Funct3, Funct7, GenParams
-from coreblocks.params.configurations import test_core_config
+from coreblocks.params import Funct3, Funct7
 from coreblocks.fu.zbs import ZbsFunction, ZbsComponent
 from test.common import RecordIntDict
 
 from test.fu.functional_common import FunctionalUnitTestCase
 
 
+@staticmethod
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbsFunction.Fn, xlen: int) -> dict[str, int]:
     val2 = i_imm if i_imm else i2
 
@@ -44,15 +44,10 @@ ops: dict[ZbsFunction.Fn, RecordIntDict] = {
 
 
 class ZbsUnitTest(FunctionalUnitTestCase[ZbsFunction.Fn]):
+    ops = ops
+    func_unit = ZbsComponent()
+    compute_result = compute_result
+    zero_imm = False
+
     def test_test(self):
         self.run_fu_test()
-
-    def __init__(self, method_name: str = "runTest"):
-        super().__init__(
-            ops,
-            ZbsComponent(),
-            compute_result,
-            gen=GenParams(test_core_config),
-            method_name=method_name,
-            zero_imm=False,
-        )

--- a/test/fu/test_zbs.py
+++ b/test/fu/test_zbs.py
@@ -46,7 +46,7 @@ class ZbsUnitTest(FunctionalUnitTestCase[ZbsFunction.Fn]):
                 return {"result": i1 | (1 << index)}
 
     def test_fu(self):
-        self.run_fu_test()
+        self.run_standard_fu_test()
 
     def test_pipeline(self):
-        self.run_fu_test(pipeline_test=True)
+        self.run_standard_fu_test(pipeline_test=True)

--- a/test/fu/test_zbs.py
+++ b/test/fu/test_zbs.py
@@ -1,53 +1,49 @@
 from coreblocks.params import Funct3, Funct7
 from coreblocks.fu.zbs import ZbsFunction, ZbsComponent
-from test.common import RecordIntDict
 
 from test.fu.functional_common import FunctionalUnitTestCase
 
 
-@staticmethod
-def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbsFunction.Fn, xlen: int) -> dict[str, int]:
-    val2 = i_imm if i_imm else i2
-
-    if fn == ZbsFunction.Fn.BCLR:
-        index = val2 & (xlen - 1)
-        return {"result": i1 & ~(1 << index)}
-    if fn == ZbsFunction.Fn.BEXT:
-        index = val2 & (xlen - 1)
-        return {"result": (i1 >> index) & 1}
-    if fn == ZbsFunction.Fn.BINV:
-        index = val2 & (xlen - 1)
-        return {"result": i1 ^ (1 << index)}
-    if fn == ZbsFunction.Fn.BSET:
-        index = val2 & (xlen - 1)
-        return {"result": i1 | (1 << index)}
-
-
-ops: dict[ZbsFunction.Fn, RecordIntDict] = {
-    ZbsFunction.Fn.BCLR: {
-        "funct3": Funct3.BCLR,
-        "funct7": Funct7.BCLR,
-    },
-    ZbsFunction.Fn.BEXT: {
-        "funct3": Funct3.BEXT,
-        "funct7": Funct7.BEXT,
-    },
-    ZbsFunction.Fn.BINV: {
-        "funct3": Funct3.BINV,
-        "funct7": Funct7.BINV,
-    },
-    ZbsFunction.Fn.BSET: {
-        "funct3": Funct3.BSET,
-        "funct7": Funct7.BSET,
-    },
-}
-
-
 class ZbsUnitTest(FunctionalUnitTestCase[ZbsFunction.Fn]):
-    ops = ops
     func_unit = ZbsComponent()
-    compute_result = compute_result
     zero_imm = False
 
-    def test_test(self):
+    ops = {
+        ZbsFunction.Fn.BCLR: {
+            "funct3": Funct3.BCLR,
+            "funct7": Funct7.BCLR,
+        },
+        ZbsFunction.Fn.BEXT: {
+            "funct3": Funct3.BEXT,
+            "funct7": Funct7.BEXT,
+        },
+        ZbsFunction.Fn.BINV: {
+            "funct3": Funct3.BINV,
+            "funct7": Funct7.BINV,
+        },
+        ZbsFunction.Fn.BSET: {
+            "funct3": Funct3.BSET,
+            "funct7": Funct7.BSET,
+        },
+    }
+
+    @staticmethod
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbsFunction.Fn, xlen: int) -> dict[str, int]:
+        val2 = i_imm if i_imm else i2
+
+        match fn:
+            case ZbsFunction.Fn.BCLR:
+                index = val2 & (xlen - 1)
+                return {"result": i1 & ~(1 << index)}
+            case ZbsFunction.Fn.BEXT:
+                index = val2 & (xlen - 1)
+                return {"result": (i1 >> index) & 1}
+            case ZbsFunction.Fn.BINV:
+                index = val2 & (xlen - 1)
+                return {"result": i1 ^ (1 << index)}
+            case ZbsFunction.Fn.BSET:
+                index = val2 & (xlen - 1)
+                return {"result": i1 | (1 << index)}
+
+    def test_fu(self):
         self.run_fu_test()

--- a/test/fu/test_zbs.py
+++ b/test/fu/test_zbs.py
@@ -1,8 +1,9 @@
 from coreblocks.params import Funct3, Funct7, GenParams
 from coreblocks.params.configurations import test_core_config
 from coreblocks.fu.zbs import ZbsFunction, ZbsComponent
+from test.common import RecordIntDict
 
-from test.fu.functional_common import GenericFunctionalTestUnit
+from test.fu.functional_common import FunctionalUnitTestCase
 
 
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbsFunction.Fn, xlen: int) -> dict[str, int]:
@@ -22,7 +23,7 @@ def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbsFunction.Fn, xl
         return {"result": i1 | (1 << index)}
 
 
-ops = {
+ops: dict[ZbsFunction.Fn, RecordIntDict] = {
     ZbsFunction.Fn.BCLR: {
         "funct3": Funct3.BCLR,
         "funct7": Funct7.BCLR,
@@ -42,9 +43,9 @@ ops = {
 }
 
 
-class ZbsUnitTest(GenericFunctionalTestUnit):
+class ZbsUnitTest(FunctionalUnitTestCase[ZbsFunction.Fn]):
     def test_test(self):
-        self.run_pipeline()
+        self.run_fu_test()
 
     def __init__(self, method_name: str = "runTest"):
         super().__init__(
@@ -52,8 +53,6 @@ class ZbsUnitTest(GenericFunctionalTestUnit):
             ZbsComponent(),
             compute_result,
             gen=GenParams(test_core_config),
-            number_of_tests=600,
-            seed=32323,
             method_name=method_name,
             zero_imm=False,
         )


### PR DESCRIPTION
Generic testing of functional units is nice, but it was kind of smelly in places. This PR refactors the FU tests a little.

Changes:
* Constructor no longer overloaded. Constructor parameters are now attributes. This eliminates the `method_name` weirdness, and also simplifies interoperation with `parameterized_class`.
* `number_of_tests` now specifies the number of tests per operation, which is much more useful - it guarantees that operations are tested equally, and the number does not need to be tweaked.
* `if` on `Fn` changed to `match`.
* Added a generic pipelining test.
* Reduced verbosity in operation lists.
* Improved typing.

Fixes #341.