### PR TITLE
Fix the pysim regression

### DIFF
--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -91,6 +91,8 @@ def verilate_model(worker_id, request: pytest.FixtureRequest):
     distributed, cocotb, mode. It executes a 'SKIP' regression test which verilates the model.
     """
     if request.session.config.getoption("coreblocks_backend") != "cocotb" or worker_id == "master":
+        # pytest expect yield on every path in fixture
+        yield None
         return
 
     lock_path = "_coreblocks_regression.lock"


### PR DESCRIPTION
Here is quick fix after #554. We don't have tests of all option combinations of our `run_tests.py` script so when the regression with pysim stopped to work after one of the refactor it wasn't catched on CI. CI will be extended in separate PR.

Resolves #603.