### PR TITLE
Refactor & improvements of regression scripts

### DIFF
--- a/scripts/run_signature.py
+++ b/scripts/run_signature.py
@@ -31,7 +31,7 @@ def run_with_cocotb(test_name: str, traces: bool, output: str) -> bool:
     arglist += [f"TESTNAME={test_name}"]
     arglist += [f"OUTPUT={output}"]
 
-    verilog_code = parent.joinpath("core.v")
+    verilog_code = f"{parent}/core.v"
     arglist += [f"VERILOG_SOURCES={verilog_code}"]
 
     if traces:

--- a/scripts/run_signature.py
+++ b/scripts/run_signature.py
@@ -31,6 +31,9 @@ def run_with_cocotb(test_name: str, traces: bool, output: str) -> bool:
     arglist += [f"TESTNAME={test_name}"]
     arglist += [f"OUTPUT={output}"]
 
+    verilog_code = parent.joinpath("core.v")
+    arglist += [f"VERILOG_SOURCES={verilog_code}"]
+
     if traces:
         arglist += ["TRACES=1"]
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -60,6 +60,9 @@ def run_regressions_with_cocotb(tests: list[str], traces: bool) -> bool:
     test_cases = ",".join(tests)
     arglist += [f"TESTCASE={test_cases}"]
 
+    verilog_code = topdir.joinpath("core.v")
+    arglist += [f"VERILOG_SOURCES={verilog_code}"]
+
     if traces:
         arglist += ["TRACES=1"]
 

--- a/test/regression/benchmark.py
+++ b/test/regression/benchmark.py
@@ -1,5 +1,6 @@
 import os
-import json
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
 from pathlib import Path
 
 from .memory import *
@@ -8,6 +9,26 @@ from .common import SimulationBackend
 test_dir = Path(__file__).parent.parent
 embench_dir = test_dir.joinpath("external/embench/build/src")
 results_dir = test_dir.joinpath("regression/benchmark_results")
+
+
+@dataclass_json
+@dataclass
+class BenchmarkResult:
+    """Result of running a single benchmark.
+
+    Attributes
+    ----------
+    cycles: int
+        A number of cycles the benchmark took.
+    instr: int
+        A count of instructions commited during the benchmark.
+    metric_values: dict[str, dict[str, int]]
+        Values of the core metrics taken at the end of the simulation.
+    """
+
+    cycles: int
+    instr: int
+    metric_values: dict[str, dict[str, int]]
 
 
 class MMIO(RandomAccessMemory):
@@ -54,16 +75,16 @@ async def run_benchmark(sim_backend: SimulationBackend, benchmark_name: str):
 
     mem_model = CoreMemoryModel(mem_segments)
 
-    success = await sim_backend.run(mem_model, timeout_cycles=2000000)
+    result = await sim_backend.run(mem_model, timeout_cycles=2000000)
 
-    if not success:
+    if not result.success:
         raise RuntimeError("Simulation timed out")
 
     if mmio.return_code() != 0:
         raise RuntimeError("The benchmark exited with a non-zero return code: %d" % mmio.return_code())
 
-    results = {"cycle": mmio.cycle_cnt(), "instr": mmio.instr_cnt()}
+    bench_results = BenchmarkResult(cycles=mmio.cycle_cnt(), instr=mmio.instr_cnt(), metric_values=result.metric_values)
 
     os.makedirs(str(results_dir), exist_ok=True)
     with open(f"{str(results_dir)}/{benchmark_name}.json", "w") as outfile:
-        json.dump(results, outfile)
+        outfile.write(bench_results.to_json())  # type: ignore

--- a/test/regression/cocotb/benchmark.Makefile
+++ b/test/regression/cocotb/benchmark.Makefile
@@ -4,9 +4,6 @@
 SIM ?= verilator
 TOPLEVEL_LANG ?= verilog
 
-VERILOG_SOURCES += $(PWD)/../../../core.v
-# use VHDL_SOURCES for VHDL files
-
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = top
 

--- a/test/regression/cocotb/signature.Makefile
+++ b/test/regression/cocotb/signature.Makefile
@@ -4,9 +4,6 @@
 SIM ?= verilator
 TOPLEVEL_LANG ?= verilog
 
-VERILOG_SOURCES += $(PWD)/../../../core.v
-# use VHDL_SOURCES for VHDL files
-
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = top
 

--- a/test/regression/cocotb/test.Makefile
+++ b/test/regression/cocotb/test.Makefile
@@ -4,9 +4,6 @@
 SIM ?= verilator
 TOPLEVEL_LANG ?= verilog
 
-VERILOG_SOURCES += $(PWD)/../../../core.v
-# use VHDL_SOURCES for VHDL files
-
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = top
 

--- a/test/regression/common.py
+++ b/test/regression/common.py
@@ -1,11 +1,28 @@
 from abc import ABC, abstractmethod
-
+from dataclasses import dataclass, field
 from .memory import CoreMemoryModel
+
+
+@dataclass
+class SimulationExecutionResult:
+    """Information about the result of the simulation.
+
+    Attributes
+    ----------
+    success: bool
+        Whether the simulation finished successfully, i.e. no timeouts,
+        no exceptions, no failed assertions etc.
+    metric_values: dict[str, dict[str, int]]
+        Values of the core metrics taken at the end of the simulation.
+    """
+
+    success: bool
+    metric_values: dict[str, dict[str, int]] = field(default_factory=dict)
 
 
 class SimulationBackend(ABC):
     @abstractmethod
-    async def run(self, mem_model: CoreMemoryModel, timeout_cycles: int) -> bool:
+    async def run(self, mem_model: CoreMemoryModel, timeout_cycles: int) -> SimulationExecutionResult:
         raise NotImplementedError
 
     @abstractmethod

--- a/test/regression/test.py
+++ b/test/regression/test.py
@@ -42,9 +42,9 @@ async def run_test(sim_backend: SimulationBackend, test_name: str):
 
     mem_model = CoreMemoryModel(mem_segments)
 
-    success = await sim_backend.run(mem_model, timeout_cycles=5000)
+    result = await sim_backend.run(mem_model, timeout_cycles=5000)
 
-    if not success:
+    if not result.success:
         raise RuntimeError("Simulation timed out")
 
     if mmio.failed_test:

--- a/transactron/core.py
+++ b/transactron/core.py
@@ -1370,7 +1370,7 @@ class Method(TransactionBase):
         .. code-block:: python
 
             m = Module()
-            with Transaction.body(m):
+            with Transaction().body(m):
                 ret = my_sum_method(m, arg1=2, arg2=3)
 
         Alternative syntax:
@@ -1378,7 +1378,7 @@ class Method(TransactionBase):
         .. highlight:: python
         .. code-block:: python
 
-            with Transaction.body(m):
+            with Transaction().body(m):
                 ret = my_sum_method(m, {"arg1": 2, "arg2": 3})
         """
         arg_rec = Record.like(self.data_in)


### PR DESCRIPTION
A few changes to the scripts running regression tests and benchmarks distilled from #572:

- Fixed small typos in doc strings in Transactron
- Removed `VERILOG_SOURCES` env flag from makefiles and now I set it in the python script.
- Added a serializable dataclass for passing info between benchmark scripts for type safety and extendability.
- The core simulators now return an object instead of a single flag, so more information can be passed back.
- Added stubs for metrics.
- The benchmark scripts now prints a table with results (I plan to add there metrics as well):
![image](https://github.com/kuznia-rdzeni/coreblocks/assets/20254506/c8f55200-5e5f-4cd1-9cbe-4a387d7fde4c)