### PR TITLE
Fix instruction cache refilling bug

### DIFF
--- a/test/cache/test_icache.py
+++ b/test/cache/test_icache.py
@@ -715,6 +715,30 @@ class TestICache(TestCaseWithSimulator):
             yield from self.expect_resp(wait=True)
             yield
             yield from self.m.accept_res.disable()
+            yield
+
+            # The second request will cause an error
+            yield from self.send_req(addr=0x00021004)
+            yield from self.send_req(addr=0x00030000)
+
+            yield from self.tick(10)
+
+            # Accept the first response
+            yield from self.m.accept_res.enable()
+            yield from self.expect_resp(wait=True)
+            yield
+
+            # Wait before accepting the second response
+            yield from self.m.accept_res.disable()
+            yield from self.tick(10)
+            yield from self.m.accept_res.enable()
+            yield from self.expect_resp(wait=True)
+
+            yield
+
+            # This request should not cause an error
+            yield from self.send_req(addr=0x00011000)
+            yield from self.expect_resp(wait=True)
 
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(cache_process)

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -13,6 +13,9 @@ class BasicFifo(Elaboratable):
     read: Method
         Reads from the FIFO. Accepts an empty argument, returns a structure.
         Ready only if the FIFO is not empty.
+    peek: Method
+        Returns the element at the front (but not delete). Ready only if the FIFO
+        is not empty. The method is nonexclusive.
     write: Method
         Writes to the FIFO. Accepts a structure, returns empty result.
         Ready only if the FIFO is not full.

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -40,6 +40,7 @@ class BasicFifo(Elaboratable):
 
         src_loc = get_src_loc(src_loc)
         self.read = Method(o=self.layout, src_loc=src_loc)
+        self.peek = Method(o=self.layout, nonexclusive=True, src_loc=src_loc)
         self.write = Method(i=self.layout, src_loc=src_loc)
         self.clear = Method(src_loc=src_loc)
         self.head = Signal(from_method_layout(layout))
@@ -91,6 +92,10 @@ class BasicFifo(Elaboratable):
         @def_method(m, self.read, self.read_ready)
         def _() -> ValueLike:
             m.d.sync += self.read_idx.eq(next_read_idx)
+            return self.head
+
+        @def_method(m, self.peek, self.read_ready)
+        def _() -> ValueLike:
             return self.head
 
         @def_method(m, self.clear)

--- a/transactron/lib/reqres.py
+++ b/transactron/lib/reqres.py
@@ -39,6 +39,8 @@ class ArgumentsToResultsZipper(Elaboratable):
 
     Attributes
     ----------
+    peek_arg: Method
+        A nonexclusive method to read (but not delete) the head of the arg queue.
     write_args: Method
         Method to write arguments with `args_layout` format to 2-FIFO.
     write_results: Method

--- a/transactron/lib/reqres.py
+++ b/transactron/lib/reqres.py
@@ -1,7 +1,7 @@
 from amaranth import *
 from ..core import *
 from ..utils import SrcLoc, get_src_loc, MethodLayout
-from .connectors import Forwarder, FIFO
+from .connectors import Forwarder
 from transactron.lib import BasicFifo
 from amaranth.utils import *
 
@@ -65,6 +65,7 @@ class ArgumentsToResultsZipper(Elaboratable):
         self.args_layout = args_layout
         self.output_layout = [("args", self.args_layout), ("results", results_layout)]
 
+        self.peek_arg = Method(o=self.args_layout, nonexclusive=True, src_loc=self.src_loc)
         self.write_args = Method(i=self.args_layout, src_loc=self.src_loc)
         self.write_results = Method(i=self.results_layout, src_loc=self.src_loc)
         self.read = Method(o=self.output_layout, src_loc=self.src_loc)
@@ -72,7 +73,7 @@ class ArgumentsToResultsZipper(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        fifo = FIFO(self.args_layout, depth=2, src_loc=self.src_loc)
+        fifo = BasicFifo(self.args_layout, depth=2, src_loc=self.src_loc)
         forwarder = Forwarder(self.results_layout, src_loc=self.src_loc)
 
         m.submodules.fifo = fifo
@@ -91,6 +92,8 @@ class ArgumentsToResultsZipper(Elaboratable):
             args = fifo.read(m)
             results = forwarder.read(m)
             return {"args": args, "results": results}
+
+        self.peek_arg.proxy(m, fifo.peek)
 
         return m
 


### PR DESCRIPTION
While working on the superscalar frontend, I found a bug when occurred when refilling a cache line.

Exact way to reproduce it:
- Issue two requests to the cache line. The first one should make a hit, the second one should cause an error when refilling.
- Wait some time before accepting any result
- Accept the first response
- Wait some time again
- Accept the second response
- Now the next request will return a response with an error bit set (even when there was a cache hit)

I added a test for this case
I also (hopefully) simplified the flow in the instruction cache.