### PR TITLE
Fix profiles on newer yosys version

### DIFF
--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -151,9 +151,20 @@ class CocotbSimulation(SimulationBackend):
         obj = self.dut
         # Skip the first component, as it is already referenced in "self.dut"
         for component in path_components[1:]:
-            # As the component may start with '_' character, we need to use '_id'
-            # function instead of 'getattr' - this is required by cocotb.
-            obj = obj._id(component, extended=False)
+            try:
+                # As the component may start with '_' character, we need to use '_id'
+                # function instead of 'getattr' - this is required by cocotb.
+                obj = obj._id(component, extended=False)
+            except AttributeError:
+                if component[0] == "\\" and component[-1] == " ":
+                    # workaround for cocotb/verilator weirdness
+                    # for some escaped names lookup fails, but works when unescaped
+                    obj = obj._id(component[1:-1], extended=False)
+                elif component[0] != "\\" and component[-1] != " ":
+                    # wrokaround for different name generation on different yosys versions
+                    obj = obj._id("\\" + component + " ", extended=False)
+                else:
+                    raise
 
         return obj
 

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -157,12 +157,8 @@ class CocotbSimulation(SimulationBackend):
                 # function instead of 'getattr' - this is required by cocotb.
                 obj = obj._id(component, extended=False)
             except AttributeError:
-                if component[0] == "\\" and component[-1] == " ":
-                    # workaround for cocotb/verilator weirdness
-                    # for some escaped names lookup fails, but works when unescaped
-                    obj = obj._id(component[1:-1], extended=False)
-                elif component[0] != "\\" and component[-1] != " ":
-                    # wrokaround for different name generation on different yosys versions
+                # Try with escaped name
+                if component[0] != "\\" and component[-1] != " ":
                     obj = obj._id("\\" + component + " ", extended=False)
                 else:
                     raise

--- a/transactron/utils/gen.py
+++ b/transactron/utils/gen.py
@@ -149,7 +149,7 @@ def escape_verilog_identifier(identifier: str) -> str:
     # The standard says how to escape a identifier, but not when. So this is
     # a non-exhaustive list of characters that Yosys escapes (it is used
     # by Amaranth when generating Verilog code).
-    characters_to_escape = [".", "$"]
+    characters_to_escape = [".", "$", "-"]
 
     for char in characters_to_escape:
         if char in identifier:
@@ -160,10 +160,7 @@ def escape_verilog_identifier(identifier: str) -> str:
 
 def get_signal_location(signal: Signal, name_map: "SignalDict") -> list[str]:
     raw_location = name_map[signal]
-
-    # Amaranth escapes identifiers when generating Verilog code, but returns non-escaped identifiers
-    # in the name map, so we need to escape it manually.
-    return [escape_verilog_identifier(component) for component in raw_location]
+    return raw_location
 
 
 def collect_metric_locations(name_map: "SignalDict") -> dict[str, MetricLocation]:


### PR DESCRIPTION
On Yosys 0.37.0 names with "-" are also escaped. I have found it in hard way when regressions tests with cocotb failed. Here is a port of resiliency changes from #596 extended with one more case when there is no escaping and there should be one.