### PR TITLE
Update amaranth version to the v0.4.x head

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 amaranth-yosys==0.35.0.0.post81
-git+https://github.com/amaranth-lang/amaranth@ab6503e352825b36bb29f1a8622b9e98aac9a6c6
+git+https://github.com/amaranth-lang/amaranth@89d1c9bb28f125316ea20bef5395e1ad26883877

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 amaranth-yosys==0.35.0.0.post81
-git+https://github.com/amaranth-lang/amaranth@3ed78d98ea6d6d1f65dfd2ee94a0ea02dce7f571
+git+https://github.com/amaranth-lang/amaranth@94c504afc7d81738ecdc9523a2615ef43ecbf51a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 amaranth-yosys==0.35.0.0.post81
-git+https://github.com/amaranth-lang/amaranth@89d1c9bb28f125316ea20bef5395e1ad26883877
+git+https://github.com/amaranth-lang/amaranth@422ba9ea51855472e1ed50c3c6eb297a4bff446d

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 amaranth-yosys==0.35.0.0.post81
-git+https://github.com/amaranth-lang/amaranth@422ba9ea51855472e1ed50c3c6eb297a4bff446d
+git+https://github.com/amaranth-lang/amaranth@a2f3c544eef8d55f29f115663eb33a467cc01178

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 amaranth-yosys==0.35.0.0.post81
-git+https://github.com/amaranth-lang/amaranth@a2f3c544eef8d55f29f115663eb33a467cc01178
+git+https://github.com/amaranth-lang/amaranth@3ed78d98ea6d6d1f65dfd2ee94a0ea02dce7f571


### PR DESCRIPTION
In #357 we need to use the `v0.4.x` head to have fix for traces which was delivered [here](https://github.com/amaranth-lang/amaranth/commit/1506f08b81fab25087bb449c96d276d294617576), because we are not ready yet to use the master branch. Till proper updates for master branch will be ready lets use the backport branch where this fix was also delivered in [that commit](https://github.com/amaranth-lang/amaranth/commit/94c504afc7d81738ecdc9523a2615ef43ecbf51a).