### PR TITLE
Add def_one_caller_wrapper

### DIFF
--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -255,9 +255,9 @@ class ManyToOneConnectTrans(Elaboratable):
 
 def def_one_caller_wrapper(method_to_wrap: Method, wrapper: Method) -> TModule:
     """
-    Function used to a wrap method that can only have one caller. After wrapping
-    many callers can call the wrapper. Results are buffered and passed to the
-    wrapped method from one source.
+    Function used to wrap a method that can only have one caller. After wrapping
+    many callers can call the wrapper. The input data are buffered and passed to the
+    wrapped method from one source (caller).
 
     Parameters
     ----------


### PR DESCRIPTION
This PR ports from #395 a `def_one_caller_wrapper`. Function which is a syntax sugar for introducing a Fifo which collect all incoming data and pass them to the one_caller method.

Examples of usage:
https://github.com/kuznia-rdzeni/coreblocks/blob/ddb21b50c9cbc46d154436b3a48a8cdbe323ceeb/coreblocks/fu/vector_unit/v_executor.py#L109
https://github.com/kuznia-rdzeni/coreblocks/blob/ddb21b50c9cbc46d154436b3a48a8cdbe323ceeb/coreblocks/transactions/lib.py#L1444