### PR TITLE
Fix typo in icache tests and return type in documentation

### DIFF
--- a/coreblocks/fu/fu_decoder.py
+++ b/coreblocks/fu/fu_decoder.py
@@ -81,8 +81,8 @@ class DecoderManager:
 
         Returns
         -------
-        return : set[OpType]
-            List of OpTypes.
+        return : Decoder
+            Instance of Decoder class.
         """
         # check how many different op types are there
         op_types = self.get_op_types()

--- a/test/frontend/test_icache.py
+++ b/test/frontend/test_icache.py
@@ -89,7 +89,7 @@ class TestSimpleWBCacheRefiller(TestCaseWithSimulator):
         while True:
             yield from self.test_module.wb_ctrl.slave_wait()
 
-            # Wishbone is addressing words, so we need to shit it a bit to get the real address.
+            # Wishbone is addressing words, so we need to shift it a bit to get the real address.
             addr = (yield self.test_module.wb_ctrl.wb.adr) << log2_int(self.cp.word_width_bytes)
 
             while random.random() < 0.5:
@@ -200,7 +200,7 @@ class TestICacheBypass(TestCaseWithSimulator):
         while True:
             yield from self.m.wb_ctrl.slave_wait()
 
-            # Wishbone is addressing words, so we need to shit it a bit to get the real address.
+            # Wishbone is addressing words, so we need to shift it a bit to get the real address.
             addr = (yield self.m.wb_ctrl.wb.adr) << log2_int(self.cp.word_width_bytes)
 
             while random.random() < 0.5:


### PR DESCRIPTION
This PR fixes certain typo in `test_icache.py` and changes return type of `get_decoder` of `DecoderManager` class in documentation from `set[OpType]` to `Decoder`