### PR TITLE
Fix logging handler connection

### DIFF
--- a/transactron/testing/logging.py
+++ b/transactron/testing/logging.py
@@ -67,7 +67,7 @@ def make_logging_process(level: tlog.LogLevel, namespace_regexp: str, on_error: 
     ch = logging.StreamHandler()
     formatter = _LogFormatter()
     ch.setFormatter(formatter)
-    root_logger.handlers = [ch]
+    root_logger.handlers += [ch]
 
     def handle_logs():
         if not (yield combined_trigger):


### PR DESCRIPTION
In #642 I have found that capturing logs with `pytest` doesn't work, it was because of bug in our code, where we substitute all log handlers with our handler instead of appending it. Here is a small fix for that.