### PR TITLE
Fix Zbb instructions en/decoding

### DIFF
--- a/coreblocks/frontend/instr_description.py
+++ b/coreblocks/frontend/instr_description.py
@@ -170,14 +170,15 @@ instructions_by_optype = {
         Encoding(Opcode.OP, Funct3.XNOR, Funct7.XNOR),
     ],
     OpType.UNARY_BIT_MANIPULATION_1: [
-        Encoding(Opcode.OP_IMM, Funct3.ORCB, funct12=Funct12.ORCB),
         Encoding(Opcode.OP_IMM, Funct3.REV8, funct12=Funct12.REV8_32),
         Encoding(Opcode.OP_IMM, Funct3.SEXTB, funct12=Funct12.SEXTB),
         Encoding(Opcode.OP, Funct3.ZEXTH, funct12=Funct12.ZEXTH),
     ],
-    # Instructions SEXTH, SEXTHB, CPOP, CLZ and CTZ  cannot be distiguished by their Funct7 code
+    # Instructions SEXTH, SEXTHB, CPOP, CLZ and CTZ cannot be distiguished by their Funct7 code
+    # ORCB is here because of optimization to not lookup Funct7 in UNARY_BIT_MANIPULATION_1
     OpType.UNARY_BIT_MANIPULATION_2: [
         Encoding(Opcode.OP_IMM, Funct3.SEXTH, funct12=Funct12.SEXTH),
+        Encoding(Opcode.OP_IMM, Funct3.ORCB, funct12=Funct12.ORCB),
     ],
     OpType.UNARY_BIT_MANIPULATION_3: [
         Encoding(Opcode.OP_IMM, Funct3.CLZ, funct12=Funct12.CLZ),

--- a/coreblocks/frontend/instr_description.py
+++ b/coreblocks/frontend/instr_description.py
@@ -164,10 +164,12 @@ instructions_by_optype = {
         Encoding(Opcode.OP, Funct3.MIN, Funct7.MIN),
         Encoding(Opcode.OP, Funct3.MINU, Funct7.MIN),
         Encoding(Opcode.OP, Funct3.ORN, Funct7.ORN),
+        Encoding(Opcode.OP, Funct3.XNOR, Funct7.XNOR),
+    ],
+    OpType.BIT_ROTATION: [
         Encoding(Opcode.OP, Funct3.ROL, Funct7.ROL),
         Encoding(Opcode.OP, Funct3.ROR, Funct7.ROR),
         Encoding(Opcode.OP_IMM, Funct3.ROR, Funct7.ROR),
-        Encoding(Opcode.OP, Funct3.XNOR, Funct7.XNOR),
     ],
     OpType.UNARY_BIT_MANIPULATION_1: [
         Encoding(Opcode.OP_IMM, Funct3.REV8, funct12=Funct12.REV8_32),

--- a/coreblocks/fu/alu.py
+++ b/coreblocks/fu/alu.py
@@ -82,14 +82,14 @@ class AluFn(DecoderManager):
                 (self.Fn.MAXU, OpType.BIT_MANIPULATION, Funct3.MAXU, Funct7.MAX),
                 (self.Fn.MIN, OpType.BIT_MANIPULATION, Funct3.MIN, Funct7.MIN),
                 (self.Fn.MINU, OpType.BIT_MANIPULATION, Funct3.MINU, Funct7.MIN),
-                (self.Fn.ORCB, OpType.UNARY_BIT_MANIPULATION_1, Funct3.ORCB, Funct7.ORCB),
-                (self.Fn.REV8, OpType.UNARY_BIT_MANIPULATION_1, Funct3.REV8, Funct7.REV8),
-                (self.Fn.SEXTB, OpType.UNARY_BIT_MANIPULATION_1, Funct3.SEXTB, Funct7.SEXTB),
-                (self.Fn.ZEXTH, OpType.UNARY_BIT_MANIPULATION_1, Funct3.ZEXTH, Funct7.ZEXTH),
-                (self.Fn.CPOP, OpType.UNARY_BIT_MANIPULATION_5, Funct3.CPOP, Funct7.CPOP),
-                (self.Fn.SEXTH, OpType.UNARY_BIT_MANIPULATION_2, Funct3.SEXTH, Funct7.SEXTH),
-                (self.Fn.CLZ, OpType.UNARY_BIT_MANIPULATION_3, Funct3.CLZ, Funct7.CLZ),
-                (self.Fn.CTZ, OpType.UNARY_BIT_MANIPULATION_4, Funct3.CTZ, Funct7.CTZ),
+                (self.Fn.REV8, OpType.UNARY_BIT_MANIPULATION_1, Funct3.REV8),
+                (self.Fn.SEXTB, OpType.UNARY_BIT_MANIPULATION_1, Funct3.SEXTB),
+                (self.Fn.ZEXTH, OpType.UNARY_BIT_MANIPULATION_1, Funct3.ZEXTH),
+                (self.Fn.ORCB, OpType.UNARY_BIT_MANIPULATION_2, Funct3.ORCB),
+                (self.Fn.SEXTH, OpType.UNARY_BIT_MANIPULATION_2, Funct3.SEXTH),
+                (self.Fn.CLZ, OpType.UNARY_BIT_MANIPULATION_3, Funct3.CLZ),
+                (self.Fn.CTZ, OpType.UNARY_BIT_MANIPULATION_4, Funct3.CTZ),
+                (self.Fn.CPOP, OpType.UNARY_BIT_MANIPULATION_5, Funct3.CPOP),
             ]
             * self.zbb_enable
         )

--- a/coreblocks/fu/shift_unit.py
+++ b/coreblocks/fu/shift_unit.py
@@ -34,8 +34,8 @@ class ShiftUnitFn(DecoderManager):
             (self.Fn.SRL, OpType.SHIFT, Funct3.SR, Funct7.SL),
             (self.Fn.SRA, OpType.SHIFT, Funct3.SR, Funct7.SA),
         ] + [
-            (self.Fn.ROR, OpType.BIT_MANIPULATION, Funct3.ROR, Funct7.ROR),
-            (self.Fn.ROL, OpType.BIT_MANIPULATION, Funct3.ROL, Funct7.ROL),
+            (self.Fn.ROR, OpType.BIT_ROTATION, Funct3.ROR),
+            (self.Fn.ROL, OpType.BIT_ROTATION, Funct3.ROL),
         ] * self.zbb_enable
 
 

--- a/coreblocks/params/optypes.py
+++ b/coreblocks/params/optypes.py
@@ -34,6 +34,7 @@ class OpType(IntEnum):
     SINGLE_BIT_MANIPULATION = auto()
     ADDRESS_GENERATION = auto()
     BIT_MANIPULATION = auto()
+    BIT_ROTATION = auto()
     UNARY_BIT_MANIPULATION_1 = auto()
     UNARY_BIT_MANIPULATION_2 = auto()
     UNARY_BIT_MANIPULATION_3 = auto()
@@ -88,6 +89,7 @@ optypes_by_extensions = {
     ],
     Extension.ZBB: [
         OpType.BIT_MANIPULATION,
+        OpType.BIT_ROTATION,
         OpType.UNARY_BIT_MANIPULATION_1,
         OpType.UNARY_BIT_MANIPULATION_2,
         OpType.UNARY_BIT_MANIPULATION_3,

--- a/test/frontend/test_instr_decoder.py
+++ b/test/frontend/test_instr_decoder.py
@@ -365,7 +365,7 @@ class TestEncodingUniqueness(TestCase):
                 Encoding(Opcode.OP_IMM, Funct3.BSET, Funct7.BSET),
                 Encoding(Opcode.OP_IMM, Funct3.BINV, Funct7.BINV),
             },
-            OpType.BIT_MANIPULATION: {
+            OpType.BIT_ROTATION: {
                 Encoding(Opcode.OP_IMM, Funct3.ROR, Funct7.ROR),
             },
         }

--- a/test/fu/test_alu.py
+++ b/test/fu/test_alu.py
@@ -28,14 +28,14 @@ class AluUnitTest(FunctionalUnitTestCase[AluFn.Fn]):
         AluFn.Fn.MAXU: ExecFn(OpType.BIT_MANIPULATION, Funct3.MAXU, Funct7.MAX),
         AluFn.Fn.MIN: ExecFn(OpType.BIT_MANIPULATION, Funct3.MIN, Funct7.MIN),
         AluFn.Fn.MINU: ExecFn(OpType.BIT_MANIPULATION, Funct3.MINU, Funct7.MIN),
-        AluFn.Fn.CPOP: ExecFn(OpType.UNARY_BIT_MANIPULATION_5, Funct3.CPOP, Funct7.CPOP),
-        AluFn.Fn.SEXTB: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.SEXTB, Funct7.SEXTB),
-        AluFn.Fn.ZEXTH: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.ZEXTH, Funct7.ZEXTH),
-        AluFn.Fn.SEXTH: ExecFn(OpType.UNARY_BIT_MANIPULATION_2, Funct3.SEXTH, Funct7.SEXTH),
-        AluFn.Fn.ORCB: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.ORCB, Funct7.ORCB),
-        AluFn.Fn.REV8: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.REV8, Funct7.REV8),
-        AluFn.Fn.CLZ: ExecFn(OpType.UNARY_BIT_MANIPULATION_3, Funct3.CLZ, Funct7.CLZ),
-        AluFn.Fn.CTZ: ExecFn(OpType.UNARY_BIT_MANIPULATION_4, Funct3.CTZ, Funct7.CTZ),
+        AluFn.Fn.SEXTB: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.SEXTB),
+        AluFn.Fn.ZEXTH: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.ZEXTH),
+        AluFn.Fn.REV8: ExecFn(OpType.UNARY_BIT_MANIPULATION_1, Funct3.REV8),
+        AluFn.Fn.SEXTH: ExecFn(OpType.UNARY_BIT_MANIPULATION_2, Funct3.SEXTH),
+        AluFn.Fn.ORCB: ExecFn(OpType.UNARY_BIT_MANIPULATION_2, Funct3.ORCB),
+        AluFn.Fn.CLZ: ExecFn(OpType.UNARY_BIT_MANIPULATION_3, Funct3.CLZ),
+        AluFn.Fn.CTZ: ExecFn(OpType.UNARY_BIT_MANIPULATION_4, Funct3.CTZ),
+        AluFn.Fn.CPOP: ExecFn(OpType.UNARY_BIT_MANIPULATION_5, Funct3.CPOP),
     }
 
     @staticmethod

--- a/test/fu/test_shift_unit.py
+++ b/test/fu/test_shift_unit.py
@@ -12,8 +12,8 @@ class ShiftUnitTest(FunctionalUnitTestCase[ShiftUnitFn.Fn]):
         ShiftUnitFn.Fn.SLL: ExecFn(OpType.SHIFT, Funct3.SLL),
         ShiftUnitFn.Fn.SRL: ExecFn(OpType.SHIFT, Funct3.SR, Funct7.SL),
         ShiftUnitFn.Fn.SRA: ExecFn(OpType.SHIFT, Funct3.SR, Funct7.SA),
-        ShiftUnitFn.Fn.ROL: ExecFn(OpType.BIT_MANIPULATION, Funct3.ROL, Funct7.ROL),
-        ShiftUnitFn.Fn.ROR: ExecFn(OpType.BIT_MANIPULATION, Funct3.ROR, Funct7.ROR),
+        ShiftUnitFn.Fn.ROL: ExecFn(OpType.BIT_ROTATION, Funct3.ROL, Funct7.ROL),
+        ShiftUnitFn.Fn.ROR: ExecFn(OpType.BIT_ROTATION, Funct3.ROR, Funct7.ROR),
     }
 
     @staticmethod


### PR DESCRIPTION
UNARY_BIT_MANIPULATION_* had only Funct12 without Funct7 specified in instruction definition -> decoder was outputting 0 ad funct7 -> ALU was using fuct7 to decode instructions and failing, because it was always 0.

Instead of adding Funct7 to instruction in decoder definitions, I optimized it by moving one instruction to other OpType, so all of the UNARY_BIT_MANIPULATION_* can be decoded only by OpType + Funct3

Issue 2) There was an OpType collsion between FUs on rotation. Both ALU and SHIFT unit used BIT_MANIPULATION optype.

Fixes ~(~all~/part of)~ all #592 
~Test job is currently in progress~