### PR TITLE
Better transformer API

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -12,7 +12,7 @@ from amaranth.sim.core import Command
 
 from transactron.core import SignalBundle, Method, TransactionModule
 from transactron.lib import AdapterBase, AdapterTrans
-from transactron._utils import mock_def_helper
+from transactron._utils import def_helper
 from coreblocks.utils import ValueLike, HasElaborate, HasDebugSignals, auto_debug_signals, LayoutLike, ModuleConnector
 from .gtkw_extension import write_vcd_ext
 
@@ -258,6 +258,10 @@ class TestCaseWithSimulator(unittest.TestCase):
         Wait for a random amount of cycles in range [1, max_cycle_cnt)
         """
         yield from self.tick(random.randrange(max_cycle_cnt))
+
+
+def mock_def_helper(tb, func: Callable[..., T], arg: Mapping[str, Any]) -> T:
+    return def_helper(f"mock definition for {tb}", func, Mapping[str, Any], arg, **arg)
 
 
 class TestbenchIO(Elaboratable):

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -362,21 +362,21 @@ class MethodTransformerTestCircuit(Elaboratable):
 
         layout = data_layout(self.iosize)
 
-        def itransform_rec(m: ModuleLike, v: Record) -> Record:
-            s = Record.like(v)
-            m.d.comb += s.data.eq(v.data + 1)
+        def itransform_rec(m: TModule, arg: Record) -> Record:
+            s = Record.like(arg)
+            m.d.comb += s.data.eq(arg.data + 1)
             return s
 
-        def otransform_rec(m: ModuleLike, v: Record) -> Record:
-            s = Record.like(v)
-            m.d.comb += s.data.eq(v.data - 1)
+        def otransform_rec(m: TModule, arg: Record) -> Record:
+            s = Record.like(arg)
+            m.d.comb += s.data.eq(arg.data - 1)
             return s
 
-        def itransform_dict(_, v: Record) -> RecordDict:
-            return {"data": v.data + 1}
+        def itransform_dict(m: TModule, data: Value) -> RecordDict:
+            return {"data": data + 1}
 
-        def otransform_dict(_, v: Record) -> RecordDict:
-            return {"data": v.data - 1}
+        def otransform_dict(m: TModule, data: Value) -> RecordDict:
+            return {"data": data - 1}
 
         if self.use_dicts:
             itransform = itransform_dict
@@ -483,8 +483,8 @@ class TestMethodFilter(TestCaseWithSimulator):
     def test_method_filter(self):
         self.initialize()
 
-        def condition(_, v):
-            return v[0]
+        def condition(data: Value):
+            return data[0]
 
         self.tc = SimpleTestCircuit(MethodFilter(self.target.adapter.iface, condition))
         m = ModuleConnector(test_circuit=self.tc, target=self.target)
@@ -515,7 +515,7 @@ class MethodProductTestCircuit(Elaboratable):
 
         combiner = None
         if self.add_combiner:
-            combiner = (layout, lambda _, vs: {"data": sum(vs)})
+            combiner = (layout, lambda vs: {"data": sum(vs)})
 
         m.submodules.product = product = MethodProduct(methods, combiner)
 
@@ -702,7 +702,7 @@ class MethodTryProductTestCircuit(Elaboratable):
 
         combiner = None
         if self.add_combiner:
-            combiner = (layout, lambda _, vs: {"data": sum(Mux(s, r, 0) for (s, r) in vs)})
+            combiner = (layout, lambda vs: {"data": sum(Mux(s, r, 0) for (s, r) in vs)})
 
         m.submodules.product = product = MethodTryProduct(methods, combiner)
 

--- a/transactron/_utils.py
+++ b/transactron/_utils.py
@@ -2,12 +2,11 @@ import itertools
 import sys
 import functools
 from inspect import Parameter, signature
-from typing import Any, Concatenate, Optional, TypeAlias, TypeGuard, TypeVar
+from typing import Concatenate, Optional, ParamSpec, TypeAlias, TypeGuard, TypeVar
 from collections.abc import Callable, Iterable, Mapping
 from amaranth import *
 from coreblocks.utils._typing import LayoutLike
 from coreblocks.utils import OneHotSwitchDynamic
-from .core import Method, TModule
 
 __all__ = [
     "Scheduler",
@@ -18,13 +17,14 @@ __all__ = [
     "GraphCC",
     "get_caller_class_name",
     "def_helper",
-    "method_def_helper",
-    "transformer_helper",
+    "bind_first_param",
 ]
 
 
 T = TypeVar("T")
 U = TypeVar("U")
+P = ParamSpec("P")
+CallableOptParam: TypeAlias = Callable[Concatenate[U, P], T] | Callable[P, T]
 
 
 class Scheduler(Elaboratable):
@@ -127,7 +127,9 @@ def _graph_ccs(gr: ROGraph[T]) -> list[GraphCC[T]]:
 MethodLayout: TypeAlias = LayoutLike
 
 
-def has_first_param(func: Callable[..., T], name: str, tp: type[U]) -> TypeGuard[Callable[Concatenate[U, ...], T]]:
+def has_first_param(
+    func: CallableOptParam[U, P, T], name: str, tp: type[U]
+) -> TypeGuard[Callable[Concatenate[U, P], T]]:
     parameters = signature(func).parameters
     return (
         len(parameters) >= 1
@@ -135,6 +137,13 @@ def has_first_param(func: Callable[..., T], name: str, tp: type[U]) -> TypeGuard
         and parameters[name].kind in {Parameter.POSITIONAL_OR_KEYWORD, Parameter.POSITIONAL_ONLY}
         and parameters[name].annotation in {Parameter.empty, tp}
     )
+
+
+def bind_first_param(func: CallableOptParam[U, P, T], name: str, tp: type[U], arg: U) -> Callable[P, T]:
+    if has_first_param(func, name, tp):
+        return functools.partial(func, arg)  # type: ignore
+    else:
+        return func  # type: ignore
 
 
 def def_helper(description, func: Callable[..., T], tp: type[U], arg: U, /, **kwargs) -> T:
@@ -148,28 +157,6 @@ def def_helper(description, func: Callable[..., T], tp: type[U], arg: U, /, **kw
         return func(**kwargs)
     else:
         raise TypeError(f"Invalid {description}: {func}")
-
-
-def mock_def_helper(tb, func: Callable[..., T], arg: Mapping[str, Any]) -> T:
-    return def_helper(f"mock definition for {tb}", func, Mapping[str, Any], arg, **arg)
-
-
-def method_def_helper(method, func: Callable[..., T], arg: Record) -> T:
-    return def_helper(f"method definition for {method}", func, Record, arg, **arg.fields)
-
-
-def transformer_helper(tr, m: TModule, func: Callable[..., T], arg: Record) -> T:
-    if has_first_param(func, "m", TModule):
-
-        @functools.wraps(func)
-        def xfunc(*args, **kwargs):
-            return func(m, *args, **kwargs)
-
-        hfunc = xfunc
-    else:
-        hfunc = func
-
-    return def_helper(f"function for {tr}", hfunc, Record, arg)
 
 
 def get_caller_class_name(default: Optional[str] = None) -> tuple[Optional[Elaboratable], str]:

--- a/transactron/core.py
+++ b/transactron/core.py
@@ -43,6 +43,7 @@ __all__ = [
 ]
 
 
+T = TypeVar("T")
 TransactionGraph: TypeAlias = Graph["Transaction"]
 TransactionGraphCC: TypeAlias = GraphCC["Transaction"]
 PriorityOrder: TypeAlias = dict["Transaction", int]
@@ -1160,6 +1161,10 @@ class Method(TransactionBase):
 
     def debug_signals(self) -> SignalBundle:
         return [self.ready, self.run, self.data_in, self.data_out]
+
+
+def method_def_helper(method: Method, func: Callable[..., T], arg: Record) -> T:
+    return def_helper(f"method definition for {method}", func, Record, arg, **arg.fields)
 
 
 def def_method(m: TModule, method: Method, ready: ValueLike = C(1)):


### PR DESCRIPTION
This PR utilizes `def_helper` mechanisms to create a nicer API for using transformers. Following changes in interpreting the function arguments of the transformer classes are made:

* The module parameter is now optional.
* Instead of taking a record of method inputs (`arg`) the functions can take individual record fields, just like methods defined via `def_method`.

To do:
* [ ] Update docstrings.