### PR TITLE
Fix fetcher throughput

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -93,9 +93,6 @@ class FetchUnit(Elaboratable):
         def flush():
             m.d.comb += flush_now.eq(1)
 
-        with m.If(flush_now):
-            m.d.sync += flushing_counter.eq(req_counter.count_next)
-
         current_pc = Signal(self.gen_params.isa.xlen, reset=self.gen_params.start_pc)
 
         stalled_unsafe = Signal()
@@ -364,6 +361,9 @@ class FetchUnit(Elaboratable):
                     serializer.write(m, valid_mask=fetch_mask, slots=raw_instrs)
                 with branch(flushing_counter != 0):
                     m.d.sync += flushing_counter.eq(flushing_counter - 1)
+
+        with m.If(flush_now):
+            m.d.sync += flushing_counter.eq(req_counter.count_next)
 
         @def_method(m, self.resume, ready=(stalled & (flushing_counter == 0)))
         def _(pc: Value, resume_from_exception: Value):


### PR DESCRIPTION
The second stage of the fetcher couldn't proceed with flushing when the output method was not ready, which limited the fetch throughput. This PR fixes that.

This change makes the loop in the `fibonacci` test run at IPC=1 basically, instead of 0.66 (there were two unnecessary wait cycles which this PR removes).

Edit: Looks like this change somehow uncovered a correctness problem.