### PR TITLE
Restore TransactionManager's debug signals

### DIFF
--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -481,6 +481,8 @@ class TransactionModule(Elaboratable):
         m = Module()
 
         m.submodules.main_module = elaboratable
-        m.submodules.transactionManager = self.manager.get_dependency(TransactionManagerKey())
+        m.submodules.transactionManager = self.transaction_manager = self.manager.get_dependency(
+            TransactionManagerKey()
+        )
 
         return m


### PR DESCRIPTION
This PR restores the debug signals of TransactionManager, which can help debug things like transactions not firing when they are supposed to.