### PR TITLE
Add simultaneous transaction count warning

### DIFF
--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -9,6 +9,7 @@ from amaranth import *
 from amaranth import tracer
 from itertools import count, chain, filterfalse, product
 from amaranth.hdl.dsl import FSM, _ModuleBuilderDomain
+from warnings import warn
 
 from coreblocks.utils import AssignType, assign, ModuleConnector
 from coreblocks.utils.utils import OneHotSwitchDynamic
@@ -358,6 +359,12 @@ class TransactionManager(Elaboratable):
                 continue
             q.extend(new_group | other_group for other_group in simultaneous if new_group & other_group)
             tr_simultaneous.add(new_group)
+
+        if len(tr_simultaneous) > 3000:
+            warn(
+                f"There is a lot of simultaneous transactions generated: {len(tr_simultaneous)}."
+                + "Elaborating can take hudge time. Are you sure that you didn't do any mistake?"
+            )
 
         # step 3: maximal group selection
         def maximal(group: frozenset[Transaction]):

--- a/coreblocks/transactions/core.py
+++ b/coreblocks/transactions/core.py
@@ -363,7 +363,7 @@ class TransactionManager(Elaboratable):
         if len(tr_simultaneous) > 3000:
             warn(
                 f"There is a lot of simultaneous transactions generated: {len(tr_simultaneous)}."
-                + "Elaborating can take hudge time. Are you sure that you didn't do any mistake?"
+                + "Elaborating can take huge time. Are you sure that you didn't do any mistake?"
             )
 
         # step 3: maximal group selection


### PR DESCRIPTION
Today my tests stuck in loop, and it looks like I did an error in using simultaneous transaction, which generated huge number of them (~30 000), so transactron haven't even started simulation. Here I add a warning so that in future it will be easier to find such problems.

Number of transactions from which warning appears was chosen empirically. By 3000 generating take already observable big time, but no such big that it will be killed by user pressing Ctrl-C.