### PR TITLE
DummyLSU: add FENCE

### DIFF
--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -443,3 +443,49 @@ class TestDummyLSUStores(TestCaseWithSimulator):
             sim.add_sync_process(self.get_resulter)
             sim.add_sync_process(self.precommiter)
             sim.add_sync_process(exception_consumer)
+
+
+class TestDummyLSUFence(TestCaseWithSimulator):
+    def get_instr(self, exec_fn):
+        return {
+            "rp_s1": 0,
+            "rp_s2": 0,
+            "rp_dst": 1,
+            "rob_id": 1,
+            "exec_fn": exec_fn,
+            "s1_val": 4,
+            "s2_val": 1,
+            "imm": 8,
+        }
+
+    def push_one_instr(self, instr):
+        yield from self.test_module.select.call()
+        yield from self.test_module.insert.call(rs_data=instr, rs_entry_id=1)
+
+        if instr["exec_fn"]["op_type"] == OpType.LOAD:
+            yield from self.test_module.io_in.slave_wait()
+            yield from self.test_module.io_in.slave_respond(1)
+            yield Settle()
+        v = yield from self.test_module.get_result.call()
+        if instr["exec_fn"]["op_type"] == OpType.LOAD:
+            self.assertEqual(v["result"], 1)
+
+    def process(self):
+        # just tests if FENCE doens't hang up the LSU
+        load_fn = {"op_type": OpType.LOAD, "funct3": Funct3.W, "funct7": 0}
+        fence_fn = {"op_type": OpType.FENCE, "funct3": 0, "funct7": 0}
+        yield from self.push_one_instr(self.get_instr(load_fn))
+        yield from self.push_one_instr(self.get_instr(fence_fn))
+        yield from self.push_one_instr(self.get_instr(load_fn))
+
+    def test_fence(self):
+        self.gp = GenParams(test_core_config.replace(phys_regs_bits=3, rob_entries_bits=3))
+        self.test_module = DummyLSUTestCircuit(self.gp)
+
+        @def_method_mock(lambda: self.test_module.exception_report)
+        def exception_consumer(arg):
+            self.assertTrue(False)
+
+        with self.run_simulation(self.test_module) as sim:
+            sim.add_sync_process(self.process)
+            sim.add_sync_process(exception_consumer)

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -17,7 +17,7 @@ class TestConfigurationsISAString(TestCase):
 
     TEST_CASES = [
         ISAStrTest(basic_core_config, "rv32i", "rv32", "rv32i"),
-        ISAStrTest(full_core_config, "rv32imcbzicsr", "rv32mcbzicsr", "rv32imcbzicsr"),
+        ISAStrTest(full_core_config, "rv32imcbzicsr", "rv32imcbzicsr", "rv32imcbzicsr"),
         ISAStrTest(tiny_core_config, "rv32i", "rv32", "rv32i"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),
     ]


### PR DESCRIPTION
Finally, someone had to do it :)
Closes #311.
Implemented and tested no-op in dummyLsu.

As we now fully support the I extension, I thought of setting `allow_partial_extensions` in core configurations to `False`. But I extension specifies `ECALL` and `EBREAK`, so `ExceptionUnit` is necessary to comply with it. Do we want to put `ExceptionUnit` in `basic_core_config`? What about the tiny one?