### PR TITLE
Refactor naming in coreblocks frontend

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -10,7 +10,7 @@ from coreblocks.params.layouts import *
 from coreblocks.params.keys import BranchResolvedKey, GenericCSRRegistersKey, InstructionPrecommitKey, WishboneDataKey
 from coreblocks.params.genparams import GenParams
 from coreblocks.params.isa import Extension
-from coreblocks.frontend.decode import Decode
+from coreblocks.frontend.decode_stage import DecodeStage
 from coreblocks.structs_common.rat import FRAT, RRAT
 from coreblocks.structs_common.rob import ReorderBuffer
 from coreblocks.structs_common.rf import RegisterFile
@@ -120,7 +120,7 @@ class Core(Elaboratable):
         m.submodules.args_discard_map = self.core_counter_increment_discard_map
 
         m.submodules.fifo_decode = fifo_decode = FIFO(self.gen_params.get(DecodeLayouts).decoded_instr, 2)
-        m.submodules.decode = Decode(
+        m.submodules.decode = DecodeStage(
             gen_params=self.gen_params, get_raw=self.fifo_fetch.read, push_decoded=fifo_decode.write
         )
 

--- a/coreblocks/frontend/decode_stage.py
+++ b/coreblocks/frontend/decode_stage.py
@@ -4,11 +4,11 @@ from coreblocks.params.isa import Funct3
 from coreblocks.params.optypes import OpType
 from transactron import Method, Transaction, TModule
 from ..params import GenParams
-from .decoder import InstrDecoder
+from .instr_decoder import InstrDecoder
 from coreblocks.params import *
 
 
-class Decode(Elaboratable):
+class DecodeStage(Elaboratable):
     """
     Simple decode unit. This is a transactional interface which instantiates a
     submodule `InstrDecoder`. This `InstrDecoder` makes actual decoding in

--- a/coreblocks/frontend/instr_decoder.py
+++ b/coreblocks/frontend/instr_decoder.py
@@ -1,18 +1,17 @@
-from dataclasses import KW_ONLY, dataclass
 from functools import reduce
 from operator import or_
-from typing import Optional
 
 from amaranth import *
 
 from coreblocks.params import *
+from .instr_description import instructions_by_optype, Encoding
 
 __all__ = ["InstrDecoder"]
 
 # Important
 #
 # In order to add new instructions to be decoded by this decoder assuming they do not required additional
-# fields to be extracted you need to add them into `_instructions_by_optype` map, and register new OpType
+# fields to be extracted you need to add them into `instructions_by_optype` map, and register new OpType
 # into new or existing extension in `optypes_by_extensions` map in `params.optypes` module.
 
 # Lists which fields are used by which Instruction's types
@@ -22,206 +21,6 @@ _rd_itypes = [InstrType.R, InstrType.I, InstrType.U, InstrType.J]
 _rs1_itypes = [InstrType.R, InstrType.I, InstrType.S, InstrType.B]
 
 _rs2_itypes = [InstrType.R, InstrType.S, InstrType.B]
-
-
-@dataclass(frozen=True)
-class Encoding:
-    """
-    Class representing encoding of single RISC-V instruction.
-
-    Parameters
-    ----------
-    opcode: Opcode
-        Opcode of instruction.
-    funct3: Optional[Funct3]
-        Three bits function identifier. If not exists for instruction then `None`.
-    funct7: Optional[Funct7]
-        Seven bits function identifier. If not exists for instruction then `None`.
-    funct12: Optional[Funct12]
-        Twelve bits function identifier. If not exists for instruction then `None`.
-    instr_type_override: Optional[InstrType]
-        Specify `InstrType` used for decoding of register and immediate for single opcode.
-        If set to `None` optype is determined from instrustion opcode, which is almost always correct.
-    rd_zero: bool
-        `rd` field is specifed as constant zero in instruction encoding. Other fields are decoded
-        accordingly to `InstrType`. Default is False.
-    rs1_zero: bool
-        `rs1` field is specifed as constant zero in instruction encoding. Other fields are decoded
-        accordingly to `InstrType`. Default is False.
-    """
-
-    opcode: Opcode
-    funct3: Optional[Funct3] = None
-    funct7: Optional[Funct7] = None
-    funct12: Optional[Funct12] = None
-    _ = KW_ONLY
-    instr_type_override: Optional[InstrType] = None
-    rd_zero: bool = False
-    rs1_zero: bool = False
-
-
-#
-# Instructions grouped by Operation types
-#
-
-_instructions_by_optype = {
-    OpType.ARITHMETIC: [
-        Encoding(Opcode.OP_IMM, Funct3.ADD),  # addi
-        Encoding(Opcode.OP, Funct3.ADD, Funct7.ADD),  # add
-        Encoding(Opcode.OP, Funct3.ADD, Funct7.SUB),  # sub
-        Encoding(Opcode.LUI),  # lui
-    ],
-    OpType.COMPARE: [
-        Encoding(Opcode.OP_IMM, Funct3.SLT),  # slti
-        Encoding(Opcode.OP_IMM, Funct3.SLTU),  # sltiu
-        Encoding(Opcode.OP, Funct3.SLT, Funct7.SLT),  # slt
-        Encoding(Opcode.OP, Funct3.SLTU, Funct7.SLT),  # sltu
-    ],
-    OpType.LOGIC: [
-        Encoding(Opcode.OP_IMM, Funct3.XOR),  # xori
-        Encoding(Opcode.OP_IMM, Funct3.OR),  # ori
-        Encoding(Opcode.OP_IMM, Funct3.AND),  # andi
-        Encoding(Opcode.OP, Funct3.XOR, Funct7.XOR),  # xor
-        Encoding(Opcode.OP, Funct3.OR, Funct7.OR),  # or
-        Encoding(Opcode.OP, Funct3.AND, Funct7.AND),  # and
-    ],
-    OpType.SHIFT: [
-        Encoding(Opcode.OP_IMM, Funct3.SLL, Funct7.SL),  # slli
-        Encoding(Opcode.OP_IMM, Funct3.SR, Funct7.SL),  # srli
-        Encoding(Opcode.OP_IMM, Funct3.SR, Funct7.SA),  # srai
-        Encoding(Opcode.OP, Funct3.SLL, Funct7.SL),  # sll
-        Encoding(Opcode.OP, Funct3.SR, Funct7.SL),  # srl
-        Encoding(Opcode.OP, Funct3.SR, Funct7.SA),  # sra
-    ],
-    OpType.AUIPC: [
-        Encoding(Opcode.AUIPC),  # auipc
-    ],
-    OpType.JAL: [
-        Encoding(Opcode.JAL),  # jal
-    ],
-    OpType.JALR: [
-        Encoding(Opcode.JALR, Funct3.JALR),  # jalr
-    ],
-    OpType.BRANCH: [
-        Encoding(Opcode.BRANCH, Funct3.BEQ),  # beq
-        Encoding(Opcode.BRANCH, Funct3.BNE),  # bne
-        Encoding(Opcode.BRANCH, Funct3.BLT),  # blt
-        Encoding(Opcode.BRANCH, Funct3.BGE),  # bge
-        Encoding(Opcode.BRANCH, Funct3.BLTU),  # bltu
-        Encoding(Opcode.BRANCH, Funct3.BGEU),  # bgeu
-    ],
-    OpType.LOAD: [
-        Encoding(Opcode.LOAD, Funct3.B),  # lb
-        Encoding(Opcode.LOAD, Funct3.BU),  # lbu
-        Encoding(Opcode.LOAD, Funct3.H),  # lh
-        Encoding(Opcode.LOAD, Funct3.HU),  # lhu
-        Encoding(Opcode.LOAD, Funct3.W),  # lw
-    ],
-    OpType.STORE: [
-        Encoding(Opcode.STORE, Funct3.B),  # sb
-        Encoding(Opcode.STORE, Funct3.H),  # sh
-        Encoding(Opcode.STORE, Funct3.W),  # sw
-    ],
-    OpType.FENCE: [
-        Encoding(Opcode.MISC_MEM, Funct3.FENCE),  # fence
-    ],
-    OpType.ECALL: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, rd_zero=True, rs1_zero=True),  # ecall
-    ],
-    OpType.EBREAK: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, rd_zero=True, rs1_zero=True),  # ebreak
-    ],
-    OpType.MRET: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET, rd_zero=True, rs1_zero=True),  # mret
-    ],
-    OpType.WFI: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.WFI, rd_zero=True, rs1_zero=True),  # wfi
-    ],
-    OpType.FENCEI: [
-        Encoding(Opcode.MISC_MEM, Funct3.FENCEI),  # fence.i
-    ],
-    OpType.CSR_REG: [
-        Encoding(Opcode.SYSTEM, Funct3.CSRRW),  # csrrw
-        Encoding(Opcode.SYSTEM, Funct3.CSRRS),  # csrrs
-        Encoding(Opcode.SYSTEM, Funct3.CSRRC),  # csrrc
-    ],
-    OpType.CSR_IMM: [
-        Encoding(Opcode.SYSTEM, Funct3.CSRRWI),  # csrrwi
-        Encoding(Opcode.SYSTEM, Funct3.CSRRSI),  # csrrsi
-        Encoding(Opcode.SYSTEM, Funct3.CSRRCI),  # csrrci
-    ],
-    OpType.MUL: [
-        Encoding(Opcode.OP, Funct3.MUL, Funct7.MULDIV),  # mul
-        Encoding(Opcode.OP, Funct3.MULH, Funct7.MULDIV),  # mulh
-        Encoding(Opcode.OP, Funct3.MULHSU, Funct7.MULDIV),  # mulsu
-        Encoding(Opcode.OP, Funct3.MULHU, Funct7.MULDIV),  # mulu
-    ],
-    OpType.DIV_REM: [
-        Encoding(Opcode.OP, Funct3.DIV, Funct7.MULDIV),  # div
-        Encoding(Opcode.OP, Funct3.DIVU, Funct7.MULDIV),  # divu
-        Encoding(Opcode.OP, Funct3.REM, Funct7.MULDIV),  # rem
-        Encoding(Opcode.OP, Funct3.REMU, Funct7.MULDIV),  # remu
-    ],
-    OpType.SINGLE_BIT_MANIPULATION: [
-        Encoding(Opcode.OP, Funct3.BCLR, Funct7.BCLR),  # bclr
-        Encoding(Opcode.OP_IMM, Funct3.BCLR, Funct7.BCLR),  # bclri
-        Encoding(Opcode.OP, Funct3.BEXT, Funct7.BEXT),  # bext
-        Encoding(Opcode.OP_IMM, Funct3.BEXT, Funct7.BEXT),  # bexti
-        Encoding(Opcode.OP, Funct3.BSET, Funct7.BSET),  # bset
-        Encoding(Opcode.OP_IMM, Funct3.BSET, Funct7.BSET),  # bseti
-        Encoding(Opcode.OP, Funct3.BINV, Funct7.BINV),  # binv
-        Encoding(Opcode.OP_IMM, Funct3.BINV, Funct7.BINV),  # binvi
-    ],
-    OpType.ADDRESS_GENERATION: [
-        Encoding(Opcode.OP, Funct3.SH1ADD, Funct7.SH1ADD),
-        Encoding(Opcode.OP, Funct3.SH2ADD, Funct7.SH2ADD),
-        Encoding(Opcode.OP, Funct3.SH3ADD, Funct7.SH3ADD),
-    ],
-    OpType.BIT_MANIPULATION: [
-        Encoding(Opcode.OP, Funct3.ANDN, Funct7.ANDN),
-        Encoding(Opcode.OP, Funct3.MAX, Funct7.MAX),
-        Encoding(Opcode.OP, Funct3.MAXU, Funct7.MAX),
-        Encoding(Opcode.OP, Funct3.MIN, Funct7.MIN),
-        Encoding(Opcode.OP, Funct3.MINU, Funct7.MIN),
-        Encoding(Opcode.OP, Funct3.ORN, Funct7.ORN),
-        Encoding(Opcode.OP, Funct3.ROL, Funct7.ROL),
-        Encoding(Opcode.OP, Funct3.ROR, Funct7.ROR),
-        Encoding(Opcode.OP_IMM, Funct3.ROR, Funct7.ROR),
-        Encoding(Opcode.OP, Funct3.XNOR, Funct7.XNOR),
-    ],
-    OpType.UNARY_BIT_MANIPULATION_1: [
-        Encoding(Opcode.OP_IMM, Funct3.ORCB, funct12=Funct12.ORCB),
-        Encoding(Opcode.OP_IMM, Funct3.REV8, funct12=Funct12.REV8_32),
-        Encoding(Opcode.OP_IMM, Funct3.SEXTB, funct12=Funct12.SEXTB),
-        Encoding(Opcode.OP, Funct3.ZEXTH, funct12=Funct12.ZEXTH),
-    ],
-    # Instructions SEXTH, SEXTHB, CPOP, CLZ and CTZ  cannot be distiguished by their Funct7 code
-    OpType.UNARY_BIT_MANIPULATION_2: [
-        Encoding(Opcode.OP_IMM, Funct3.SEXTH, funct12=Funct12.SEXTH),
-    ],
-    OpType.UNARY_BIT_MANIPULATION_3: [
-        Encoding(Opcode.OP_IMM, Funct3.CLZ, funct12=Funct12.CLZ),
-    ],
-    OpType.UNARY_BIT_MANIPULATION_4: [
-        Encoding(Opcode.OP_IMM, Funct3.CTZ, funct12=Funct12.CTZ),
-    ],
-    OpType.UNARY_BIT_MANIPULATION_5: [
-        Encoding(Opcode.OP_IMM, Funct3.CPOP, funct12=Funct12.CPOP),
-    ],
-    OpType.CLMUL: [
-        Encoding(Opcode.OP, Funct3.CLMUL, Funct7.CLMUL),
-        Encoding(Opcode.OP, Funct3.CLMULH, Funct7.CLMUL),
-        Encoding(Opcode.OP, Funct3.CLMULR, Funct7.CLMUL),
-    ],
-    OpType.SRET: [
-        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.SRET, rd_zero=True, rs1_zero=True),  # sret
-    ],
-    OpType.SFENCEVMA: [
-        Encoding(
-            Opcode.SYSTEM, Funct3.PRIV, Funct7.SFENCEVMA, rd_zero=True, instr_type_override=InstrType.R
-        ),  # sfence.vma
-    ],
-}
 
 
 class InstrDecoder(Elaboratable):
@@ -367,7 +166,7 @@ class InstrDecoder(Elaboratable):
         for ext, optypes in optypes_by_extensions.items():
             if extensions & ext:
                 for optype in optypes:
-                    for encoding in _instructions_by_optype[optype]:
+                    for encoding in instructions_by_optype[optype]:
                         supported_encodings.add(encoding)
                         encoding_to_optype[encoding] = optype
 

--- a/coreblocks/frontend/instr_description.py
+++ b/coreblocks/frontend/instr_description.py
@@ -1,0 +1,204 @@
+from dataclasses import KW_ONLY, dataclass
+from typing import Optional
+
+from coreblocks.params import *
+
+
+@dataclass(frozen=True)
+class Encoding:
+    """
+    Class representing encoding of single RISC-V instruction.
+
+    Parameters
+    ----------
+    opcode: Opcode
+        Opcode of instruction.
+    funct3: Optional[Funct3]
+        Three bits function identifier. If not exists for instruction then `None`.
+    funct7: Optional[Funct7]
+        Seven bits function identifier. If not exists for instruction then `None`.
+    funct12: Optional[Funct12]
+        Twelve bits function identifier. If not exists for instruction then `None`.
+    instr_type_override: Optional[InstrType]
+        Specify `InstrType` used for decoding of register and immediate for single opcode.
+        If set to `None` optype is determined from instrustion opcode, which is almost always correct.
+    rd_zero: bool
+        `rd` field is specifed as constant zero in instruction encoding. Other fields are decoded
+        accordingly to `InstrType`. Default is False.
+    rs1_zero: bool
+        `rs1` field is specifed as constant zero in instruction encoding. Other fields are decoded
+        accordingly to `InstrType`. Default is False.
+    """
+
+    opcode: Opcode
+    funct3: Optional[Funct3] = None
+    funct7: Optional[Funct7] = None
+    funct12: Optional[Funct12] = None
+    _ = KW_ONLY
+    instr_type_override: Optional[InstrType] = None
+    rd_zero: bool = False
+    rs1_zero: bool = False
+
+
+#
+# Instructions grouped by Operation types
+#
+
+instructions_by_optype = {
+    OpType.ARITHMETIC: [
+        Encoding(Opcode.OP_IMM, Funct3.ADD),  # addi
+        Encoding(Opcode.OP, Funct3.ADD, Funct7.ADD),  # add
+        Encoding(Opcode.OP, Funct3.ADD, Funct7.SUB),  # sub
+        Encoding(Opcode.LUI),  # lui
+    ],
+    OpType.COMPARE: [
+        Encoding(Opcode.OP_IMM, Funct3.SLT),  # slti
+        Encoding(Opcode.OP_IMM, Funct3.SLTU),  # sltiu
+        Encoding(Opcode.OP, Funct3.SLT, Funct7.SLT),  # slt
+        Encoding(Opcode.OP, Funct3.SLTU, Funct7.SLT),  # sltu
+    ],
+    OpType.LOGIC: [
+        Encoding(Opcode.OP_IMM, Funct3.XOR),  # xori
+        Encoding(Opcode.OP_IMM, Funct3.OR),  # ori
+        Encoding(Opcode.OP_IMM, Funct3.AND),  # andi
+        Encoding(Opcode.OP, Funct3.XOR, Funct7.XOR),  # xor
+        Encoding(Opcode.OP, Funct3.OR, Funct7.OR),  # or
+        Encoding(Opcode.OP, Funct3.AND, Funct7.AND),  # and
+    ],
+    OpType.SHIFT: [
+        Encoding(Opcode.OP_IMM, Funct3.SLL, Funct7.SL),  # slli
+        Encoding(Opcode.OP_IMM, Funct3.SR, Funct7.SL),  # srli
+        Encoding(Opcode.OP_IMM, Funct3.SR, Funct7.SA),  # srai
+        Encoding(Opcode.OP, Funct3.SLL, Funct7.SL),  # sll
+        Encoding(Opcode.OP, Funct3.SR, Funct7.SL),  # srl
+        Encoding(Opcode.OP, Funct3.SR, Funct7.SA),  # sra
+    ],
+    OpType.AUIPC: [
+        Encoding(Opcode.AUIPC),  # auipc
+    ],
+    OpType.JAL: [
+        Encoding(Opcode.JAL),  # jal
+    ],
+    OpType.JALR: [
+        Encoding(Opcode.JALR, Funct3.JALR),  # jalr
+    ],
+    OpType.BRANCH: [
+        Encoding(Opcode.BRANCH, Funct3.BEQ),  # beq
+        Encoding(Opcode.BRANCH, Funct3.BNE),  # bne
+        Encoding(Opcode.BRANCH, Funct3.BLT),  # blt
+        Encoding(Opcode.BRANCH, Funct3.BGE),  # bge
+        Encoding(Opcode.BRANCH, Funct3.BLTU),  # bltu
+        Encoding(Opcode.BRANCH, Funct3.BGEU),  # bgeu
+    ],
+    OpType.LOAD: [
+        Encoding(Opcode.LOAD, Funct3.B),  # lb
+        Encoding(Opcode.LOAD, Funct3.BU),  # lbu
+        Encoding(Opcode.LOAD, Funct3.H),  # lh
+        Encoding(Opcode.LOAD, Funct3.HU),  # lhu
+        Encoding(Opcode.LOAD, Funct3.W),  # lw
+    ],
+    OpType.STORE: [
+        Encoding(Opcode.STORE, Funct3.B),  # sb
+        Encoding(Opcode.STORE, Funct3.H),  # sh
+        Encoding(Opcode.STORE, Funct3.W),  # sw
+    ],
+    OpType.FENCE: [
+        Encoding(Opcode.MISC_MEM, Funct3.FENCE),  # fence
+    ],
+    OpType.ECALL: [
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.ECALL, rd_zero=True, rs1_zero=True),  # ecall
+    ],
+    OpType.EBREAK: [
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, rd_zero=True, rs1_zero=True),  # ebreak
+    ],
+    OpType.MRET: [
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.MRET, rd_zero=True, rs1_zero=True),  # mret
+    ],
+    OpType.WFI: [
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.WFI, rd_zero=True, rs1_zero=True),  # wfi
+    ],
+    OpType.FENCEI: [
+        Encoding(Opcode.MISC_MEM, Funct3.FENCEI),  # fence.i
+    ],
+    OpType.CSR_REG: [
+        Encoding(Opcode.SYSTEM, Funct3.CSRRW),  # csrrw
+        Encoding(Opcode.SYSTEM, Funct3.CSRRS),  # csrrs
+        Encoding(Opcode.SYSTEM, Funct3.CSRRC),  # csrrc
+    ],
+    OpType.CSR_IMM: [
+        Encoding(Opcode.SYSTEM, Funct3.CSRRWI),  # csrrwi
+        Encoding(Opcode.SYSTEM, Funct3.CSRRSI),  # csrrsi
+        Encoding(Opcode.SYSTEM, Funct3.CSRRCI),  # csrrci
+    ],
+    OpType.MUL: [
+        Encoding(Opcode.OP, Funct3.MUL, Funct7.MULDIV),  # mul
+        Encoding(Opcode.OP, Funct3.MULH, Funct7.MULDIV),  # mulh
+        Encoding(Opcode.OP, Funct3.MULHSU, Funct7.MULDIV),  # mulsu
+        Encoding(Opcode.OP, Funct3.MULHU, Funct7.MULDIV),  # mulu
+    ],
+    OpType.DIV_REM: [
+        Encoding(Opcode.OP, Funct3.DIV, Funct7.MULDIV),  # div
+        Encoding(Opcode.OP, Funct3.DIVU, Funct7.MULDIV),  # divu
+        Encoding(Opcode.OP, Funct3.REM, Funct7.MULDIV),  # rem
+        Encoding(Opcode.OP, Funct3.REMU, Funct7.MULDIV),  # remu
+    ],
+    OpType.SINGLE_BIT_MANIPULATION: [
+        Encoding(Opcode.OP, Funct3.BCLR, Funct7.BCLR),  # bclr
+        Encoding(Opcode.OP_IMM, Funct3.BCLR, Funct7.BCLR),  # bclri
+        Encoding(Opcode.OP, Funct3.BEXT, Funct7.BEXT),  # bext
+        Encoding(Opcode.OP_IMM, Funct3.BEXT, Funct7.BEXT),  # bexti
+        Encoding(Opcode.OP, Funct3.BSET, Funct7.BSET),  # bset
+        Encoding(Opcode.OP_IMM, Funct3.BSET, Funct7.BSET),  # bseti
+        Encoding(Opcode.OP, Funct3.BINV, Funct7.BINV),  # binv
+        Encoding(Opcode.OP_IMM, Funct3.BINV, Funct7.BINV),  # binvi
+    ],
+    OpType.ADDRESS_GENERATION: [
+        Encoding(Opcode.OP, Funct3.SH1ADD, Funct7.SH1ADD),
+        Encoding(Opcode.OP, Funct3.SH2ADD, Funct7.SH2ADD),
+        Encoding(Opcode.OP, Funct3.SH3ADD, Funct7.SH3ADD),
+    ],
+    OpType.BIT_MANIPULATION: [
+        Encoding(Opcode.OP, Funct3.ANDN, Funct7.ANDN),
+        Encoding(Opcode.OP, Funct3.MAX, Funct7.MAX),
+        Encoding(Opcode.OP, Funct3.MAXU, Funct7.MAX),
+        Encoding(Opcode.OP, Funct3.MIN, Funct7.MIN),
+        Encoding(Opcode.OP, Funct3.MINU, Funct7.MIN),
+        Encoding(Opcode.OP, Funct3.ORN, Funct7.ORN),
+        Encoding(Opcode.OP, Funct3.ROL, Funct7.ROL),
+        Encoding(Opcode.OP, Funct3.ROR, Funct7.ROR),
+        Encoding(Opcode.OP_IMM, Funct3.ROR, Funct7.ROR),
+        Encoding(Opcode.OP, Funct3.XNOR, Funct7.XNOR),
+    ],
+    OpType.UNARY_BIT_MANIPULATION_1: [
+        Encoding(Opcode.OP_IMM, Funct3.ORCB, funct12=Funct12.ORCB),
+        Encoding(Opcode.OP_IMM, Funct3.REV8, funct12=Funct12.REV8_32),
+        Encoding(Opcode.OP_IMM, Funct3.SEXTB, funct12=Funct12.SEXTB),
+        Encoding(Opcode.OP, Funct3.ZEXTH, funct12=Funct12.ZEXTH),
+    ],
+    # Instructions SEXTH, SEXTHB, CPOP, CLZ and CTZ  cannot be distiguished by their Funct7 code
+    OpType.UNARY_BIT_MANIPULATION_2: [
+        Encoding(Opcode.OP_IMM, Funct3.SEXTH, funct12=Funct12.SEXTH),
+    ],
+    OpType.UNARY_BIT_MANIPULATION_3: [
+        Encoding(Opcode.OP_IMM, Funct3.CLZ, funct12=Funct12.CLZ),
+    ],
+    OpType.UNARY_BIT_MANIPULATION_4: [
+        Encoding(Opcode.OP_IMM, Funct3.CTZ, funct12=Funct12.CTZ),
+    ],
+    OpType.UNARY_BIT_MANIPULATION_5: [
+        Encoding(Opcode.OP_IMM, Funct3.CPOP, funct12=Funct12.CPOP),
+    ],
+    OpType.CLMUL: [
+        Encoding(Opcode.OP, Funct3.CLMUL, Funct7.CLMUL),
+        Encoding(Opcode.OP, Funct3.CLMULH, Funct7.CLMUL),
+        Encoding(Opcode.OP, Funct3.CLMULR, Funct7.CLMUL),
+    ],
+    OpType.SRET: [
+        Encoding(Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.SRET, rd_zero=True, rs1_zero=True),  # sret
+    ],
+    OpType.SFENCEVMA: [
+        Encoding(
+            Opcode.SYSTEM, Funct3.PRIV, Funct7.SFENCEVMA, rd_zero=True, instr_type_override=InstrType.R
+        ),  # sfence.vma
+    ],
+}

--- a/test/frontend/test_decode_stage.py
+++ b/test/frontend/test_decode_stage.py
@@ -2,7 +2,7 @@ from transactron.lib import AdapterTrans, FIFO
 
 from ..common import TestCaseWithSimulator, TestbenchIO, SimpleTestCircuit, ModuleConnector
 
-from coreblocks.frontend.decode import Decode
+from coreblocks.frontend.decode_stage import DecodeStage
 from coreblocks.params import GenParams, FetchLayouts, DecodeLayouts, OpType, Funct3, Funct7
 from coreblocks.params.configurations import test_core_config
 
@@ -17,7 +17,7 @@ class TestDecode(TestCaseWithSimulator):
         self.fifo_in_write = TestbenchIO(AdapterTrans(fifo_in.write))
         self.fifo_out_read = TestbenchIO(AdapterTrans(fifo_out.read))
 
-        self.decode = Decode(self.gen_params, fifo_in.read, fifo_out.write)
+        self.decode = DecodeStage(self.gen_params, fifo_in.read, fifo_out.write)
         self.m = SimpleTestCircuit(
             ModuleConnector(
                 decode=self.decode,

--- a/test/frontend/test_instr_decoder.py
+++ b/test/frontend/test_instr_decoder.py
@@ -4,7 +4,7 @@ from ..common import TestCaseWithSimulator
 
 from coreblocks.params import *
 from coreblocks.params.configurations import test_core_config
-from coreblocks.frontend.decoder import InstrDecoder, Encoding, _instructions_by_optype
+from coreblocks.frontend.instr_decoder import InstrDecoder, Encoding, instructions_by_optype
 from unittest import TestCase
 from typing import Optional
 
@@ -325,7 +325,7 @@ class TestEncodingUniqueness(TestCase):
         # if value is None -> there is an instruction with prefix equal to this code
         known_codes: dict[code_type, Optional[Encoding]] = dict()
 
-        for instructions in _instructions_by_optype.values():
+        for instructions in instructions_by_optype.values():
             for instruction in instructions:
                 code = instruction_code(instruction)
                 prefixes = code_prefixes(code)
@@ -386,7 +386,7 @@ class TestEncodingUniqueness(TestCase):
 
             return (funct3, funct7)
 
-        for ext, instructions in _instructions_by_optype.items():
+        for ext, instructions in instructions_by_optype.items():
             known_codes: set[code_type] = set()
             ext_collisions = collisions[ext] if ext in collisions else set()
 

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -8,7 +8,7 @@ from coreblocks.params.configurations import test_core_config
 from coreblocks.params.layouts import ExceptionRegisterLayouts
 from coreblocks.params.keys import AsyncInterruptInsertSignalKey, ExceptionReportKey
 from transactron.utils.dependencies import DependencyManager
-from coreblocks.frontend.decoder import OpType
+from coreblocks.params.optypes import OpType
 
 from ..common import *
 


### PR DESCRIPTION
Another part of #446. This time I cleaned the `decode.py` and `decoder.py` files, which we regularly confused. I have split `decoder.py` into two files. One `instr_decoder.py` which implements decoding and the second one `instr_description.py` which contains description of all instructions (I expect that in future description will grow a lot, but decoding logic not). `decode.py` has been renamed to `decoder_stage.py`.