### PR TITLE
Fix tests with binutils 2.41

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -263,7 +263,7 @@ class TestCoreAsmSource(TestCoreBase):
         self.base_dir = "test/asm/"
         self.bin_src = []
 
-        with tempfile.NamedTemporaryFile() as asm_tmp:
+        with tempfile.NamedTemporaryFile() as asm_tmp, tempfile.NamedTemporaryFile() as bin_tmp:
             subprocess.check_call(
                 [
                     "riscv64-unknown-elf-as",
@@ -276,9 +276,10 @@ class TestCoreAsmSource(TestCoreBase):
                     self.base_dir + self.source_file,
                 ]
             )
-            code = subprocess.check_output(
-                ["riscv64-unknown-elf-objcopy", "-O", "binary", "-j", ".text", asm_tmp.name, "/dev/stdout"]
+            subprocess.check_call(
+                ["riscv64-unknown-elf-objcopy", "-O", "binary", "-j", ".text", asm_tmp.name, bin_tmp.name]
             )
+            code = bin_tmp.read()
             for word_idx in range(0, len(code), 4):
                 word = code[word_idx : word_idx + 4]
                 bin_instr = int.from_bytes(word, "little")


### PR DESCRIPTION
The tests broke on my machine because of https://github.com/bminor/binutils-gdb/commit/014a602b86f08de96fc80ef3f96a87db6cccad56
which was fixed half a year later by https://github.com/bminor/binutils-gdb/commit/f82ee0c8dc4ee32556e23e6cd83ef083618f704f
so the only binutils version affected is 2.41.

Nevertheless, apparently using objcopy output to pipe is not something officially supported, so we can avoid such issues now and in the future by using another temporary file.