### PR TITLE
Stall fetch on JALR instruction

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -287,7 +287,9 @@ class FetchUnit(Elaboratable):
                 )
 
                 # If there was an access fault, mark every instruction as unsafe
-                m.d.av_comb += instr_unsafe[i].eq(predecoders[i].is_unsafe | access_fault)
+                m.d.av_comb += instr_unsafe[i].eq(
+                    predecoders[i].is_unsafe | access_fault | (predecoders[i].cfi_type == CfiType.JALR)
+                )
 
             m.submodules.prio_encoder = prio_encoder = PriorityEncoder(fetch_width)
             m.d.av_comb += prio_encoder.i.eq((Cat(instr_unsafe) | Cat(instr_redirects)) & instr_valid)


### PR DESCRIPTION
If we don't have a prediction for the target of a JALR instruction (so always now), the best we can do is to stall the fetch unit.