### PR TITLE
Cache cocotb-config

### DIFF
--- a/test/regression/cocotb/cocotb-config
+++ b/test/regression/cocotb/cocotb-config
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+COCOTB_CONFIG=`which -a cocotb-config | tail -n 1`
+
 if [ ! -f "cocotb-config.cache" ]; then
-    cocotb-config --python-bin >> cocotb-config.cache
-    cocotb-config --prefix >> cocotb-config.cache
-    cocotb-config --makefiles >> cocotb-config.cache
-    cocotb-config --lib-dir >> cocotb-config.cache
-    cocotb-config --libpython >> cocotb-config.cache
+    $COCOTB_CONFIG --python-bin >> cocotb-config.cache
+    $COCOTB_CONFIG --prefix >> cocotb-config.cache
+    $COCOTB_CONFIG --makefiles >> cocotb-config.cache
+    $COCOTB_CONFIG --lib-dir >> cocotb-config.cache
+    $COCOTB_CONFIG --libpython >> cocotb-config.cache
 fi
 
 case $1 in

--- a/test/regression/cocotb/cocotb-config
+++ b/test/regression/cocotb/cocotb-config
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ ! -f "cocotb-config.cache" ]; then
+    cocotb-config --python-bin >> cocotb-config.cache
+    cocotb-config --prefix >> cocotb-config.cache
+    cocotb-config --makefiles >> cocotb-config.cache
+    cocotb-config --lib-dir >> cocotb-config.cache
+    cocotb-config --libpython >> cocotb-config.cache
+fi
+
+case $1 in
+    "--python-bin") N=1 ;;
+    "--prefix") N=2 ;;
+    "--makefiles") N=3 ;;
+    "--lib-dir") N=4 ;;
+    "--libpython") N=5 ;;
+esac
+
+sed "${N}q;d" cocotb-config.cache
+

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -73,7 +73,10 @@ def regression_body_with_cocotb(test_name: str, traces: bool):
     if traces:
         arglist += ["TRACES=1"]
 
-    res = subprocess.run(arglist)
+    my_env = dict(os.environ)
+    my_env["PATH"] = os.path.join(os.getcwd(), "test/regression/cocotb") + ":" + my_env["PATH"]
+
+    res = subprocess.run(arglist, env=my_env)
 
     assert res.returncode == 0
 


### PR DESCRIPTION
It turns out that `cocotb-config`, which is run multiple times for each cocotb run, has quite a lot of overhead. Thankfully, for a given installation, it always returns the same values, so they can be cached. This PR drastically reduces regression test run time, especially on multicore machines.