### PR TITLE
Clean up pytest

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -33,12 +33,9 @@ def main():
     pytest_arguments = ["--max-worker-restart=1"]
 
     if args.trace:
-        os.environ["__COREBLOCKS_DUMP_TRACES"] = "1"
         pytest_arguments.append("--coreblocks-traces")
-
     if args.profile:
-        os.environ["__TRANSACTRON_PROFILE"] = "1"
-
+        pytest_arguments.append("--coreblocks-profile")
     if args.test_name:
         pytest_arguments += [f"--coreblocks-test-name={args.test_name}"]
     if args.count:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import re
+import os
 from typing import Optional
 import pytest
 
@@ -13,6 +14,7 @@ def pytest_addoption(parser: pytest.Parser):
         help="Simulation backend for regression tests",
     )
     group.addoption("--coreblocks-traces", action="store_true", help="Generate traces from regression tests")
+    group.addoption("--coreblocks-profile", action="store_true", help="Write execution profiles")
     group.addoption("--coreblocks-list", action="store_true", help="List all tests in flatten format.")
     group.addoption(
         "--coreblocks-test-name",
@@ -90,3 +92,15 @@ def deselect_based_on_count(items: list[pytest.Item], config: pytest.Config) -> 
 def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Config) -> None:
     deselect_based_on_flatten_name(items, config)
     deselect_based_on_count(items, config)
+
+
+def pytest_runtest_setup(item: pytest.Item):
+    """
+    This function is called to perform the setup phase for every test, so
+    it is a perfect moment to set environment variables.
+    """
+    if item.config.getoption("--coreblocks-traces", False):  # type: ignore
+        os.environ["__TRANSACTRON_DUMP_TRACES"] = "1"
+
+    if item.config.getoption("--coreblocks-profile", False):  # type: ignore
+        os.environ["__TRANSACTRON_PROFILE"] = "1"

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -81,11 +81,11 @@ def regression_body_with_cocotb(test_name: str, traces: bool):
     assert len(list(tree.iter("failure"))) == 0
 
 
-def regression_body_with_pysim(test_name: str, traces: bool, verbose: bool):
+def regression_body_with_pysim(test_name: str, traces: bool):
     traces_file = None
     if traces:
         traces_file = REGRESSION_TESTS_PREFIX + test_name
-    asyncio.run(run_test(PySimulation(verbose, traces_file=traces_file), test_name))
+    asyncio.run(run_test(PySimulation(verbose=False, traces_file=traces_file), test_name))
 
 
 @pytest.fixture(scope="session")
@@ -126,8 +126,18 @@ def verilate_model(worker_id, request: pytest.FixtureRequest):
         os.remove(counter_path)
 
 
-def test_entrypoint(test_name: str, backend: Literal["pysim", "cocotb"], traces: bool, verbose: bool, verilate_model):
-    if backend == "cocotb":
-        regression_body_with_cocotb(test_name, traces)
-    elif backend == "pysim":
-        regression_body_with_pysim(test_name, traces, verbose)
+@pytest.fixture
+def sim_backend(request: pytest.FixtureRequest):
+    return request.config.getoption("coreblocks_backend")
+
+
+@pytest.fixture
+def traces_enabled(request: pytest.FixtureRequest):
+    return request.config.getoption("coreblocks_traces")
+
+
+def test_entrypoint(test_name: str, sim_backend: Literal["pysim", "cocotb"], traces_enabled: bool, verilate_model):
+    if sim_backend == "cocotb":
+        regression_body_with_cocotb(test_name, traces_enabled)
+    elif sim_backend == "pysim":
+        regression_body_with_pysim(test_name, traces_enabled)

--- a/transactron/testing/infrastructure.py
+++ b/transactron/testing/infrastructure.py
@@ -241,7 +241,7 @@ class TestCaseWithSimulator(unittest.TestCase):
     @contextmanager
     def run_simulation(self, module: HasElaborate, max_cycles: float = 10e4, add_transaction_module=True):
         traces_file = None
-        if "__COREBLOCKS_DUMP_TRACES" in os.environ:
+        if "__TRANSACTRON_DUMP_TRACES" in os.environ:
             traces_file = unittest.TestCase.id(self)
 
         clk_period = 1e-6


### PR DESCRIPTION
- Renamed `__COREBLOCKS_DUMP_TRACES` -> `__TRANSACTRON_DUMP_TRACES`
- Regression tests are now showed as 'skipped' without `--coreblocks-regression` flag instead of not showing them at all.
- Previously regression tests were parametrized by constant parameters. Now parameters are indeed parameters. 
- `__TRANSACTRON_PROFILE` is now set in `pytest`, so profiling can be also turned on using pytest flags.

With these changes in, I suggest removing `run_tests.py` scripts, as it will be purely a wrapper over `pytest` command. My argument is that `run_tests.py` script is another layer of indirection that can contain bugs (#605) and needs to be understood when making changes.