### PR TITLE
Fix riscv-test job dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
-    needs: build-regression-tests
+    needs: [ build-regression-tests, build-core ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-core:
-    name: Synthethise full core
+    name: Synthesize full core
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
I didn't want to block #513, so the issue which I found during review is corrected here. In #513 generation of verilog was moved to separate job. `riscv-tests` use artifact of that job, but the dependencies weren't updated.