### PR TITLE
Settle-free testing

### DIFF
--- a/coreblocks/lsu/dummyLsu.py
+++ b/coreblocks/lsu/dummyLsu.py
@@ -2,7 +2,7 @@ from amaranth import *
 
 from coreblocks.transactions import Method, def_method, Transaction, TModule
 from coreblocks.params import *
-from coreblocks.peripherals.wishbone import WishboneMaster
+from coreblocks.peripherals.wishbone import WishboneMasterProtocol
 from coreblocks.utils import assign, ModuleLike
 from coreblocks.utils.protocols import FuncBlock
 
@@ -26,7 +26,7 @@ class LSUDummyInternals(Elaboratable):
         Signals that `resultData` is valid.
     """
 
-    def __init__(self, gen_params: GenParams, bus: WishboneMaster, current_instr: Record) -> None:
+    def __init__(self, gen_params: GenParams, bus: WishboneMasterProtocol, current_instr: Record) -> None:
         """
         Parameters
         ----------
@@ -190,7 +190,7 @@ class LSUDummy(FuncBlock, Elaboratable):
         Used to inform LSU that new instruction is ready to be retired.
     """
 
-    def __init__(self, gen_params: GenParams, bus: WishboneMaster) -> None:
+    def __init__(self, gen_params: GenParams, bus: WishboneMasterProtocol) -> None:
         """
         Parameters
         ----------

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -1,10 +1,9 @@
 import random
-from collections import deque
 from typing import Optional
 
-from amaranth.sim import Settle, Passive
+from amaranth import *
 
-from coreblocks.transactions.lib import Adapter
+from coreblocks.transactions.lib import Adapter, AdapterTrans
 from coreblocks.params import OpType, GenParams
 from coreblocks.lsu.dummyLsu import LSUDummy
 from coreblocks.params.configurations import test_core_config
@@ -12,9 +11,10 @@ from coreblocks.params.isa import *
 from coreblocks.params.keys import ExceptionReportKey
 from coreblocks.params.dependencies import DependencyManager
 from coreblocks.params.layouts import ExceptionRegisterLayouts
-from coreblocks.peripherals.wishbone import *
-from test.common import TestbenchIO, TestCaseWithSimulator, def_method_mock, int_to_signed, signed_to_int
-from test.peripherals.test_wishbone import WishboneInterfaceWrapper
+from coreblocks.peripherals.wishbone import WishboneParameters
+from coreblocks.utils import LayoutLike
+from test.common import TestCaseWithSimulator, int_to_signed, signed_to_int
+from test.transactional_testing import Sim, SimFIFO, WaitSettled
 
 
 def generate_register(max_reg_val: int, phys_regs_bits: int) -> tuple[int, int, Optional[dict[str, int]], int]:
@@ -72,6 +72,37 @@ def check_align(addr: int, op: tuple[OpType, Funct3]) -> bool:
     return False
 
 
+class WishboneMasterStub(Elaboratable):
+    def __init__(self, wb_params: WishboneParameters):
+        # initialisation taken from peripherals/wishbone.py -- maybe there is possibility to make it common?
+        self.wb_params = wb_params
+        self.generate_layouts(wb_params)
+
+        self.request_adapter = Adapter(i=self.requestLayout)
+        self.request = self.request_adapter.iface
+        self.result_adapter = Adapter(o=self.resultLayout)
+        self.result = self.result_adapter.iface
+
+    def generate_layouts(self, wb_params: WishboneParameters):
+        # generate method layouts locally
+        self.requestLayout: LayoutLike = [
+            ("addr", wb_params.addr_width),
+            ("data", wb_params.data_width),
+            ("we", 1),
+            ("sel", wb_params.data_width // wb_params.granularity),
+        ]
+
+        self.resultLayout: LayoutLike = [("data", wb_params.data_width), ("err", 1)]
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.request_adapter = self.request_adapter
+        m.submodules.result_adapter = self.result_adapter
+
+        return m
+
+
 class DummyLSUTestCircuit(Elaboratable):
     def __init__(self, gen: GenParams):
         self.gen = gen
@@ -84,22 +115,19 @@ class DummyLSUTestCircuit(Elaboratable):
             addr_width=32,
         )
 
-        self.bus = WishboneMaster(wb_params)
+        self.bus = WishboneMasterStub(wb_params)
 
-        m.submodules.exception_report = self.exception_report = TestbenchIO(
-            Adapter(i=self.gen.get(ExceptionRegisterLayouts).report)
-        )
+        m.submodules.exception_report = self.exception_report = Adapter(i=self.gen.get(ExceptionRegisterLayouts).report)
 
-        self.gen.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
+        self.gen.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.iface)
 
         m.submodules.func_unit = func_unit = LSUDummy(self.gen, self.bus)
 
-        m.submodules.select_mock = self.select = TestbenchIO(AdapterTrans(func_unit.select))
-        m.submodules.insert_mock = self.insert = TestbenchIO(AdapterTrans(func_unit.insert))
-        m.submodules.update_mock = self.update = TestbenchIO(AdapterTrans(func_unit.update))
-        m.submodules.get_result_mock = self.get_result = TestbenchIO(AdapterTrans(func_unit.get_result))
-        m.submodules.precommit_mock = self.precommit = TestbenchIO(AdapterTrans(func_unit.precommit))
-        self.io_in = WishboneInterfaceWrapper(self.bus.wbMaster)
+        m.submodules.select_mock = self.select = AdapterTrans(func_unit.select)
+        m.submodules.insert_mock = self.insert = AdapterTrans(func_unit.insert)
+        m.submodules.update_mock = self.update = AdapterTrans(func_unit.update)
+        m.submodules.get_result_mock = self.get_result = AdapterTrans(func_unit.get_result)
+        m.submodules.precommit_mock = self.precommit = AdapterTrans(func_unit.precommit)
         m.submodules.bus = self.bus
         return m
 
@@ -133,7 +161,6 @@ class TestDummyLSULoads(TestCaseWithSimulator):
                     misaligned = True
                     break
 
-            self.announce_queue.append(ann_data)
             exec_fn = {"op_type": op[0], "funct3": op[1], "funct7": 0}
 
             # calculate word address and mask
@@ -142,7 +169,7 @@ class TestDummyLSULoads(TestCaseWithSimulator):
 
             rp_dst = random.randint(0, 2**self.gp.phys_regs_bits - 1)
             rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
-            instr = {
+            instr_data = {
                 "rp_s1": rp_s1,
                 "rp_s2": 0,
                 "rp_dst": rp_dst,
@@ -152,340 +179,355 @@ class TestDummyLSULoads(TestCaseWithSimulator):
                 "s2_val": 0,
                 "imm": imm,
             }
-            self.instr_queue.append(instr)
-            self.mem_data_queue.append(
-                {
-                    "addr": addr,
-                    "mask": mask,
-                    "sign": signess,
-                    "rnd_bytes": bytes.fromhex(f"{random.randint(0,2**32-1):08x}"),
-                    "misaligned": misaligned,
-                    "err": bus_err,
-                }
-            )
-
-            if misaligned or bus_err:
-                self.exception_queue.append(
-                    {
-                        "rob_id": rob_id,
-                        "cause": ExceptionCause.LOAD_ADDRESS_MISALIGNED
-                        if misaligned
-                        else ExceptionCause.LOAD_ACCESS_FAULT,
-                    }
-                )
-
-            self.exception_result.append(
-                misaligned or bus_err,
-            )
-
-    def setUp(self) -> None:
-        random.seed(14)
-        self.tests_number = 100
-        self.gp = GenParams(test_core_config.replace(phys_regs_bits=3, rob_entries_bits=3))
-        self.test_module = DummyLSUTestCircuit(self.gp)
-        self.instr_queue = deque()
-        self.announce_queue = deque()
-        self.mem_data_queue = deque()
-        self.returned_data = deque()
-        self.exception_queue = deque()
-        self.exception_result = deque()
-        self.generate_instr(2**7, 2**7)
-
-    def random_wait(self):
-        for i in range(random.randint(0, 10)):
-            yield
-
-    def wishbone_slave(self):
-        yield Passive()
-
-        while True:
-            yield from self.test_module.io_in.slave_wait()
-            generated_data = self.mem_data_queue.pop()
-
-            if generated_data["misaligned"]:
-                continue
-
-            mask = generated_data["mask"]
-            sign = generated_data["sign"]
-            yield from self.test_module.io_in.slave_verify(generated_data["addr"], 0, 0, mask)
-            yield from self.random_wait()
-
-            resp_data = int((generated_data["rnd_bytes"][:4]).hex(), 16)
-            data_shift = (mask & -mask).bit_length() - 1
-            assert mask.bit_length() == data_shift + mask.bit_count(), "Unexpected mask"
-
-            size = mask.bit_count() * 8
-            data_mask = 2**size - 1
-            data = (resp_data >> (data_shift * 8)) & data_mask
-            if sign:
-                data = int_to_signed(signed_to_int(data, size), 32)
-            if not generated_data["err"]:
-                self.returned_data.append(data)
-            yield from self.test_module.io_in.slave_respond(resp_data, err=generated_data["err"])
-            yield Settle()
-
-    def inserter(self):
-        for i in range(self.tests_number):
-            req = self.instr_queue.pop()
-            ret = yield from self.test_module.select.call()
-            self.assertEqual(ret["rs_entry_id"], 0)
-            yield from self.test_module.insert.call(rs_data=req, rs_entry_id=1)
-            announc = self.announce_queue.pop()
-            if announc is not None:
-                yield from self.test_module.update.call(announc)
-            yield from self.random_wait()
-
-    def consumer(self):
-        for i in range(self.tests_number):
-            v = yield from self.test_module.get_result.call()
-            exc = self.exception_result.pop()
-            if not exc:
-                self.assertEqual(v["result"], self.returned_data.pop())
-            self.assertEqual(v["exception"], exc)
-
-            yield from self.random_wait()
-
-    def test(self):
-        @def_method_mock(lambda: self.test_module.exception_report)
-        def exception_consumer(arg):
-            self.assertDictEqual(arg, self.exception_queue.pop())
-
-        with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.wishbone_slave)
-            sim.add_sync_process(self.inserter)
-            sim.add_sync_process(self.consumer)
-            sim.add_sync_process(exception_consumer)
-
-
-class TestDummyLSULoadsCycles(TestCaseWithSimulator):
-    def generate_instr(self, max_reg_val, max_imm_val):
-        s1_val = random.randint(0, max_reg_val // 4) * 4
-        imm = random.randint(0, max_imm_val // 4) * 4
-        rp_dst = random.randint(0, 2**self.gp.phys_regs_bits - 1)
-        rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
-
-        exec_fn = {"op_type": OpType.LOAD, "funct3": Funct3.W, "funct7": 0}
-        instr = {
-            "rp_s1": 0,
-            "rp_s2": 0,
-            "rp_dst": rp_dst,
-            "rob_id": rob_id,
-            "exec_fn": exec_fn,
-            "s1_val": s1_val,
-            "s2_val": 0,
-            "imm": imm,
-        }
-
-        wish_data = {
-            "addr": (s1_val + imm) >> 2,
-            "mask": 0xF,
-            "rnd_bytes": bytes.fromhex(f"{random.randint(0,2**32-1):08x}"),
-        }
-        return instr, wish_data
-
-    def setUp(self) -> None:
-        random.seed(14)
-        self.gp = GenParams(test_core_config.replace(phys_regs_bits=3, rob_entries_bits=3))
-        self.test_module = DummyLSUTestCircuit(self.gp)
-
-    def one_instr_test(self):
-        instr, wish_data = self.generate_instr(2**7, 2**7)
-
-        ret = yield from self.test_module.select.call()
-        self.assertEqual(ret["rs_entry_id"], 0)
-        yield from self.test_module.insert.call(rs_data=instr, rs_entry_id=1)
-        yield from self.test_module.io_in.slave_wait()
-
-        mask = wish_data["mask"]
-        yield from self.test_module.io_in.slave_verify(wish_data["addr"], 0, 0, mask)
-        data = wish_data["rnd_bytes"][:4]
-        data = int(data.hex(), 16)
-        yield from self.test_module.io_in.slave_respond(data)
-        yield Settle()
-
-        v = yield from self.test_module.get_result.call()
-        self.assertEqual(v["result"], data)
-
-    def test(self):
-        @def_method_mock(lambda: self.test_module.exception_report)
-        def exception_consumer(arg):
-            self.assertTrue(False)
-
-        with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.one_instr_test)
-            sim.add_sync_process(exception_consumer)
-
-
-class TestDummyLSUStores(TestCaseWithSimulator):
-    def generate_instr(self, max_reg_val, max_imm_val):
-        ops = {
-            "SB": (OpType.STORE, Funct3.B),
-            "SH": (OpType.STORE, Funct3.H),
-            "SW": (OpType.STORE, Funct3.W),
-        }
-        for i in range(self.tests_number):
-            while True:
-                # generate opcode
-                (op, mask, _) = generate_random_op(ops)
-                # generate rp1, val1 which create addr
-                rp_s1, s1_val, ann_data1, addr = generate_register(max_reg_val, self.gp.phys_regs_bits)
-                imm = generate_imm(max_imm_val)
-                addr += imm
-                if check_align(addr, op):
-                    break
-
-            rp_s2, s2_val, ann_data2, data = generate_register(0xFFFFFFFF, self.gp.phys_regs_bits)
-            if rp_s1 == rp_s2 and ann_data1 is not None and ann_data2 is not None:
-                ann_data2 = None
-                data = ann_data1["value"]
-            # decide in which order we would get announcments
-            if random.randint(0, 1):
-                self.announce_queue.append((ann_data1, ann_data2))
-            else:
-                self.announce_queue.append((ann_data2, ann_data1))
-
-            exec_fn = {"op_type": op[0], "funct3": op[1], "funct7": 0}
-
-            # calculate word address and mask
-            mask = shift_mask_based_on_addr(mask, addr)
-            addr = addr >> 2
-
-            rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
-            instr = {
-                "rp_s1": rp_s1,
-                "rp_s2": rp_s2,
-                "rp_dst": 0,
-                "rob_id": rob_id,
-                "exec_fn": exec_fn,
-                "s1_val": s1_val,
-                "s2_val": s2_val,
-                "imm": imm,
+            mem_data = {
+                "addr": addr,
+                "mask": mask,
+                "sign": signess,
+                "rnd_bytes": random.randint(0, 2**32 - 1),
+                "misaligned": misaligned,
+                "err": bus_err,
             }
-            self.instr_queue.append(instr)
-            self.mem_data_queue.append({"addr": addr, "mask": mask, "data": bytes.fromhex(f"{data:08x}")})
+            exc_data = (
+                {
+                    "rob_id": rob_id,
+                    "cause": ExceptionCause.LOAD_ADDRESS_MISALIGNED if misaligned else ExceptionCause.LOAD_ACCESS_FAULT,
+                }
+                if misaligned or bus_err
+                else None
+            )
+            self.instr_queue.init_push({"instr": instr_data, "ann": ann_data, "mem": mem_data, "exc": exc_data})
 
     def setUp(self) -> None:
         random.seed(14)
         self.tests_number = 100
         self.gp = GenParams(test_core_config.replace(phys_regs_bits=3, rob_entries_bits=3))
         self.test_module = DummyLSUTestCircuit(self.gp)
-        self.instr_queue = deque()
-        self.announce_queue = deque()
-        self.mem_data_queue = deque()
-        self.get_result_data = deque()
-        self.precommit_data = deque()
+        self.instr_queue = SimFIFO()
+        self.mem_data_queue = SimFIFO()
+        self.mem_result_queue = SimFIFO()
+        self.returned_data = SimFIFO()
+        self.exception_queue = SimFIFO()
+        self.exception_result = SimFIFO()
         self.generate_instr(2**7, 2**7)
+        self.announce_queue = SimFIFO()
 
-    def random_wait(self):
-        for i in range(random.randint(0, 8)):
-            yield
+    @Sim.def_method_mock(
+        lambda self: self.test_module.bus.request_adapter,
+        enable=lambda self: self.mem_data_queue.not_empty(),
+        max_delay=10,
+        enabled_active=True,
+    )
+    async def wishbone_request(self, addr, data, we, sel):
+        generated_data = await self.mem_data_queue.pop()
+        mask = generated_data["mask"]
+        sign = generated_data["sign"]
 
-    def wishbone_slave(self):
-        for i in range(self.tests_number):
-            yield from self.test_module.io_in.slave_wait()
-            generated_data = self.mem_data_queue.pop()
+        await WaitSettled()
 
-            mask = generated_data["mask"]
-            b_dict = {1: 0, 2: 8, 4: 16, 8: 24}
-            h_dict = {3: 0, 0xC: 16}
-            if mask in b_dict:
-                data = (int(generated_data["data"][-1:].hex(), 16) & 0xFF) << b_dict[mask]
-            elif mask in h_dict:
-                data = (int(generated_data["data"][-2:].hex(), 16) & 0xFFFF) << h_dict[mask]
-            else:
-                data = int(generated_data["data"][-4:].hex(), 16)
-            yield from self.test_module.io_in.slave_verify(generated_data["addr"], data, 1, mask)
-            yield from self.random_wait()
+        self.assertEqual(addr, generated_data["addr"])
+        self.assertEqual(data, 0)
+        self.assertEqual(we, 0)
+        self.assertEqual(sel, mask)
 
-            yield from self.test_module.io_in.slave_respond(0)
-            yield Settle()
+        resp_data = generated_data["rnd_bytes"]
+        data_shift = (mask & -mask).bit_length() - 1
+        assert mask.bit_length() == data_shift + mask.bit_count(), "Unexpected mask"
 
-    def inserter(self):
-        for i in range(self.tests_number):
-            req = self.instr_queue.pop()
-            self.get_result_data.appendleft(req["rob_id"])
-            ret = yield from self.test_module.select.call()
-            self.assertEqual(ret["rs_entry_id"], 0)
-            yield from self.test_module.insert.call(rs_data=req, rs_entry_id=0)
-            self.precommit_data.appendleft(req["rob_id"])
-            announc = self.announce_queue.pop()
-            for j in range(2):
-                if announc[j] is not None:
-                    yield from self.random_wait()
-                    yield from self.test_module.update.call(announc[j])
-            yield from self.random_wait()
+        size = mask.bit_count() * 8
+        data_mask = 2**size - 1
+        data = (resp_data >> (data_shift * 8)) & data_mask
+        if sign:
+            data = int_to_signed(signed_to_int(data, size), 32)
+        if not generated_data["err"]:
+            await self.returned_data.push(data)
 
-    def get_resulter(self):
-        for i in range(self.tests_number):
-            v = yield from self.test_module.get_result.call()
-            rob_id = self.get_result_data.pop()
-            self.assertEqual(v["rob_id"], rob_id)
-            self.assertEqual(v["rp_dst"], 0)
-            yield from self.random_wait()
-            self.precommit_data.pop()  # retire
+        await self.mem_result_queue.push({"data": resp_data, "err": generated_data["err"]})
 
-    def precommiter(self):
-        yield Passive()
-        while True:
-            while len(self.precommit_data) == 0:
-                yield
-            rob_id = self.precommit_data[-1]  # precommit is called continously until instruction is retired
-            yield from self.test_module.precommit.call(rob_id=rob_id)
+    @Sim.def_method_mock(
+        lambda self: self.test_module.bus.result_adapter,
+        enable=lambda self: self.mem_result_queue.not_empty(),
+        enabled_active=True,
+    )
+    async def wishbone_result(self):
+        return await self.mem_result_queue.pop()
+
+    @Sim.queue_reader(lambda self: self.instr_queue, max_delay=10)
+    async def inserter(self, req):
+        ret = await Sim.call(self.test_module.select)
+        self.assertEqual(ret["rs_entry_id"], 0)
+
+        await Sim.call(self.test_module.insert, rs_data=req["instr"], rs_entry_id=0)
+
+        if not req["mem"]["misaligned"]:
+            await self.mem_data_queue.push(req["mem"])
+        if req["ann"] is not None:
+            await self.announce_queue.push(req["ann"])
+        await self.exception_result.push(req["exc"] is not None)
+        if req["exc"] is not None:
+            await self.exception_queue.push(req["exc"])
+
+    @Sim.queue_reader(lambda self: self.announce_queue, max_delay=10)
+    async def announcer(self, announc):
+        await Sim.call(self.test_module.update, announc)
+
+    @Sim.def_method_mock(
+        lambda self: self.test_module.get_result, max_delay=10, active=lambda self: self.exception_result.not_empty()
+    )
+    async def consumer(self, arg):
+        await WaitSettled()
+        exc = await self.exception_result.pop()
+        if not exc:
+            self.assertEqual(arg["result"], await self.returned_data.pop())
+        self.assertEqual(arg["exception"], exc)
+
+    @Sim.def_method_mock(
+        lambda self: self.test_module.exception_report, active=lambda self: self.exception_queue.not_empty()
+    )
+    async def exception_consumer(self, arg):
+        await WaitSettled()
+        self.assertDictEqual(arg, await self.exception_queue.pop())
 
     def test(self):
-        @def_method_mock(lambda: self.test_module.exception_report)
-        def exception_consumer(arg):
-            self.assertTrue(False)
-
         with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.wishbone_slave)
-            sim.add_sync_process(self.inserter)
-            sim.add_sync_process(self.get_resulter)
-            sim.add_sync_process(self.precommiter)
-            sim.add_sync_process(exception_consumer)
+            tsim = Sim()
+            tsim.add_process(self.wishbone_request)
+            tsim.add_process(self.wishbone_result)
+            tsim.add_process(self.inserter)
+            tsim.add_process(self.announcer)
+            tsim.add_process(self.consumer)
+            tsim.add_process(self.exception_consumer)
+            sim.add_sync_process(tsim.process)
 
 
-class TestDummyLSUFence(TestCaseWithSimulator):
-    def get_instr(self, exec_fn):
-        return {
-            "rp_s1": 0,
-            "rp_s2": 0,
-            "rp_dst": 1,
-            "rob_id": 1,
-            "exec_fn": exec_fn,
-            "s1_val": 4,
-            "s2_val": 1,
-            "imm": 8,
-        }
-
-    def push_one_instr(self, instr):
-        yield from self.test_module.select.call()
-        yield from self.test_module.insert.call(rs_data=instr, rs_entry_id=1)
-
-        if instr["exec_fn"]["op_type"] == OpType.LOAD:
-            yield from self.test_module.io_in.slave_wait()
-            yield from self.test_module.io_in.slave_respond(1)
-            yield Settle()
-        v = yield from self.test_module.get_result.call()
-        if instr["exec_fn"]["op_type"] == OpType.LOAD:
-            self.assertEqual(v["result"], 1)
-
-    def process(self):
-        # just tests if FENCE doens't hang up the LSU
-        load_fn = {"op_type": OpType.LOAD, "funct3": Funct3.W, "funct7": 0}
-        fence_fn = {"op_type": OpType.FENCE, "funct3": 0, "funct7": 0}
-        yield from self.push_one_instr(self.get_instr(load_fn))
-        yield from self.push_one_instr(self.get_instr(fence_fn))
-        yield from self.push_one_instr(self.get_instr(load_fn))
-
-    def test_fence(self):
-        self.gp = GenParams(test_core_config.replace(phys_regs_bits=3, rob_entries_bits=3))
-        self.test_module = DummyLSUTestCircuit(self.gp)
-
-        @def_method_mock(lambda: self.test_module.exception_report)
-        def exception_consumer(arg):
-            self.assertTrue(False)
-
-        with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.process)
-            sim.add_sync_process(exception_consumer)
+# class TestDummyLSULoadsCycles(TestCaseWithSimulator):
+#    def generate_instr(self, max_reg_val, max_imm_val):
+#        s1_val = random.randint(0, max_reg_val // 4) * 4
+#        imm = random.randint(0, max_imm_val // 4) * 4
+#        rp_dst = random.randint(0, 2**self.gp.phys_regs_bits - 1)
+#        rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
+#
+#        exec_fn = {"op_type": OpType.LOAD, "funct3": Funct3.W, "funct7": 0}
+#        instr = {
+#            "rp_s1": 0,
+#            "rp_s2": 0,
+#            "rp_dst": rp_dst,
+#            "rob_id": rob_id,
+#            "exec_fn": exec_fn,
+#            "s1_val": s1_val,
+#            "s2_val": 0,
+#            "imm": imm,
+#        }
+#
+#        wish_data = {
+#            "addr": (s1_val + imm) >> 2,
+#            "mask": 0xF,
+#            "rnd_bytes": bytes.fromhex(f"{random.randint(0,2**32-1):08x}"),
+#        }
+#        return instr, wish_data
+#
+#    def setUp(self) -> None:
+#        random.seed(14)
+#        self.gp = GenParams(test_core_config.replace(phys_regs_bits=3, rob_entries_bits=3))
+#        self.test_module = DummyLSUTestCircuit(self.gp)
+#
+#    def one_instr_test(self):
+#        instr, wish_data = self.generate_instr(2**7, 2**7)
+#
+#        ret = yield from self.test_module.select.call()
+#        self.assertEqual(ret["rs_entry_id"], 0)
+#        yield from self.test_module.insert.call(rs_data=instr, rs_entry_id=1)
+#        yield from self.test_module.io_in.slave_wait()
+#
+#        mask = wish_data["mask"]
+#        yield from self.test_module.io_in.slave_verify(wish_data["addr"], 0, 0, mask)
+#        data = wish_data["rnd_bytes"][:4]
+#        data = int(data.hex(), 16)
+#        yield from self.test_module.io_in.slave_respond(data)
+#        yield Settle()
+#
+#        v = yield from self.test_module.get_result.call()
+#        self.assertEqual(v["result"], data)
+#
+#    def test(self):
+#        @def_method_mock(lambda: self.test_module.exception_report)
+#        def exception_consumer(arg):
+#            self.assertTrue(False)
+#
+#        with self.run_simulation(self.test_module) as sim:
+#            sim.add_sync_process(self.one_instr_test)
+#            sim.add_sync_process(exception_consumer)
+#
+#
+# class TestDummyLSUStores(TestCaseWithSimulator):
+#    def generate_instr(self, max_reg_val, max_imm_val):
+#        ops = {
+#            "SB": (OpType.STORE, Funct3.B),
+#            "SH": (OpType.STORE, Funct3.H),
+#            "SW": (OpType.STORE, Funct3.W),
+#        }
+#        for i in range(self.tests_number):
+#            while True:
+#                # generate opcode
+#                (op, mask, _) = generate_random_op(ops)
+#                # generate rp1, val1 which create addr
+#                rp_s1, s1_val, ann_data1, addr = generate_register(max_reg_val, self.gp.phys_regs_bits)
+#                imm = generate_imm(max_imm_val)
+#                addr += imm
+#                if check_align(addr, op):
+#                    break
+#
+#            rp_s2, s2_val, ann_data2, data = generate_register(0xFFFFFFFF, self.gp.phys_regs_bits)
+#            if rp_s1 == rp_s2 and ann_data1 is not None and ann_data2 is not None:
+#                ann_data2 = None
+#                data = ann_data1["value"]
+#            # decide in which order we would get announcments
+#            if random.randint(0, 1):
+#                self.announce_queue.append((ann_data1, ann_data2))
+#            else:
+#                self.announce_queue.append((ann_data2, ann_data1))
+#
+#            exec_fn = {"op_type": op[0], "funct3": op[1], "funct7": 0}
+#
+#            # calculate word address and mask
+#            mask = shift_mask_based_on_addr(mask, addr)
+#            addr = addr >> 2
+#
+#            rob_id = random.randint(0, 2**self.gp.rob_entries_bits - 1)
+#            instr = {
+#                "rp_s1": rp_s1,
+#                "rp_s2": rp_s2,
+#                "rp_dst": 0,
+#                "rob_id": rob_id,
+#                "exec_fn": exec_fn,
+#                "s1_val": s1_val,
+#                "s2_val": s2_val,
+#                "imm": imm,
+#            }
+#            self.instr_queue.append(instr)
+#            self.mem_data_queue.append({"addr": addr, "mask": mask, "data": bytes.fromhex(f"{data:08x}")})
+#
+#    def setUp(self) -> None:
+#        random.seed(14)
+#        self.tests_number = 100
+#        self.gp = GenParams(test_core_config.replace(phys_regs_bits=3, rob_entries_bits=3))
+#        self.test_module = DummyLSUTestCircuit(self.gp)
+#        self.instr_queue = deque()
+#        self.announce_queue = deque()
+#        self.mem_data_queue = deque()
+#        self.get_result_data = deque()
+#        self.precommit_data = deque()
+#        self.generate_instr(2**7, 2**7)
+#
+#    def random_wait(self):
+#        for i in range(random.randint(0, 8)):
+#            yield
+#
+#    def wishbone_slave(self):
+#        for i in range(self.tests_number):
+#            yield from self.test_module.io_in.slave_wait()
+#            generated_data = self.mem_data_queue.pop()
+#
+#            mask = generated_data["mask"]
+#            b_dict = {1: 0, 2: 8, 4: 16, 8: 24}
+#            h_dict = {3: 0, 0xC: 16}
+#            if mask in b_dict:
+#                data = (int(generated_data["data"][-1:].hex(), 16) & 0xFF) << b_dict[mask]
+#            elif mask in h_dict:
+#                data = (int(generated_data["data"][-2:].hex(), 16) & 0xFFFF) << h_dict[mask]
+#            else:
+#                data = int(generated_data["data"][-4:].hex(), 16)
+#            yield from self.test_module.io_in.slave_verify(generated_data["addr"], data, 1, mask)
+#            yield from self.random_wait()
+#
+#            yield from self.test_module.io_in.slave_respond(0)
+#            yield Settle()
+#
+#    def inserter(self):
+#        for i in range(self.tests_number):
+#            req = self.instr_queue.pop()
+#            self.get_result_data.appendleft(req["rob_id"])
+#            ret = yield from self.test_module.select.call()
+#            self.assertEqual(ret["rs_entry_id"], 0)
+#            yield from self.test_module.insert.call(rs_data=req, rs_entry_id=0)
+#            self.precommit_data.appendleft(req["rob_id"])
+#            announc = self.announce_queue.pop()
+#            for j in range(2):
+#                if announc[j] is not None:
+#                    yield from self.random_wait()
+#                    yield from self.test_module.update.call(announc[j])
+#            yield from self.random_wait()
+#
+#    def get_resulter(self):
+#        for i in range(self.tests_number):
+#            v = yield from self.test_module.get_result.call()
+#            rob_id = self.get_result_data.pop()
+#            self.assertEqual(v["rob_id"], rob_id)
+#            self.assertEqual(v["rp_dst"], 0)
+#            yield from self.random_wait()
+#            self.precommit_data.pop()  # retire
+#
+#    def precommiter(self):
+#        yield Passive()
+#        while True:
+#            while len(self.precommit_data) == 0:
+#                yield
+#            rob_id = self.precommit_data[-1]  # precommit is called continously until instruction is retired
+#            yield from self.test_module.precommit.call(rob_id=rob_id)
+#
+#    def test(self):
+#        @def_method_mock(lambda: self.test_module.exception_report)
+#        def exception_consumer(arg):
+#            self.assertTrue(False)
+#
+#        with self.run_simulation(self.test_module) as sim:
+#            sim.add_sync_process(self.wishbone_slave)
+#            sim.add_sync_process(self.inserter)
+#            sim.add_sync_process(self.get_resulter)
+#            sim.add_sync_process(self.precommiter)
+#            sim.add_sync_process(exception_consumer)
+#
+#
+# class TestDummyLSUFence(TestCaseWithSimulator):
+#    def get_instr(self, exec_fn):
+#        return {
+#            "rp_s1": 0,
+#            "rp_s2": 0,
+#            "rp_dst": 1,
+#            "rob_id": 1,
+#            "exec_fn": exec_fn,
+#            "s1_val": 4,
+#            "s2_val": 1,
+#            "imm": 8,
+#        }
+#
+#    def push_one_instr(self, instr):
+#        yield from self.test_module.select.call()
+#        yield from self.test_module.insert.call(rs_data=instr, rs_entry_id=1)
+#
+#        if instr["exec_fn"]["op_type"] == OpType.LOAD:
+#            yield from self.test_module.io_in.slave_wait()
+#            yield from self.test_module.io_in.slave_respond(1)
+#            yield Settle()
+#        v = yield from self.test_module.get_result.call()
+#        if instr["exec_fn"]["op_type"] == OpType.LOAD:
+#            self.assertEqual(v["result"], 1)
+#
+#    def process(self):
+#        # just tests if FENCE doens't hang up the LSU
+#        load_fn = {"op_type": OpType.LOAD, "funct3": Funct3.W, "funct7": 0}
+#        fence_fn = {"op_type": OpType.FENCE, "funct3": 0, "funct7": 0}
+#        yield from self.push_one_instr(self.get_instr(load_fn))
+#        yield from self.push_one_instr(self.get_instr(fence_fn))
+#        yield from self.push_one_instr(self.get_instr(load_fn))
+#
+#    def test_fence(self):
+#        self.gp = GenParams(test_core_config.replace(phys_regs_bits=3, rob_entries_bits=3))
+#        self.test_module = DummyLSUTestCircuit(self.gp)
+#
+#        @def_method_mock(lambda: self.test_module.exception_report)
+#        def exception_consumer(arg):
+#            self.assertTrue(False)
+#
+#        with self.run_simulation(self.test_module) as sim:
+#            sim.add_sync_process(self.process)
+#            sim.add_sync_process(exception_consumer)

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -47,13 +47,13 @@ def generate_imm() -> int:
     if random.randint(0, 1):
         return 0
     else:
-        return random.randint(-2**11, 2**11-1)
+        return random.randint(-(2**11), 2**11 - 1)
 
 
 def calculate_wb_sel(addr: int, num_bytes: int) -> tuple[int, int]:
     rest = addr % 4
     wb_addr = addr >> 2
-    wb_sel = (2 ** num_bytes - 1) << rest
+    wb_sel = (2**num_bytes - 1) << rest
     return wb_addr, wb_sel
 
 
@@ -209,14 +209,7 @@ class TestDummyLSU(TestCaseWithSimulator):
                 "misaligned": misaligned,
                 "err": bus_err,
             }
-            exc_data = (
-                {
-                    "rob_id": rob_id,
-                    "cause": cause
-                }
-                if cause is not None
-                else None
-            )
+            exc_data = {"rob_id": rob_id, "cause": cause} if cause is not None else None
             ann_data = []
             if ann_data1 is not None:
                 ann_data.append(ann_data1)
@@ -267,9 +260,9 @@ class TestDummyLSU(TestCaseWithSimulator):
 
         if not generated_data["err"]:
             ret_data = resp_data >> (data_shift * 8)
-            ret_data &= (2 ** (num_bytes * 8) - 1)
+            ret_data &= 2 ** (num_bytes * 8) - 1
             if sign:
-                ret_data = int_to_signed(signed_to_int(ret_data, num_bytes*8), 32)
+                ret_data = int_to_signed(signed_to_int(ret_data, num_bytes * 8), 32)
             await self.returned_data.push(ret_data)
 
         await self.mem_result_queue.push({"data": resp_data, "err": generated_data["err"]})

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -8,7 +8,7 @@ from coreblocks.params import ROBLayouts, RFLayouts, GenParams, LSULayouts, Sche
 from coreblocks.params.configurations import test_core_config
 
 from ..common import *
-from ..transactional_testing import Exit, Sim, SimFIFO, SimSignal, Wait
+from ..transactional_testing import Exit, WaitSettled, Sim, SimFIFO, SimSignal
 import random
 
 
@@ -103,7 +103,7 @@ class RetirementTest(TestCaseWithSimulator):
         async def free_reg_process():
             if await self.rf_exp_q.not_empty():
                 reg = await Sim.call(retc.free_rf_adapter)
-                await Wait()
+                await WaitSettled()
                 self.assertEqual(reg["reg_id"], await self.rf_exp_q.pop())
             else:
                 await Exit()
@@ -116,7 +116,7 @@ class RetirementTest(TestCaseWithSimulator):
             if await self.rat_map_q.not_empty():
                 current_map = await self.rat_map_q.peek()
                 val = await Sim.get(retc.rat.entries[current_map["rl_dst"]])
-                await Wait()
+                await WaitSettled()
                 if val == current_map["rp_dst"]:
                     await self.rat_map_q.pop()
                     await wait_cycles.set_final(0)
@@ -131,12 +131,12 @@ class RetirementTest(TestCaseWithSimulator):
 
         @Sim.def_method_mock(lambda: retc.mock_rf_free)
         async def rf_free_process(reg_id):
-            await Wait()
+            await WaitSettled()
             self.assertEqual(reg_id, await self.rf_free_q.pop())
 
         @Sim.def_method_mock(lambda: retc.mock_precommit)
         async def precommit_process(rob_id):
-            await Wait()
+            await WaitSettled()
             self.assertEqual(rob_id, await self.precommit_q.pop())
 
         @Sim.def_method_mock(lambda: retc.mock_exception_cause)

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -9,7 +9,6 @@ from coreblocks.params.configurations import test_core_config
 
 from ..common import *
 from ..transactional_testing import Exit, Sim, SimFIFO, SimSignal, Wait
-from collections import deque
 import random
 
 
@@ -145,5 +144,15 @@ class RetirementTest(TestCaseWithSimulator):
             return {"cause": 0, "rob_id": 0}  # keep exception cause method enabled
 
         with self.run_simulation(retc) as sim:
-            tsim = Sim([retire_process, peek_process, rf_free_process, precommit_process, exception_cause_process, free_reg_process, rat_process])
+            tsim = Sim(
+                [
+                    retire_process,
+                    peek_process,
+                    rf_free_process,
+                    precommit_process,
+                    exception_cause_process,
+                    free_reg_process,
+                    rat_process,
+                ]
+            )
             sim.add_sync_process(tsim.process)

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -144,15 +144,12 @@ class RetirementTest(TestCaseWithSimulator):
             return {"cause": 0, "rob_id": 0}  # keep exception cause method enabled
 
         with self.run_simulation(retc) as sim:
-            tsim = Sim(
-                [
-                    retire_process,
-                    peek_process,
-                    rf_free_process,
-                    precommit_process,
-                    exception_cause_process,
-                    free_reg_process,
-                    rat_process,
-                ]
-            )
+            tsim = Sim()
+            tsim.add_process(retire_process)
+            tsim.add_process(peek_process)
+            tsim.add_process(rf_free_process)
+            tsim.add_process(precommit_process)
+            tsim.add_process(exception_cause_process)
+            tsim.add_process(free_reg_process)
+            tsim.add_process(rat_process)
             sim.add_sync_process(tsim.process)

--- a/test/transactional_testing.py
+++ b/test/transactional_testing.py
@@ -44,6 +44,7 @@ class ActionKind(IntEnum):
     GET_COMPLETE = auto()
     PUT = auto()
     PUT_FINAL = auto()
+    PUSH = auto()
     PRINT = auto()
     _YIELD = auto()
     RESET = auto()
@@ -145,7 +146,7 @@ class SimFIFO(SimQueueBase[_T]):
         def action():
             self._queue.append(value)
 
-        await Action(ActionKind.PUT_FINAL, self, action)
+        await Action(ActionKind.PUSH, self, action)
 
     async def not_empty(self) -> bool:
         return await Action(ActionKind.GET, self, lambda: bool(self._queue))
@@ -365,6 +366,7 @@ class Sim:
                             case Action(
                                 ActionKind.PUT_FINAL
                                 | ActionKind.GET_COMPLETE
+                                | ActionKind.PUSH
                                 | ActionKind.PRINT
                                 | ActionKind.RESET as kind,
                                 subject,

--- a/test/transactional_testing.py
+++ b/test/transactional_testing.py
@@ -313,8 +313,10 @@ class Sim:
                 try:
                     while True:
                         Sim._is_running = True
-                        cmd = running.send(to_send)
-                        Sim._is_running = False
+                        try:
+                            cmd = running.send(to_send)
+                        finally:
+                            Sim._is_running = False
 
                         match cmd:
                             case Passive():

--- a/test/transactional_testing.py
+++ b/test/transactional_testing.py
@@ -1,0 +1,180 @@
+
+from collections import defaultdict, deque
+from amaranth import *
+from collections.abc import Callable, Generator, Iterable
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Generic, Optional, TypeAlias, TypeVar
+
+from amaranth.sim import Settle
+from .common import TestGen
+
+
+_T = TypeVar("_T")
+TTestGen: TypeAlias = Generator["Action | Exit", Any, _T]
+ActionFun: TypeAlias = Callable[[], TestGen[Any] | Any]
+
+
+class ActionKind(Enum):
+    GET = auto()
+    GET_COMPLETE = auto()
+    PUT = auto()
+    PUT_FINAL = auto()
+
+
+@dataclass
+class Exit:
+    pass
+
+
+@dataclass
+class Action:
+    kind: ActionKind
+    subject: Any
+    action: ActionFun
+
+
+class SimFIFO(Generic[_T]):
+    def __init__(self, init: Iterable[_T] = ()):
+        self._queue = deque(init)
+
+    def push(self, value: _T) -> TTestGen[None]:
+        def action():
+            self._queue.append(value)
+        yield Action(ActionKind.PUT_FINAL, self._queue, action)
+
+    def empty(self) -> TTestGen[bool]:
+        return (yield Action(ActionKind.GET, self, lambda: bool(self._queue)))
+
+    def peek(self) -> TTestGen[_T]:
+        return (yield Action(ActionKind.GET, self, lambda: self._queue[0]))
+
+    def pop(self) -> TTestGen[_T]:
+        def complete():
+            self._queue.popleft()
+        yield Action(ActionKind.GET_COMPLETE, self._queue, complete)
+        return (yield Action(ActionKind.GET, self, lambda: self._queue[0]))
+
+
+class SimSignal(Generic[_T]):
+    def __init__(self):
+        self._value = None
+
+    def get(self) -> TTestGen[_T]:
+        return (yield Action(ActionKind.GET, self, lambda: self._value))
+
+    def set(self, value: _T, *, final: bool = False) -> TTestGen[None]:
+        def action():
+            self._value = value
+        yield Action(ActionKind.PUT_FINAL if final else ActionKind.PUT, self, action)
+
+    def set_final(self, value: _T) -> TTestGen[None]:
+        return self.set(value, final=True)
+
+
+class Sim:
+    def __init__(self, processes: Iterable[Callable[[], TTestGen[None]]]):
+        self.processes = list(processes)
+
+    def process(self) -> TestGen[None]:
+        def run_action(action: ActionFun):
+            result = action()
+            if isinstance(result, Generator):
+                return (yield from result)
+            else:
+                return result
+
+        process_map = {id(process): process for process in self.processes}
+
+        active = list(map(id, self.processes))
+        exited = set[int]()
+
+        # TODO nie zadziała!
+        # Sygnały mogą się zmieniać po settlu. Trzeba pamiętać, jakie były wartości
+        # dla ostatnich odczytów, i restartować te procesy, którym odczyty się zmieniły.
+
+        while active:
+            need_settle = False
+            gets = defaultdict[int, set[int]](set)
+            puts = dict[int, int]()
+            put_finals = defaultdict[int, list[Action]](list)
+            get_completes = defaultdict[int, list[Action]](list)
+            already_run = list[int]()
+            to_run = deque(active)
+
+            while to_run:
+                process = to_run.popleft()
+                already_run.append(id(process))
+                running = process_map[process]()
+                to_send = None
+                try:
+                    while True:
+                        cmd = running.send(to_send)
+                        match cmd:
+                            case Exit():
+                                exited.add(id(process))
+                                break
+                            case Action(ActionKind.GET, subject, action):
+                                gets[id(subject)].add(id(process))
+                                if isinstance(subject, Value) and need_settle:
+                                    yield Settle()
+                                    need_settle = False
+                                to_send = (yield from run_action(action))
+                            case Action(ActionKind.PUT, subject, action):
+                                if id(subject) in puts and puts[id(subject)] != id(process):
+                                    raise RuntimeError
+                                puts[id(subject)] = id(process)
+                                if isinstance(subject, Value):
+                                    need_settle = True
+                                to_run.extend(gets[id(subject)])
+                                for i in gets[id(subject)]:
+                                    del put_finals[i]
+                                    del get_completes[i]
+                                already_run = [i for i in already_run if i not in gets[id(subject)]]
+                                gets[id(subject)] = set()
+                                yield from run_action(action)
+                            case Action(ActionKind.PUT_FINAL, subject, action):
+                                put_finals[id(process)].append(cmd)
+                            case Action(ActionKind.GET_COMPLETE, subject, action):
+                                get_completes[id(process)].append(cmd)
+                except StopIteration:
+                    pass
+
+            get_completes_subjects = set[int]()
+            for i, cmds in get_completes.items():
+                for cmd in cmds:
+                    if id(cmd.subject) in get_completes_subjects:
+                        raise RuntimeError
+                    get_completes_subjects.add(id(cmd.subject))
+                    yield from run_action(cmd.action)
+
+            for i, cmds in put_finals.items():
+                for cmd in cmds:
+                    if id(cmd.subject) in puts:
+                        raise RuntimeError
+                    puts[id(cmd.subject)] = i
+                    yield from run_action(cmd.action)
+
+            active = already_run
+
+            yield
+
+    @staticmethod
+    def exit() -> TTestGen[Any]:
+        yield Exit()
+
+    @staticmethod
+    def get(value: Value) -> TTestGen[int]:
+        def action():
+            return (yield value)
+        return (yield Action(ActionKind.GET, value, action))
+
+    @staticmethod
+    def set(signal: Signal, value: int, *, final: bool = False) -> TTestGen[None]:
+        def action():
+            yield signal.eq(value)
+        yield Action(ActionKind.PUT_FINAL if final else ActionKind.PUT, signal, action)
+
+    @staticmethod
+    def set_final(signal: Signal, value: int) -> TTestGen[None]:
+        return Sim.set(signal, value, final=True)

--- a/test/transactional_testing.py
+++ b/test/transactional_testing.py
@@ -146,9 +146,14 @@ class Sim:
                 nonlocal already_run
                 to_run.extend(processes)
                 for i in processes:
-                    del put_finals[i]
-                    del get_completes[i]
-                    exits.remove(i)
+                    if i in put_finals:
+                        del put_finals[i]
+                    if i in get_completes:
+                        del get_completes[i]
+                    if i in exits:
+                        exits.remove(i)
+                    if i in passives:
+                        passives.remove(i)
                 already_run = [i for i in already_run if i not in processes]
 
             def perform_settle():
@@ -158,7 +163,7 @@ class Sim:
                     new_v = yield value
                     if new_v != v:
                         get_results[subject] = (value, new_v)
-                        to_restart.update(gets[id(subject)])
+                        to_restart.update(gets[subject])
                 restart_processes(to_restart)
 
             while to_run:

--- a/test/transactional_testing.py
+++ b/test/transactional_testing.py
@@ -179,6 +179,10 @@ class Sim:
                         for j in states[i].puts:
                             del puts[j]
                         del states[i]
+                    if i in put_finals:
+                        del put_finals[i]
+                    if i in get_completes:
+                        del get_completes[i]
                     if i in suspended:
                         suspended[i].close()
                         del suspended[i]

--- a/test/transactional_testing.py
+++ b/test/transactional_testing.py
@@ -136,8 +136,11 @@ class SimSignal(Generic[_T]):
 class Sim:
     _is_running: ClassVar[bool] = False
 
-    def __init__(self, processes: Iterable[Callable[[], TTestGen[None]]]):
+    def __init__(self, processes: Iterable[Process] = ()):
         self.processes = list(processes)
+
+    def add_process(self, process: Process):
+        self.processes.append(process)
 
     def process(self) -> TestGen[None]:
         def run_action(action: ActionFun):

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -459,10 +459,8 @@ class TestMethodFilter(TestCaseWithSimulator):
     async def source(self):
         i = await self.queue.pop_or_exit()
         v = await Sim.call(self.tc.method.adapter, data=i)
-        if i & 1:
-            self.assertEqual(v["data"], (i + 1) & ((1 << self.iosize) - 1))
-        else:
-            self.assertEqual(v["data"], 0)
+        # TODO: execute this finally
+        self.assertEqual(v["data"], (i + 1) & ((1 << self.iosize) - 1) if i & 1 else 0)
 
     @Sim.def_method_mock(lambda self: self.target)
     async def target_mock(self, data):

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -15,7 +15,7 @@ from coreblocks.transactions.lib import *
 from coreblocks.utils import *
 from coreblocks.utils._typing import LayoutLike, ModuleLike
 from coreblocks.utils import ModuleConnector
-from ..transactional_testing import Sim, SimFIFO, Wait
+from ..transactional_testing import Sim, SimFIFO, Wait, WaitSettled
 from ..common import (
     SimpleTestCircuit,
     TestCaseWithSimulator,
@@ -459,7 +459,7 @@ class TestMethodFilter(TestCaseWithSimulator):
     async def source(self):
         i = await self.queue.pop_or_exit()
         v = await Sim.call(self.tc.method.adapter, data=i)
-        await Wait()
+        await WaitSettled()
         self.assertEqual(v["data"], (i + 1) & ((1 << self.iosize) - 1) if i & 1 else 0)
 
     @Sim.def_method_mock(lambda self: self.target)

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -15,7 +15,7 @@ from coreblocks.transactions.lib import *
 from coreblocks.utils import *
 from coreblocks.utils._typing import LayoutLike, ModuleLike
 from coreblocks.utils import ModuleConnector
-from ..transactional_testing import Sim, SimFIFO
+from ..transactional_testing import Sim, SimFIFO, Wait
 from ..common import (
     SimpleTestCircuit,
     TestCaseWithSimulator,
@@ -459,7 +459,7 @@ class TestMethodFilter(TestCaseWithSimulator):
     async def source(self):
         i = await self.queue.pop_or_exit()
         v = await Sim.call(self.tc.method.adapter, data=i)
-        # TODO: execute this finally
+        await Wait()
         self.assertEqual(v["data"], (i + 1) & ((1 << self.iosize) - 1) if i & 1 else 0)
 
     @Sim.def_method_mock(lambda self: self.target)

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -15,7 +15,7 @@ from coreblocks.transactions.lib import *
 from coreblocks.utils import *
 from coreblocks.utils._typing import LayoutLike, ModuleLike
 from coreblocks.utils import ModuleConnector
-from ..transactional_testing import Sim, SimFIFO, Wait, WaitSettled
+from ..transactional_testing import Sim, SimFIFO, WaitSettled
 from ..common import (
     SimpleTestCircuit,
     TestCaseWithSimulator,


### PR DESCRIPTION
This PR is (Yet Another) experiment in making tests simpler to write. The testing mechanism introduced here runs settles when needed, so that a test writer never needs to write a `Settle` himself. Tools for synchronizing processes are also introduced. The downside? Use of side effects in process code needs to be restricted to provided primitives, because the process runtime restarts processes behind the scenes (effectively, backtracks them) when synchronization fails.

How is it different from the current way of testing?

* Coroutine syntax (`async`/`await`) is used instead of generator syntax (`yield`). This makes the code cleaner in my opinion.
* No uncontrolled side effects in processes. This includes modifying global variables, queues, and others; however, controlled replacements for these are provided. Debug prints work, but they may be written multiple times per cycle because of backtracking.
* The process code is executed completely once per cycle, there is no primitive for waiting a cycle (like `yield` was doing previously). I'd very much like to have this feature, however - because there is no simple way to implement a nondeterminism effect in Python's coroutines - this can't really be done without making the syntax awful. As most of our testing code is basically in method mocks, this isn't a big limitation.
* Signal writes are provided in two varieties:
  * Instantaneous writes (like blocking assignment in Verilog); written values are visible by other processes in the same cycle. If there are other signals which depend on the written signal in the simulated circuit, changes are automatically propagated (no settles!).
  * Final writes (like nonblocking assignment in Verilog); written values are visible in the next cycle.
* Writes are restricted so that only one process can write a given signal in a clock cycle, and it can do it only once. This is to guarantee that inter-process dependencies are correctly resolved.
* Two synchronization primitives are provided: signals and FIFOs.
  * Behavior of signals mirror Amaranth signals, but they are handled by the simulation runtime and can contain arbitrary values. They can be used to store state, and also to synchronize processes (as an instantaneously written value is guaranteed to be seen by processes in the same clock cycle).
  * FIFOs allow a single push and pop in a given clock cycle. In doing so, they mirror the behavior of in-circuit FIFOs.
* `TestbenchIO` is not used; instead, method calling and mocking are reimplemented.

As you can see in the tests I've rewritten to use this new mechanism, tests look mostly like before - but there are no `Settle`s and `sched_prio`s. One can use as many FIFOs, method calls etc. in each process as one wants, and as long as there is no dependency cycle, everything should work just fine.

To-do:

* [x] Minor cleanups. The main simulation code still has some copy-pastes and needs to be refactored a little.
* [ ] Performance improvements. The new mechanism has some performance loss compared to the old one. On my computer, the old retirement test took ~0.75 s, the new one took ~0.95s, a 25% loss. It should be possible to reduce it by scheduling processes in such a way that the number of internal `Settle`s and backtracks are minimized.
* [ ] Assertions. It turns out failure is a side effect ;) Currently, consistency is enforced by waiting for values to become stable before calling asserts. This is possibly error-prone, as one must remember to insert the wait. Edit: maybe introduce a read-only phase for processes?
* [x] Controlled debug prints, for easier debugging.
* [ ] A clean way of doing `comb`-like signal assignments is needed.
* [ ] A cleaner way for keeping the simulation alive until something happens (e.g. all queues are empty) is needed.
* [ ] Code organization. I'm not sold on all these static methods, but I have no better idea right now.
* [ ] Documentation.

What do you think? Can this save us from the test hell?