### PR TITLE
Add `condition` based MetodFilter

### DIFF
--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -470,23 +470,25 @@ class TestMethodFilter(TestCaseWithSimulator):
     def cmeth_mock(self, data):
         return {"data": data % 2}
 
-    def test_method_filter_with_methods(self):
+    @parameterized.expand([(True,), (False,)])
+    def test_method_filter_with_methods(self, use_condition):
         self.initialize()
         self.cmeth = TestbenchIO(Adapter(i=self.layout, o=data_layout(1)))
-        self.tc = SimpleTestCircuit(MethodFilter(self.target.adapter.iface, self.cmeth.adapter.iface))
+        self.tc = SimpleTestCircuit(MethodFilter(self.target.adapter.iface, self.cmeth.adapter.iface, use_condition = use_condition))
         m = ModuleConnector(test_circuit=self.tc, target=self.target, cmeth=self.cmeth)
         with self.run_simulation(m) as sim:
             sim.add_sync_process(self.source)
             sim.add_sync_process(self.target_mock)
             sim.add_sync_process(self.cmeth_mock)
 
-    def test_method_filter(self):
+    @parameterized.expand([(True,), (False,)])
+    def test_method_filter(self, use_condition):
         self.initialize()
 
         def condition(_, v):
             return v[0]
 
-        self.tc = SimpleTestCircuit(MethodFilter(self.target.adapter.iface, condition))
+        self.tc = SimpleTestCircuit(MethodFilter(self.target.adapter.iface, condition, use_condition=use_condition))
         m = ModuleConnector(test_circuit=self.tc, target=self.target)
         with self.run_simulation(m) as sim:
             sim.add_sync_process(self.source)

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -474,7 +474,9 @@ class TestMethodFilter(TestCaseWithSimulator):
     def test_method_filter_with_methods(self, use_condition):
         self.initialize()
         self.cmeth = TestbenchIO(Adapter(i=self.layout, o=data_layout(1)))
-        self.tc = SimpleTestCircuit(MethodFilter(self.target.adapter.iface, self.cmeth.adapter.iface, use_condition = use_condition))
+        self.tc = SimpleTestCircuit(
+            MethodFilter(self.target.adapter.iface, self.cmeth.adapter.iface, use_condition=use_condition)
+        )
         m = ModuleConnector(test_circuit=self.tc, target=self.target, cmeth=self.cmeth)
         with self.run_simulation(m) as sim:
             sim.add_sync_process(self.source)

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -143,6 +143,7 @@ class MethodFilter(Elaboratable):
 
         return m
 
+
 class MethodProduct(Elaboratable):
     def __init__(
         self,


### PR DESCRIPTION
This MR is the first fragment of #395 to port to the trunk. Here I extend `MethodFilter` with possibility to use `condition` under the hood to ignore situations, where method is not ready and condition is false. This has the caveats that resulting filter is `single_caller` so both versions should coexistence.