### PR TITLE
Support for UnionLayout in assign and other changes

### DIFF
--- a/test/transactron/test_assign.py
+++ b/test/transactron/test_assign.py
@@ -18,19 +18,34 @@ class ExampleEnum(Enum, shape=1):
     ONE = 1
 
 
+def with_reversed(pairs: list[tuple[str, str]]):
+    return pairs + [(b, a) for (a, b) in pairs]
+
+
 layout_a = [("a", 1)]
 layout_ab = [("a", 1), ("b", 2)]
 layout_ac = [("a", 1), ("c", 3)]
 layout_a_alt = [("a", 2)]
 layout_a_enum = [("a", ExampleEnum)]
 
-params_build_wrap_extr = [
-    ("normal", lambda mk, lay: mk(lay), lambda x: x, lambda r: r),
-    ("rec", lambda mk, lay: mk([("x", lay)]), lambda x: {"x": x}, lambda r: r.x),
-    ("dict", lambda mk, lay: {"x": mk(lay)}, lambda x: {"x": x}, lambda r: r["x"]),
-    ("list", lambda mk, lay: [mk(lay)], lambda x: {0: x}, lambda r: r[0]),
-    ("array", lambda mk, lay: Signal(data.ArrayLayout(reclayout2datalayout(lay), 1)), lambda x: {0: x}, lambda r: r[0]),
-]
+# Defines functions build, wrap, extr used in TestAssign
+params_funs = {
+    "normal": (lambda mk, lay: mk(lay), lambda x: x, lambda r: r),
+    "rec": (lambda mk, lay: mk([("x", lay)]), lambda x: {"x": x}, lambda r: r.x),
+    "dict": (lambda mk, lay: {"x": mk(lay)}, lambda x: {"x": x}, lambda r: r["x"]),
+    "list": (lambda mk, lay: [mk(lay)], lambda x: {0: x}, lambda r: r[0]),
+    "union": (
+        lambda mk, lay: Signal(data.UnionLayout({"x": reclayout2datalayout(lay)})),
+        lambda x: {"x": x},
+        lambda r: r.x,
+    ),
+    "array": (lambda mk, lay: Signal(data.ArrayLayout(reclayout2datalayout(lay), 1)), lambda x: {0: x}, lambda r: r[0]),
+}
+
+
+params_pairs = [(k, k) for k in params_funs if k != "union"] + with_reversed(
+    [("rec", "dict"), ("list", "array"), ("union", "dict")]
+)
 
 
 def mkproxy(layout):
@@ -56,52 +71,58 @@ params_mk = [
 
 
 @parameterized_class(
-    ["name", "build", "wrap", "extr", "mk"],
+    ["name", "buildl", "wrapl", "extrl", "buildr", "wrapr", "extrr", "mk"],
     [
-        (f"{n}_{c}", *map(staticmethod, (b, w, e)), staticmethod(m))
-        for n, b, w, e in params_build_wrap_extr
+        (f"{nl}_{nr}_{c}", *map(staticmethod, params_funs[nl] + params_funs[nr] + (m,)))
+        for nl, nr in params_pairs
         for c, m in params_mk
     ],
 )
 class TestAssign(TestCase):
     # constructs `assign` arguments (views, proxies, dicts) which have an "inner" and "outer" part
     # parameterized with a constructor and a layout of the inner part
-    build: Callable[[Callable[[MethodLayout], AssignArg], MethodLayout], AssignArg]
+    buildl: Callable[[Callable[[MethodLayout], AssignArg], MethodLayout], AssignArg]
+    buildr: Callable[[Callable[[MethodLayout], AssignArg], MethodLayout], AssignArg]
     # constructs field specifications for `assign`, takes field specifications for the inner part
-    wrap: Callable[[AssignFields], AssignFields]
+    wrapl: Callable[[AssignFields], AssignFields]
+    wrapr: Callable[[AssignFields], AssignFields]
     # extracts the inner part of the structure
-    extr: Callable[[AssignArg], ArrayProxy]
+    extrl: Callable[[AssignArg], ArrayProxy]
+    extrr: Callable[[AssignArg], ArrayProxy]
     # constructor, takes a layout
     mk: Callable[[MethodLayout], AssignArg]
 
+    def test_wraps_eq(self):
+        assert self.wrapl({}) == self.wrapr({})
+
     def test_rhs_exception(self):
         with pytest.raises(KeyError):
-            list(assign(self.build(self.mk, layout_a), self.build(self.mk, layout_ab), fields=AssignType.RHS))
+            list(assign(self.buildl(self.mk, layout_a), self.buildr(self.mk, layout_ab), fields=AssignType.RHS))
         with pytest.raises(KeyError):
-            list(assign(self.build(self.mk, layout_ab), self.build(self.mk, layout_ac), fields=AssignType.RHS))
+            list(assign(self.buildl(self.mk, layout_ab), self.buildr(self.mk, layout_ac), fields=AssignType.RHS))
 
     def test_all_exception(self):
         with pytest.raises(KeyError):
-            list(assign(self.build(self.mk, layout_a), self.build(self.mk, layout_ab), fields=AssignType.ALL))
+            list(assign(self.buildl(self.mk, layout_a), self.buildr(self.mk, layout_ab), fields=AssignType.ALL))
         with pytest.raises(KeyError):
-            list(assign(self.build(self.mk, layout_ab), self.build(self.mk, layout_a), fields=AssignType.ALL))
+            list(assign(self.buildl(self.mk, layout_ab), self.buildr(self.mk, layout_a), fields=AssignType.ALL))
         with pytest.raises(KeyError):
-            list(assign(self.build(self.mk, layout_ab), self.build(self.mk, layout_ac), fields=AssignType.ALL))
+            list(assign(self.buildl(self.mk, layout_ab), self.buildr(self.mk, layout_ac), fields=AssignType.ALL))
 
     def test_missing_exception(self):
         with pytest.raises(KeyError):
-            list(assign(self.build(self.mk, layout_a), self.build(self.mk, layout_ab), fields=self.wrap({"b"})))
+            list(assign(self.buildl(self.mk, layout_a), self.buildr(self.mk, layout_ab), fields=self.wrapl({"b"})))
         with pytest.raises(KeyError):
-            list(assign(self.build(self.mk, layout_ab), self.build(self.mk, layout_a), fields=self.wrap({"b"})))
+            list(assign(self.buildl(self.mk, layout_ab), self.buildr(self.mk, layout_a), fields=self.wrapl({"b"})))
         with pytest.raises(KeyError):
-            list(assign(self.build(self.mk, layout_a), self.build(self.mk, layout_a), fields=self.wrap({"b"})))
+            list(assign(self.buildl(self.mk, layout_a), self.buildr(self.mk, layout_a), fields=self.wrapl({"b"})))
 
     def test_wrong_bits(self):
         with pytest.raises(ValueError):
-            list(assign(self.build(self.mk, layout_a), self.build(self.mk, layout_a_alt)))
+            list(assign(self.buildl(self.mk, layout_a), self.buildr(self.mk, layout_a_alt)))
         if self.mk != mkproxy:  # Arrays are troublesome and defeat some checks
             with pytest.raises(ValueError):
-                list(assign(self.build(self.mk, layout_a), self.build(self.mk, layout_a_enum)))
+                list(assign(self.buildl(self.mk, layout_a), self.buildr(self.mk, layout_a_enum)))
 
     @parameterized.expand(
         [
@@ -114,12 +135,12 @@ class TestAssign(TestCase):
         ]
     )
     def test_assign_a(self, name, layout1: MethodLayout, layout2: MethodLayout, atype: AssignType):
-        lhs = self.build(self.mk, layout1)
-        rhs = self.build(self.mk, layout2)
-        alist = list(assign(lhs, rhs, fields=self.wrap(atype)))
+        lhs = self.buildl(self.mk, layout1)
+        rhs = self.buildr(self.mk, layout2)
+        alist = list(assign(lhs, rhs, fields=self.wrapl(atype)))
         assert len(alist) == 1
-        self.assertIs_AP(alist[0].lhs, self.extr(lhs).a)
-        self.assertIs_AP(alist[0].rhs, self.extr(rhs).a)
+        self.assertIs_AP(alist[0].lhs, self.extrl(lhs).a)
+        self.assertIs_AP(alist[0].rhs, self.extrr(rhs).a)
 
     def assertIs_AP(self, expr1, expr2):  # noqa: N802
         if isinstance(expr1, ArrayProxy) and isinstance(expr2, ArrayProxy):

--- a/transactron/utils/assign.py
+++ b/transactron/utils/assign.py
@@ -126,19 +126,19 @@ def assign(
     rhs_fields = assign_arg_fields(rhs)
 
     def rec_call(name: str | int):
-            subfields = fields
-            if isinstance(fields, Mapping):
-                subfields = fields[name]
-            elif isinstance(fields, Iterable):
-                subfields = AssignType.ALL
+        subfields = fields
+        if isinstance(fields, Mapping):
+            subfields = fields[name]
+        elif isinstance(fields, Iterable):
+            subfields = AssignType.ALL
 
-            return assign(
-                lhs[name],  # type: ignore
-                rhs[name],  # type: ignore
-                fields=subfields,
-                lhs_strict=isinstance(lhs, ValueLike),
-                rhs_strict=isinstance(rhs, ValueLike),
-            )
+        return assign(
+            lhs[name],  # type: ignore
+            rhs[name],  # type: ignore
+            fields=subfields,
+            lhs_strict=isinstance(lhs, ValueLike),
+            rhs_strict=isinstance(rhs, ValueLike),
+        )
 
     if lhs_fields is not None and rhs_fields is not None:
         # asserts for type checking

--- a/transactron/utils/assign.py
+++ b/transactron/utils/assign.py
@@ -3,7 +3,7 @@ from typing import Optional, TypeAlias, cast, TYPE_CHECKING
 from collections.abc import Sequence, Iterable, Mapping
 from amaranth import *
 from amaranth.hdl import ShapeLike, ValueCastable
-from amaranth.hdl._ast import ArrayProxy
+from amaranth.hdl._ast import ArrayProxy, Slice
 from amaranth.lib import data
 from ._typing import ValueLike
 
@@ -18,8 +18,9 @@ __all__ = [
 
 class AssignType(Enum):
     COMMON = 1
-    RHS = 2
-    ALL = 3
+    LHS = 2
+    RHS = 3
+    ALL = 4
 
 
 AssignFields: TypeAlias = AssignType | Iterable[str | int] | Mapping[str | int, "AssignFields"]
@@ -93,6 +94,9 @@ def assign(
 
         AssignType.COMMON
             Only fields common to `lhs` and `rhs` are assigned.
+        AssignType.LHS
+            All fields in `lhs` are assigned. If one of them is not present
+            in `rhs`, an exception is raised.
         AssignType.RHS
             All fields in `rhs` are assigned. If one of them is not present
             in `lhs`, an exception is raised.
@@ -134,6 +138,8 @@ def assign(
 
         if fields is AssignType.COMMON:
             names = lhs_fields & rhs_fields
+        elif fields is AssignType.LHS:
+            names = lhs_fields
         elif fields is AssignType.RHS:
             names = rhs_fields
         elif fields is AssignType.ALL:
@@ -160,8 +166,8 @@ def assign(
                 lhs[name],  # type: ignore
                 rhs[name],  # type: ignore
                 fields=subfields,
-                lhs_strict=not isinstance(lhs, Mapping),
-                rhs_strict=not isinstance(rhs, Mapping),
+                lhs_strict=isinstance(lhs, ValueLike),
+                rhs_strict=isinstance(rhs, ValueLike),
             )
     else:
         if not isinstance(fields, AssignType):
@@ -170,17 +176,19 @@ def assign(
             raise TypeError("Unsupported assignment lhs: {} rhs: {}".format(lhs, rhs))
 
         # If a single-value structure, assign its only field
-        if lhs_fields is not None and len(lhs_fields) == 1:
+        while lhs_fields is not None and len(lhs_fields) == 1:
             lhs = lhs[next(iter(lhs_fields))]  # type: ignore
-        if rhs_fields is not None and len(rhs_fields) == 1:
+            lhs_fields = assign_arg_fields(lhs)
+        while rhs_fields is not None and len(rhs_fields) == 1:
             rhs = rhs[next(iter(rhs_fields))]  # type: ignore
+            rhs_fields = assign_arg_fields(rhs)
 
         def has_explicit_shape(val: ValueLike):
-            return isinstance(val, Signal) or isinstance(val, ArrayProxy)
+            return isinstance(val, (Signal, ArrayProxy, Slice, ValueCastable))
 
         if (
-            isinstance(lhs, data.View)
-            or isinstance(rhs, data.View)
+            isinstance(lhs, ValueCastable)
+            or isinstance(rhs, ValueCastable)
             or (lhs_strict or has_explicit_shape(lhs))
             and (rhs_strict or has_explicit_shape(rhs))
         ):


### PR DESCRIPTION
I decided to abandon the automatic union field selection idea and implemented an explicit form of assignment. The behavior implemented is:

* If an union is assigned to an union, they need to be identical. This is handled by the general unstructured case.
* If an union is assigned to a dict (or vice versa), the dict is required to be a singleton. The field named in the dict is assigned.

This should allow simple usage of unions in method calls and method return values.

Additional changes are:

* All `ValueCastable`s are treated strictly, not just `View`s. This enforces strictness in `Enum` assignment: if an `Enum` is assigned, it needs to be assigned from the same type of `Enum`.
* Single-field structure exception is now applied recursively, for graceful handling of weird corner cases.