### PR TITLE
Hardware metrics (the preview PR)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: "verilog-full-core"
-          path: core.v
+          path: |
+            core.v
+            core.v.json
 
 
   build-riscof-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ venv.bak/
 # Verilog files
 *.v
 
+# Verilog generation debug files
+*.v.json
+
 # Waveform dumps
 *.vcd
 *.gtkw

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -68,7 +68,7 @@ class Core(Elaboratable):
             self.icache_refiller = SimpleCommonBusCacheRefiller(
                 cache_layouts, self.gen_params.icache_params, self.bus_master_instr_adapter
             )
-            self.icache = ICache(cache_layouts, self.gen_params.icache_params, self.icache_refiller)
+            self.icache = ICache(self.gen_params, self.icache_refiller)
         else:
             self.icache = ICacheBypass(cache_layouts, gen_params.icache_params, self.bus_master_instr_adapter)
 

--- a/coreblocks/frontend/fetch.py
+++ b/coreblocks/frontend/fetch.py
@@ -3,6 +3,7 @@ from transactron.core import Priority
 from transactron.lib import BasicFifo, Semaphore
 from coreblocks.frontend.icache import ICacheInterface
 from coreblocks.frontend.rvc import InstrDecompress, is_instr_compressed
+from coreblocks.structs_common.hw_metrics import HwCounter
 from transactron import def_method, Method, Transaction, TModule
 from ..params import *
 
@@ -135,11 +136,15 @@ class UnalignedFetch(Elaboratable):
         self.stall_exception = Method()
         self.stall_exception.add_conflict(self.resume, Priority.LEFT)
 
+        self.perf_rvc = HwCounter(self.gen_params, "frontend.ifu.rvc", "Number of decompressed RVC instructions")
+
         # PC of the last fetched instruction. For now only used in tests.
         self.pc = Signal(self.gen_params.isa.xlen)
 
     def elaborate(self, platform) -> TModule:
         m = TModule()
+
+        m.submodules += [self.perf_rvc]
 
         m.submodules.req_limiter = req_limiter = Semaphore(2)
 
@@ -230,6 +235,7 @@ class UnalignedFetch(Elaboratable):
                 with m.If(~cache_resp.error):
                     m.d.sync += current_pc.eq(current_pc + Mux(is_rvc, C(2, 3), C(4, 3)))
 
+                self.perf_rvc.incr_when(m, is_rvc)
                 self.cont(m, instr=instr, pc=current_pc, access_fault=cache_resp.error, rvc=is_rvc)
 
         @def_method(m, self.resume, ready=(stalled & ~flushing))

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -48,6 +48,8 @@ class CoreConfiguration:
         Enables 16-bit Compressed Instructions extension.
     embedded: bool
         Enables Reduced Integer (E) extension.
+    hardware_metrics: bool
+        Enable hardware metrics. If disabled, metrics will not be synthesized.
     phys_regs_bits: int
         Size of the Physical Register File is 2**phys_regs_bits.
     rob_entries_bits: int
@@ -75,6 +77,8 @@ class CoreConfiguration:
 
     compressed: bool = False
     embedded: bool = False
+
+    hardware_metrics: bool = True
 
     phys_regs_bits: int = 6
     rob_entries_bits: int = 7

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -47,6 +47,8 @@ class GenParams(DependentCache):
             block_size_bits=cfg.icache_block_size_bits,
         )
 
+        self.hardware_metrics_enabled = cfg.hardware_metrics
+
         # Verification temporally disabled
         # if not optypes_required_by_extensions(self.isa.extensions) <= optypes_supported(func_units_config):
         #     raise Exception(f"Functional unit configuration fo not support all extension required by{isa_str}")

--- a/coreblocks/structs_common/hw_metrics.py
+++ b/coreblocks/structs_common/hw_metrics.py
@@ -1,0 +1,545 @@
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json
+from typing import Optional
+from abc import ABC
+
+from amaranth import *
+from amaranth.utils import bits_for
+
+from transactron.utils import ValueLike
+from transactron import Method, def_method, TModule
+from transactron.utils import SignalBundle
+from transactron.lib import FIFO
+from coreblocks.params.genparams import GenParams
+from transactron.utils.dependencies import DependencyManager, ListKey
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class MetricRegisterModel:
+    """
+    Represents a single register of a core metric, serving as a fundamental
+    building block that holds a singular value.
+
+    Attributes
+    ----------
+    name: str
+        The unique identifier for the register (among remaning
+        registers of a specific metric).
+    description: str
+        A brief description of the metric's purpose.
+    width: int
+        The bit-width of the register.
+    """
+
+    name: str
+    description: str
+    width: int
+
+
+@dataclass_json
+@dataclass
+class MetricModel:
+    """
+    Provides information about a metric exposed by the core. Each metric
+    comprises multiple registers, each dedicated to storing specific values.
+
+    The configuration of registers is internally determined by a
+    specific metric typ eand is not user-configurable.
+
+    Attributes
+    ----------
+    fully_qualified_name: str
+        The fully qualified name of the metric, with name components joined by dots ('.'),
+        e.g., 'foo.bar.requests'.
+    description: str
+        A human-readable description of the metric's functionality.
+    regs: list[MetricRegisterModel]
+        A list of registers associated with the metric.
+    """
+
+    fully_qualified_name: str
+    description: str
+    regs: dict[str, MetricRegisterModel] = field(default_factory=dict)
+
+
+class HwMetricRegister(MetricRegisterModel):
+    """
+    A concrete implementation of a metric register that holds its value as Amaranth signal.
+
+    Attributes
+    ----------
+    value: Signal
+        Amaranth signal representing the value of the register.
+    """
+
+    def __init__(self, name: str, width_bits: int, description: str = "", reset: int = 0):
+        """
+        Parameters
+        ----------
+        name: str
+            The unique identifier for the register (among remaning
+            registers of a specific metric).
+        width: int
+            The bit-width of the register.
+        description: str
+            A brief description of the metric's purpose.
+        reset: int
+            The reset value of the register.
+        """
+        super().__init__(name, description, width_bits)
+
+        self.value = Signal(width_bits, reset=reset, name=name)
+
+
+@dataclass(frozen=True)
+class HwMetricsListKey(ListKey["HwMetric"]):
+    """DependencyManager key collecting hardware metrics globally as a list."""
+
+    # This key is defined here, because it is only used internally by HwMetric and HardwareMetricsManager
+    pass
+
+
+class HwMetric(ABC, MetricModel):
+    """
+    A base for all metric implementations. It should be only used for declaring
+    new types of metrics.
+
+    It takes care of registering the metric in the dependency manager.
+
+    Attributes
+    ----------
+    gen_params: GenParams
+        Core generation parameters.
+    signals: dict[str, Signal]
+        A mapping from a register name to a Signal containing the value of that register.
+    """
+
+    def __init__(self, gen_params: GenParams, fully_qualified_name: str, description: str):
+        """
+        Parameters
+        ----------
+        gen_params: GenParams
+            Core generation parameters.
+        fully_qualified_name: str
+            The fully qualified name of the metric.
+        description: str
+            A human-readable description of the metric's functionality.
+        """
+        super().__init__(fully_qualified_name, description)
+
+        self.gen_params = gen_params
+
+        self.signals: dict[str, Signal] = {}
+
+        # add the metric to the global list
+        gen_params.get(DependencyManager).add_dependency(HwMetricsListKey(), self)
+
+    def add_registers(self, regs: list[HwMetricRegister]):
+        """
+        Adds registers to a metric. Should be only called by inheriting classes
+        during initialization.
+
+        Parameters
+        ----------
+        regs: list[HwMetricRegister]
+            A list of registers to be registered.
+        """
+        for reg in regs:
+            if reg.name in self.regs:
+                raise RuntimeError(f"Register {reg.name}' is already added to the metric {self.fully_qualified_name}")
+
+            self.regs[reg.name] = reg
+            self.signals[reg.name] = reg.value
+
+
+class HwCounter(Elaboratable, HwMetric):
+    """Hardware Counter
+
+    The most basic hardware metric that can just increase its value.
+    """
+
+    def __init__(self, gen_params: GenParams, fully_qualified_name: str, description: str = "", *, width_bits: int = 0):
+        """
+        Parameters
+        ----------
+        gen_params: GenParams
+            Core generation parameters.
+        fully_qualified_name: str
+            The fully qualified name of the metric.
+        description: str
+            A human-readable description of the metric's functionality.
+        width_bits: int
+            The bit-width of the register. If unspecified or equal to 0,
+            the register will have `xlen` bits width.
+        """
+
+        super().__init__(gen_params, fully_qualified_name, description)
+
+        self.count = HwMetricRegister(
+            "count", gen_params.isa.xlen if width_bits == 0 else width_bits, "the value of the counter"
+        )
+
+        self.add_registers([self.count])
+
+        self._incr = Method()
+
+    def elaborate(self, platform):
+        if not self.gen_params.hardware_metrics_enabled:
+            return Module()
+
+        m = TModule()
+
+        @def_method(m, self._incr)
+        def _():
+            m.d.sync += self.count.value.eq(self.count.value + 1)
+
+        return m
+
+    def incr(self, m: TModule):
+        """
+        Increases the value of the counter by 1.
+
+        Should be called in the body of either a transaction or a method.
+
+        Parameters
+        ----------
+        m: TModule
+            Transactron module
+        """
+        if not self.gen_params.hardware_metrics_enabled:
+            return
+
+        self._incr(m)
+
+    def incr_when(self, m: TModule, cond: ValueLike):
+        """
+        Conditionally increases the value of the counter by 1.
+
+        Should be called in the body of either a transaction or a method.
+
+        Parameters
+        ----------
+        m: TModule
+            Transactron module
+        cond: ValueLike
+            Signal to indicate if the counter should increase.
+        """
+
+        if not self.gen_params.hardware_metrics_enabled:
+            return
+
+        with m.If(cond):
+            self._incr(m)
+
+
+class HwExpHistogram(Elaboratable, HwMetric):
+    """Hardware Exponential Histogram
+
+    Represents the distribution of sampled data through a histogram. A histogram
+    samples observations (usually things like request durations or queue sizes) and counts
+    them in configurable buckets. The buckets are of exponential size. For example,
+    a histogram with 5 buckets would have the following value ranges:
+    [0, 1); [1, 2); [2, 4); [4, 8); [8, 16).
+
+    Additionally, the histogram tracks the number of observations, the sum
+    of observed values, and the minimum and maximum values.
+    """
+
+    def __init__(self, gen_params: GenParams, fully_qualified_name: str, description: str = "", *, max_value: int):
+        """
+        Parameters
+        ----------
+        gen_params: GenParams
+            Core generation parameters.
+        fully_qualified_name: str
+            The fully qualified name of the metric.
+        description: str
+            A human-readable description of the metric's functionality.
+        max_value: int
+            The maximum value that the histogram would be able to count. This
+            value is used to calculate the number of buckets.
+        """
+
+        super().__init__(gen_params, fully_qualified_name, description)
+        self.max_sample_width = bits_for(max_value)
+        self.bucket_count = self.max_sample_width + 1
+
+        self._add = Method(i=[("sample", self.max_sample_width)])
+
+        self.count = HwMetricRegister("count", gen_params.isa.xlen, "the count of events that have been observed")
+        self.sum = HwMetricRegister("sum", gen_params.isa.xlen, "the total sum of all observed values")
+        self.min = HwMetricRegister(
+            "min",
+            self.max_sample_width,
+            "the minimum of all observed values",
+            reset=(1 << self.max_sample_width) - 1,
+        )
+        self.max = HwMetricRegister("max", self.max_sample_width, "the maximum of all observed values")
+        self.buckets = [
+            HwMetricRegister(
+                f"bucket-{2**i}",
+                gen_params.isa.xlen,
+                f"the cumulative counter for the observation bucket [{0 if i == 0 else 2**(i-1)}, {2**i})",
+            )
+            for i in range(self.bucket_count)
+        ]
+
+        self.add_registers([self.count, self.sum, self.max, self.min] + self.buckets)
+
+    def elaborate(self, platform):
+        if not self.gen_params.hardware_metrics_enabled:
+            return Module()
+
+        m = TModule()
+
+        @def_method(m, self._add)
+        def _(sample):
+            m.d.sync += self.count.value.eq(self.count.value + 1)
+            m.d.sync += self.sum.value.eq(self.sum.value + sample)
+
+            with m.If(sample > self.max.value):
+                m.d.sync += self.max.value.eq(sample)
+
+            with m.If(sample < self.min.value):
+                m.d.sync += self.min.value.eq(sample)
+
+            # No bits are set - goes to the first bucket.
+            with m.If(sample == 0):
+                m.d.sync += self.buckets[0].value.eq(self.buckets[0].value + 1)
+
+            # todo: perhaps replace with a recursive implementation of the priority encoder
+            bucket_idx = Signal(range(self.max_sample_width))
+            for i in range(self.max_sample_width):
+                with m.If(sample[i]):
+                    m.d.av_comb += bucket_idx.eq(i)
+
+            for i, bucket in enumerate(self.buckets):
+                if i == 0:
+                    continue
+
+                with m.If(bucket_idx == i - 1):
+                    m.d.sync += bucket.value.eq(bucket.value + 1)
+
+        return m
+
+    def add(self, m: TModule, sample: Value):
+        """
+        Adds a new sample to the histogram.
+
+        Should be called in the body of either a transaction or a method.
+
+        Parameters
+        ----------
+        m: TModule
+            Transactron module
+        sample: ValueLike
+            The value that will be added to the histogram
+        """
+
+        if not self.gen_params.hardware_metrics_enabled:
+            return
+
+        self._add(m, sample)
+
+
+class LatencyMeasurer(Elaboratable):
+    """
+    Measures duration between two events, e.g. request processing latency.
+    It can track multiple events at the same time, i.e. the second event can
+    be registered as started, before the first finishes. However, they must be
+    processed in the FIFO order.
+
+    The module exposes an exponential histogram of the measured latencies.
+    """
+
+    def __init__(
+        self,
+        gen_params: GenParams,
+        fully_qualified_name: str,
+        description: str = "",
+        *,
+        slots_number: int,
+        max_latency: int,
+    ):
+        """
+        Parameters
+        ----------
+        gen_params: GenParams
+            Core generation parameters.
+        fully_qualified_name: str
+            The fully qualified name of the metric.
+        slots_number: str
+            A number of events that the module can track simultaneously.
+        max_latency: int
+            The maximum latency of an event. Used to set signal widths and
+            number of buckets in the histogram. If a latency turns to be
+            bigger than the maximum, it will overflow and result in a false
+            measurement.
+        """
+        self.gen_params = gen_params
+        self.fully_qualified_name = fully_qualified_name
+        self.description = description
+        self.slots_number = slots_number
+        self.max_latency = max_latency
+
+        self._start = Method()
+        self._stop = Method()
+
+    def elaborate(self, platform):
+        if not self.gen_params.hardware_metrics_enabled:
+            return Module()
+
+        m = TModule()
+
+        epoch_width = bits_for(self.max_latency)
+
+        m.submodules.fifo = self.fifo = FIFO([("epoch", epoch_width)], self.slots_number)
+        m.submodules.histogram = self.histogram = HwExpHistogram(
+            self.gen_params, self.fully_qualified_name, self.description, max_value=self.max_latency
+        )
+
+        epoch = Signal(epoch_width)
+
+        m.d.sync += epoch.eq(epoch + 1)
+
+        @def_method(m, self._start)
+        def _():
+            self.fifo.write(m, epoch)
+
+        @def_method(m, self._stop)
+        def _():
+            ret = self.fifo.read(m)
+            # The result of substracting two unsigned n-bit is a signed (n+1)-bit value,
+            # so we need to cast the result and discard the most significant bit.
+            duration = (epoch - ret.epoch).as_unsigned()[:-1]
+            self.histogram.add(m, duration)
+
+        return m
+
+    def start(self, m: TModule):
+        """
+        Registers the start of an event. Can be called before the previous events
+        finish. If there are no slots available, the method will be blocked.
+
+        Should be called in the body of either a transaction or a method.
+
+        Parameters
+        ----------
+        m: TModule
+            Transactron module
+        """
+
+        if not self.gen_params.hardware_metrics_enabled:
+            return
+
+        self._start(m)
+
+    def stop(self, m: TModule):
+        """
+        Registers the end of the oldest event (the FIFO order). If there are no
+        started events in the queue, the method will block.
+
+        Should be called in the body of either a transaction or a method.
+
+        Parameters
+        ----------
+        m: TModule
+            Transactron module
+        """
+
+        if not self.gen_params.hardware_metrics_enabled:
+            return
+
+        self._stop(m)
+
+
+class HardwareMetricsManager:
+    """
+    Collects all metrics registered in the core and provides an easy
+    access to them.
+    """
+
+    def __init__(self, dep_manager: DependencyManager):
+        """
+        Parameters
+        ----------
+        dep_manager: DependencyManager
+            The dependency manager of the core.
+        """
+        self.dep_manager = dep_manager
+
+        self._metrics: Optional[dict[str, HwMetric]] = None
+
+    def _collect_metrics(self) -> dict[str, HwMetric]:
+        # We lazily collect all metrics so that the metrics manager can be
+        # constructed at any time. Otherwise, if a metric object was created
+        # after the manager object had been created, that metric wouldn't end up
+        # being registered.
+        metrics: dict[str, HwMetric] = {}
+        for metric in self.dep_manager.get_dependency(HwMetricsListKey()):
+            if metric.fully_qualified_name in metrics:
+                raise RuntimeError(f"Metric '{metric.fully_qualified_name}' is already registered")
+
+            metrics[metric.fully_qualified_name] = metric
+
+        return metrics
+
+    def get_metrics(self) -> dict[str, HwMetric]:
+        """
+        Returns all metrics registered in the core.
+        """
+        if self._metrics is None:
+            self._metrics = self._collect_metrics()
+        return self._metrics
+
+    def get_register_value(self, metric_name: str, reg_name: str) -> Signal:
+        """
+        Returns the signal holding the register value of the given metric.
+
+        Parameters
+        ----------
+        metric_name: str
+            The name of the metric.
+        reg_name: str
+            The name of the register.
+        """
+
+        metrics = self.get_metrics()
+        if metric_name not in metrics:
+            raise RuntimeError(f"Couldn't find metric '{metric_name}'")
+        return metrics[metric_name].signals[reg_name]
+
+    def debug_signals(self) -> SignalBundle:
+        """
+        Returns tree-like SignalBundle composed of all metric registers.
+        """
+        metrics = self.get_metrics()
+
+        def rec(metric_names: list[str], depth: int = 1):
+            bundle: list[SignalBundle] = []
+            components: dict[str, list[str]] = {}
+
+            for metric in metric_names:
+                parts = metric.split(".")
+
+                if len(parts) == depth:
+                    signals = metrics[metric].signals
+                    reg_values = [signals[reg_name] for reg_name in signals]
+
+                    bundle.append({metric: reg_values})
+
+                    continue
+
+                component_prefix = ".".join(parts[:depth])
+
+                if component_prefix not in components:
+                    components[component_prefix] = []
+                components[component_prefix].append(metric)
+
+            for component_name, elements in components.items():
+                bundle.append({component_name: rec(elements, depth + 1)})
+
+            return bundle
+
+        return {"metrics": rec(list(self.get_metrics().keys()))}

--- a/coreblocks/utils/gen_info.py
+++ b/coreblocks/utils/gen_info.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass
+class CoreMetricLocation:
+    """Information about the location of a metric in the generated Verilog code.
+
+    Attributes
+    ----------
+    regs : dict[str, list[str]]
+        The location of each register of that metric. The location is a list of
+        Verilog identifiers that denote a path consiting of modules names
+        (and the signal name at the end) leading to the register wire.
+    """
+
+    regs: dict[str, list[str]] = field(default_factory=dict)
+
+
+@dataclass_json
+@dataclass
+class CoreGenInfo:
+    """Various information about the generated core.
+
+    Attributes
+    ----------
+    core_metrics_location : dict[str, CoreMetricInfo]
+        Mapping from a metric name to an object storing Verilog locations
+        of its registers.
+    """
+
+    core_metrics_location: dict[str, CoreMetricLocation] = field(default_factory=dict)
+
+    def encode(self, file_name: str):
+        """
+        Encodes the generation information as JSON and saves it to a file.
+        """
+        with open(file_name, "w") as fp:
+            fp.write(self.to_json())  # type: ignore
+
+    @staticmethod
+    def decode(file_name: str) -> "CoreGenInfo":
+        """
+        Loads the generation information from a JSON file.
+        """
+        with open(file_name, "r") as fp:
+            return CoreGenInfo.from_json(fp.read())  # type: ignore

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -61,7 +61,10 @@ def run_benchmarks_with_cocotb(benchmarks: list[str], traces: bool) -> bool:
     arglist += [f"TESTCASE={test_cases}"]
 
     verilog_code = topdir.joinpath("core.v")
+    gen_info_path = f"{verilog_code}.json"
+
     arglist += [f"VERILOG_SOURCES={verilog_code}"]
+    arglist += [f"_COREBLOCKS_GEN_INFO={gen_info_path}"]
 
     if traces:
         arglist += ["TRACES=1"]

--- a/scripts/run_signature.py
+++ b/scripts/run_signature.py
@@ -32,7 +32,10 @@ def run_with_cocotb(test_name: str, traces: bool, output: str) -> bool:
     arglist += [f"OUTPUT={output}"]
 
     verilog_code = f"{parent}/core.v"
+    gen_info_path = f"{verilog_code}.json"
+
     arglist += [f"VERILOG_SOURCES={verilog_code}"]
+    arglist += [f"_COREBLOCKS_GEN_INFO={gen_info_path}"]
 
     if traces:
         arglist += ["TRACES=1"]

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -61,7 +61,10 @@ def run_regressions_with_cocotb(tests: list[str], traces: bool) -> bool:
     arglist += [f"TESTCASE={test_cases}"]
 
     verilog_code = topdir.joinpath("core.v")
+    gen_info_path = f"{verilog_code}.json"
+
     arglist += [f"VERILOG_SOURCES={verilog_code}"]
+    arglist += [f"_COREBLOCKS_GEN_INFO={gen_info_path}"]
 
     if traces:
         arglist += ["TRACES=1"]

--- a/scripts/synthesize.py
+++ b/scripts/synthesize.py
@@ -171,6 +171,12 @@ def main():
     )
 
     parser.add_argument(
+        "--strip-debug",
+        action="store_true",
+        help="Remove debugging signals. Default: %(default)s",
+    )
+
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -187,7 +193,11 @@ def main():
     if args.unit not in core_units:
         raise KeyError(f"Unknown core unit '{args.unit}'")
 
-    synthesize(str_to_coreconfig[args.config], args.platform, core_units[args.unit])
+    config = str_to_coreconfig[args.config]
+    if args.strip_debug:
+        config = config.replace(hardware_metrics=False)
+
+    synthesize(config, args.platform, core_units[args.unit])
 
 
 if __name__ == "__main__":

--- a/test/frontend/test_icache.py
+++ b/test/frontend/test_icache.py
@@ -280,7 +280,7 @@ class ICacheTestCircuit(Elaboratable):
         m = Module()
 
         m.submodules.refiller = self.refiller = MockedCacheRefiller(self.gen_params)
-        m.submodules.cache = self.cache = ICache(self.gen_params.get(ICacheLayouts), self.cp, self.refiller)
+        m.submodules.cache = self.cache = ICache(self.gen_params, self.refiller)
         m.submodules.issue_req = self.issue_req = TestbenchIO(AdapterTrans(self.cache.issue_req))
         m.submodules.accept_res = self.accept_res = TestbenchIO(AdapterTrans(self.cache.accept_res))
         m.submodules.flush_cache = self.flush_cache = TestbenchIO(AdapterTrans(self.cache.flush))

--- a/test/gtkw_extension.py
+++ b/test/gtkw_extension.py
@@ -29,11 +29,7 @@ class _VCDWriterExt(_VCDWriter):
                 elif len(traces.fields) == 1:  # to make gtkwave view less verbose
                     gtkw_traces(next(iter(traces.fields.values())))
             elif isinstance(traces, Signal):
-                if len(traces) > 1 and not traces.decoder:
-                    suffix = "[{}:0]".format(len(traces) - 1)
-                else:
-                    suffix = ""
-                self.gtkw_save.trace(".".join(self.gtkw_names[traces]) + suffix)
+                self.gtkw_save.trace(".".join(self.gtkw_names[traces]))
 
         if self.vcd_writer is not None:
             self.vcd_writer.close(timestamp)

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import inspect
+import os
 from typing import Any
 from collections.abc import Coroutine
 from dataclasses import dataclass
@@ -13,6 +14,11 @@ from cocotb.result import SimTimeoutError
 
 from .memory import *
 from .common import SimulationBackend, SimulationExecutionResult
+<<<<<<< HEAD
+=======
+
+from coreblocks.utils.gen_info import CoreGenInfo
+>>>>>>> 48022965 (Add Hardware Metrics)
 
 
 @dataclass
@@ -137,6 +143,23 @@ class CocotbSimulation(SimulationBackend):
         self.dut = dut
         self.finish_event = Event()
 
+        try:
+            gen_info_path = os.environ["_COREBLOCKS_GEN_INFO"]
+        except KeyError:
+            raise RuntimeError("No core generation info provided")
+
+        self.gen_info = CoreGenInfo.decode(gen_info_path)
+
+    def get_cocotb_handle(self, path_components: list[str]) -> ModifiableObject:
+        obj = self.dut
+        # Skip the first component, as it is already referenced in "self.dut"
+        for component in path_components[1:]:
+            # As the component may start with '_' character, we need to use '_id'
+            # function instead of 'getattr' - this is required by cocotb.
+            obj = obj._id(component, extended=False)
+
+        return obj
+
     async def run(self, mem_model: CoreMemoryModel, timeout_cycles: int = 5000) -> SimulationExecutionResult:
         clk = Clock(self.dut.clk, 1, "ns")
         cocotb.start_soon(clk.start())
@@ -157,7 +180,16 @@ class CocotbSimulation(SimulationBackend):
         except SimTimeoutError:
             success = False
 
-        return SimulationExecutionResult(success)
+        result = SimulationExecutionResult(success)
+
+        for metric_name, metric_loc in self.gen_info.core_metrics_location.items():
+            result.metric_values[metric_name] = {}
+            for reg_name, reg_loc in metric_loc.regs.items():
+                value = int(self.get_cocotb_handle(reg_loc))
+                result.metric_values[metric_name][reg_name] = value
+                cocotb.logging.debug(f"Metric {metric_name}/{reg_name}={value}")
+
+        return result
 
     def stop(self):
         self.finish_event.set()

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -14,11 +14,8 @@ from cocotb.result import SimTimeoutError
 
 from .memory import *
 from .common import SimulationBackend, SimulationExecutionResult
-<<<<<<< HEAD
-=======
 
 from coreblocks.utils.gen_info import CoreGenInfo
->>>>>>> 48022965 (Add Hardware Metrics)
 
 
 @dataclass

--- a/test/structs_common/test_hw_metrics.py
+++ b/test/structs_common/test_hw_metrics.py
@@ -1,0 +1,305 @@
+import json
+import random
+
+from amaranth import *
+
+from coreblocks.structs_common.hw_metrics import HwCounter, HwExpHistogram, HardwareMetricsManager
+from coreblocks.params import GenParams
+from coreblocks.params.configurations import test_core_config
+from transactron import *
+from transactron.utils import DependencyManager
+
+from ..common import *
+
+
+class CounterInMethodCircuit(Elaboratable):
+    def __init__(self, gen_params: GenParams):
+        self.method = Method()
+        self.counter = HwCounter(gen_params, "in_method")
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.counter = self.counter
+
+        @def_method(m, self.method)
+        def _():
+            self.counter.incr(m)
+
+        return m
+
+
+class CounterWithConditionInMethodCircuit(Elaboratable):
+    def __init__(self, gen_params: GenParams):
+        self.method = Method(i=[("cond", 1)])
+        self.counter = HwCounter(gen_params, "with_condition_in_method")
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.counter = self.counter
+
+        @def_method(m, self.method)
+        def _(cond):
+            self.counter.incr_when(m, cond)
+
+        return m
+
+
+class CounterWithoutMethodCircuit(Elaboratable):
+    def __init__(self, gen_params: GenParams):
+        self.cond = Signal()
+        self.counter = HwCounter(gen_params, "with_condition_without_method")
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.counter = self.counter
+
+        with Transaction().body(m):
+            self.counter.incr_when(m, self.cond)
+
+        return m
+
+
+class TestHwCounter(TestCaseWithSimulator):
+    def setUp(self) -> None:
+        self.gen_params = GenParams(test_core_config.replace(hardware_metrics=True))
+
+        random.seed(42)
+
+    def test_counter_in_method(self):
+        m = SimpleTestCircuit(CounterInMethodCircuit(self.gen_params))
+
+        def test_process():
+            called_cnt = 0
+            for _ in range(200):
+                call_now = random.randint(0, 1) == 0
+
+                if call_now:
+                    yield from m.method.call()
+                else:
+                    yield
+
+                val = yield m._dut.counter.count.value
+                self.assertEqual(val, called_cnt)
+
+                if call_now:
+                    called_cnt += 1
+
+        with self.run_simulation(m) as sim:
+            sim.add_sync_process(test_process)
+
+    def test_counter_with_condition_in_method(self):
+        m = SimpleTestCircuit(CounterWithConditionInMethodCircuit(self.gen_params))
+
+        def test_process():
+            called_cnt = 0
+            for _ in range(200):
+                call_now = random.randint(0, 1) == 0
+                condition = random.randint(0, 1)
+
+                if call_now:
+                    yield from m.method.call(cond=condition)
+                else:
+                    yield
+
+                val = yield m._dut.counter.count.value
+                self.assertEqual(val, called_cnt)
+
+                if call_now and condition == 1:
+                    called_cnt += 1
+
+        with self.run_simulation(m) as sim:
+            sim.add_sync_process(test_process)
+
+    def test_counter_with_condition_without_method(self):
+        m = CounterWithoutMethodCircuit(self.gen_params)
+
+        def test_process():
+            called_cnt = 0
+            for _ in range(200):
+                condition = random.randint(0, 1)
+
+                yield m.cond.eq(condition)
+                yield
+
+                val = yield m.counter.count.value
+                self.assertEqual(val, called_cnt)
+
+                if condition == 1:
+                    called_cnt += 1
+
+        with self.run_simulation(m) as sim:
+            sim.add_sync_process(test_process)
+
+
+class ExpHistogramCircuit(Elaboratable):
+    def __init__(self, gen_params: GenParams, max_value: int):
+        self.method = Method(i=data_layout(32))
+        self.histogram = HwExpHistogram(gen_params, "histogram", max_value=max_value)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.histogram = self.histogram
+
+        @def_method(m, self.method)
+        def _(data):
+            self.histogram.add(m, data[0 : self.histogram.max_sample_width])
+
+        return m
+
+
+class TestHwHistogram(TestCaseWithSimulator):
+    def setUp(self) -> None:
+        self.gen_params = GenParams(test_core_config.replace(hardware_metrics=True))
+
+        random.seed(42)
+
+    def test_counter_in_method(self):
+        max_value = 100
+
+        m = SimpleTestCircuit(ExpHistogramCircuit(self.gen_params, max_value))
+
+        def test_process():
+            min = max_value + 1
+            max = 0
+            sum = 0
+            count = 0
+
+            bucket_cnt = 8
+            buckets = [0] * bucket_cnt
+
+            for _ in range(500):
+                if random.randrange(3) == 0:
+                    value = random.randint(0, max_value)
+                    value = 6
+                    if value < min:
+                        min = value
+                    if value > max:
+                        max = value
+                    sum += value
+                    count += 1
+                    for i in range(bucket_cnt):
+                        if value < 2**i:
+                            buckets[i] += 1
+                            break
+
+                    yield from m.method.call(data=value)
+                    yield
+                else:
+                    yield
+
+                histogram = m._dut.histogram
+                # Skip the assertion if the min is still uninitialized
+                if min != max_value + 1:
+                    self.assertEqual(min, (yield histogram.min.value))
+
+                self.assertEqual(max, (yield histogram.max.value))
+                self.assertEqual(sum, (yield histogram.sum.value))
+                self.assertEqual(count, (yield histogram.count.value))
+
+                for i in range(bucket_cnt):
+                    self.assertEqual(buckets[i], (yield histogram.buckets[i].value))
+
+        with self.run_simulation(m) as sim:
+            sim.add_sync_process(test_process)
+
+
+class MetricManagerTestCircuit(Elaboratable):
+    def __init__(self, gen_params: GenParams):
+        self.incr_counters = Method(i=[("counter1", 1), ("counter2", 1), ("counter3", 1)])
+
+        self.counter1 = HwCounter(gen_params, "foo.counter1", "this is the description")
+        self.counter2 = HwCounter(gen_params, "bar.baz.counter2")
+        self.counter3 = HwCounter(gen_params, "bar.baz.counter3", "yet another description")
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules += [self.counter1, self.counter2, self.counter3]
+
+        @def_method(m, self.incr_counters)
+        def _(counter1, counter2, counter3):
+            self.counter1.incr_when(m, counter1)
+            self.counter2.incr_when(m, counter2)
+            self.counter3.incr_when(m, counter3)
+
+        return m
+
+
+class TestMetricsManager(TestCaseWithSimulator):
+    def setUp(self) -> None:
+        self.gen_params = GenParams(test_core_config.replace(hardware_metrics=True))
+        self.metrics_manager = HardwareMetricsManager(self.gen_params.get(DependencyManager))
+
+        random.seed(42)
+
+    def test_metrics_metadata(self):
+        # We need to initialize the circuit to make sure that metrics are registered
+        # in the dependency manager.
+        m = MetricManagerTestCircuit(self.gen_params)
+
+        # Run the simulation so Amaranth doesn't scream that we have unused elaboratables.
+        with self.run_simulation(m):
+            pass
+
+        self.assertEqual(
+            self.metrics_manager.get_metrics()["foo.counter1"].to_json(),  # type: ignore
+            json.dumps(
+                {
+                    "fully_qualified_name": "foo.counter1",
+                    "description": "this is the description",
+                    "regs": {"count": {"name": "count", "description": "the value of the counter", "width": 32}},
+                }
+            ),
+        )
+
+        self.assertEqual(
+            self.metrics_manager.get_metrics()["bar.baz.counter2"].to_json(),  # type: ignore
+            json.dumps(
+                {
+                    "fully_qualified_name": "bar.baz.counter2",
+                    "description": "",
+                    "regs": {"count": {"name": "count", "description": "the value of the counter", "width": 32}},
+                }
+            ),
+        )
+
+        self.assertEqual(
+            self.metrics_manager.get_metrics()["bar.baz.counter3"].to_json(),  # type: ignore
+            json.dumps(
+                {
+                    "fully_qualified_name": "bar.baz.counter3",
+                    "description": "yet another description",
+                    "regs": {"count": {"name": "count", "description": "the value of the counter", "width": 32}},
+                }
+            ),
+        )
+
+    def test_returned_reg_values(self):
+        m = SimpleTestCircuit(MetricManagerTestCircuit(self.gen_params))
+
+        def test_process():
+            counters = [0] * 3
+            for _ in range(200):
+                rand = [random.randint(0, 1) for _ in range(3)]
+
+                yield from m.incr_counters.call(counter1=rand[0], counter2=rand[1], counter3=rand[2])
+                yield
+
+                for i in range(3):
+                    if rand[i] == 1:
+                        counters[i] += 1
+
+                self.assertEqual(counters[0], (yield self.metrics_manager.get_register_value("foo.counter1", "count")))
+                self.assertEqual(
+                    counters[1], (yield self.metrics_manager.get_register_value("bar.baz.counter2", "count"))
+                )
+                self.assertEqual(
+                    counters[2], (yield self.metrics_manager.get_register_value("bar.baz.counter3", "count"))
+                )
+
+        with self.run_simulation(m) as sim:
+            sim.add_sync_process(test_process)


### PR DESCRIPTION
edit: this PR contains all the changes to provide more context. I am going to split it into a few smaller ones that will be easier to review.

I thought it will be nice to have more observability in our core. It is good to know what's happening, what are causing delays, what the bottlenecks are. It also provides positive value for debugging - it can be easily noticed that something went wrong, when for example number of illegal instructions is bigger than expected.

The metrics can be optionally printed on the screen after the regression test is run (right now only for pysim backend):
![image](https://github.com/kuznia-rdzeni/coreblocks/assets/20254506/cedbad40-7ab7-47e6-b8f3-869b73b58fef)

Signals are also exposed in the gtkwave:
![image](https://github.com/kuznia-rdzeni/coreblocks/assets/20254506/2a89a905-9e8a-4a08-8a23-40dd37a41590)

Benchmarks:
![image](https://github.com/kuznia-rdzeni/coreblocks/assets/20254506/c8f55200-5e5f-4cd1-9cbe-4a387d7fde4c)

I added metrics in a few places to show how to use this feature. When this PR is ready to review, I will create another PR which adds metrics in the core.

Yet left to do:
- [x] Add support for cocotb simulator
- [x] Add documentation (after we agree on the interfaces etc)
- [x] Make sure that the core with metrics disabled synthesizes almost unchanged.  

Criticism is welcome
