### PR TITLE
Allow additional method arguments in Adapter

### DIFF
--- a/test/stages/test_retirement.py
+++ b/test/stages/test_retirement.py
@@ -33,7 +33,9 @@ class RetirementTestCircuit(Elaboratable):
             scheduler_layouts.free_rf_layout, 2**self.gen_params.phys_regs_bits
         )
 
-        m.submodules.mock_rob_peek = self.mock_rob_peek = TestbenchIO(Adapter(o=rob_layouts.peek_layout))
+        m.submodules.mock_rob_peek = self.mock_rob_peek = TestbenchIO(
+            Adapter(o=rob_layouts.peek_layout, nonexclusive=True)
+        )
 
         m.submodules.mock_rob_retire = self.mock_rob_retire = TestbenchIO(Adapter(o=rob_layouts.retire_layout))
 

--- a/transactron/lib/adapters.py
+++ b/transactron/lib/adapters.py
@@ -100,9 +100,7 @@ class Adapter(AdapterBase):
             See transactron.core.Method.__init__ for parameters description.
         """
 
-        if "src_loc" not in kwargs:
-            kwargs["src_loc"] = 0
-        kwargs["src_loc"] = get_src_loc(kwargs["src_loc"])
+        kwargs["src_loc"] = get_src_loc(kwargs.setdefault("src_loc", 0))
 
         super().__init__(Method(**kwargs))
         self.data_in = Record.like(self.iface.data_out)

--- a/transactron/lib/adapters.py
+++ b/transactron/lib/adapters.py
@@ -3,6 +3,7 @@ from amaranth import *
 from ..utils import SrcLoc, get_src_loc
 from ..core import *
 from ..core import SignalBundle
+from ..utils._typing import type_self_kwargs_as
 
 __all__ = [
     "AdapterBase",
@@ -91,6 +92,7 @@ class Adapter(AdapterBase):
         Data passed as argument to the defined method.
     """
 
+    @type_self_kwargs_as(Method.__init__)
     def __init__(self, **kwargs):
         """
         Parameters

--- a/transactron/lib/adapters.py
+++ b/transactron/lib/adapters.py
@@ -3,7 +3,6 @@ from amaranth import *
 from ..utils import SrcLoc, get_src_loc
 from ..core import *
 from ..core import SignalBundle
-from typing import Optional
 
 __all__ = [
     "AdapterBase",
@@ -92,22 +91,20 @@ class Adapter(AdapterBase):
         Data passed as argument to the defined method.
     """
 
-    def __init__(
-        self, *, name: Optional[str] = None, i: MethodLayout = (), o: MethodLayout = (), src_loc: int | SrcLoc = 0
-    ):
+    def __init__(self, **kwargs):
         """
         Parameters
         ----------
-        i: record layout
-            The input layout of the defined method.
-        o: record layout
-            The output layout of the defined method.
-        src_loc: int | SrcLoc
-            How many stack frames deep the source location is taken from.
-            Alternatively, the source location to use instead of the default.
+        **kwargs
+            Keyword arguments for Method that will be created.
+            See transactron.core.Method.__init__ for parameters description.
         """
-        src_loc = get_src_loc(src_loc)
-        super().__init__(Method(name=name, i=i, o=o, src_loc=src_loc))
+
+        if "src_loc" not in kwargs:
+            kwargs["src_loc"] = 0
+        kwargs["src_loc"] = get_src_loc(kwargs["src_loc"])
+
+        super().__init__(Method(**kwargs))
         self.data_in = Record.like(self.iface.data_out)
         self.data_out = Record.like(self.iface.data_in)
 

--- a/transactron/utils/_typing.py
+++ b/transactron/utils/_typing.py
@@ -1,10 +1,14 @@
 from typing import (
+    Callable,
+    Concatenate,
     Generic,
     NoReturn,
     Optional,
+    ParamSpec,
     Protocol,
     TypeAlias,
     TypeVar,
+    cast,
     runtime_checkable,
     Union,
     Any,
@@ -64,6 +68,7 @@ RecordValueDict: TypeAlias = Mapping[str, Union[ValueLike, "RecordValueDict"]]
 
 T = TypeVar("T")
 U = TypeVar("U")
+P = ParamSpec("P")
 
 ROGraph: TypeAlias = Mapping[T, Iterable[T]]
 Graph: TypeAlias = dict[T, set[T]]
@@ -136,3 +141,16 @@ class HasElaborate(Protocol):
 class HasDebugSignals(Protocol):
     def debug_signals(self) -> SignalBundle:
         ...
+
+
+def type_self_kwargs_as(as_func: Callable[Concatenate[Any, P], Any]):
+    """
+    Decorator used to annotate `**kwargs` type to be the same as named arguments from `as_func` method.
+
+    Works only with methods with (self, **kwargs) signature. `self` parameter is also required in `as_func`.
+    """
+
+    def return_func(func: Callable[Concatenate[Any, ...], T]) -> Callable[Concatenate[Any, P], T]:
+        return cast(Callable[Concatenate[Any, P], T], func)
+
+    return return_func


### PR DESCRIPTION
Fixes ancient "bug" with mocking non-exclusive methods. Who would thought that mocked Method created in adapter actually needs to be specified nonexclusive?

I think that forwarding arguments via `**kwargs` makes more sense here, other solution would be to explicitly add all other Method parameters to Adapter.