### PR TITLE
Remove riscvmodel dependency

### DIFF
--- a/coreblocks/params/instr.py
+++ b/coreblocks/params/instr.py
@@ -3,7 +3,7 @@ from abc import abstractmethod, ABC
 from amaranth.hdl import ValueCastable
 from amaranth import *
 
-from transactron.utils import ValueLike
+from transactron.utils import ValueLike, int_to_signed
 from coreblocks.params.isa_params import *
 from coreblocks.frontend.decoder.isa import *
 
@@ -71,6 +71,7 @@ class ITypeInstr(RISCVInstr):
 
     @staticmethod
     def encode(opcode: int, rd: int, funct3: int, rs1: int, imm: int):
+        imm = int_to_signed(imm, 12)
         return int(f"{imm:012b}{rs1:05b}{funct3:03b}{rd:05b}{opcode:05b}11", 2)
 
 
@@ -87,6 +88,7 @@ class STypeInstr(RISCVInstr):
 
     @staticmethod
     def encode(opcode: int, imm: int, funct3: int, rs1: int, rs2: int):
+        imm = int_to_signed(imm, 12)
         imm_str = f"{imm:012b}"
         return int(f"{imm_str[5:12]:07b}{rs2:05b}{rs1:05b}{funct3:03b}{imm_str[0:5]:05b}{opcode:05b}11", 2)
 
@@ -114,6 +116,7 @@ class BTypeInstr(RISCVInstr):
 
     @staticmethod
     def encode(opcode: int, imm: int, funct3: int, rs1: int, rs2: int):
+        imm = int_to_signed(imm, 13)
         imm_str = f"{imm:013b}"
         return int(
             f"{imm_str[12]:01b}{imm_str[5:11]:06b}{rs2:05b}{rs1:05b}{funct3:03b}{imm_str[1:5]:04b}"
@@ -133,6 +136,7 @@ class UTypeInstr(RISCVInstr):
 
     @staticmethod
     def encode(opcode: int, rd: int, imm: int):
+        imm = int_to_signed(imm, 20)
         return int(f"{imm:020b}{rd:05b}{opcode:05b}11", 2)
 
 
@@ -147,6 +151,7 @@ class JTypeInstr(RISCVInstr):
 
     @staticmethod
     def encode(opcode: int, rd: int, imm: int):
+        imm = int_to_signed(imm, 21)
         imm_str = f"{imm:021b}"
         return int(
             f"{imm_str[20]:01b}{imm_str[1:11]:010b}{imm_str[11]:01b}{imm_str[12:20]:08b}{rd:05b}{opcode:05b}11", 2

--- a/coreblocks/params/instr.py
+++ b/coreblocks/params/instr.py
@@ -53,6 +53,10 @@ class RTypeInstr(RISCVInstr):
     def pack(self) -> Value:
         return Cat(C(0b11, 2), self.opcode, self.rd, self.funct3, self.rs1, self.rs2, self.funct7)
 
+    @staticmethod
+    def encode(opcode: int, rd: int, funct3: int, rs1: int, rs2: int, funct7: int):
+        return int(f"{funct7:07b}{rs2:05b}{rs1:05b}{funct3:03b}{rd:05b}{opcode:05b}11", 2)
+
 
 class ITypeInstr(RISCVInstr):
     def __init__(self, opcode: ValueLike, rd: ValueLike, funct3: ValueLike, rs1: ValueLike, imm: ValueLike):
@@ -65,6 +69,10 @@ class ITypeInstr(RISCVInstr):
     def pack(self) -> Value:
         return Cat(C(0b11, 2), self.opcode, self.rd, self.funct3, self.rs1, self.imm)
 
+    @staticmethod
+    def encode(opcode: int, rd: int, funct3: int, rs1: int, imm: int):
+        return int(f"{imm:012b}{rs1:05b}{funct3:03b}{rd:05b}{opcode:05b}11", 2)
+
 
 class STypeInstr(RISCVInstr):
     def __init__(self, opcode: ValueLike, imm: ValueLike, funct3: ValueLike, rs1: ValueLike, rs2: ValueLike):
@@ -76,6 +84,11 @@ class STypeInstr(RISCVInstr):
 
     def pack(self) -> Value:
         return Cat(C(0b11, 2), self.opcode, self.imm[0:5], self.funct3, self.rs1, self.rs2, self.imm[5:12])
+
+    @staticmethod
+    def encode(opcode: int, imm: int, funct3: int, rs1: int, rs2: int):
+        imm_str = f"{imm:012b}"
+        return int(f"{imm_str[5:12]:07b}{rs2:05b}{rs1:05b}{funct3:03b}{imm_str[0:5]:05b}{opcode:05b}11", 2)
 
 
 class BTypeInstr(RISCVInstr):
@@ -99,6 +112,15 @@ class BTypeInstr(RISCVInstr):
             self.imm[12],
         )
 
+    @staticmethod
+    def encode(opcode: int, imm: int, funct3: int, rs1: int, rs2: int):
+        imm_str = f"{imm:013b}"
+        return int(
+            f"{imm_str[12]:01b}{imm_str[5:11]:06b}{rs2:05b}{rs1:05b}{funct3:03b}{imm_str[1:5]:04b}"
+            + f"{imm_str[11]:01b}{opcode:05b}11",
+            2,
+        )
+
 
 class UTypeInstr(RISCVInstr):
     def __init__(self, opcode: ValueLike, rd: ValueLike, imm: ValueLike):
@@ -108,6 +130,10 @@ class UTypeInstr(RISCVInstr):
 
     def pack(self) -> Value:
         return Cat(C(0b11, 2), self.opcode, self.rd, self.imm[12:])
+
+    @staticmethod
+    def encode(opcode: int, rd: int, imm: int):
+        return int(f"{imm:020b}{rd:05b}{opcode:05b}11", 2)
 
 
 class JTypeInstr(RISCVInstr):
@@ -119,6 +145,13 @@ class JTypeInstr(RISCVInstr):
     def pack(self) -> Value:
         return Cat(C(0b11, 2), self.opcode, self.rd, self.imm[12:20], self.imm[11], self.imm[1:11], self.imm[20])
 
+    @staticmethod
+    def encode(opcode: int, rd: int, imm: int):
+        imm_str = f"{imm:021b}"
+        return int(
+            f"{imm_str[20]:01b}{imm_str[1:11]:010b}{imm_str[11]:01b}{imm_str[12:20]:08b}{rd:05b}{opcode:05b}11", 2
+        )
+
 
 class IllegalInstr(RISCVInstr):
     def __init__(self):
@@ -126,6 +159,10 @@ class IllegalInstr(RISCVInstr):
 
     def pack(self) -> Value:
         return C(1).replicate(32)  # Instructions with all bits set to 1 are reserved to be illegal.
+
+    @staticmethod
+    def encode(opcode: int, rd: int, imm: int):
+        return int("1" * 32, 2)
 
 
 class EBreakInstr(ITypeInstr):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ black==23.3.0
 docutils==0.15.2
 flake8==6.0.0
 pep8-naming==0.13.3
-git+https://github.com/kristopher38/riscv-python-model@b5d0737#riscv-model
 markupsafe==2.0.1
 myst-parser==0.18.0
 numpydoc==1.5.0

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -58,11 +58,6 @@ class CoreTestElaboratable(Elaboratable):
 
         return m
 
-from riscvmodel.insn import (
-    InstructionADDI,
-    InstructionLUI,
-)
-import logging
 
 class TestCoreBase(TestCaseWithSimulator):
     gen_params: GenParams
@@ -83,22 +78,6 @@ class TestCoreBase(TestCaseWithSimulator):
         # handle addi sign extension, see: https://stackoverflow.com/a/59546567
         if val & 0x800:
             lui_imm = (lui_imm + 1) & (0xFFFFF)
-
-
-        lui_org = InstructionLUI(reg_id, lui_imm).encode()
-        lui_my = UTypeInstr.encode(Opcode.LUI, reg_id, lui_imm)
-        #logging.debug(lui_my)
-        if (lui_org != lui_my):
-            logging.error("LUI")
-            assert False
-        addi_org = InstructionADDI(reg_id, reg_id, addi_imm).encode()
-        addi_my = ITypeInstr.encode(Opcode.OP_IMM, reg_id, Funct3.ADD, reg_id, addi_imm)
-        if (addi_org != addi_my):
-            logging.error("MY")
-            logging.error(addi_imm)
-            logging.error(f"{addi_my:032b}")
-            logging.error(f"{addi_org:032b}")
-            assert False
 
         yield from self.push_instr(UTypeInstr.encode(Opcode.LUI, reg_id, lui_imm))
         yield from self.push_instr(ITypeInstr.encode(Opcode.OP_IMM, reg_id, Funct3.ADD, reg_id, addi_imm))

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7,7 +7,9 @@ from transactron.utils import align_to_power_of_two, signed_to_int
 from transactron.testing import TestCaseWithSimulator, TestbenchIO
 
 from coreblocks.core import Core
+from coreblocks.frontend.decoder import Opcode, Funct3
 from coreblocks.params import GenParams
+from coreblocks.params.instr import *
 from coreblocks.params.configurations import CoreConfiguration, basic_core_config, full_core_config
 from coreblocks.peripherals.wishbone import WishboneSignature, WishboneMemorySlave
 
@@ -16,10 +18,6 @@ import random
 import subprocess
 import tempfile
 from parameterized import parameterized_class
-from riscvmodel.insn import (
-    InstructionADDI,
-    InstructionLUI,
-)
 
 
 class CoreTestElaboratable(Elaboratable):
@@ -81,8 +79,8 @@ class TestCoreBase(TestCaseWithSimulator):
         if val & 0x800:
             lui_imm = (lui_imm + 1) & (0xFFFFF)
 
-        yield from self.push_instr(InstructionLUI(reg_id, lui_imm).encode())
-        yield from self.push_instr(InstructionADDI(reg_id, reg_id, addi_imm).encode())
+        yield from self.push_instr(UTypeInstr.encode(Opcode.LUI, reg_id, lui_imm))
+        yield from self.push_instr(ITypeInstr.encode(Opcode.OP_IMM, reg_id, Funct3.ADD, reg_id, addi_imm))
 
 
 class TestCoreAsmSourceBase(TestCoreBase):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -58,6 +58,11 @@ class CoreTestElaboratable(Elaboratable):
 
         return m
 
+from riscvmodel.insn import (
+    InstructionADDI,
+    InstructionLUI,
+)
+import logging
 
 class TestCoreBase(TestCaseWithSimulator):
     gen_params: GenParams
@@ -78,6 +83,22 @@ class TestCoreBase(TestCaseWithSimulator):
         # handle addi sign extension, see: https://stackoverflow.com/a/59546567
         if val & 0x800:
             lui_imm = (lui_imm + 1) & (0xFFFFF)
+
+
+        lui_org = InstructionLUI(reg_id, lui_imm).encode()
+        lui_my = UTypeInstr.encode(Opcode.LUI, reg_id, lui_imm)
+        #logging.debug(lui_my)
+        if (lui_org != lui_my):
+            logging.error("LUI")
+            assert False
+        addi_org = InstructionADDI(reg_id, reg_id, addi_imm).encode()
+        addi_my = ITypeInstr.encode(Opcode.OP_IMM, reg_id, Funct3.ADD, reg_id, addi_imm)
+        if (addi_org != addi_my):
+            logging.error("MY")
+            logging.error(addi_imm)
+            logging.error(f"{addi_my:032b}")
+            logging.error(f"{addi_org:032b}")
+            assert False
 
         yield from self.push_instr(UTypeInstr.encode(Opcode.LUI, reg_id, lui_imm))
         yield from self.push_instr(ITypeInstr.encode(Opcode.OP_IMM, reg_id, Funct3.ADD, reg_id, addi_imm))


### PR DESCRIPTION
After #597 there is no need to have riscvmodel in our dependencies any longer. So here is a PR to remove it.

Resolves #183