### PR TITLE
Intuitive condition statement

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -172,10 +172,10 @@ class Retirement(Elaboratable):
                         m.d.av_comb += commit.eq(1)
 
                     # Condition is used to avoid FRAT locking during normal operation
-                    with condition(m, priority=False) as cond:
+                    with condition(m) as cond:
                         with cond(commit):
                             retire_instr(rob_entry)
-                        with cond(~commit):
+                        with cond():
                             # Not using default condition, because we want to block if branch is not ready
                             flush_instr(rob_entry)
 

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -342,7 +342,7 @@ class FetchUnit(Elaboratable):
                 with m.If(s1_data.instr_block_cross):
                     m.d.av_comb += raw_instrs[0].pc.eq(fetch_block_addr - 2)
 
-            with condition(m, priority=False) as branch:
+            with condition(m) as branch:
                 with branch(flushing_counter == 0):
                     with m.If(access_fault | unsafe_stall):
                         # TODO: Raise different code for page fault when supported
@@ -361,7 +361,7 @@ class FetchUnit(Elaboratable):
 
                     # Make sure this is called only once to avoid a huge mux on arguments
                     serializer.write(m, valid_mask=fetch_mask, slots=raw_instrs)
-                with branch(flushing_counter != 0):
+                with branch():
                     m.d.sync += flushing_counter.eq(flushing_counter - 1)
 
         with m.If(flush_now):

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -100,12 +100,10 @@ class PrivilegedFuncUnit(Elaboratable):
                 m.d.sync += finished.eq(1)
                 self.perf_instr.incr(m, instr_fn, cond=info.side_fx)
 
-                with condition(m) as branch:
-                    with branch(~info.side_fx):
-                        pass
-                    with branch(instr_fn == PrivilegedFn.Fn.MRET):
+                with condition(m, nonblocking=True) as branch:
+                    with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.MRET)):
                         mret(m)
-                    with branch(instr_fn == PrivilegedFn.Fn.FENCEI):
+                    with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.FENCEI)):
                         flush_icache(m)
 
         @def_method(m, self.accept, ready=instr_valid & finished)

--- a/transactron/lib/transformers.py
+++ b/transactron/lib/transformers.py
@@ -191,11 +191,9 @@ class MethodFilter(Elaboratable, Transformer):
             if self.use_condition:
                 cond = Signal()
                 m.d.top_comb += cond.eq(self.condition(m, arg))
-                with condition(m, nonblocking=False, priority=False) as branch:
+                with condition(m, nonblocking=True) as branch:
                     with branch(cond):
                         m.d.comb += ret.eq(self.target(m, arg))
-                    with branch(~cond):
-                        pass
             else:
                 with m.If(self.condition(m, arg)):
                     m.d.comb += ret.eq(self.target(m, arg))


### PR DESCRIPTION
This PR slightly modifies the semantics of `condition` to make it simpler to use in typical use cases. The condition of the default branch is now the negation of the alternative of the conditions of all the other cases. This makes the default branch mutually exclusive with the other branches, which makes the weird and not really useful fallover behavior go away. Uses of `condition` were changed to make use of the modified semantics.