### PR TITLE
Autumn cleaning: types

### DIFF
--- a/coreblocks/fu/div_unit.py
+++ b/coreblocks/fu/div_unit.py
@@ -1,6 +1,6 @@
 from dataclasses import KW_ONLY, dataclass
 from enum import IntFlag, auto
-from typing import Sequence, Tuple
+from collections.abc import Sequence
 
 from amaranth import *
 
@@ -34,7 +34,7 @@ class DivFn(DecoderManager):
         ]
 
 
-def get_input(arg: Record) -> Tuple[Value, Value]:
+def get_input(arg: Record) -> tuple[Value, Value]:
     return arg.s1_val, Mux(arg.imm, arg.imm, arg.s2_val)
 
 

--- a/coreblocks/fu/mul_unit.py
+++ b/coreblocks/fu/mul_unit.py
@@ -1,5 +1,5 @@
 from enum import IntFlag, IntEnum, auto
-from typing import Sequence, Tuple
+from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass
 
 from amaranth import *
@@ -45,7 +45,7 @@ class MulFn(DecoderManager):
         ]
 
 
-def get_input(arg: Record) -> Tuple[Value, Value]:
+def get_input(arg: Record) -> tuple[Value, Value]:
     """
     Operation of getting two input values.
 
@@ -56,7 +56,7 @@ def get_input(arg: Record) -> Tuple[Value, Value]:
 
     Returns
     -------
-    return : Tuple[Value, Value]
+    return : tuple[Value, Value]
         Two input values.
     """
     return arg.s1_val, Mux(arg.imm, arg.imm, arg.s2_val)

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from amaranth import *
 

--- a/coreblocks/stages/func_blocks_unifier.py
+++ b/coreblocks/stages/func_blocks_unifier.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from amaranth import *
 

--- a/coreblocks/structs_common/rs.py
+++ b/coreblocks/structs_common/rs.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Optional
+from collections.abc import Iterable
+from typing import Optional
 from amaranth import *
 from amaranth.lib.coding import PriorityEncoder
 from transactron import Method, def_method, TModule

--- a/coreblocks/utils/_typing.py
+++ b/coreblocks/utils/_typing.py
@@ -1,18 +1,14 @@
 from typing import (
-    ContextManager,
     Generic,
     NoReturn,
     Optional,
     Protocol,
-    Sequence,
-    Tuple,
-    Type,
     TypeAlias,
-    Iterable,
-    Mapping,
     TypeVar,
     runtime_checkable,
 )
+from collections.abc import Iterable, Mapping, Sequence
+from contextlib import AbstractContextManager
 from enum import Enum
 from amaranth import *
 from amaranth.lib.data import View
@@ -21,16 +17,18 @@ from amaranth.hdl.dsl import _ModuleBuilderSubmodules, _ModuleBuilderDomainSet, 
 from amaranth.hdl.rec import Direction, Layout
 
 # Types representing Amaranth concepts
-FragmentLike = Fragment | Elaboratable
-ValueLike = Value | int | Enum | ValueCastable
-ShapeLike = Shape | ShapeCastable | int | range | Type[Enum]
+FragmentLike: TypeAlias = Fragment | Elaboratable
+ValueLike: TypeAlias = Value | int | Enum | ValueCastable
+ShapeLike: TypeAlias = Shape | ShapeCastable | int | range | type[Enum]
 StatementLike: TypeAlias = Statement | Iterable["StatementLike"]
-LayoutLike = Layout | Sequence[Tuple[str, ShapeLike | "LayoutLike"] | Tuple[str, ShapeLike | "LayoutLike", Direction]]
+LayoutLike: TypeAlias = (
+    Layout | Sequence[tuple[str, ShapeLike | "LayoutLike"] | tuple[str, ShapeLike | "LayoutLike", Direction]]
+)
 SwitchKey: TypeAlias = str | int | Enum
 
 # Internal Coreblocks types
 SignalBundle: TypeAlias = Signal | Record | View | Iterable["SignalBundle"] | Mapping[str, "SignalBundle"]
-LayoutList = list[Tuple[str, ShapeLike | "LayoutList"]]
+LayoutList: TypeAlias = list[tuple[str, ShapeLike | "LayoutList"]]
 
 
 class _ModuleBuilderDomainsLike(Protocol):
@@ -55,28 +53,30 @@ class ModuleLike(Protocol, Generic[_T_ModuleBuilderDomains]):
     domains: _ModuleBuilderDomainSet
     d: _T_ModuleBuilderDomains
 
-    def If(self, cond: ValueLike) -> ContextManager[None]:  # noqa: N802
+    def If(self, cond: ValueLike) -> AbstractContextManager[None]:  # noqa: N802
         ...
 
-    def Elif(self, cond: ValueLike) -> ContextManager[None]:  # noqa: N802
+    def Elif(self, cond: ValueLike) -> AbstractContextManager[None]:  # noqa: N802
         ...
 
-    def Else(self) -> ContextManager[None]:  # noqa: N802
+    def Else(self) -> AbstractContextManager[None]:  # noqa: N802
         ...
 
-    def Switch(self, test: ValueLike) -> ContextManager[None]:  # noqa: N802
+    def Switch(self, test: ValueLike) -> AbstractContextManager[None]:  # noqa: N802
         ...
 
-    def Case(self, *patterns: SwitchKey) -> ContextManager[None]:  # noqa: N802
+    def Case(self, *patterns: SwitchKey) -> AbstractContextManager[None]:  # noqa: N802
         ...
 
-    def Default(self) -> ContextManager[None]:  # noqa: N802
+    def Default(self) -> AbstractContextManager[None]:  # noqa: N802
         ...
 
-    def FSM(self, reset: Optional[str] = ..., domain: str = ..., name: str = ...) -> ContextManager[FSM]:  # noqa: N802
+    def FSM(  # noqa: N802
+        self, reset: Optional[str] = ..., domain: str = ..., name: str = ...
+    ) -> AbstractContextManager[FSM]:
         ...
 
-    def State(self, name: str) -> ContextManager[None]:  # noqa: N802
+    def State(self, name: str) -> AbstractContextManager[None]:  # noqa: N802
         ...
 
     @property

--- a/coreblocks/utils/_typing.py
+++ b/coreblocks/utils/_typing.py
@@ -22,13 +22,13 @@ ValueLike: TypeAlias = Value | int | Enum | ValueCastable
 ShapeLike: TypeAlias = Shape | ShapeCastable | int | range | type[Enum]
 StatementLike: TypeAlias = Statement | Iterable["StatementLike"]
 LayoutLike: TypeAlias = (
-    Layout | Sequence[tuple[str, ShapeLike | "LayoutLike"] | tuple[str, ShapeLike | "LayoutLike", Direction]]
+    Layout | Sequence[tuple[str, "ShapeLike | LayoutLike"] | tuple[str, "ShapeLike | LayoutLike", Direction]]
 )
 SwitchKey: TypeAlias = str | int | Enum
 
 # Internal Coreblocks types
 SignalBundle: TypeAlias = Signal | Record | View | Iterable["SignalBundle"] | Mapping[str, "SignalBundle"]
-LayoutList: TypeAlias = list[tuple[str, ShapeLike | "LayoutList"]]
+LayoutList: TypeAlias = list[tuple[str, "ShapeLike | LayoutList"]]
 
 
 class _ModuleBuilderDomainsLike(Protocol):

--- a/coreblocks/utils/utils.py
+++ b/coreblocks/utils/utils.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from enum import Enum
-from typing import Iterable, Literal, Mapping, Optional, TypeAlias, cast, overload
+from typing import Literal, Optional, TypeAlias, cast, overload
+from collections.abc import Iterable, Mapping
 from amaranth import *
 from amaranth.hdl.ast import Assign, ArrayProxy
 from amaranth.lib import data

--- a/transactron/_utils.py
+++ b/transactron/_utils.py
@@ -1,7 +1,8 @@
 import itertools
 import sys
 from inspect import Parameter, signature
-from typing import Callable, Iterable, Optional, TypeAlias, TypeVar, Mapping
+from typing import Optional, TypeAlias, TypeVar
+from collections.abc import Callable, Iterable, Mapping
 from amaranth import *
 from coreblocks.utils._typing import LayoutLike
 from coreblocks.utils import OneHotSwitchDynamic

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -1,7 +1,8 @@
 from amaranth import *
 from ..core import *
 from ..core import RecordDict
-from typing import Optional, Callable, Tuple
+from typing import Optional
+from collections.abc import Callable
 from coreblocks.utils import ValueLike, assign, AssignType
 from .connectors import Forwarder, ManyToOneConnectTrans, ConnectTrans
 
@@ -35,8 +36,8 @@ class MethodTransformer(Elaboratable):
         self,
         target: Method,
         *,
-        i_transform: Optional[Tuple[MethodLayout, Callable[[TModule, Record], RecordDict]]] = None,
-        o_transform: Optional[Tuple[MethodLayout, Callable[[TModule, Record], RecordDict]]] = None,
+        i_transform: Optional[tuple[MethodLayout, Callable[[TModule, Record], RecordDict]]] = None,
+        o_transform: Optional[tuple[MethodLayout, Callable[[TModule, Record], RecordDict]]] = None,
     ):
         """
         Parameters
@@ -132,7 +133,7 @@ class MethodProduct(Elaboratable):
     def __init__(
         self,
         targets: list[Method],
-        combiner: Optional[Tuple[MethodLayout, Callable[[TModule, list[Record]], RecordDict]]] = None,
+        combiner: Optional[tuple[MethodLayout, Callable[[TModule, list[Record]], RecordDict]]] = None,
     ):
         """Method product.
 


### PR DESCRIPTION
This PR cleans up the usage of typing. In particular:

* Deprecated aliases from `typing`. These are not scheduled for removal yet, but shouldn't be used anyway.
* Type aliases are changed to use the `TypeAlias` annotation. When we move to 3.12 someday, it will be easier to find them and switch to PEP 695 syntax.