### PR TITLE
Clear ExcepionCauseRegister after flushing core

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -145,6 +145,7 @@ class Core(Elaboratable):
             rf_free=rf.free,
             precommit=self.func_blocks_unifier.get_extra_method(InstructionPrecommitKey()),
             exception_cause_get=self.exception_cause_register.get,
+            exception_cause_clear=self.exception_cause_register.clear,
             frat_rename=frat.rename,
             fetch_continue=self.fetch.verify_branch,
             fetch_stall=self.fetch.stall_exception,

--- a/coreblocks/stages/retirement.py
+++ b/coreblocks/stages/retirement.py
@@ -21,6 +21,7 @@ class Retirement(Elaboratable):
         rf_free: Method,
         precommit: Method,
         exception_cause_get: Method,
+        exception_cause_clear: Method,
         frat_rename: Method,
         fetch_continue: Method,
         fetch_stall: Method,
@@ -34,6 +35,7 @@ class Retirement(Elaboratable):
         self.rf_free = rf_free
         self.precommit = precommit
         self.exception_cause_get = exception_cause_get
+        self.exception_cause_clear = exception_cause_clear
         self.rename = frat_rename
         self.fetch_continue = fetch_continue
         self.fetch_stall = fetch_stall
@@ -114,6 +116,9 @@ class Retirement(Elaboratable):
                 # mtvec without mode is [mxlen-1:2], mode is two last bits. Only direct mode is supported
                 resume_pc = m_csr.mtvec.read(m) & ~(0b11)
                 fetch_continue_fwd.write(m, pc=resume_pc)
+
+                # Release pending trap state - allow accepting new reports
+                self.exception_cause_clear(m)
 
                 m.d.sync += side_fx.eq(1)
 

--- a/coreblocks/structs_common/exception.py
+++ b/coreblocks/structs_common/exception.py
@@ -5,7 +5,7 @@ from coreblocks.params.genparams import GenParams
 from coreblocks.params.isa import ExceptionCause
 from coreblocks.params.layouts import ExceptionRegisterLayouts
 from coreblocks.params.keys import ExceptionReportKey
-from transactron.core import Priority, TModule, def_method, Method
+from transactron.core import TModule, def_method, Method
 
 
 def should_update_prioriy(m: TModule, current_cause: Value, new_cause: Value) -> Value:
@@ -61,8 +61,6 @@ class ExceptionCauseRegister(Elaboratable):
         self.get = Method(o=gp.get(ExceptionRegisterLayouts).get)
 
         self.clear = Method()
-
-        self.clear.add_conflict(self.report, Priority.LEFT)
 
         self.rob_get_indices = rob_get_indices
 

--- a/test/asm/exception_handler.asm
+++ b/test/asm/exception_handler.asm
@@ -10,6 +10,33 @@ loop:
     mv x1, x2
     mv x2, x3
     bne x2, x4, loop
+
+    # report another exception after full rob_idx overflow
+    # so it has the same rob index as previous report
+    li x10, 0
+    li x11, 13
+rob_loop:
+    addi x10, x10, 1
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    bne x10, x11, rob_loop
+
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+.4byte 0 # exception
+
+    li x11, 0xaaaa # verify exception return
+
 infloop:
     j infloop
 

--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -42,6 +42,8 @@ class RetirementTestCircuit(Elaboratable):
         m.submodules.mock_precommit = self.mock_precommit = TestbenchIO(Adapter(i=lsu_layouts.precommit))
 
         m.submodules.mock_exception_cause = self.mock_exception_cause = TestbenchIO(Adapter(o=exception_layouts.get))
+        m.submodules.mock_exception_clear = self.mock_exception_clear = TestbenchIO(Adapter())
+
         m.submodules.generic_csr = self.generic_csr = GenericCSRRegisters(self.gen_params)
         self.gen_params.get(DependencyManager).add_dependency(GenericCSRRegistersKey(), self.generic_csr)
 
@@ -62,6 +64,7 @@ class RetirementTestCircuit(Elaboratable):
             rf_free=self.mock_rf_free.adapter.iface,
             precommit=self.mock_precommit.adapter.iface,
             exception_cause_get=self.mock_exception_cause.adapter.iface,
+            exception_cause_clear=self.mock_exception_clear.adapter.iface,
             frat_rename=self.frat.rename,
             fetch_stall=self.mock_fetch_stall.adapter.iface,
             fetch_continue=self.mock_fetch_continue.adapter.iface,

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -245,7 +245,7 @@ class TestCoreRandomized(TestCoreBase):
         ("csr", "csr.asm", 200, {1: 1, 2: 4}, full_core_config),
         ("exception", "exception.asm", 200, {1: 1, 2: 2}, basic_core_config),
         ("exception_mem", "exception_mem.asm", 200, {1: 1, 2: 2}, basic_core_config),
-        ("exception_handler", "exception_handler.asm", 1100, {2: 987, 15: 15}, full_core_config),
+        ("exception_handler", "exception_handler.asm", 1500, {2: 987, 11: 0xAAAA, 15: 16}, full_core_config),
     ],
 )
 class TestCoreAsmSource(TestCoreBase):


### PR DESCRIPTION
Oops.
It worked on test because exceptions were close together, and `rob_id` didn't do the full overflow cycle to break the instruction age comparison
