### PR TITLE
Remove unneeded random_wait

### DIFF
--- a/test/common/infrastructure.py
+++ b/test/common/infrastructure.py
@@ -225,11 +225,9 @@ class TestCaseWithSimulator(unittest.TestCase):
 
     def random_wait(self, max_cycle_cnt: int, *, min_cycle_cnt: int = 0):
         """
-        Wait for a random amount of cycles in range [min_cycle_cnt, max_cycle_cnt)
+        Wait for a random amount of cycles in range [min_cycle_cnt, max_cycle_cnt]
         """
-        if max_cycle_cnt == 0:
-            return
-        yield from self.tick(random.randrange(min_cycle_cnt, max_cycle_cnt))
+        yield from self.tick(random.randrange(min_cycle_cnt, max_cycle_cnt + 1))
 
     def random_wait_geom(self, prob: float = 0.5):
         """

--- a/test/common/infrastructure.py
+++ b/test/common/infrastructure.py
@@ -230,3 +230,10 @@ class TestCaseWithSimulator(unittest.TestCase):
         if max_cycle_cnt == 0:
             return
         yield from self.tick(random.randrange(min_cycle_cnt, max_cycle_cnt))
+
+    def random_wait_geom(self, prob: float = 0.5):
+        """
+        Wait till the first success, where there is `prob` probability for success in each cycle.
+        """
+        while random.random() > prob:
+            yield

--- a/test/common/infrastructure.py
+++ b/test/common/infrastructure.py
@@ -195,7 +195,7 @@ class TestCaseWithSimulator(unittest.TestCase):
 
         self.assertTrue(res, "Simulation time limit exceeded")
 
-    def tick(self, cycle_cnt=1):
+    def tick(self, cycle_cnt: int = 1):
         """
         Yields for the given number of cycles.
         """
@@ -203,8 +203,10 @@ class TestCaseWithSimulator(unittest.TestCase):
         for _ in range(cycle_cnt):
             yield
 
-    def random_wait(self, max_cycle_cnt):
+    def random_wait(self, max_cycle_cnt: int):
         """
-        Wait for a random amount of cycles in range [1, max_cycle_cnt)
+        Wait for a random amount of cycles in range [0, max_cycle_cnt)
         """
+        if max_cycle_cnt == 0:
+            return
         yield from self.tick(random.randrange(max_cycle_cnt))

--- a/test/fu/functional_common.py
+++ b/test/fu/functional_common.py
@@ -4,7 +4,7 @@ import random
 from collections import deque
 from typing import Generic, TypeVar
 
-from amaranth import Elaboratable, Module, Signal
+from amaranth import Elaboratable, Signal
 from amaranth.sim import Passive
 
 from coreblocks.params import GenParams
@@ -15,8 +15,9 @@ from coreblocks.params.isa import Funct3, Funct7
 from coreblocks.params.keys import AsyncInterruptInsertSignalKey, ExceptionReportKey
 from coreblocks.params.layouts import ExceptionRegisterLayouts
 from coreblocks.params.optypes import OpType
-from transactron.lib import AdapterTrans, Adapter
-from test.common import RecordIntDict, RecordIntDictRet, TestbenchIO, TestCaseWithSimulator
+from transactron.lib import Adapter
+from test.common import RecordIntDict, RecordIntDictRet, TestbenchIO, TestCaseWithSimulator, SimpleTestCircuit
+from transactron.utils import ModuleConnector
 
 
 class FunctionalTestCircuit(Elaboratable):
@@ -30,27 +31,6 @@ class FunctionalTestCircuit(Elaboratable):
     func_unit : FunctionalComponentParams
         Class of functional unit to be tested.
     """
-
-    def __init__(self, gen_params: GenParams, func_unit: FunctionalComponentParams):
-        self.gen_params = gen_params
-        self.func_unit = func_unit
-
-    def elaborate(self, platform):
-        m = Module()
-
-        m.submodules.report_mock = self.report_mock = TestbenchIO(
-            Adapter(i=self.gen_params.get(ExceptionRegisterLayouts).report)
-        )
-        self.gen_params.get(DependencyManager).add_dependency(ExceptionReportKey(), self.report_mock.adapter.iface)
-        self.gen_params.get(DependencyManager).add_dependency(AsyncInterruptInsertSignalKey(), Signal())
-
-        m.submodules.func_unit = func_unit = self.func_unit.get_module(self.gen_params)
-
-        # mocked input and output
-        m.submodules.issue_method = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))
-        m.submodules.accept_method = self.accept = TestbenchIO(AdapterTrans(func_unit.accept))
-
-        return m
 
 
 @dataclass
@@ -115,7 +95,14 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
 
     def setUp(self):
         self.gen_params = GenParams(test_core_config)
-        self.m = FunctionalTestCircuit(self.gen_params, self.func_unit)
+
+        self.report_mock = TestbenchIO(Adapter(i=self.gen_params.get(ExceptionRegisterLayouts).report))
+
+        self.gen_params.get(DependencyManager).add_dependency(ExceptionReportKey(), self.report_mock.adapter.iface)
+        self.gen_params.get(DependencyManager).add_dependency(AsyncInterruptInsertSignalKey(), Signal())
+
+        self.m = SimpleTestCircuit(self.func_unit.get_module(self.gen_params))
+        self.circ = ModuleConnector(dut=self.m, report_mock=self.report_mock)
 
         random.seed(self.seed)
         self.requests = deque[RecordIntDict]()
@@ -157,33 +144,29 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
             if cause is not None:
                 self.exceptions.append({"rob_id": rob_id, "cause": cause, "pc": pc})
 
-    def random_wait(self):
-        for i in range(random.randint(0, self.max_wait)):
-            yield
-
     def consumer(self):
         while self.responses:
             expected = self.responses.pop()
             result = yield from self.m.accept.call()
             self.assertDictEqual(expected, result)
-            yield from self.random_wait()
+            yield from self.random_wait(self.max_wait)
 
     def producer(self):
         while self.requests:
             req = self.requests.pop()
             yield from self.m.issue.call(req)
-            yield from self.random_wait()
+            yield from self.random_wait(self.max_wait)
 
     def exception_consumer(self):
         while self.exceptions:
             expected = self.exceptions.pop()
-            result = yield from self.m.report_mock.call()
+            result = yield from self.report_mock.call()
             self.assertDictEqual(expected, result)
-            yield from self.random_wait()
+            yield from self.random_wait(self.max_wait)
 
         # keep partialy dependent tests from hanging up and detect extra calls
         yield Passive()
-        result = yield from self.m.report_mock.call()
+        result = yield from self.report_mock.call()
         self.assertFalse(True, "unexpected report call")
 
     def pipeline_verifier(self):
@@ -199,7 +182,7 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
         else:
             self.max_wait = 10
 
-        with self.run_simulation(self.m) as sim:
+        with self.run_simulation(self.circ) as sim:
             sim.add_sync_process(self.producer)
             sim.add_sync_process(self.consumer)
             sim.add_sync_process(self.exception_consumer)

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -89,7 +89,6 @@ class TestRSSelect(TestCaseWithSimulator):
 
                 self.instr_in.append(instr)
                 yield from self.m.instr_in.call(instr)
-                yield
                 yield from self.random_wait(random_wait)
 
         return process
@@ -111,7 +110,6 @@ class TestRSSelect(TestCaseWithSimulator):
                 yield from io.enable()
                 yield from io.method_handle(mock)
                 yield from io.disable()
-                yield
                 yield from self.random_wait(random_wait)
 
         return process
@@ -122,7 +120,6 @@ class TestRSSelect(TestCaseWithSimulator):
                 result = yield from self.m.instr_out.call()
                 outputs = self.expected_out.popleft()
 
-                yield
                 yield from self.random_wait(random_wait)
                 yield Settle()
                 self.assertEqual(result, outputs)

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -53,10 +53,6 @@ class TestRSSelect(TestCaseWithSimulator):
         self.instr_in = deque()
         random.seed(1789)
 
-    def random_wait(self, n: int):
-        for i in range(random.randrange(n + 1)):
-            yield
-
     def create_instr_input_process(self, instr_count: int, optypes: set[OpType], random_wait: int = 0):
         def process():
             for i in range(instr_count):
@@ -93,6 +89,7 @@ class TestRSSelect(TestCaseWithSimulator):
 
                 self.instr_in.append(instr)
                 yield from self.m.instr_in.call(instr)
+                yield
                 yield from self.random_wait(random_wait)
 
         return process
@@ -114,6 +111,7 @@ class TestRSSelect(TestCaseWithSimulator):
                 yield from io.enable()
                 yield from io.method_handle(mock)
                 yield from io.disable()
+                yield
                 yield from self.random_wait(random_wait)
 
         return process
@@ -124,6 +122,7 @@ class TestRSSelect(TestCaseWithSimulator):
                 result = yield from self.m.instr_out.call()
                 outputs = self.expected_out.popleft()
 
+                yield
                 yield from self.random_wait(random_wait)
                 yield Settle()
                 self.assertEqual(result, outputs)

--- a/test/stages/test_backend.py
+++ b/test/stages/test_backend.py
@@ -73,6 +73,7 @@ class TestBackend(TestCaseWithSimulator):
         self.gen_params = GenParams(test_core_config)
         self.m = BackendTestCircuit(self.gen_params, self.fu_count)
         random.seed(14)
+        self.max_wait = 3
 
         self.fu_inputs = []
         # Create list with info if we processed all results from FU
@@ -96,10 +97,6 @@ class TestBackend(TestCaseWithSimulator):
                     self.expected_output[t] = 1
             self.fu_inputs.append(inputs)
 
-    def random_wait(self):
-        for i in range(random.randint(0, 3)):
-            yield
-
     def generate_producer(self, i: int):
         """
         This is an helper function, which generates a producer process,
@@ -112,7 +109,7 @@ class TestBackend(TestCaseWithSimulator):
             for rob_id, result, rp_dst in inputs:
                 io: TestbenchIO = self.m.fu_fifo_ins[i]
                 yield from io.call_init(rob_id=rob_id, result=result, rp_dst=rp_dst)
-                yield from self.random_wait()
+                yield from self.random_wait(self.max_wait)
             self.producer_end[i] = True
 
         return producer
@@ -151,7 +148,7 @@ class TestBackend(TestCaseWithSimulator):
                 del self.expected_output[t]
             else:
                 self.expected_output[t] -= 1
-            yield from self.random_wait()
+            yield from self.random_wait(self.max_wait)
 
     def test_one_out(self):
         self.fu_count = 1

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -110,15 +110,11 @@ class TestCSRUnit(TestCaseWithSimulator):
             "exp": exp,
         }
 
-    def random_wait(self, prob: float = 0.5):
-        while random.random() < prob:
-            yield
-
     def process_test(self):
         yield from self.dut.fetch_continue.enable()
         yield from self.dut.exception_report.enable()
         for _ in range(self.cycles):
-            yield from self.random_wait()
+            yield from self.random_wait_geom()
 
             op = yield from self.generate_instruction()
 
@@ -126,14 +122,14 @@ class TestCSRUnit(TestCaseWithSimulator):
 
             yield from self.dut.insert.call(rs_data=op["instr"])
 
-            yield from self.random_wait()
+            yield from self.random_wait_geom()
             if op["exp"]["rs1"]["rp_s1"]:
                 yield from self.dut.update.call(reg_id=op["exp"]["rs1"]["rp_s1"], reg_val=op["exp"]["rs1"]["value"])
 
-            yield from self.random_wait()
+            yield from self.random_wait_geom()
             yield from self.dut.precommit.call(side_fx=1)
 
-            yield from self.random_wait()
+            yield from self.random_wait_geom()
             res = yield from self.dut.accept.call()
 
             self.assertTrue(self.dut.fetch_continue.done())
@@ -165,7 +161,7 @@ class TestCSRUnit(TestCaseWithSimulator):
         yield from self.dut.fetch_continue.enable()
         yield from self.dut.exception_report.enable()
         for csr in self.exception_csr_numbers:
-            yield from self.random_wait()
+            yield from self.random_wait_geom()
 
             yield from self.dut.select.call()
 
@@ -183,10 +179,10 @@ class TestCSRUnit(TestCaseWithSimulator):
                 }
             )
 
-            yield from self.random_wait()
+            yield from self.random_wait_geom()
             yield from self.dut.precommit.call(rob_id=rob_id, side_fx=1)
 
-            yield from self.random_wait()
+            yield from self.random_wait_geom()
             res = yield from self.dut.accept.call()
 
             self.assertEqual(res["exception"], 1)

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -131,7 +131,7 @@ class TestForwarder(TestFifoBase):
 
 
 class TestMemoryBank(TestCaseWithSimulator):
-    test_conf = [(9, 4, 4, 4, 14), (16, 2, 2, 4, 15), (16, 2, 2, 2, 16), (12, 4, 2, 2, 17)]
+    test_conf = [(9, 3, 3, 3, 14), (16, 1, 1, 3, 15), (16, 1, 1, 1, 16), (12, 3, 1, 1, 17)]
 
     parametrized_input = [tc + sf for tc, sf in itertools.product(test_conf, [(True,), (False,)])]
 


### PR DESCRIPTION
To resolve #564, here is a PR which remove unneeded `random_wait` from many places. Additionally it refactores two next tests to use `SimpleTestCircuit`