### PR TITLE
Enable hardware metrics in Coreblocks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Synthesize
         run: |
           . venv/bin/activate
-          PYTHONHASHSEED=0 ./scripts/synthesize.py --verbose --config ${{ matrix.config }}
+          PYTHONHASHSEED=0 ./scripts/synthesize.py --verbose --strip-debug --config ${{ matrix.config }}
 
       - name: Print synthesis information
         run: cat ./build/top.tim

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -1,6 +1,6 @@
 from amaranth import *
 
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyManager, DependencyContext
 from coreblocks.stages.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.structs_common.instr_counter import CoreInstructionCounter
 from coreblocks.structs_common.interrupt_controller import InterruptController
@@ -32,6 +32,7 @@ from coreblocks.cache.refiller import SimpleCommonBusCacheRefiller
 from coreblocks.frontend.fetch import Fetch, UnalignedFetch
 from transactron.lib.transformers import MethodMap, MethodProduct
 from transactron.lib import BasicFifo
+from transactron.lib.metrics import HwMetricsEnabledKey
 
 __all__ = ["Core"]
 
@@ -39,6 +40,10 @@ __all__ = ["Core"]
 class Core(Elaboratable):
     def __init__(self, *, gen_params: GenParams, wb_instr_bus: WishboneBus, wb_data_bus: WishboneBus):
         self.gen_params = gen_params
+
+        dep_manager = DependencyContext.get()
+        if self.gen_params.debug_signals_enabled:
+            dep_manager.add_dependency(HwMetricsEnabledKey(), True)
 
         self.wb_instr_bus = wb_instr_bus
         self.wb_data_bus = wb_data_bus

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -48,6 +48,8 @@ class CoreConfiguration:
         Enables 16-bit Compressed Instructions extension.
     embedded: bool
         Enables Reduced Integer (E) extension.
+    debug_signals: bool
+        Enable debug signals (for example hardware metrics etc). If disabled, none of them will be synthesized.
     phys_regs_bits: int
         Size of the Physical Register File is 2**phys_regs_bits.
     rob_entries_bits: int
@@ -75,6 +77,8 @@ class CoreConfiguration:
 
     compressed: bool = False
     embedded: bool = False
+
+    debug_signals: bool = True
 
     phys_regs_bits: int = 6
     rob_entries_bits: int = 7

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -47,6 +47,8 @@ class GenParams(DependentCache):
             block_size_bits=cfg.icache_block_size_bits,
         )
 
+        self.debug_signals_enabled = cfg.debug_signals
+
         # Verification temporally disabled
         # if not optypes_required_by_extensions(self.isa.extensions) <= optypes_supported(func_units_config):
         #     raise Exception(f"Functional unit configuration fo not support all extension required by{isa_str}")

--- a/scripts/gen_verilog.py
+++ b/scripts/gen_verilog.py
@@ -73,6 +73,12 @@ def main():
     )
 
     parser.add_argument(
+        "--strip-debug",
+        action="store_true",
+        help="Remove debugging signals. Default: %(default)s",
+    )
+
+    parser.add_argument(
         "-o", "--output", action="store", default="core.v", help="Output file path. Default: %(default)s"
     )
 
@@ -83,7 +89,11 @@ def main():
     if args.config not in str_to_coreconfig:
         raise KeyError(f"Unknown config '{args.config}'")
 
-    gen_verilog(str_to_coreconfig[args.config], args.output)
+    config = str_to_coreconfig[args.config]
+    if args.strip_debug:
+        config = config.replace(debug_signals=False)
+
+    gen_verilog(config, args.output)
 
 
 if __name__ == "__main__":

--- a/scripts/synthesize.py
+++ b/scripts/synthesize.py
@@ -173,6 +173,12 @@ def main():
     )
 
     parser.add_argument(
+        "--strip-debug",
+        action="store_true",
+        help="Remove debugging signals. Default: %(default)s",
+    )
+
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -189,7 +195,11 @@ def main():
     if args.unit not in core_units:
         raise KeyError(f"Unknown core unit '{args.unit}'")
 
-    synthesize(str_to_coreconfig[args.config], args.platform, core_units[args.unit])
+    config = str_to_coreconfig[args.config]
+    if args.strip_debug:
+        config = config.replace(debug_signals=False)
+
+    synthesize(config, args.platform, core_units[args.unit])
 
 
 if __name__ == "__main__":

--- a/test/regression/pysim.py
+++ b/test/regression/pysim.py
@@ -1,11 +1,15 @@
+import re
+
 from amaranth.sim import Passive, Settle
 from amaranth.utils import log2_int
+from amaranth import *
 
 from .memory import *
 from .common import SimulationBackend, SimulationExecutionResult
 
-from transactron.testing import PysimSimulator
+from transactron.testing import PysimSimulator, TestGen
 from transactron.utils.dependencies import DependencyContext, DependencyManager
+from transactron.lib.metrics import HardwareMetricsManager
 from ..peripherals.test_wishbone import WishboneInterfaceWrapper
 
 from coreblocks.core import Core
@@ -21,6 +25,8 @@ class PySimulation(SimulationBackend):
         self.cycle_cnt = 0
         self.verbose = verbose
         self.traces_file = traces_file
+
+        self.metrics_manager = HardwareMetricsManager()
 
     def _wishbone_slave(
         self, mem_model: CoreMemoryModel, wb_ctrl: WishboneInterfaceWrapper, is_instr_bus: bool, delay: int = 0
@@ -82,13 +88,43 @@ class PySimulation(SimulationBackend):
 
         return f
 
-    def _waiter(self):
+    def _waiter(self, on_finish: Callable[[], TestGen[None]]):
         def f():
             while self.running:
                 self.cycle_cnt += 1
                 yield
 
+            yield from on_finish()
+
         return f
+
+    def pretty_dump_metrics(self, metric_values: dict[str, dict[str, int]], filter_regexp: str = ".*"):
+        print()
+        print("=== Core metrics dump ===")
+
+        put_space_before = True
+        for metric_name in sorted(metric_values.keys()):
+            if not re.search(filter_regexp, metric_name):
+                continue
+
+            metric = self.metrics_manager.get_metrics()[metric_name]
+
+            if metric.description != "":
+                if not put_space_before:
+                    print()
+
+                print(f"# {metric.description}")
+
+            for reg in metric.regs.values():
+                reg_value = metric_values[metric_name][reg.name]
+
+                desc = f" # {reg.description} [reg width={reg.width}]"
+                print(f"{metric_name}/{reg.name} {reg_value}{desc}")
+
+            put_space_before = False
+            if metric.description != "":
+                print()
+                put_space_before = True
 
     async def run(self, mem_model: CoreMemoryModel, timeout_cycles: int = 5000) -> SimulationExecutionResult:
         with DependencyContext(DependencyManager()):
@@ -105,13 +141,26 @@ class PySimulation(SimulationBackend):
             sim = PysimSimulator(core, max_cycles=timeout_cycles, traces_file=self.traces_file)
             sim.add_sync_process(self._wishbone_slave(mem_model, wb_instr_ctrl, is_instr_bus=True))
             sim.add_sync_process(self._wishbone_slave(mem_model, wb_data_ctrl, is_instr_bus=False))
-            sim.add_sync_process(self._waiter())
+
+            metric_values: dict[str, dict[str, int]] = {}
+
+            def on_sim_finish():
+                # Collect metric values before we finish the simulation
+                for metric_name, metric in self.metrics_manager.get_metrics().items():
+                    metric = self.metrics_manager.get_metrics()[metric_name]
+                    metric_values[metric_name] = {}
+                    for reg_name in metric.regs:
+                        metric_values[metric_name][reg_name] = yield self.metrics_manager.get_register_value(
+                            metric_name, reg_name
+                        )
+
+            sim.add_sync_process(self._waiter(on_finish=on_sim_finish))
             success = sim.run()
 
             if self.verbose:
-                print(f"Simulation finished in {self.cycle_cnt} cycles")
+                self.pretty_dump_metrics(metric_values)
 
-            return SimulationExecutionResult(success)
+            return SimulationExecutionResult(success, metric_values)
 
     def stop(self):
         self.running = False


### PR DESCRIPTION
- Hardware metrics will be enabled in Coreblocks by default
- Added a flag to `gen_verilog.py` and `synthesize.py` to disable debug signals
- Added one hardware counter to the core to test if it works (more counters in another PR)
- Metrics are read in the pysim backend of regression tests (cocotb backend in another PR)
Result:
```
$ scripts/run_tests.py -a -v -b pysim rv32uc-rvc
...
=== Core metrics dump ===
# Number of retired instructions
backend.retirement.retired_instr/count 212 # the value of the counter [reg width=32]
...
```