### PR TITLE
retirement: Disable side effects on exception (proposed corrections)

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -136,6 +136,7 @@ class Core(Elaboratable):
             rf_free=rf.free,
             precommit=self.func_blocks_unifier.get_extra_method(InstructionPrecommitKey()),
             exception_cause_get=self.exception_cause_register.get,
+            frat_rename=frat.rename,
         )
 
         m.submodules.csr_generic = self.csr_generic

--- a/coreblocks/params/layouts.py
+++ b/coreblocks/params/layouts.py
@@ -106,6 +106,9 @@ class CommonLayoutFields:
         self.error: LayoutListField = ("error", 1)
         """Request ended with an error."""
 
+        self.side_fx: LayoutListField = ("side_fx", 1)
+        """Side effects are enabled."""
+
 
 class SchedulerLayouts:
     """Layouts used in the scheduler."""
@@ -221,7 +224,7 @@ class RATLayouts:
 
         self.rat_rename_out: LayoutList = [fields.rp_s1, fields.rp_s2]
 
-        self.rat_commit_in: LayoutList = [fields.rl_dst, fields.rp_dst]
+        self.rat_commit_in: LayoutList = [fields.rl_dst, fields.rp_dst, fields.side_fx]
 
         self.rat_commit_out: LayoutList = [self.old_rp_dst]
 
@@ -328,7 +331,7 @@ class RetirementLayouts:
     def __init__(self, gen_params: GenParams):
         fields = gen_params.get(CommonLayoutFields)
 
-        self.precommit: LayoutList = [fields.rob_id]
+        self.precommit: LayoutList = [fields.rob_id, fields.side_fx]
 
 
 class RSLayouts:

--- a/coreblocks/stages/retirement.py
+++ b/coreblocks/stages/retirement.py
@@ -70,6 +70,7 @@ class Retirement(Elaboratable):
             rp_freed = Signal(self.gen_params.phys_regs_bits)
             with m.If(side_fx):
                 m.d.comb += rp_freed.eq(rat_out.old_rp_dst)
+                self.instret_csr.increment(m)
             with m.Else():
                 m.d.comb += rp_freed.eq(rob_entry.rob_data.rp_dst)
                 # free the phys_reg with computed value and restore old reg into FRAT as well
@@ -81,7 +82,5 @@ class Retirement(Elaboratable):
             # put old rp_dst to free RF list
             with m.If(rp_freed):  # don't put rp0 to free list - reserved to no-return instructions
                 self.free_rf_put(m, rp_freed)
-
-            self.instret_csr.increment(m)
 
         return m

--- a/coreblocks/stages/retirement.py
+++ b/coreblocks/stages/retirement.py
@@ -18,7 +18,8 @@ class Retirement(Elaboratable):
         free_rf_put: Method,
         rf_free: Method,
         precommit: Method,
-        exception_cause_get: Method
+        exception_cause_get: Method,
+        frat_rename: Method,
     ):
         self.gen_params = gen_params
         self.rob_peek = rob_peek
@@ -28,6 +29,7 @@ class Retirement(Elaboratable):
         self.rf_free = rf_free
         self.precommit = precommit
         self.exception_cause_get = exception_cause_get
+        self.rename = frat_rename
 
         self.instret_csr = DoubleCounterCSR(gen_params, CSRAddress.INSTRET, CSRAddress.INSTRETH)
 
@@ -36,18 +38,23 @@ class Retirement(Elaboratable):
 
         m.submodules.instret_csr = self.instret_csr
 
+        side_fx = Signal(reset=1)
+
         with Transaction().body(m):
             # TODO: do we prefer single precommit call per instruction?
             # If so, the precommit method should send an acknowledge signal here.
             # Just calling once is not enough, because the insn might not be in relevant unit yet.
             rob_entry = self.rob_peek(m)
-            self.precommit(m, rob_id=rob_entry.rob_id)
+            self.precommit(m, rob_id=rob_entry.rob_id, side_fx=side_fx)
 
         with Transaction().body(m):
             rob_entry = self.rob_retire(m)
 
             # TODO: Trigger InterruptCoordinator (handle exception) when rob_entry.exception is set.
-            with m.If(rob_entry.exception):
+            with m.If(rob_entry.exception & side_fx):
+                m.d.sync += side_fx.eq(0)
+                # TODO: only set mcause/trigger IC if cause is actual exception and not e.g.
+                # misprediction or pipeline flush after some fence.i or changing ISA
                 mcause = self.gen_params.get(DependencyManager).get_dependency(GenericCSRRegistersKey()).mcause
                 cause = self.exception_cause_get(m).cause
                 entry = Signal(self.gen_params.isa.xlen)
@@ -56,13 +63,24 @@ class Retirement(Elaboratable):
                 mcause.write(m, entry)
 
             # set rl_dst -> rp_dst in R-RAT
-            rat_out = self.r_rat_commit(m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rob_entry.rob_data.rp_dst)
+            rat_out = self.r_rat_commit(
+                m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rob_entry.rob_data.rp_dst, side_fx=side_fx
+            )
 
-            self.rf_free(m, rat_out.old_rp_dst)
+            rp_freed = Signal(self.gen_params.phys_regs_bits)
+            with m.If(side_fx):
+                m.d.comb += rp_freed.eq(rat_out.old_rp_dst)
+            with m.Else():
+                m.d.comb += rp_freed.eq(rob_entry.rob_data.rp_dst)
+                # free the phys_reg with computed value and restore old reg into FRAT as well
+                # TODO: are method priorities enough?
+                self.rename(m, rl_s1=0, rl_s2=0, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rat_out.old_rp_dst)
+
+            self.rf_free(m, rp_freed)
 
             # put old rp_dst to free RF list
-            with m.If(rat_out.old_rp_dst):  # don't put rp0 to free list - reserved to no-return instructions
-                self.free_rf_put(m, rat_out.old_rp_dst)
+            with m.If(rp_freed):  # don't put rp0 to free list - reserved to no-return instructions
+                self.free_rf_put(m, rp_freed)
 
             self.instret_csr.increment(m)
 

--- a/coreblocks/structs_common/rat.py
+++ b/coreblocks/structs_common/rat.py
@@ -42,8 +42,9 @@ class RRAT(Elaboratable):
         m = TModule()
 
         @def_method(m, self.commit)
-        def _(rp_dst: Value, rl_dst: Value):
-            m.d.sync += self.entries[rl_dst].eq(rp_dst)
+        def _(rp_dst: Value, rl_dst: Value, side_fx: Value):
+            with m.If(side_fx):
+                m.d.sync += self.entries[rl_dst].eq(rp_dst)
             return {"old_rp_dst": self.entries[rl_dst]}
 
         return m

--- a/test/asm/exception.asm
+++ b/test/asm/exception.asm
@@ -1,0 +1,5 @@
+li x2, 2
+li x1, 1
+.4byte 0  /* should be unimp, but it would test nothing since unimp is system and stalls the fetcher >:( */
+li x2, 9
+

--- a/test/asm/exception_mem.asm
+++ b/test/asm/exception_mem.asm
@@ -1,0 +1,11 @@
+# Data adress space:
+# 0x0 - one
+# 0x4 - two
+li x1, 1
+sw x1, 0(x0)
+li x2, 2
+sw x2, 4(x0)
+.4byte 0  /* should be unimp, but it would test nothing since unimp is system and stalls the fetcher >:( */
+sw x1, 4(x0)  /* TODO: actually check the side fx */
+li x2, 9
+

--- a/test/lsu/test_dummylsu.py
+++ b/test/lsu/test_dummylsu.py
@@ -431,7 +431,7 @@ class TestDummyLSUStores(TestCaseWithSimulator):
             while len(self.precommit_data) == 0:
                 yield
             rob_id = self.precommit_data[-1]  # precommit is called continously until instruction is retired
-            yield from self.test_module.precommit.call(rob_id=rob_id)
+            yield from self.test_module.precommit.call(rob_id=rob_id, side_fx=1)
 
     def test(self):
         @def_method_mock(lambda: self.test_module.exception_report)

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -130,7 +130,7 @@ class TestCSRUnit(TestCaseWithSimulator):
                 yield from self.dut.update.call(reg_id=op["exp"]["rs1"]["rp_s1"], reg_val=op["exp"]["rs1"]["value"])
 
             yield from self.random_wait()
-            yield from self.dut.precommit.call()
+            yield from self.dut.precommit.call(side_fx=1)
 
             yield from self.random_wait()
             res = yield from self.dut.accept.call()
@@ -183,7 +183,7 @@ class TestCSRUnit(TestCaseWithSimulator):
             )
 
             yield from self.random_wait()
-            yield from self.dut.precommit.call(rob_id=rob_id)
+            yield from self.dut.precommit.call(rob_id=rob_id, side_fx=1)
 
             yield from self.random_wait()
             res = yield from self.dut.accept.call()

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -243,6 +243,8 @@ class TestCoreRandomized(TestCoreBase):
         ("fibonacci", "fibonacci.asm", 1200, {2: 2971215073}, basic_core_config),
         ("fibonacci_mem", "fibonacci_mem.asm", 610, {3: 55}, basic_core_config),
         ("csr", "csr.asm", 200, {1: 1, 2: 4}, full_core_config),
+        ("exception", "exception.asm", 200, {1: 1, 2: 2}, basic_core_config),
+        ("exception_mem", "exception_mem.asm", 200, {1: 1, 2: 2}, basic_core_config),
     ],
 )
 class TestCoreAsmSource(TestCoreBase):


### PR DESCRIPTION
This is an updated version of #493, created to discuss possible solutions to the problems in that PR. This branch is intended to be merged into #493 by @Arusekk.

Changes introduced:

* New LSU from #511.
* Combinational side_fx signal in retirement, to fix the issue reported by @piotro888.
* FRAT rename calls in retirement moved to a separate transaction, to avoid mutual locking of retirement and renaming during normal core operation. Verified in benchmarks that there is no loss in IPC.