### PR TITLE
Fix broken synthesis after cleanup

### DIFF
--- a/constants/ecp5_platforms.py
+++ b/constants/ecp5_platforms.py
@@ -60,6 +60,7 @@ class PinManager:
             if name in self.pin_bag:
                 self.pin_bag.remove(name)
                 return name
+        raise RuntimeError("Named pins %s not free" % ", ".join(names))
 
 
 ResourceBuilder: TypeAlias = Callable[[PinManager], list[Resource]]
@@ -124,8 +125,6 @@ def make_ecp5_platform(resource_builder: ResourceBuilder):
         default_rst = "rst"
 
         clk_pin = pins.named_pin(ecp5_bg756_pclk)
-        if clk_pin is None:
-            raise RuntimeError("No free clk pin found.")
         resources = [
             Resource("rst", 0, PinsN(pins.p(), dir="i"), Attrs(IO_TYPE="LVCMOS33")),
             Resource("clk", 0, Pins(clk_pin, dir="i"), Clock(12e6), Attrs(IO_TYPE="LVCMOS33")),

--- a/constants/ecp5_platforms.py
+++ b/constants/ecp5_platforms.py
@@ -8,7 +8,7 @@ from amaranth.build import Resource, Attrs, Pins, Clock, PinsN
 from constants.ecp5_pinout import ecp5_bg756_pins, ecp5_bg756_pclk
 
 from coreblocks.peripherals.wishbone import WishboneParameters
-from coreblocks.transactions.lib import AdapterBase
+from transactron.lib import AdapterBase
 
 __all__ = ["make_ecp5_platform"]
 
@@ -123,9 +123,12 @@ def make_ecp5_platform(resource_builder: ResourceBuilder):
         default_clk = "clk"
         default_rst = "rst"
 
+        clk_pin = pins.named_pin(ecp5_bg756_pclk)
+        if clk_pin is None:
+            raise RuntimeError("No free clk pin found.")
         resources = [
             Resource("rst", 0, PinsN(pins.p(), dir="i"), Attrs(IO_TYPE="LVCMOS33")),
-            Resource("clk", 0, Pins(pins.named_pin(ecp5_bg756_pclk), dir="i"), Clock(12e6), Attrs(IO_TYPE="LVCMOS33")),
+            Resource("clk", 0, Pins(clk_pin, dir="i"), Clock(12e6), Attrs(IO_TYPE="LVCMOS33")),
         ] + resource_builder(pins)
 
         connectors = []

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,6 +2,8 @@
   "include": [
     "coreblocks",
     "test",
+    "constants",
+    "transactron",
     "scripts"
   ],
 


### PR DESCRIPTION
This fix #465. There was no type analysis activated for `constants` directory, so the error wasn't detected by pyright. Additionally there was one more type error, which is fixed by this MR.

Synthesis job: https://github.com/kuznia-rdzeni/coreblocks/actions/runs/6433713558