### PR TITLE
Bump amaranth-yosys version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-amaranth-yosys==0.10.0.dev46
+amaranth-yosys==0.25.0.0.post77
 git+https://github.com/amaranth-lang/amaranth@ccf7aaf00db54c7647b2f0f0cfdf34835c16fa8f


### PR DESCRIPTION
This fixes a long standing bug which could cause generated verilog to contain `""` in places where an identifier is expected (which is, suffice to say, not a valid verilog identifier). More details [here](https://github.com/amaranth-lang/amaranth/issues/936)

This fix is particularly applicable in `feature/interrupts` branch which had that exact problem and it caused the CI to fail. Root of the issue was in creating a [FIFO of depth 1](https://github.com/kuznia-rdzeni/coreblocks/blob/master/coreblocks/fu/zbc.py#L187) in ZBC unit, which in turn has caused [some signals to have a 0-width shape](https://github.com/kuznia-rdzeni/coreblocks/blob/master/coreblocks/utils/fifo.py#L49) and generate statements like `assign "" = \$30 ;` and `\$30  <= "";`. This was resolved by bumping amaranth-yosys version but separate fix should be PRed for the FIFO depth as well.

I'm not entirely sure why this only happened on `feature/interrupts` branch since we don't store any artifacts with generated verilog to compare with.