### PR TITLE
More readable exception on invalid def_method_mock function

### DIFF
--- a/transactron/utils/transactron_helpers.py
+++ b/transactron/utils/transactron_helpers.py
@@ -69,7 +69,11 @@ def has_first_param(func: Callable[..., T], name: str, tp: type[U]) -> TypeGuard
 
 
 def def_helper(description, func: Callable[..., T], tp: type[U], arg: U, /, **kwargs) -> T:
-    parameters = signature(func).parameters
+    try:
+        parameters = signature(func).parameters
+    except ValueError:
+        raise TypeError(f"Invalid python method signature for {func} (missing `self` for class-level mock?)")
+
     kw_parameters = set(
         n for n, p in parameters.items() if p.kind in {Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY}
     )


### PR DESCRIPTION
Writing class-level mock with `def_method_mock` and without `self` argument passes typing and produces very unreadable exception of `Invalid method signature` without any indication of method/mock that caused problem (not even is stack trace!)

As this is an easy to do mistake, I think this patch is worth including.