### PR TITLE
Run linker on internal asm tests

### DIFF
--- a/test/asm/link.ld
+++ b/test/asm/link.ld
@@ -1,0 +1,26 @@
+OUTPUT_ARCH( "riscv" )
+
+start = 0x0;
+
+MEMORY
+{
+    data (wxa!ri) : ORIGIN = 0x00000000, LENGTH = 1K
+    text (rxai!w) : ORIGIN = 0x10000000, LENGTH = 64K
+}
+
+PHDRS
+{
+  text PT_LOAD;
+  data_init PT_LOAD;
+  data PT_NULL;
+}
+
+SECTIONS
+{
+  .text.init : { *(.text.init) } >text AT>text :text
+  .text : { *(.text) } >text AT>text :text
+  . = ALIGN(0x1000);
+  .data : { *(.data) } >data AT>data :data_init
+  .bss : { *(.bss) } >data AT>data :data
+  _end = .;
+}

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -265,7 +265,11 @@ class TestCoreAsmSource(TestCoreBase):
         self.base_dir = "test/asm/"
         self.bin_src = []
 
-        with tempfile.NamedTemporaryFile() as asm_tmp, tempfile.NamedTemporaryFile() as bin_tmp:
+        with (
+            tempfile.NamedTemporaryFile() as asm_tmp,
+            tempfile.NamedTemporaryFile() as ld_tmp,
+            tempfile.NamedTemporaryFile() as bin_tmp,
+        ):
             subprocess.check_call(
                 [
                     "riscv64-unknown-elf-as",
@@ -279,7 +283,19 @@ class TestCoreAsmSource(TestCoreBase):
                 ]
             )
             subprocess.check_call(
-                ["riscv64-unknown-elf-objcopy", "-O", "binary", "-j", ".text", asm_tmp.name, bin_tmp.name]
+                [
+                    "riscv64-unknown-elf-ld",
+                    "-m",
+                    "elf32lriscv",
+                    "-T",
+                    self.base_dir + "link.ld",
+                    asm_tmp.name,
+                    "-o",
+                    ld_tmp.name,
+                ]
+            )
+            subprocess.check_call(
+                ["riscv64-unknown-elf-objcopy", "-O", "binary", "-j", ".text", ld_tmp.name, bin_tmp.name]
             )
             code = bin_tmp.read()
             for word_idx in range(0, len(code), 4):


### PR DESCRIPTION
Linker run was somehow missing for our internal assembly tests.
I created basic linker flow (with slightly modified script from our `riscv-tests` env).

It is needed to run asm test that I written for testing exceptions.

`la` (load address) instruction is example that doesn't work without linking.
`la` translates to:
before:
```
10:   00000317                auipc   t1,0x0
14:   00030313                mv      t1,t1
```
after:
```
10000010:       00000317                auipc   t1,0x0
10000014:       02430313                addi    t1,t1,36 # 10000034 <exception_handler>
```
