### PR TITLE
Bump Pyright version

### DIFF
--- a/constants/ecp5_platforms.py
+++ b/constants/ecp5_platforms.py
@@ -55,7 +55,7 @@ class PinManager:
     def p(self, count: int = 1):
         return " ".join([self.pin_bag.pop() for _ in range(count)])
 
-    def named_pin(self, names: list[str]):
+    def named_pin(self, names: Iterable[str]):
         for name in names:
             if name in self.pin_bag:
                 self.pin_bag.remove(name)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ myst-parser==0.18.0
 numpydoc==1.5.0
 parameterized==0.8.1
 pre-commit==2.16.0
-pyright==1.1.308
+pyright==1.1.332
 Sphinx==5.1.1
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-mermaid==0.8.1

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -73,7 +73,7 @@ class WishboneSlave:
 
         while True:
             while not (self.bus.stb.value and self.bus.cyc.value):
-                await clock_edge_event
+                await clock_edge_event  # type: ignore
 
             sig_m = WishboneMasterSignals()
             self.bus.sample(sig_m)
@@ -124,10 +124,10 @@ class WishboneSlave:
             )
 
             for _ in range(self.delay):
-                await clock_edge_event
+                await clock_edge_event  # type: ignore
 
             self.bus.drive(sig_s)
-            await clock_edge_event
+            await clock_edge_event  # type: ignore
             self.bus.drive(WishboneSlaveSignals())
 
 


### PR DESCRIPTION
This PR bumps Pyright version to better support new typing features.

The `type: ignore` comments are because `cocotb` isn't type-stubbed.