### PR TITLE
Fix memory protection in regression tests

### DIFF
--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -147,7 +147,7 @@ class CocotbSimulation(SimulationBackend):
         instr_wb = WishboneSlave(self.dut, "wb_instr", self.dut.clk, mem_model, is_instr_bus=True)
         cocotb.start_soon(instr_wb.start())
 
-        data_wb = WishboneSlave(self.dut, "wb_data", self.dut.clk, mem_model, is_instr_bus=True)
+        data_wb = WishboneSlave(self.dut, "wb_data", self.dut.clk, mem_model, is_instr_bus=False)
         cocotb.start_soon(data_wb.start())
 
         res = await with_timeout(self.finish_event.wait(), timeout_cycles, "ns")

--- a/test/regression/memory.py
+++ b/test/regression/memory.py
@@ -160,11 +160,11 @@ def load_segments_from_elf(file_path: str) -> list[RandomAccessMemory]:
             data = b"\x00" * (paddr - seg_start) + segment.data() + b"\x00" * (seg_end - (paddr + len(segment.data())))
 
             flags = SegmentFlags(0)
-            if flags_raw & P_FLAGS.PF_R == flags_raw & P_FLAGS.PF_R:
+            if flags_raw & P_FLAGS.PF_R:
                 flags |= SegmentFlags.READ
-            if flags_raw & P_FLAGS.PF_W == flags_raw & P_FLAGS.PF_W:
+            if flags_raw & P_FLAGS.PF_W:
                 flags |= SegmentFlags.WRITE
-            if flags_raw & P_FLAGS.PF_X == flags_raw & P_FLAGS.PF_X:
+            if flags_raw & P_FLAGS.PF_X:
                 flags |= SegmentFlags.EXECUTABLE
 
             segments.append(RandomAccessMemory(range(seg_start, seg_end), flags, data))


### PR DESCRIPTION
I found a bug in #466 - all memory segments were set to all RWX flags. After fixing that, regression tests started to fail.

First bug is simple - wrong flag on data memory (only in cocotb backend)
Second bug is problematic. In `rv32uc-rvc` test there is a `data` and not `.data` (!) section that is embedded into instruction memory. This section is written by rvc tests, but not flagged as writeable in ELF file. I don't have currently solution to it (ignore for this specific test, or maybe data section can be added to linker script?)