### PR TITLE
Source locations for transactions and methods

### DIFF
--- a/transactron/core.py
+++ b/transactron/core.py
@@ -1052,7 +1052,7 @@ class Method(TransactionBase):
             assert len(self.data_in) == 0
 
     @staticmethod
-    def like(other: "Method", *, name: Optional[str] = None) -> "Method":
+    def like(other: "Method", *, name: Optional[str] = None, src_loc: int | SrcLoc = 0) -> "Method":
         """Constructs a new `Method` based on another.
 
         The returned `Method` has the same input/output data layouts as the
@@ -1064,13 +1064,16 @@ class Method(TransactionBase):
             The `Method` which serves as a blueprint for the new `Method`.
         name : str, optional
             Name of the new `Method`.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
 
         Returns
         -------
         Method
             The freshly constructed `Method`.
         """
-        return Method(name=name, i=other.data_in.layout, o=other.data_out.layout)
+        return Method(name=name, i=other.data_in.layout, o=other.data_out.layout, src_loc=get_src_loc(src_loc))
 
     def proxy(self, m: TModule, method: "Method"):
         """Define as a proxy for another method.

--- a/transactron/core.py
+++ b/transactron/core.py
@@ -395,6 +395,7 @@ class TransactionManager(Elaboratable):
             # TODO: some simpler way?
             method = Method(name=transaction.name)
             method.owner = transaction.owner
+            method.src_loc = transaction.src_loc
             method.ready = transaction.request
             method.run = transaction.grant
             method.defined = transaction.defined

--- a/transactron/lib/buttons.py
+++ b/transactron/lib/buttons.py
@@ -1,5 +1,6 @@
 from amaranth import *
 from ..core import *
+from ..utils import SrcLoc, get_src_loc
 
 __all__ = ["ClickIn", "ClickOut"]
 
@@ -23,14 +24,18 @@ class ClickIn(Elaboratable):
         The data input.
     """
 
-    def __init__(self, layout: MethodLayout):
+    def __init__(self, layout: MethodLayout, src_loc: int | SrcLoc = 0):
         """
         Parameters
         ----------
         layout: record layout
             The data format for the input.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
-        self.get = Method(o=layout)
+        src_loc = get_src_loc(src_loc)
+        self.get = Method(o=layout, src_loc=src_loc)
         self.btn = Signal()
         self.dat = Record(layout)
 
@@ -76,14 +81,18 @@ class ClickOut(Elaboratable):
         The data output.
     """
 
-    def __init__(self, layout: MethodLayout):
+    def __init__(self, layout: MethodLayout, *, src_loc: int | SrcLoc = 0):
         """
         Parameters
         ----------
         layout: record layout
             The data format for the output.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
-        self.put = Method(i=layout)
+        src_loc = get_src_loc(src_loc)
+        self.put = Method(i=layout, src_loc=src_loc)
         self.btn = Signal()
         self.dat = Record(layout)
 

--- a/transactron/lib/connectors.py
+++ b/transactron/lib/connectors.py
@@ -29,7 +29,9 @@ class FIFO(Elaboratable):
         The write method. Accepts a `Record`, returns empty result.
     """
 
-    def __init__(self, layout: MethodLayout, depth: int, fifo_type=amaranth.lib.fifo.SyncFIFO):
+    def __init__(
+        self, layout: MethodLayout, depth: int, fifo_type=amaranth.lib.fifo.SyncFIFO, *, src_loc: int | SrcLoc = 0
+    ):
         """
         Parameters
         ----------
@@ -40,13 +42,17 @@ class FIFO(Elaboratable):
         fifoType: Elaboratable
             FIFO module conforming to Amaranth library FIFO interface. Defaults
             to SyncFIFO.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
         self.width = len(Record(layout))
         self.depth = depth
         self.fifoType = fifo_type
 
-        self.read = Method(o=layout, src_loc=1)
-        self.write = Method(i=layout, src_loc=1)
+        src_loc = get_src_loc(src_loc)
+        self.read = Method(o=layout, src_loc=src_loc)
+        self.write = Method(i=layout, src_loc=src_loc)
 
     def elaborate(self, platform):
         m = TModule()
@@ -91,16 +97,20 @@ class Forwarder(Elaboratable):
         The write method. Accepts a `Record`, returns empty result.
     """
 
-    def __init__(self, layout: MethodLayout):
+    def __init__(self, layout: MethodLayout, *, src_loc: int | SrcLoc = 0):
         """
         Parameters
         ----------
         layout: record layout
             The format of records forwarded.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
-        self.read = Method(o=layout, src_loc=1)
-        self.write = Method(i=layout, src_loc=1)
-        self.clear = Method(src_loc=1)
+        src_loc = get_src_loc(src_loc)
+        self.read = Method(o=layout, src_loc=src_loc)
+        self.write = Method(i=layout, src_loc=src_loc)
+        self.clear = Method(src_loc=src_loc)
         self.head = Record.like(self.read.data_out)
 
         self.clear.add_conflict(self.read, Priority.LEFT)
@@ -156,7 +166,7 @@ class Connect(Elaboratable):
         `Record`.
     """
 
-    def __init__(self, layout: MethodLayout = (), rev_layout: MethodLayout = ()):
+    def __init__(self, layout: MethodLayout = (), rev_layout: MethodLayout = (), *, src_loc: int | SrcLoc = 0):
         """
         Parameters
         ----------
@@ -164,9 +174,13 @@ class Connect(Elaboratable):
             The format of records forwarded.
         rev_layout: record layout
             The format of records forwarded in the reverse direction.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
-        self.read = Method(o=layout, i=rev_layout, src_loc=1)
-        self.write = Method(i=layout, o=rev_layout, src_loc=1)
+        src_loc = get_src_loc(src_loc)
+        self.read = Method(o=layout, i=rev_layout, src_loc=src_loc)
+        self.write = Method(i=layout, o=rev_layout, src_loc=src_loc)
 
     def elaborate(self, platform):
         m = TModule()

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -1,7 +1,8 @@
 from amaranth import *
 from transactron import Method, def_method, Priority, TModule
-from transactron.utils._typing import ValueLike, MethodLayout
+from transactron.utils._typing import ValueLike, MethodLayout, SrcLoc
 from transactron.utils.amaranth_ext import mod_incr
+from transactron.utils.transactron_helpers import get_src_loc
 
 
 class BasicFifo(Elaboratable):
@@ -21,7 +22,7 @@ class BasicFifo(Elaboratable):
 
     """
 
-    def __init__(self, layout: MethodLayout, depth: int) -> None:
+    def __init__(self, layout: MethodLayout, depth: int, *, src_loc: int | SrcLoc = 0) -> None:
         """
         Parameters
         ----------
@@ -30,15 +31,18 @@ class BasicFifo(Elaboratable):
             If integer is given, Record with field `data` and width of this paramter is used as internal layout.
         depth: int
             Size of the FIFO.
-
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
         self.layout = layout
         self.width = len(Record(self.layout))
         self.depth = depth
 
-        self.read = Method(o=self.layout)
-        self.write = Method(i=self.layout)
-        self.clear = Method()
+        src_loc = get_src_loc(src_loc)
+        self.read = Method(o=self.layout, src_loc=src_loc)
+        self.write = Method(i=self.layout, src_loc=src_loc)
+        self.clear = Method(src_loc=src_loc)
         self.head = Record(self.layout)
 
         self.buff = Memory(width=self.width, depth=self.depth)

--- a/transactron/lib/simultaneous.py
+++ b/transactron/lib/simultaneous.py
@@ -1,6 +1,6 @@
 from amaranth import *
 
-from ..utils import get_src_loc
+from ..utils import get_src_loc, SrcLoc
 from ..core import *
 from ..core import TransactionBase
 from contextlib import contextmanager
@@ -13,7 +13,7 @@ __all__ = [
 
 
 @contextmanager
-def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True):
+def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True, src_loc: int | SrcLoc = 1):
     """Conditions using simultaneous transactions.
 
     This context manager allows to easily define conditions utilizing
@@ -44,6 +44,9 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True):
         States that the conditions are not mutually exclusive and should
         be tested in order. This influences the scheduling order of generated
         transactions.
+    src_loc : int | SrcLoc
+        How many stack frames deep the source location is taken from.
+        Alternatively, the source location to use instead of the default.
 
     Examples
     --------
@@ -61,7 +64,7 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True):
     this = TransactionBase.get()
     transactions = list[Transaction]()
     last = False
-    src_loc = get_src_loc(0)
+    src_loc = get_src_loc(src_loc)
 
     @contextmanager
     def branch(cond: Optional[ValueLike] = None):

--- a/transactron/lib/simultaneous.py
+++ b/transactron/lib/simultaneous.py
@@ -1,4 +1,6 @@
 from amaranth import *
+
+from ..utils import get_src_loc
 from ..core import *
 from ..core import TransactionBase
 from contextlib import contextmanager
@@ -59,6 +61,7 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True):
     this = TransactionBase.get()
     transactions = list[Transaction]()
     last = False
+    src_loc = get_src_loc(0)
 
     @contextmanager
     def branch(cond: Optional[ValueLike] = None):
@@ -67,7 +70,7 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True):
             raise RuntimeError("Condition clause added after catch-all")
         req = cond if cond is not None else 1
         name = f"{this.name}_cond{len(transactions)}"
-        with (transaction := Transaction(name=name)).body(m, request=req):
+        with (transaction := Transaction(name=name, src_loc=src_loc)).body(m, request=req):
             yield
         if transactions and priority:
             transactions[-1].schedule_before(transaction)

--- a/transactron/lib/simultaneous.py
+++ b/transactron/lib/simultaneous.py
@@ -1,6 +1,6 @@
 from amaranth import *
 
-from ..utils import get_src_loc, SrcLoc
+from ..utils import SrcLoc
 from ..core import *
 from ..core import TransactionBase
 from contextlib import contextmanager
@@ -13,7 +13,7 @@ __all__ = [
 
 
 @contextmanager
-def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True, src_loc: int | SrcLoc = 1):
+def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True):
     """Conditions using simultaneous transactions.
 
     This context manager allows to easily define conditions utilizing
@@ -44,9 +44,6 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True, s
         States that the conditions are not mutually exclusive and should
         be tested in order. This influences the scheduling order of generated
         transactions.
-    src_loc : int | SrcLoc
-        How many stack frames deep the source location is taken from.
-        Alternatively, the source location to use instead of the default.
 
     Examples
     --------
@@ -64,10 +61,9 @@ def condition(m: TModule, *, nonblocking: bool = False, priority: bool = True, s
     this = TransactionBase.get()
     transactions = list[Transaction]()
     last = False
-    src_loc = get_src_loc(src_loc)
 
     @contextmanager
-    def branch(cond: Optional[ValueLike] = None):
+    def branch(cond: Optional[ValueLike] = None, *, src_loc: int | SrcLoc = 2):
         nonlocal last
         if last:
             raise RuntimeError("Condition clause added after catch-all")

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -70,6 +70,7 @@ class MethodMap(Transformer):
         *,
         i_transform: Optional[tuple[MethodLayout, Callable[[TModule, Record], RecordDict]]] = None,
         o_transform: Optional[tuple[MethodLayout, Callable[[TModule, Record], RecordDict]]] = None,
+        src_loc: int | SrcLoc = 0
     ):
         """
         Parameters
@@ -84,6 +85,9 @@ class MethodMap(Transformer):
             Output mapping function. If specified, it should be a pair of a
             function and a output layout for the transformed method.
             If not present, output is passed unmodified.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
         if i_transform is None:
             i_transform = (target.data_in.layout, lambda _, x: x)
@@ -91,7 +95,8 @@ class MethodMap(Transformer):
             o_transform = (target.data_out.layout, lambda _, x: x)
 
         self.target = target
-        self.method = Method(i=i_transform[0], o=o_transform[0])
+        src_loc = get_src_loc(src_loc)
+        self.method = Method(i=i_transform[0], o=o_transform[0], src_loc=src_loc)
         self.i_fun = i_transform[1]
         self.o_fun = o_transform[1]
 
@@ -129,7 +134,9 @@ class MethodFilter(Transformer):
         target: Method,
         condition: Callable[[TModule, Record], ValueLike],
         default: Optional[RecordDict] = None,
+        *,
         use_condition: bool = False,
+        src_loc: int | SrcLoc = 0
     ):
         """
         Parameters
@@ -145,13 +152,19 @@ class MethodFilter(Transformer):
         use_condition : bool
             Instead of `m.If` use simultaneus `condition` which allow to execute
             this filter if the condition is False and target is not ready.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
         if default is None:
             default = Record.like(target.data_out)
 
         self.target = target
         self.use_condition = use_condition
-        self.method = Method(i=target.data_in.layout, o=target.data_out.layout, single_caller=self.use_condition)
+        src_loc = get_src_loc(src_loc)
+        self.method = Method(
+            i=target.data_in.layout, o=target.data_out.layout, single_caller=self.use_condition, src_loc=src_loc
+        )
         self.condition = condition
         self.default = default
 
@@ -184,6 +197,8 @@ class MethodProduct(Transformer):
         self,
         targets: list[Method],
         combiner: Optional[tuple[MethodLayout, Callable[[TModule, list[Record]], RecordDict]]] = None,
+        *,
+        src_loc: int | SrcLoc = 0
     ):
         """Method product.
 
@@ -202,6 +217,9 @@ class MethodProduct(Transformer):
             A pair of the output layout and the combiner function. The
             combiner function takes two parameters: a `Module` and
             a list of outputs of the target methods.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
 
         Attributes
         ----------
@@ -212,7 +230,8 @@ class MethodProduct(Transformer):
             combiner = (targets[0].data_out.layout, lambda _, x: x[0])
         self.targets = targets
         self.combiner = combiner
-        self.method = Method(i=targets[0].data_in.layout, o=combiner[0])
+        src_loc = get_src_loc(src_loc)
+        self.method = Method(i=targets[0].data_in.layout, o=combiner[0], src_loc=src_loc)
 
     def elaborate(self, platform):
         m = TModule()
@@ -232,6 +251,8 @@ class MethodTryProduct(Transformer):
         self,
         targets: list[Method],
         combiner: Optional[tuple[MethodLayout, Callable[[TModule, list[tuple[Value, Record]]], RecordDict]]] = None,
+        *,
+        src_loc: int | SrcLoc = 0
     ):
         """Method product with optional calling.
 
@@ -251,6 +272,9 @@ class MethodTryProduct(Transformer):
             combiner function takes two parameters: a `Module` and
             a list of pairs. Each pair contains a bit which signals
             that a given call succeeded, and the result of the call.
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
 
         Attributes
         ----------
@@ -261,7 +285,8 @@ class MethodTryProduct(Transformer):
             combiner = ([], lambda _, __: {})
         self.targets = targets
         self.combiner = combiner
-        self.method = Method(i=targets[0].data_in.layout, o=combiner[0])
+        self.src_loc = get_src_loc(src_loc)
+        self.method = Method(i=targets[0].data_in.layout, o=combiner[0], src_loc=self.src_loc)
 
     def elaborate(self, platform):
         m = TModule()
@@ -271,7 +296,7 @@ class MethodTryProduct(Transformer):
             results: list[tuple[Value, Record]] = []
             for target in self.targets:
                 success = Signal()
-                with Transaction().body(m):
+                with Transaction(src_loc=self.src_loc).body(m):
                     m.d.comb += success.eq(1)
                     results.append((success, target(m, arg)))
             return self.combiner[1](m, results)
@@ -314,7 +339,7 @@ class Collector(Transformer):
     def elaborate(self, platform):
         m = TModule()
 
-        m.submodules.forwarder = forwarder = Forwarder(self.method.data_out.layout)
+        m.submodules.forwarder = forwarder = Forwarder(self.method.data_out.layout, src_loc=self.src_loc)
 
         m.submodules.connect = ManyToOneConnectTrans(
             get_results=[get for get in self.method_list], put_result=forwarder.write, src_loc=self.src_loc
@@ -378,6 +403,7 @@ class ConnectAndMapTrans(Elaboratable):
         *,
         i_fun: Optional[Callable[[TModule, Record], RecordDict]] = None,
         o_fun: Optional[Callable[[TModule, Record], RecordDict]] = None,
+        src_loc: int | SrcLoc = 0
     ):
         """
         Parameters
@@ -390,11 +416,15 @@ class ConnectAndMapTrans(Elaboratable):
             Input transformation (`method1` to `method2`).
         o_fun: function or Method, optional
             Output transformation (`method2` to `method1`).
+        src_loc: int | SrcLoc
+            How many stack frames deep the source location is taken from.
+            Alternatively, the source location to use instead of the default.
         """
         self.method1 = method1
         self.method2 = method2
         self.i_fun = i_fun or (lambda _, x: x)
         self.o_fun = o_fun or (lambda _, x: x)
+        self.src_loc = get_src_loc(src_loc)
 
     def elaborate(self, platform):
         m = TModule()
@@ -403,6 +433,7 @@ class ConnectAndMapTrans(Elaboratable):
             self.method2,
             i_transform=(self.method1.data_out.layout, self.i_fun),
             o_transform=(self.method1.data_in.layout, self.o_fun),
+            src_loc=self.src_loc,
         )
         m.submodules.connect = ConnectTrans(self.method1, transformer.method)
 

--- a/transactron/utils/_typing.py
+++ b/transactron/utils/_typing.py
@@ -25,6 +25,7 @@ __all__ = [
     "LayoutLike",
     "SwitchKey",
     "MethodLayout",
+    "SrcLoc",
     "SignalBundle",
     "LayoutListField",
     "LayoutList",
@@ -50,6 +51,7 @@ LayoutLike: TypeAlias = (
 )
 SwitchKey: TypeAlias = str | int | Enum
 MethodLayout: TypeAlias = LayoutLike
+SrcLoc: TypeAlias = tuple[str, int]
 
 # Internal Coreblocks types
 SignalBundle: TypeAlias = Signal | Record | View | Iterable["SignalBundle"] | Mapping[str, "SignalBundle"]

--- a/transactron/utils/transactron_helpers.py
+++ b/transactron/utils/transactron_helpers.py
@@ -108,5 +108,5 @@ def silence_mustuse(elaboratable: Elaboratable):
         raise
 
 
-def get_src_loc(src_loc_at: int | SrcLoc) -> SrcLoc:
-    return tracer.get_src_loc(1 + src_loc_at) if isinstance(src_loc_at, int) else src_loc_at
+def get_src_loc(src_loc: int | SrcLoc) -> SrcLoc:
+    return tracer.get_src_loc(1 + src_loc) if isinstance(src_loc, int) else src_loc

--- a/transactron/utils/transactron_helpers.py
+++ b/transactron/utils/transactron_helpers.py
@@ -2,9 +2,10 @@ import sys
 from contextlib import contextmanager
 from typing import Optional, Any, Concatenate, TypeGuard, TypeVar
 from collections.abc import Callable, Mapping
-from ._typing import ROGraph, GraphCC
+from ._typing import ROGraph, GraphCC, SrcLoc
 from inspect import Parameter, signature
 from amaranth import *
+from amaranth import tracer
 
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "def_helper",
     "method_def_helper",
     "mock_def_helper",
+    "get_src_loc",
 ]
 
 T = TypeVar("T")
@@ -104,3 +106,7 @@ def silence_mustuse(elaboratable: Elaboratable):
     except Exception:
         elaboratable._MustUse__silence = True  # type: ignore
         raise
+
+
+def get_src_loc(src_loc_at: int | SrcLoc) -> SrcLoc:
+    return tracer.get_src_loc(1 + src_loc_at) if isinstance(src_loc_at, int) else src_loc_at


### PR DESCRIPTION
Storing source locations for transactions and methods allows to disambiguate them in Transactron's debugging output.

TODO:
- [x] Choose adequate `src_loc_at` for Transactron library and other reusable Elaboratables.