### PR TITLE
Precommit using validate_arguments

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -60,8 +60,10 @@ class Retirement(Elaboratable):
         self.core_state = Method(o=self.gen_params.get(RetirementLayouts).core_state, nonexclusive=True)
         self.dependency_manager.add_dependency(CoreStateKey(), self.core_state)
 
+        # The argument is only used in argument validation, it is not needed in the method body.
+        # A dummy combiner is provided.
         self.precommit = Method(
-            i=layouts.precommit_in, o=layouts.precommit_out, nonexclusive=True, combiner=lambda m, args, runs: args[0]
+            i=layouts.precommit_in, o=layouts.precommit_out, nonexclusive=True, combiner=lambda m, args, runs: 0
         )
         self.dependency_manager.add_dependency(InstructionPrecommitKey(), self.precommit)
 

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -142,11 +142,10 @@ class LSUDummy(FuncUnit, Elaboratable):
 
         with Transaction().body(m):
             precommit = self.dependency_manager.get_dependency(InstructionPrecommitKey())
-            info = precommit(m)
-            with m.If(info.rob_id == request_rob_id):
-                m.d.comb += rob_id_match.eq(1)
+            info = precommit(m, request_rob_id)
+            m.d.comb += rob_id_match.eq(1)
             with m.If(~info.side_fx):
-                m.d.comb += flush.eq(1)
+                m.d.av_comb += flush.eq(1)
 
         return m
 

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -15,7 +15,7 @@ from coreblocks.interface.layouts import LSULayouts, FuncUnitLayouts
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 from coreblocks.func_blocks.fu.lsu.pma import PMAChecker
 from coreblocks.func_blocks.fu.lsu.lsu_requester import LSURequester
-from coreblocks.interface.keys import ExceptionReportKey, CommonBusDataKey, InstructionPrecommitKey
+from coreblocks.interface.keys import CoreStateKey, ExceptionReportKey, CommonBusDataKey, InstructionPrecommitKey
 
 __all__ = ["LSUDummy", "LSUComponent"]
 
@@ -54,6 +54,11 @@ class LSUDummy(FuncUnit, Elaboratable):
     def elaborate(self, platform):
         m = TModule()
         flush = Signal()  # exception handling, requests are not issued
+
+        with Transaction().body(m):
+            core_state = self.dependency_manager.get_dependency(CoreStateKey())
+            state = core_state(m)
+            m.d.comb += flush.eq(state.flushing)
 
         # Signals for handling issue logic
         request_rob_id = Signal(self.gen_params.rob_entries_bits)
@@ -142,10 +147,8 @@ class LSUDummy(FuncUnit, Elaboratable):
 
         with Transaction().body(m):
             precommit = self.dependency_manager.get_dependency(InstructionPrecommitKey())
-            info = precommit(m, request_rob_id)
+            precommit(m, request_rob_id)
             m.d.comb += rob_id_match.eq(1)
-            with m.If(~info.side_fx):
-                m.d.av_comb += flush.eq(1)
 
         return m
 

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -105,27 +105,27 @@ class PrivilegedFuncUnit(Elaboratable):
             m.d.sync += finished.eq(1)
             self.perf_instr.incr(m, instr_fn, cond=info.side_fx)
 
-                priv_data = priv_mode.read(m).data
+            priv_data = priv_mode.read(m).data
 
-                illegal_mret = (instr_fn == PrivilegedFn.Fn.MRET) & (priv_data != PrivilegeLevel.MACHINE)
-                # future todo: WFI should be illegal in U-Mode only if S-Mode is supported
-                illegal_wfi = (
-                    (instr_fn == PrivilegedFn.Fn.WFI)
-                    & (priv_data == PrivilegeLevel.USER)
-                    & csr.m_mode.mstatus_tw.read(m).data
-                )
+            illegal_mret = (instr_fn == PrivilegedFn.Fn.MRET) & (priv_data != PrivilegeLevel.MACHINE)
+            # future todo: WFI should be illegal in U-Mode only if S-Mode is supported
+            illegal_wfi = (
+                (instr_fn == PrivilegedFn.Fn.WFI)
+                & (priv_data == PrivilegeLevel.USER)
+                & csr.m_mode.mstatus_tw.read(m).data
+            )
 
-                with condition(m, nonblocking=True) as branch:
-                    with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.MRET) & ~illegal_mret):
-                        mret(m)
-                    with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.FENCEI)):
-                        flush_icache(m)
-                    with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.WFI) & ~illegal_wfi):
-                        # async_interrupt_active implies wfi_resume. WFI should continue normal execution
-                        # when interrupt is enabled in xie, but disabled via global mstatus.xIE
-                        m.d.sync += finished.eq(wfi_resume)
+            with condition(m, nonblocking=True) as branch:
+                with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.MRET) & ~illegal_mret):
+                    mret(m)
+                with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.FENCEI)):
+                    flush_icache(m)
+                with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.WFI) & ~illegal_wfi):
+                    # async_interrupt_active implies wfi_resume. WFI should continue normal execution
+                    # when interrupt is enabled in xie, but disabled via global mstatus.xIE
+                    m.d.sync += finished.eq(wfi_resume)
 
-                m.d.sync += illegal_instruction.eq(illegal_wfi | illegal_mret)
+            m.d.sync += illegal_instruction.eq(illegal_wfi | illegal_mret)
 
         @def_method(m, self.accept, ready=instr_valid & finished)
         def _():

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -101,10 +101,9 @@ class PrivilegedFuncUnit(Elaboratable):
 
         with Transaction().body(m, request=instr_valid & ~finished):
             precommit = self.dm.get_dependency(InstructionPrecommitKey())
-            info = precommit(m)
-            with m.If(info.rob_id == instr_rob):
-                m.d.sync += finished.eq(1)
-                self.perf_instr.incr(m, instr_fn, cond=info.side_fx)
+            info = precommit(m, instr_rob)
+            m.d.sync += finished.eq(1)
+            self.perf_instr.incr(m, instr_fn, cond=info.side_fx)
 
                 priv_data = priv_mode.read(m).data
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -355,7 +355,9 @@ class RetirementLayouts:
     def __init__(self, gen_params: GenParams):
         fields = gen_params.get(CommonLayoutFields)
 
-        self.precommit = make_layout(fields.rob_id, fields.side_fx)
+        self.precommit_in = make_layout(fields.rob_id)
+
+        self.precommit_out = make_layout(fields.side_fx)
 
         self.flushing = ("flushing", 1)
         """ Core is currently flushed """
@@ -581,10 +583,6 @@ class LSULayouts:
     def __init__(self, gen_params: GenParams):
         fields = gen_params.get(CommonLayoutFields)
 
-        retirement = gen_params.get(RetirementLayouts)
-
-        self.precommit = retirement.precommit
-
         self.store: LayoutListField = ("store", 1)
 
         self.issue = make_layout(fields.addr, fields.data, fields.funct3, self.store)
@@ -637,10 +635,6 @@ class CSRUnitLayouts:
         )
 
         self.rs = gen_params.get(RSInterfaceLayouts, rs_entries_bits=self.rs_entries_bits, data_layout=data_layout)
-
-        retirement = gen_params.get(RetirementLayouts)
-
-        self.precommit = retirement.precommit
 
 
 class ExceptionRegisterLayouts:

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -147,13 +147,10 @@ class TestRetirement(TestCaseWithSimulator):
         assert not self.rf_free_q
 
     def precommit_process(self):
-        yield from self.retc.precommit_adapter.call_init()
         while self.precommit_q:
-            yield Tick()
-            info = yield from self.retc.precommit_adapter.call_result()
+            info = yield from self.retc.precommit_adapter.call_try(rob_id=self.precommit_q[0])
             assert info is not None
             assert info["side_fx"]
-            assert self.precommit_q[0] == info["rob_id"]
             self.precommit_q.popleft()
 
     @def_method_mock(lambda self: self.retc.mock_rf_free, sched_prio=2)

--- a/test/func_blocks/lsu/test_pma.py
+++ b/test/func_blocks/lsu/test_pma.py
@@ -6,7 +6,7 @@ from coreblocks.params import GenParams
 from coreblocks.func_blocks.fu.lsu.dummyLsu import LSUDummy
 from coreblocks.params.configurations import test_core_config
 from coreblocks.arch import *
-from coreblocks.interface.keys import ExceptionReportKey, InstructionPrecommitKey
+from coreblocks.interface.keys import CoreStateKey, ExceptionReportKey, InstructionPrecommitKey
 from transactron.utils.dependencies import DependencyContext
 from coreblocks.interface.layouts import ExceptionRegisterLayouts, RetirementLayouts
 from coreblocks.peripherals.wishbone import *
@@ -75,6 +75,9 @@ class PMAIndirectTestCircuit(Elaboratable):
         )
         DependencyContext.get().add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
 
+        m.submodules.core_state = self.core_state = TestbenchIO(Adapter(o=layouts.core_state, nonexclusive=True))
+        DependencyContext.get().add_dependency(CoreStateKey(), self.core_state.adapter.iface)
+
         m.submodules.func_unit = func_unit = LSUDummy(self.gen, self.bus_master_adapter)
 
         m.submodules.issue_mock = self.issue = TestbenchIO(AdapterTrans(func_unit.issue))
@@ -133,6 +136,10 @@ class TestPMAIndirect(TestCaseWithSimulator):
         @def_method_mock(lambda: self.test_module.exception_report)
         def exception_consumer(arg):
             assert False
+
+        @def_method_mock(lambda: self.test_module.core_state)
+        def core_state_process():
+            return {"flushing": 0}
 
         with self.run_simulation(self.test_module) as sim:
             sim.add_process(self.process)

--- a/transactron/testing/testbenchio.py
+++ b/transactron/testing/testbenchio.py
@@ -99,6 +99,7 @@ class TestbenchIO(Elaboratable):
         enable: Optional[Callable[[], bool]] = None,
         validate_arguments: Optional[Callable[..., bool]] = None,
         extra_settle_count: int = 0,
+        disable_after: bool = True,
     ) -> TestGen[None]:
         enable = enable or (lambda: True)
         yield from self.set_enable(enable())
@@ -127,6 +128,7 @@ class TestbenchIO(Elaboratable):
         ret_out = mock_def_helper(self, function, arg)
         yield from self.method_return(ret_out or {})
         yield Tick()
+        yield from self.set_enable(False)
 
     def method_handle_loop(
         self,
@@ -139,7 +141,11 @@ class TestbenchIO(Elaboratable):
         yield Passive()
         while True:
             yield from self.method_handle(
-                function, enable=enable, validate_arguments=validate_arguments, extra_settle_count=extra_settle_count
+                function,
+                enable=enable,
+                validate_arguments=validate_arguments,
+                extra_settle_count=extra_settle_count,
+                disable_after=False,
             )
 
     # Debug signals

--- a/transactron/testing/testbenchio.py
+++ b/transactron/testing/testbenchio.py
@@ -99,7 +99,6 @@ class TestbenchIO(Elaboratable):
         enable: Optional[Callable[[], bool]] = None,
         validate_arguments: Optional[Callable[..., bool]] = None,
         extra_settle_count: int = 0,
-        disable_after: bool = True,
     ) -> TestGen[None]:
         enable = enable or (lambda: True)
         yield from self.set_enable(enable())
@@ -145,7 +144,6 @@ class TestbenchIO(Elaboratable):
                 enable=enable,
                 validate_arguments=validate_arguments,
                 extra_settle_count=extra_settle_count,
-                disable_after=False,
             )
 
     # Debug signals


### PR DESCRIPTION
This PR makes the `precommit` method in ROB runnable only if the `rob_id` from its argument matches. This allows to eliminate `m.If` expressions comparing `rob_id`s in FUs.

What do you think? Is this a good idea? I kind of like it because this seems to fit better to Transactron's philosophy: actions which are impossible due to external factors are not performed because of methods not being ready.

This PR depends on #663 and #679.

TODO:
* [x] Solve #678 
* [x] Fix tests