### PR TITLE
Use 'assign' in testbenchio

### DIFF
--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -160,7 +160,7 @@ class TestRetirement(TestCaseWithSimulator):
 
     @def_method_mock(lambda self: self.retc.mock_instr_decrement)
     def instr_decrement_process(self):
-        pass
+        return {"empty": 0}
 
     @def_method_mock(lambda self: self.retc.mock_trap_entry)
     def mock_trap_entry_process(self):

--- a/test/func_blocks/fu/common/test_rs.py
+++ b/test/func_blocks/fu/common/test_rs.py
@@ -240,7 +240,7 @@ class TestRSMethodSelect(TestCaseWithSimulator):
         assert (yield self.m._dut.select.ready) == 0
 
         # After take, select ready should be true, with 0 index returned
-        yield from self.m.take.call()
+        yield from self.m.take.call(rs_entry_id=0)
         yield Settle()
         assert (yield self.m._dut.select.ready) == 1
         assert (yield from self.m.select.call())["rs_entry_id"] == 0

--- a/test/peripherals/test_wishbone.py
+++ b/test/peripherals/test_wishbone.py
@@ -89,7 +89,7 @@ class TestWishboneMaster(TestCaseWithSimulator):
 
             # RTY and ERR responese
             yield from twbm.requestAdapter.call(addr=2, data=0, we=0, sel=0)
-            resp = yield from twbm.requestAdapter.call_try()
+            resp = yield from twbm.requestAdapter.call_try(addr=0, data=0, we=0, sel=0)
             assert resp is None  # verify cycle restart
 
         def result_process():

--- a/test/transactron/test_adapter.py
+++ b/test/transactron/test_adapter.py
@@ -48,7 +48,7 @@ class TestAdapterTrans(TestCaseWithSimulator):
     def proc(self):
         for _ in range(3):
             # this would previously timeout if the output layout was empty (as is in this case)
-            yield from self.consumer.action.call()
+            yield from self.consumer.action.call(data=0)
         for expected in [4, 1, 0]:
             obtained = (yield from self.echo.action.call(data=expected))["data"]
             assert expected == obtained

--- a/transactron/testing/functions.py
+++ b/transactron/testing/functions.py
@@ -2,7 +2,7 @@ from amaranth import *
 from amaranth.lib.data import Layout, StructLayout, View
 from amaranth.sim.core import Command
 from typing import TypeVar, Any, Generator, TypeAlias, TYPE_CHECKING, Union
-from transactron.utils._typing import RecordValueDict, RecordIntDict
+from transactron.utils._typing import RecordIntDict
 
 
 if TYPE_CHECKING:
@@ -12,14 +12,6 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 TestGen: TypeAlias = Generator[Union[Command, Value, "Statement", "CoreblocksCommand", None], Any, T]
-
-
-def set_inputs(values: RecordValueDict, field: View) -> TestGen[None]:
-    for name, value in values.items():
-        if isinstance(value, dict):
-            yield from set_inputs(value, getattr(field, name))
-        else:
-            yield getattr(field, name).eq(value)
 
 
 def get_outputs(field: View) -> TestGen[RecordIntDict]:

--- a/transactron/testing/testbenchio.py
+++ b/transactron/testing/testbenchio.py
@@ -2,9 +2,9 @@ from amaranth import *
 from amaranth.sim import Settle, Passive
 from typing import Optional, Callable
 from transactron.lib import AdapterBase
-from transactron.utils import ValueLike, SignalBundle, mock_def_helper
+from transactron.utils import ValueLike, SignalBundle, mock_def_helper, assign
 from transactron.utils._typing import RecordIntDictRet, RecordValueDict, RecordIntDict
-from .functions import set_inputs, get_outputs, TestGen
+from .functions import get_outputs, TestGen
 
 
 class TestbenchIO(Elaboratable):
@@ -35,7 +35,7 @@ class TestbenchIO(Elaboratable):
             yield
 
     def set_inputs(self, data: RecordValueDict = {}) -> TestGen[None]:
-        yield from set_inputs(data, self.adapter.data_in)
+        yield from assign(self.adapter.data_in, data)
 
     def get_outputs(self) -> TestGen[RecordIntDictRet]:
         return (yield from get_outputs(self.adapter.data_out))


### PR DESCRIPTION
By using `assign` instead of `set_inputs` we get all the shiny features that it offers, like support for array layouts, union layouts, strict checking.

It was surprisingly easy to replace `set_inputs` with `assign` - I didn't have to modify `assign` code nor modify any types.