### PR TITLE
Update dockerfiles

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ jobs:
     name: Synthesis benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    container: ghcr.io/kuznia-rdzeni/amaranth-synth:ecp5-3.11
+    container: ghcr.io/kuznia-rdzeni/amaranth-synth:ecp5-2023.11.19_v
     steps:
       - uses: actions/checkout@v3
 
@@ -63,7 +63,7 @@ jobs:
   build-perf-benchmarks:
     name: Build performance benchmarks
     runs-on: ubuntu-latest
-    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2023.10.08_v
+    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2023.11.19_v
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
     name: Run performance benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    container: ghcr.io/kuznia-rdzeni/verilator:v5.008-3.11
+    container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
     needs: build-perf-benchmarks
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
   build-regression-tests:
     name: Build regression tests
     runs-on: ubuntu-latest
-    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2023.10.08_v
+    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2023.11.19_v
     outputs:
         cache_hit: ${{ steps.cache-regression.outputs.cache-hit }}
     steps:
@@ -54,7 +54,7 @@ jobs:
     name: Run regression tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: ghcr.io/kuznia-rdzeni/verilator:v5.008-3.11
+    container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
     needs: build-regression-tests
     steps:
       - name: Checkout

--- a/docker/AmaranthSynthECP5.Dockerfile
+++ b/docker/AmaranthSynthECP5.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:23.04
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
-    python3.11 python3-pip git yosys lsb-release \
+    python3.11 python3-pip python3.11-venv git yosys lsb-release \
     build-essential cmake python3-dev libboost-all-dev libeigen3-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Verilator.Dockerfile
+++ b/docker/Verilator.Dockerfile
@@ -3,12 +3,12 @@ FROM ubuntu:23.04
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
-    python3.11 libpython3.11 python3-pip git lsb-release \
+    python3.11 libpython3.11 python3-pip python3.11-venv git lsb-release \
     perl perl-doc help2man make autoconf g++ flex bison ccache numactl \
     libgoogle-perftools-dev libfl-dev zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --recursive \
+RUN git clone --recursive --shallow-since=2023.03.01 \
     https://github.com/verilator/verilator.git \
     verilator && \
     cd verilator && \

--- a/docker/riscv-toolchain.Dockerfile
+++ b/docker/riscv-toolchain.Dockerfile
@@ -3,15 +3,40 @@ FROM ubuntu:23.04
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
-    autoconf automake autotools-dev curl python3 bc lsb-release \
+    autoconf automake autotools-dev curl python3.11 python3.11-venv python3-pip bc lsb-release \
     libmpc-dev libmpfr-dev libgmp-dev gawk build-essential \
-    bison flex texinfo gperf libtool patchutils zlib1g-dev \
-    libexpat-dev ninja-build git ca-certificates python-is-python3 && \
+    bison flex texinfo gperf libtool patchutils zlib1g-dev device-tree-compiler \
+    libexpat-dev ninja-build git ca-certificates python-is-python3 \ 
+    libssl-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/riscv/riscv-gnu-toolchain && \
+RUN git clone --shallow-since=2023.05.01 https://github.com/riscv/riscv-gnu-toolchain && \
     cd riscv-gnu-toolchain && \
     git checkout 2023.05.14 && \
     ./configure --with-multilib-generator="rv32i-ilp32--a*zifence*zicsr;rv32im-ilp32--a*zifence*zicsr;rv32ic-ilp32--a*zifence*zicsr;rv32imc-ilp32--a*zifence*zicsr;rv32imfc-ilp32f--a*zifence;rv32i_zmmul-ilp32--a*zifence*zicsr;rv32ic_zmmul-ilp32--a*zifence*zicsr" && \
     make -j$(nproc) && \
     cd / && rm -rf riscv-gnu-toolchain
+
+RUN git clone --shallow-since=2023.10.01 https://github.com/riscv-software-src/riscv-isa-sim.git spike && \
+    cd spike && \
+    git checkout eeef09ebb894c3bb7e42b7b47aae98792b8eef79 && \
+    mkdir build/ install/  && \
+    cd build/ && \
+    ../configure --prefix=/spike/install/ && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -rf build/
+
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git .pyenv && \
+    export PATH=/.pyenv/bin:$PATH && \
+    export PYENV_ROOT=/root/.pyenv && \
+    eval "$(pyenv init --path)" && \
+    pyenv install 3.6.15 && \
+    pyenv global 3.6.15 && \
+    python -V && \
+    python -m venv venv3.6 && \
+    . venv3.6/bin/activate && \
+    python -m pip install --upgrade pip && \
+    python -m pip install riscof && \
+    pyenv global system


### PR DESCRIPTION
While updating #454 I have found that we don't have venv in dockers, so it have to be manually installed before running the regression tests by hand. Here is a PR which update dockers to contain this package. Additionally I integrated changes added by @piotro888 in #513 to update dockers only once.

(Dockers are being currently uploaded)