### PR TITLE
Remove assertNotNone typechecker workarounds

### DIFF
--- a/test/scheduler/test_wakeup_select.py
+++ b/test/scheduler/test_wakeup_select.py
@@ -101,7 +101,6 @@ class TestWakeupSelect(TestCaseWithSimulator):
                 take_position = cast(int, take_position["rs_entry_id"])
                 entry = rs[take_position]
                 assert entry is not None
-                entry = cast(RecordIntDict, entry)  # for type checking
 
                 self.taken.append(entry)
                 yield from self.m.take_row_mock.call_init(entry)

--- a/test/stages/test_backend.py
+++ b/test/stages/test_backend.py
@@ -135,10 +135,6 @@ class TestBackend(TestCaseWithSimulator):
             assert rs_result is not None
             assert rob_result is not None
 
-            # this is needed to make the typechecker happy
-            if rf_result is None or rs_result is None or rob_result is None:
-                continue
-
             assert rf_result["reg_val"] == rs_result["value"]
             assert rf_result["reg_id"] == rs_result["reg_id"]
 

--- a/test/structs_common/test_csr.py
+++ b/test/structs_common/test_csr.py
@@ -246,7 +246,7 @@ class TestCSRRegister(TestCaseWithSimulator):
 
             read_result = yield from self.dut.read.call_result()
             assert read_result is not None
-            previous_data = read_result["data"]  # type: ignore
+            previous_data = read_result["data"]
 
             yield from self.dut._fu_read.disable()
             yield from self.dut._fu_write.disable()

--- a/test/transactions/test_transaction_lib.py
+++ b/test/transactions/test_transaction_lib.py
@@ -358,10 +358,6 @@ class TestManyToOneConnectTrans(TestCaseWithSimulator):
 
             assert result is not None
 
-            # this is needed to make the typechecker happy
-            if result is None:
-                continue
-
             t = (result["field1"], result["field2"])
             assert t in self.expected_output
             if self.expected_output[t] == 1:


### PR DESCRIPTION
Closes #243 

After switch to pytest, we no longer use `self.assertNotNone()`, but plain asserts, which are recognized correctly by the typechecker.