### PR TITLE
ROB refactor

### DIFF
--- a/coreblocks/core_structs/rob.py
+++ b/coreblocks/core_structs/rob.py
@@ -70,7 +70,6 @@ class ReorderBuffer(Elaboratable):
             m.d.av_comb += write_port.addr.eq(end_idx)
             m.d.av_comb += write_port.data.eq(arg)
             m.d.comb += write_port.en.eq(1)
-            m.d.sync += self.done[end_idx].eq(0)
             m.d.sync += end_idx.eq(end_idx + 1)
             return end_idx
 

--- a/coreblocks/core_structs/rob.py
+++ b/coreblocks/core_structs/rob.py
@@ -42,6 +42,8 @@ class ReorderBuffer(Elaboratable):
         peek_possible = start_idx != end_idx
         put_possible = (end_idx + 1)[0 : len(end_idx)] != start_idx
 
+        done = Array(Signal() for _ in range(2**self.params.rob_entries_bits))
+
         @def_method(m, self.peek, ready=peek_possible)
         def _():
             return {
@@ -50,17 +52,17 @@ class ReorderBuffer(Elaboratable):
                 "exception": self.data[start_idx].exception,
             }
 
-        @def_method(m, self.retire, ready=self.data[start_idx].done)
+        @def_method(m, self.retire, ready=done[start_idx])
         def _():
             self.perf_rob_wait_time.stop(m)
             m.d.sync += start_idx.eq(start_idx + 1)
-            m.d.sync += self.data[start_idx].done.eq(0)
+            m.d.sync += done[start_idx].eq(0)
 
         @def_method(m, self.put, ready=put_possible)
         def _(arg):
             self.perf_rob_wait_time.start(m)
             m.d.sync += self.data[end_idx].rob_data.eq(arg)
-            m.d.sync += self.data[end_idx].done.eq(0)
+            m.d.sync += done[end_idx].eq(0)
             m.d.sync += end_idx.eq(end_idx + 1)
             return end_idx
 
@@ -69,7 +71,7 @@ class ReorderBuffer(Elaboratable):
         # could mark fields in ROB as done when they shouldn't.
         @def_method(m, self.mark_done)
         def _(rob_id: Value, exception):
-            m.d.sync += self.data[rob_id].done.eq(1)
+            m.d.sync += done[rob_id].eq(1)
             m.d.sync += self.data[rob_id].exception.eq(exception)
 
         @def_method(m, self.get_indices)

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -258,11 +258,6 @@ class ROBLayouts:
 
         self.id_layout = make_layout(fields.rob_id)
 
-        self.internal_layout = make_layout(
-            self.rob_data,
-            fields.exception,
-        )
-
         self.mark_done_layout = make_layout(
             fields.rob_id,
             fields.exception,

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -260,7 +260,6 @@ class ROBLayouts:
 
         self.internal_layout = make_layout(
             self.rob_data,
-            self.done,
             fields.exception,
         )
 

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -3,10 +3,11 @@ import random
 from collections import namedtuple, deque
 from typing import Callable, Optional, Iterable
 from amaranth import *
+from amaranth.lib.data import View
 from amaranth.sim import Settle
 from parameterized import parameterized_class
 from coreblocks.interface.keys import CoreStateKey
-from coreblocks.interface.layouts import RetirementLayouts
+from coreblocks.interface.layouts import ROBLayouts, RetirementLayouts
 from coreblocks.func_blocks.fu.common.rs_func_block import RSBlockComponent
 
 from transactron.core import Method
@@ -267,7 +268,9 @@ class TestScheduler(TestCaseWithSimulator):
 
     def make_output_process(self, io: TestbenchIO, output_queues: Iterable[deque]):
         def check(got, expected):
-            rl_dst = yield self.m.rob.data[got["rs_data"]["rob_id"]].rob_data.rl_dst
+            rl_dst = yield View(
+                self.gen_params.get(ROBLayouts).data_layout, self.m.rob.data[got["rs_data"]["rob_id"]]
+            ).rl_dst
             s1 = self.rf_state[expected["rp_s1"]]
             s2 = self.rf_state[expected["rp_s2"]]
 


### PR DESCRIPTION
This PR modifies the ROB to use a `Memory` for data storage. On ECP5, it looks like all this did was reducing the "LUTs used as DFF" metric.

https://github.com/kuznia-rdzeni/coreblocks/actions/runs/8649428131