### PR TITLE
Fix get_caller_class_name to handle calls in elaborate

### DIFF
--- a/test/transactions/test_transactions.py
+++ b/test/transactions/test_transactions.py
@@ -28,8 +28,9 @@ class TestNames(TestCase):
         mgr = TransactionManager()
         mgr._MustUse__silence = True  # type: ignore
 
-        class T:
+        class T(Elaboratable):
             def __init__(self):
+                self._MustUse__silence = True  # type: ignore
                 Transaction(manager=mgr)
 
         T()


### PR DESCRIPTION
This fixes call graph generation when using `condition` and in other cases.