### PR TITLE
Fix dataclass-json requirement.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,5 +17,4 @@ cocotb==1.7.2
 cocotb-bus==0.2.1
 pytest==7.2.2
 pyelftools==0.29
-dataclasses-json==0.6.3
 tabulate==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 amaranth-yosys==0.35.0.0.post81
 git+https://github.com/amaranth-lang/amaranth@94c504afc7d81738ecdc9523a2615ef43ecbf51a
+dataclasses-json==0.6.3


### PR DESCRIPTION
In #583 there was a change in a way how the requirements are installed for the core synthesis. Instead `requiremets-dev.txt` the `requirements.txt` are used. This PR is a fix for #580 which fails after #583.