### PR TITLE
Data dependent method calling

### DIFF
--- a/test/transactions/test_methods.py
+++ b/test/transactions/test_methods.py
@@ -1,3 +1,4 @@
+import random
 from amaranth import *
 from amaranth.sim import *
 
@@ -529,3 +530,82 @@ class TestNonexclusiveMethod(TestCaseWithSimulator):
 
         with self.run_simulation(circ) as sim:
             sim.add_sync_process(process)
+
+class DataDependentConditionalCircuit(Elaboratable):
+    def __init__(self, n = 2, bad_number = 3):
+        self.bad_number = bad_number
+        self.method = Method(i=data_layout(n))
+
+        self.in_t1 = Record(data_layout(n))
+        self.in_t2 = Record(data_layout(n))
+        self.ready = Signal()
+        self.req_t1 = Signal()
+        self.req_t2 = Signal()
+
+        self.out_m = Signal()
+        self.out_t1 = Signal()
+        self.out_t2 = Signal()
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        @def_method(m, self.method, self.ready, ready_function = lambda rec: rec.data!=self.bad_number)
+        def _(data):
+            m.d.comb += self.out_m.eq(1)
+
+        with Transaction().body(m, request = self.req_t1):
+            m.d.comb += self.out_t1.eq(1)
+            self.method(m, self.in_t1)
+
+        with Transaction().body(m, request = self.req_t2):
+            m.d.comb += self.out_t2.eq(1)
+            self.method(m, self.in_t2)
+
+        return m
+
+class TestDataDependentConditionalMethod(TestCaseWithSimulator):
+    def setUp(self):
+        self.test_number=150
+        self.bad_number = 3
+        self.n = 2
+        self.circ = DataDependentConditionalCircuit(self.n, self.bad_number)
+
+    def test_random(self):
+        random.seed(14)
+        def process():
+            for _ in range(self.test_number):
+                in1 = random.randrange(0, 2**self.n)
+                in2 = random.randrange(0, 2**self.n)
+                m_ready = random.randrange(2)
+                req_t1 = random.randrange(2)
+                req_t2 = random.randrange(2)
+
+                yield self.circ.in_t1.eq(in1)
+                yield self.circ.in_t2.eq(in2)
+                yield self.circ.req_t1.eq(req_t1)
+                yield self.circ.req_t2.eq(req_t2)
+                yield self.circ.ready.eq(m_ready)
+                yield Settle()
+                yield Delay(1e-8)
+                
+                out_m = yield self.circ.out_m
+                out_t1 = yield self.circ.out_t1
+                out_t2 = yield self.circ.out_t2
+                
+                if not m_ready or not (req_t1 or req_t2) or (in1 == self.bad_number and in2 == self.bad_number):
+                    self.assertEqual(out_m, 0)
+                    self.assertEqual(out_t1, 0)
+                    self.assertEqual(out_t2, 0)
+                    continue
+                # Here method global ready signal is high and we requested one of the transactions
+                # we also know that one of the transactions request correct input data
+
+                self.assertEqual(out_m, 1)
+                self.assertEqual(out_t1 ^ out_t2, 1)
+                # inX == self.bad_number implies out_tX==0
+                self.assertTrue(in1 != self.bad_number or not out_t1)
+                self.assertTrue(in2 != self.bad_number or not out_t2)
+
+        with self.run_simulation(self.circ, 100) as sim:
+            sim.add_process(process)
+


### PR DESCRIPTION
We have currently concept of single caller methods (#416, #425). Such methods allow us to add condition in `ready` signal which depends from input argument. Such conditions are only supported in single caller methods, because when there are two or more callers there is a risk that we end up with combinational cycle. Goal of this PR is to extend data dependent readiness of methods to multi caller methods.

Current implementation of transactron assume that readiness signal is constant for the whole cycle. So we use it to calculate `runnable` signal for each transaction. When ready signal depend from data we can decided **after** scheduling a transaction to execution that method isn't ready. This cause change in `runnable` and an another transaction can be chosen to execution, which data will be potentially accepted by method, so the `ready` will be high one more time and the whole story will repeat.

Solution which I propose in this PR is to calculate data dependent readiness **before** scheduling the transaction, so that we already know that method will accept data from this transaction. The old `ready` signal is used as global readiness for the whole method for backward compatibility.

Additionally I modified types in `method_uses` to be more strict. Instead of `ValueLike` only `Record` is accepted. This allow to properly type input argument for the `user_ready_function`.