### PR TITLE
Simpler way of using method transformations

### DIFF
--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -399,19 +399,15 @@ class MethodTransformerTestCircuit(Elaboratable):
             def _(arg: Record):
                 return otransform(m, arg)
 
-            trans = MethodTransformer(
-                self.target.adapter.iface, i_transform=(layout, imeth), o_transform=(layout, ometh)
-            )
+            trans = MethodMap(self.target.adapter.iface, i_transform=(layout, imeth), o_transform=(layout, ometh))
         else:
-            trans = MethodTransformer(
+            trans = MethodMap(
                 self.target.adapter.iface,
                 i_transform=(layout, itransform),
                 o_transform=(layout, otransform),
             )
 
-        m.submodules.trans = trans
-
-        m.submodules.source = self.source = TestbenchIO(AdapterTrans(trans.method))
+        m.submodules.source = self.source = TestbenchIO(AdapterTrans(trans.use(m)))
 
         return m
 
@@ -517,9 +513,9 @@ class MethodProductTestCircuit(Elaboratable):
         if self.add_combiner:
             combiner = (layout, lambda _, vs: {"data": sum(vs)})
 
-        m.submodules.product = product = MethodProduct(methods, combiner)
+        product = MethodProduct(methods, combiner)
 
-        m.submodules.method = self.method = TestbenchIO(AdapterTrans(product.method))
+        m.submodules.method = self.method = TestbenchIO(AdapterTrans(product.use(m)))
 
         return m
 
@@ -704,9 +700,9 @@ class MethodTryProductTestCircuit(Elaboratable):
         if self.add_combiner:
             combiner = (layout, lambda _, vs: {"data": sum(Mux(s, r, 0) for (s, r) in vs)})
 
-        m.submodules.product = product = MethodTryProduct(methods, combiner)
+        product = MethodTryProduct(methods, combiner)
 
-        m.submodules.method = self.method = TestbenchIO(AdapterTrans(product.method))
+        m.submodules.method = self.method = TestbenchIO(AdapterTrans(product.use(m)))
 
         return m
 

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -351,7 +351,7 @@ class TestManyToOneConnectTrans(TestCaseWithSimulator):
                 sim.add_sync_process(self.generate_producer(i))
 
 
-class MethodTransformerTestCircuit(Elaboratable):
+class MethodMapTestCircuit(Elaboratable):
     def __init__(self, iosize: int, use_methods: bool, use_dicts: bool):
         self.iosize = iosize
         self.use_methods = use_methods
@@ -413,7 +413,7 @@ class MethodTransformerTestCircuit(Elaboratable):
 
 
 class TestMethodTransformer(TestCaseWithSimulator):
-    m: MethodTransformerTestCircuit
+    m: MethodMapTestCircuit
 
     def source(self):
         for i in range(2**self.m.iosize):
@@ -426,19 +426,19 @@ class TestMethodTransformer(TestCaseWithSimulator):
         return {"data": (data << 1) | (data >> (self.m.iosize - 1))}
 
     def test_method_transformer(self):
-        self.m = MethodTransformerTestCircuit(4, False, False)
+        self.m = MethodMapTestCircuit(4, False, False)
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.source)
             sim.add_sync_process(self.target)
 
     def test_method_transformer_dicts(self):
-        self.m = MethodTransformerTestCircuit(4, False, True)
+        self.m = MethodMapTestCircuit(4, False, True)
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.source)
             sim.add_sync_process(self.target)
 
     def test_method_transformer_with_methods(self):
-        self.m = MethodTransformerTestCircuit(4, True, True)
+        self.m = MethodMapTestCircuit(4, True, True)
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(self.source)
             sim.add_sync_process(self.target)

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -8,7 +8,7 @@ from transactron.utils import ValueLike, assign, AssignType, ModuleLike
 from .connectors import Forwarder, ManyToOneConnectTrans, ConnectTrans
 
 __all__ = [
-    "Combiner",
+    "Transformer",
     "MethodMap",
     "MethodFilter",
     "MethodProduct",
@@ -19,10 +19,10 @@ __all__ = [
 ]
 
 
-class Combiner(ABC):
-    """Method combiner abstract class.
+class Transformer(ABC):
+    """Method transformer abstract class.
 
-    Method combiners construct a new method which utilizes other methods.
+    Method transformers construct a new method which utilizes other methods.
 
     Attributes
     ----------
@@ -34,18 +34,18 @@ class Combiner(ABC):
 
     def use(self, m: ModuleLike):
         """
-        Returns the method and adds the combiner to a module.
+        Returns the method and adds the transformer to a module.
 
         Parameters
         ----------
         m: Module or TModule
-            The module to which this combiner is added as a submodule.
+            The module to which this transformer is added as a submodule.
         """
         m.submodules += self
         return self.method
 
 
-class MethodMap(Combiner, Elaboratable):
+class MethodMap(Transformer, Elaboratable):
     """Bidirectional map for methods.
 
     Takes a target method and creates a transformed method which calls the
@@ -101,7 +101,7 @@ class MethodMap(Combiner, Elaboratable):
         return m
 
 
-class MethodFilter(Combiner, Elaboratable):
+class MethodFilter(Transformer, Elaboratable):
     """Method filter.
 
     Takes a target method and creates a method which calls the target method
@@ -157,7 +157,7 @@ class MethodFilter(Combiner, Elaboratable):
         return m
 
 
-class MethodProduct(Combiner, Elaboratable):
+class MethodProduct(Transformer, Elaboratable):
     def __init__(
         self,
         targets: list[Method],
@@ -205,7 +205,7 @@ class MethodProduct(Combiner, Elaboratable):
         return m
 
 
-class MethodTryProduct(Combiner, Elaboratable):
+class MethodTryProduct(Transformer, Elaboratable):
     def __init__(
         self,
         targets: list[Method],
@@ -257,7 +257,7 @@ class MethodTryProduct(Combiner, Elaboratable):
         return m
 
 
-class Collector(Combiner, Elaboratable):
+class Collector(Transformer, Elaboratable):
     """Single result collector.
 
     Creates method that collects results of many methods with identical

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -8,6 +8,7 @@ from transactron.utils import ValueLike, assign, AssignType, ModuleLike
 from .connectors import Forwarder, ManyToOneConnectTrans, ConnectTrans
 
 __all__ = [
+    "Combiner",
     "MethodMap",
     "MethodFilter",
     "MethodProduct",
@@ -45,11 +46,11 @@ class Combiner(ABC):
 
 
 class MethodMap(Combiner, Elaboratable):
-    """Method transformer.
+    """Bidirectional map for methods.
 
     Takes a target method and creates a transformed method which calls the
-    original target method, transforming the input and output values.
-    The transformation functions take two parameters, a `Module` and the
+    original target method, mapping the input and output values with
+    functions. The mapping functions take two parameters, a `Module` and the
     `Record` being transformed. Alternatively, a `Method` can be
     passed.
 
@@ -72,13 +73,13 @@ class MethodMap(Combiner, Elaboratable):
         target: Method
             The target method.
         i_transform: (record layout, function or Method), optional
-            Input transformation. If specified, it should be a pair of a
+            Input mapping function. If specified, it should be a pair of a
             function and a input layout for the transformed method.
-            If not present, input is not transformed.
+            If not present, input is passed unmodified.
         o_transform: (record layout, function or Method), optional
-            Output transformation. If specified, it should be a pair of a
+            Output mapping function. If specified, it should be a pair of a
             function and a output layout for the transformed method.
-            If not present, output is not transformed.
+            If not present, output is passed unmodified.
         """
         if i_transform is None:
             i_transform = (target.data_in.layout, lambda _, x: x)

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -15,7 +15,7 @@ __all__ = [
     "MethodTryProduct",
     "Collector",
     "CatTrans",
-    "ConnectAndTransformTrans",
+    "ConnectAndMapTrans",
 ]
 
 
@@ -336,14 +336,13 @@ class CatTrans(Elaboratable):
         return m
 
 
-class ConnectAndTransformTrans(Elaboratable):
-    """Connecting transaction with transformations.
+class ConnectAndMapTrans(Elaboratable):
+    """Connecting transaction with mapping functions.
 
     Behaves like `ConnectTrans`, but modifies the transferred data using
-    functions or `Method`s. Equivalent to a combination of
-    `ConnectTrans` and `MethodTransformer`. The transformation
-    functions take two parameters, a `Module` and the `Record` being
-    transformed.
+    functions or `Method`s. Equivalent to a combination of `ConnectTrans`
+    and `MethodMap`. The mapping functions take two parameters, a `Module`
+    and the `Record` being transformed.
     """
 
     def __init__(


### PR DESCRIPTION
This PR allows the use of `MethodTransformer` etc. to be less wordy.