### PR TITLE
Method brancher

### DIFF
--- a/test/transactions/test_lib_sugar.py
+++ b/test/transactions/test_lib_sugar.py
@@ -1,0 +1,54 @@
+from amaranth import *
+from transactron.lib.sugar import MethodBrancher
+from test.common import *
+from transactron import *
+
+
+class TestMethodBrancher(TestCaseWithSimulator):
+    class Circuit(Elaboratable):
+        def __init__(self, method: Method):
+            self.method = method
+            self.sig = Signal(2)
+            self.out = Record(self.method.data_out.layout)
+
+        def elaborate(self, platform):
+            m = TModule()
+
+            with Transaction().body(m):
+                b = MethodBrancher(m, self.method)
+                with m.If(self.sig == 0):
+                    m.d.comb += self.out.eq(b(data=1))
+                with m.If(self.sig == 1):
+                    m.d.comb += self.out.eq(b(data=2))
+            return m
+
+    def setUp(self):
+        random.seed(14)
+        self.test_number = 15
+        self.method_mock = MethodMock(i=data_layout(2), o=data_layout(4))
+        self.circ = SimpleTestCircuit(self.Circuit(self.method_mock.get_method()))
+
+        self.m = ModuleConnector(circ=self.circ, method_mock=self.method_mock)
+
+    @def_method_mock(lambda self: self.method_mock)
+    def mock_process(self, data):
+        return {"data": data * 3}
+
+    def process(self):
+        for _ in range(self.test_number):
+            input = random.randrange(3)
+            yield self.circ._dut.sig.eq(input)
+            yield
+            data_out = yield self.circ._dut.out.data
+            match input:
+                case 0:
+                    self.assertEqual(data_out, 3)
+                case 1:
+                    self.assertEqual(data_out, 6)
+                case 2 | 3:
+                    self.assertEqual(data_out, 0)
+
+    def test_brancher(self):
+        with self.run_simulation(self.m, 100) as sim:
+            sim.add_sync_process(self.process)
+            sim.add_sync_process(self.mock_process)

--- a/transactron/lib/sugar.py
+++ b/transactron/lib/sugar.py
@@ -1,0 +1,77 @@
+from amaranth import *
+from ..core import *
+from typing import Optional
+from transactron.core import RecordDict
+from transactron.utils import assign
+
+__all__ = ["MethodBrancher"]
+
+
+class MethodBrancher:
+    """Syntax sugar for calling the same method in different `m.If` branches.
+
+    Sometimes it is handy to write:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        with Transaction().body(m):
+            with m.If(cond):
+                method(arg1)
+            with m.Else():
+                method(arg2)
+
+    But such code is not allowed, because a method is called twice in a transaction.
+    So normaly it has to be rewritten to:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        rec = Record(method.data_in.layout)
+        with Transaction().body(m):
+            with m.If(cond):
+                m.d.comb += assign(rec, arg1)
+            with m.Else():
+                m.d.comb += assign(rec, arg2)
+            method(rec)
+
+    But such a form is less readable. `MethodBrancher` is designed to do this
+    transformation automatically, so you can write:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        with Transaction().body(m):
+            b_method = MethodBrancher(m, method)
+            with m.If(cond):
+                b_method(arg1)
+            with m.Else():
+                b_method(arg2)
+
+    IMPORTANT: `MethodBrancher` should be constructed within a `Transaction` or
+    `Method` that should call the passed `method`. It creates a method call
+    as part of `__init__` function.
+    """
+
+    def __init__(self, m: TModule, method: Method):
+        """
+        Parameters
+        ----------
+        m : TModule
+            Module to add connections to.
+        method : Method
+            Method to wrap.
+        """
+        self.m = m
+        self.method = method
+        self.rec_in = Record(method.data_in.layout)
+        self.rec_out = Record(method.data_out.layout)
+        self.valid = Signal()
+        with self.m.If(self.valid):
+            self.m.d.comb += self.rec_out.eq(method(m, self.rec_in))
+
+    def __call__(self, arg: Optional[RecordDict] = None, /, **kwargs: RecordDict) -> Record:
+        self.m.d.comb += assign(self.rec_in, arg if arg is not None else kwargs)
+        self.m.d.comb += self.valid.eq(1)
+
+        return self.rec_out


### PR DESCRIPTION
As requested by @piotro888 here is the port of `MethodBrancher` from #395. I had to write a test for the Brancher, so I have decided to port also `MethodMock`, which simplify syntax. Instead of creating low level Adapter and TestbenchIO after that (and a long chain of accessors to get a real method), we can create a MethodMock which presents high level abstraction.