### PR TITLE
Reverse precommit

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -12,7 +12,6 @@ from coreblocks.interface.keys import (
     BranchVerifyKey,
     FetchResumeKey,
     GenericCSRRegistersKey,
-    InstructionPrecommitKey,
     CommonBusDataKey,
     FlushICacheKey,
 )
@@ -97,7 +96,7 @@ class Core(Elaboratable):
         self.func_blocks_unifier = FuncBlocksUnifier(
             gen_params=gen_params,
             blocks=gen_params.func_units_config,
-            extra_methods_required=[InstructionPrecommitKey(), FetchResumeKey()],
+            extra_methods_required=[FetchResumeKey()],
         )
 
         self.announcement = ResultAnnouncement(
@@ -173,7 +172,6 @@ class Core(Elaboratable):
             r_rat_peek=rrat.peek,
             free_rf_put=free_rf_fifo.write,
             rf_free=rf.free,
-            precommit=self.func_blocks_unifier.get_extra_method(InstructionPrecommitKey()),
             exception_cause_get=self.exception_cause_register.get,
             exception_cause_clear=self.exception_cause_register.clear,
             frat_rename=frat.rename,

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from transactron.lib.dependencies import SimpleKey, UnifierKey, ListKey
 from transactron import Method
-from transactron.lib import MethodTryProduct, Collector
+from transactron.lib import Collector
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
 from amaranth import Signal
 
@@ -32,7 +32,7 @@ class CommonBusDataKey(SimpleKey[BusMasterInterface]):
 
 
 @dataclass(frozen=True)
-class InstructionPrecommitKey(UnifierKey, unifier=MethodTryProduct):
+class InstructionPrecommitKey(SimpleKey[Method]):
     pass
 
 

--- a/test/func_blocks/csr/test_csr.py
+++ b/test/func_blocks/csr/test_csr.py
@@ -8,8 +8,8 @@ from coreblocks.priv.csr.csr_register import CSRRegister
 from coreblocks.params import GenParams
 from coreblocks.frontend.decoder import Funct3, ExceptionCause, OpType
 from coreblocks.params.configurations import test_core_config
-from coreblocks.interface.layouts import ExceptionRegisterLayouts
-from coreblocks.interface.keys import AsyncInterruptInsertSignalKey, ExceptionReportKey
+from coreblocks.interface.layouts import ExceptionRegisterLayouts, RetirementLayouts
+from coreblocks.interface.keys import AsyncInterruptInsertSignalKey, ExceptionReportKey, InstructionPrecommitKey
 from transactron.utils.dependencies import DependencyManager
 
 from transactron.testing import *
@@ -24,13 +24,17 @@ class CSRUnitTestCircuit(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
+        m.submodules.precommit = self.precommit = TestbenchIO(
+            Adapter(o=self.gen_params.get(RetirementLayouts).precommit, nonexclusive=True)
+        )
+        self.gen_params.get(DependencyManager).add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
+
         m.submodules.dut = self.dut = CSRUnit(self.gen_params)
 
         m.submodules.select = self.select = TestbenchIO(AdapterTrans(self.dut.select))
         m.submodules.insert = self.insert = TestbenchIO(AdapterTrans(self.dut.insert))
         m.submodules.update = self.update = TestbenchIO(AdapterTrans(self.dut.update))
         m.submodules.accept = self.accept = TestbenchIO(AdapterTrans(self.dut.get_result))
-        m.submodules.precommit = self.precommit = TestbenchIO(AdapterTrans(self.dut.precommit))
         m.submodules.exception_report = self.exception_report = TestbenchIO(
             Adapter(i=self.gen_params.get(ExceptionRegisterLayouts).report)
         )

--- a/test/func_blocks/lsu/test_pma.py
+++ b/test/func_blocks/lsu/test_pma.py
@@ -6,9 +6,9 @@ from coreblocks.params import GenParams
 from coreblocks.func_blocks.fu.lsu.dummyLsu import LSUDummy
 from coreblocks.params.configurations import test_core_config
 from coreblocks.frontend.decoder import *
-from coreblocks.interface.keys import ExceptionReportKey
+from coreblocks.interface.keys import ExceptionReportKey, InstructionPrecommitKey
 from transactron.utils.dependencies import DependencyManager
-from coreblocks.interface.layouts import ExceptionRegisterLayouts
+from coreblocks.interface.layouts import ExceptionRegisterLayouts, RetirementLayouts
 from coreblocks.peripherals.wishbone import *
 from transactron.testing import TestbenchIO, TestCaseWithSimulator, def_method_mock
 from coreblocks.peripherals.bus_adapter import WishboneMasterAdapter
@@ -64,11 +64,15 @@ class PMAIndirectTestCircuit(Elaboratable):
 
         self.gen.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
 
+        m.submodules.precommit = self.precommit = TestbenchIO(
+            Adapter(o=self.gen.get(RetirementLayouts).precommit, nonexclusive=True)
+        )
+        self.gen.get(DependencyManager).add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
+
         m.submodules.func_unit = func_unit = LSUDummy(self.gen, self.bus_master_adapter)
 
         m.submodules.issue_mock = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))
         m.submodules.accept_mock = self.accept = TestbenchIO(AdapterTrans(func_unit.accept))
-        m.submodules.precommit_mock = self.precommit = TestbenchIO(AdapterTrans(func_unit.precommit))
         self.io_in = WishboneInterfaceWrapper(self.bus.wb_master)
         m.submodules.bus = self.bus
         m.submodules.bus_master_adapter = self.bus_master_adapter


### PR DESCRIPTION
The `precommit` mechanism is currently implemented by retirement calling the precommit method on various functional units and blocks. This had the problem (which we experienced previously) that having method calls in these methods can lead to performance issues, which we fixed by using a `TryProduct`. Still, the architecture seems somewhat backwards: the `precommit` methods are almost always called, in all the units at once - in a way, retirement "broadcasts" some information via a method.

A simpler way to achieve this would be to reverse the calling direction, which I did in this PR. The retirement module defines the precommit method, which is nonexclusive and called from functional units and blocks.

The change looks pretty much cosmetic, but I have in mind another change, which would slightly simplify the implementations of units and eliminate the error-prone `rob_id` comparisons.