### PR TITLE
Use DependencyContext in Coreblocks

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -3,7 +3,7 @@ from coreblocks.interface.layouts import RetirementLayouts
 
 from transactron.core import Method, Transaction, TModule, def_method
 from transactron.lib.simultaneous import condition
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from transactron.lib.metrics import *
 
 from coreblocks.params.genparams import GenParams
@@ -53,7 +53,7 @@ class Retirement(Elaboratable):
             max_latency=2 * 2**gen_params.rob_entries_bits,
         )
 
-        self.dependency_manager = gen_params.get(DependencyManager)
+        self.dependency_manager = DependencyContext.get()
         self.core_state = Method(o=self.gen_params.get(RetirementLayouts).core_state, nonexclusive=True)
         self.dependency_manager.add_dependency(CoreStateKey(), self.core_state)
 

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -1,7 +1,7 @@
 from amaranth import *
 from amaranth.lib.wiring import flipped, connect
 
-from transactron.utils.dependencies import DependencyManager, DependencyContext
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.func_blocks.interface.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.priv.traps.instr_counter import CoreInstructionCounter
 from coreblocks.priv.traps.interrupt_controller import InterruptController
@@ -41,9 +41,9 @@ class Core(Elaboratable):
     def __init__(self, *, gen_params: GenParams, wb_instr_bus: WishboneInterface, wb_data_bus: WishboneInterface):
         self.gen_params = gen_params
 
-        dep_manager = DependencyContext.get()
+        self.connections = DependencyContext.get()
         if self.gen_params.debug_signals_enabled:
-            dep_manager.add_dependency(HwMetricsEnabledKey(), True)
+            self.connections.add_dependency(HwMetricsEnabledKey(), True)
 
         self.wb_instr_bus = wb_instr_bus
         self.wb_data_bus = wb_data_bus
@@ -83,7 +83,6 @@ class Core(Elaboratable):
         self.RF = RegisterFile(gen_params=self.gen_params)
         self.ROB = ReorderBuffer(gen_params=self.gen_params)
 
-        self.connections = gen_params.get(DependencyManager)
         self.connections.add_dependency(CommonBusDataKey(), self.bus_master_data_adapter)
         self.connections.add_dependency(FlushICacheKey(), self.icache.flush)
 

--- a/coreblocks/func_blocks/csr/csr.py
+++ b/coreblocks/func_blocks/csr/csr.py
@@ -6,7 +6,7 @@ from transactron import Method, def_method, Transaction, TModule
 from transactron.utils import assign
 from coreblocks.params.genparams import GenParams
 from transactron.utils.data_repr import bits_from_int
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.params.fu_params import BlockComponentParams
 from coreblocks.interface.layouts import FetchLayouts, FuncUnitLayouts, CSRUnitLayouts
 from coreblocks.frontend.decoder import Funct3, ExceptionCause, OpType
@@ -73,7 +73,7 @@ class CSRUnit(FuncBlock, Elaboratable):
             Core generation parameters.
         """
         self.gen_params = gen_params
-        self.dependency_manager = gen_params.get(DependencyManager)
+        self.dependency_manager = DependencyContext.get()
 
         self.fetch_resume = Method(o=gen_params.get(FetchLayouts).resume)
 
@@ -261,7 +261,7 @@ class CSRUnit(FuncBlock, Elaboratable):
 @dataclass(frozen=True)
 class CSRBlockComponent(BlockComponentParams):
     def get_module(self, gen_params: GenParams) -> FuncBlock:
-        connections = gen_params.get(DependencyManager)
+        connections = DependencyContext.get()
         unit = CSRUnit(gen_params)
         connections.add_dependency(FetchResumeKey(), unit.fetch_resume)
         return unit

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 from amaranth import *
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 
 from transactron import *
 from transactron.lib import FIFO
@@ -50,7 +50,7 @@ class ExceptionFuncUnit(FuncUnit, Elaboratable):
         self.issue = Method(i=layouts.issue)
         self.accept = Method(o=layouts.accept)
 
-        dm = gen_params.get(DependencyManager)
+        dm = DependencyContext.get()
         self.report = dm.get_dependency(ExceptionReportKey())
 
     def elaborate(self, platform):

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -8,7 +8,7 @@ from transactron import *
 from transactron.core import def_method
 from transactron.lib import *
 from transactron.lib import logging
-from transactron.utils import DependencyManager
+from transactron.utils import DependencyContext
 from coreblocks.params import GenParams, FunctionalComponentParams, Extension
 from coreblocks.frontend.decoder import Funct3, OpType, ExceptionCause
 from coreblocks.interface.layouts import FuncUnitLayouts, JumpBranchLayouts
@@ -133,7 +133,7 @@ class JumpBranchFuncUnit(FuncUnit, Elaboratable):
 
         self.jb_fn = jb_fn
 
-        self.dm = gen_params.get(DependencyManager)
+        self.dm = DependencyContext.get()
         self.dm.add_dependency(BranchVerifyKey(), self.fifo_branch_resolved.read)
 
         self.perf_instr = TaggedCounter(
@@ -189,9 +189,7 @@ class JumpBranchFuncUnit(FuncUnit, Elaboratable):
 
             jmp_addr_misaligned = (jb.jmp_addr & (0b1 if Extension.C in self.gen_params.isa.extensions else 0b11)) != 0
 
-            async_interrupt_active = self.gen_params.get(DependencyManager).get_dependency(
-                AsyncInterruptInsertSignalKey()
-            )
+            async_interrupt_active = DependencyContext.get().get_dependency(AsyncInterruptInsertSignalKey())
 
             misprediction = Signal()
             m.d.av_comb += misprediction.eq(~(is_auipc | (jb.taken == funct7_info.predicted_taken)))

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -3,7 +3,7 @@ from amaranth import *
 
 from transactron import Method, def_method, Transaction, TModule
 from transactron.lib.connectors import FIFO, Forwarder
-from transactron.utils import ModuleLike, DependencyManager
+from transactron.utils import ModuleLike, DependencyContext
 from transactron.lib.simultaneous import condition
 from transactron.lib.logging import HardwareLogger
 
@@ -206,7 +206,7 @@ class LSUDummy(FuncUnit, Elaboratable):
         self.fu_layouts = gen_params.get(FuncUnitLayouts)
         self.lsu_layouts = gen_params.get(LSULayouts)
 
-        self.dependency_manager = self.gen_params.get(DependencyManager)
+        self.dependency_manager = DependencyContext.get()
         self.report = self.dependency_manager.get_dependency(ExceptionReportKey())
 
         self.issue = Method(i=self.fu_layouts.issue, single_caller=True)
@@ -312,7 +312,7 @@ class LSUDummy(FuncUnit, Elaboratable):
 @dataclass(frozen=True)
 class LSUComponent(FunctionalComponentParams):
     def get_module(self, gen_params: GenParams) -> FuncUnit:
-        connections = gen_params.get(DependencyManager)
+        connections = DependencyContext.get()
         bus_master = connections.get_dependency(CommonBusDataKey())
         unit = LSUDummy(gen_params, bus_master)
         return unit

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -8,7 +8,7 @@ from transactron import *
 from transactron.lib import BasicFifo, logging
 from transactron.lib.metrics import TaggedCounter
 from transactron.lib.simultaneous import condition
-from transactron.utils import DependencyManager, OneHotSwitch
+from transactron.utils import DependencyContext, OneHotSwitch
 
 from coreblocks.params import *
 from coreblocks.params import GenParams, FunctionalComponentParams
@@ -48,7 +48,7 @@ class PrivilegedFuncUnit(Elaboratable):
         self.priv_fn = PrivilegedFn()
 
         self.layouts = layouts = gp.get(FuncUnitLayouts)
-        self.dm = gp.get(DependencyManager)
+        self.dm = DependencyContext.get()
 
         self.issue = Method(i=layouts.issue)
         self.accept = Method(o=layouts.accept)
@@ -151,7 +151,7 @@ class PrivilegedFuncUnit(Elaboratable):
 class PrivilegedUnitComponent(FunctionalComponentParams):
     def get_module(self, gp: GenParams) -> FuncUnit:
         unit = PrivilegedFuncUnit(gp)
-        connections = gp.get(DependencyManager)
+        connections = DependencyContext.get()
         connections.add_dependency(FetchResumeKey(), unit.fetch_resume_fifo.read)
         return unit
 

--- a/coreblocks/func_blocks/interface/func_blocks_unifier.py
+++ b/coreblocks/func_blocks/interface/func_blocks_unifier.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from amaranth import *
 
 from coreblocks.params import GenParams, BlockComponentParams
-from transactron.lib.dependencies import UnifierKey, DependencyManager
+from transactron.lib.dependencies import UnifierKey, DependencyContext
 from transactron import Method, TModule
 from transactron.lib import MethodProduct, Collector, Unifier
 
@@ -30,7 +30,7 @@ class FuncBlocksUnifier(Elaboratable):
         self.unifiers: dict[str, Unifier] = {}
         self.extra_methods: dict[UnifierKey, Method] = {}
 
-        connections = gen_params.get(DependencyManager)
+        connections = DependencyContext.get()
 
         for key in extra_methods_required:
             method, unifiers = connections.get_dependency(key)

--- a/coreblocks/priv/csr/csr_register.py
+++ b/coreblocks/priv/csr/csr_register.py
@@ -11,7 +11,7 @@ from coreblocks.interface.layouts import CSRRegisterLayouts
 
 from transactron import Method, def_method, TModule
 from transactron.lib.transformers import MethodMap, MethodFilter
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from transactron.utils.transactron_helpers import get_src_loc
 from transactron.utils._typing import ValueLike, SrcLoc
 
@@ -136,7 +136,7 @@ class CSRRegister(Elaboratable):
 
         # append to global CSR list
         if csr_number is not None:
-            dm = gen_params.get(DependencyManager)
+            dm = DependencyContext.get()
             dm.add_dependency(CSRListKey(), self)
 
         if csr_number and self.width != gen_params.isa.xlen:

--- a/coreblocks/priv/traps/exception.py
+++ b/coreblocks/priv/traps/exception.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.params.genparams import GenParams
 
 from coreblocks.frontend.decoder.isa import ExceptionCause
@@ -63,7 +63,7 @@ class ExceptionCauseRegister(Elaboratable):
         # Break long combinational paths from single-cycle FUs
         self.fu_report_fifo = BasicFifo(self.layouts.report, 2)
         self.report = self.fu_report_fifo.write
-        dm = gen_params.get(DependencyManager)
+        dm = DependencyContext.get()
         dm.add_dependency(ExceptionReportKey(), self.report)
 
         self.get = Method(o=self.layouts.get, nonexclusive=True)

--- a/coreblocks/priv/traps/interrupt_controller.py
+++ b/coreblocks/priv/traps/interrupt_controller.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.params.genparams import GenParams
 from coreblocks.interface.keys import AsyncInterruptInsertSignalKey, MretKey
 
@@ -8,7 +8,7 @@ from transactron.core import Method, TModule, def_method
 
 class InterruptController(Elaboratable):
     def __init__(self, gp: GenParams):
-        dm = gp.get(DependencyManager)
+        dm = DependencyContext.get()
 
         self.interrupt_insert = Signal()
         dm.add_dependency(AsyncInterruptInsertSignalKey(), self.interrupt_insert)

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -9,7 +9,7 @@ from coreblocks.params import GenParams
 from coreblocks.frontend.decoder.optypes import OpType
 from transactron.lib.connectors import Connect
 from transactron.utils import assign, AssignType
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.interface.keys import CoreStateKey
 from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 
@@ -298,7 +298,7 @@ class RSInsertion(Elaboratable):
 
             # when core is flushed, rp_dst are discarded.
             # source operands may never become ready, skip waiting for them in any in RSes/FBs.
-            core_state = self.gen_params.get(DependencyManager).get_dependency(CoreStateKey())
+            core_state = DependencyContext.get().get_dependency(CoreStateKey())
             flushing = core_state(m).flushing
 
             data = {

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -47,7 +47,7 @@ class RetirementTestCircuit(Elaboratable):
         m.submodules.mock_exception_clear = self.mock_exception_clear = TestbenchIO(Adapter())
 
         m.submodules.generic_csr = self.generic_csr = GenericCSRRegisters(self.gen_params)
-        self.gen_params.get(DependencyManager).add_dependency(GenericCSRRegistersKey(), self.generic_csr)
+        DependencyContext.get().add_dependency(GenericCSRRegistersKey(), self.generic_csr)
 
         m.submodules.mock_fetch_continue = self.mock_fetch_continue = TestbenchIO(Adapter(i=fetch_layouts.resume))
         m.submodules.mock_instr_decrement = self.mock_instr_decrement = TestbenchIO(
@@ -73,7 +73,7 @@ class RetirementTestCircuit(Elaboratable):
 
         m.submodules.free_rf_fifo_adapter = self.free_rf_adapter = TestbenchIO(AdapterTrans(self.free_rf.read))
 
-        precommit = self.gen_params.get(DependencyManager).get_dependency(InstructionPrecommitKey())
+        precommit = DependencyContext.get().get_dependency(InstructionPrecommitKey())
         m.submodules.precommit_adapter = self.precommit_adapter = TestbenchIO(AdapterTrans(precommit))
 
         return m

--- a/test/func_blocks/csr/test_csr.py
+++ b/test/func_blocks/csr/test_csr.py
@@ -10,7 +10,7 @@ from coreblocks.frontend.decoder import Funct3, ExceptionCause, OpType
 from coreblocks.params.configurations import test_core_config
 from coreblocks.interface.layouts import ExceptionRegisterLayouts, RetirementLayouts
 from coreblocks.interface.keys import AsyncInterruptInsertSignalKey, ExceptionReportKey, InstructionPrecommitKey
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 
 from transactron.testing import *
 
@@ -27,7 +27,7 @@ class CSRUnitTestCircuit(Elaboratable):
         m.submodules.precommit = self.precommit = TestbenchIO(
             Adapter(o=self.gen_params.get(RetirementLayouts).precommit, nonexclusive=True)
         )
-        self.gen_params.get(DependencyManager).add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
+        DependencyContext.get().add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
 
         m.submodules.dut = self.dut = CSRUnit(self.gen_params)
 
@@ -38,8 +38,8 @@ class CSRUnitTestCircuit(Elaboratable):
         m.submodules.exception_report = self.exception_report = TestbenchIO(
             Adapter(i=self.gen_params.get(ExceptionRegisterLayouts).report)
         )
-        self.gen_params.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
-        self.gen_params.get(DependencyManager).add_dependency(AsyncInterruptInsertSignalKey(), Signal())
+        DependencyContext.get().add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
+        DependencyContext.get().add_dependency(AsyncInterruptInsertSignalKey(), Signal())
 
         m.submodules.fetch_resume = self.fetch_resume = TestbenchIO(AdapterTrans(self.dut.fetch_resume))
 

--- a/test/func_blocks/fu/functional_common.py
+++ b/test/func_blocks/fu/functional_common.py
@@ -10,7 +10,7 @@ from amaranth.sim import Passive
 
 from coreblocks.params import GenParams
 from coreblocks.params.configurations import test_core_config
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.params.fu_params import FunctionalComponentParams
 from coreblocks.frontend.decoder.isa import Funct3, Funct7
 from coreblocks.interface.keys import AsyncInterruptInsertSignalKey, ExceptionReportKey
@@ -100,8 +100,8 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
 
         self.report_mock = TestbenchIO(Adapter(i=self.gen_params.get(ExceptionRegisterLayouts).report))
 
-        self.gen_params.get(DependencyManager).add_dependency(ExceptionReportKey(), self.report_mock.adapter.iface)
-        self.gen_params.get(DependencyManager).add_dependency(AsyncInterruptInsertSignalKey(), Signal())
+        DependencyContext.get().add_dependency(ExceptionReportKey(), self.report_mock.adapter.iface)
+        DependencyContext.get().add_dependency(AsyncInterruptInsertSignalKey(), Signal())
 
         self.m = SimpleTestCircuit(self.func_unit.get_module(self.gen_params))
         self.circ = ModuleConnector(dut=self.m, report_mock=self.report_mock)

--- a/test/func_blocks/lsu/test_dummylsu.py
+++ b/test/func_blocks/lsu/test_dummylsu.py
@@ -10,7 +10,7 @@ from coreblocks.func_blocks.fu.lsu.dummyLsu import LSUDummy
 from coreblocks.params.configurations import test_core_config
 from coreblocks.frontend.decoder import *
 from coreblocks.interface.keys import ExceptionReportKey, InstructionPrecommitKey
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.interface.layouts import ExceptionRegisterLayouts, RetirementLayouts
 from coreblocks.peripherals.wishbone import *
 from transactron.testing import TestbenchIO, TestCaseWithSimulator, def_method_mock
@@ -82,12 +82,12 @@ class DummyLSUTestCircuit(Elaboratable):
             Adapter(i=self.gen.get(ExceptionRegisterLayouts).report)
         )
 
-        self.gen.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
+        DependencyContext.get().add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
 
         m.submodules.precommit = self.precommit = TestbenchIO(
             Adapter(o=self.gen.get(RetirementLayouts).precommit, nonexclusive=True)
         )
-        self.gen.get(DependencyManager).add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
+        DependencyContext.get().add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
 
         m.submodules.func_unit = func_unit = LSUDummy(self.gen, self.bus_master_adapter)
 

--- a/test/func_blocks/lsu/test_pma.py
+++ b/test/func_blocks/lsu/test_pma.py
@@ -7,7 +7,7 @@ from coreblocks.func_blocks.fu.lsu.dummyLsu import LSUDummy
 from coreblocks.params.configurations import test_core_config
 from coreblocks.frontend.decoder import *
 from coreblocks.interface.keys import ExceptionReportKey, InstructionPrecommitKey
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.interface.layouts import ExceptionRegisterLayouts, RetirementLayouts
 from coreblocks.peripherals.wishbone import *
 from transactron.testing import TestbenchIO, TestCaseWithSimulator, def_method_mock
@@ -62,12 +62,12 @@ class PMAIndirectTestCircuit(Elaboratable):
             Adapter(i=self.gen.get(ExceptionRegisterLayouts).report)
         )
 
-        self.gen.get(DependencyManager).add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
+        DependencyContext.get().add_dependency(ExceptionReportKey(), self.exception_report.adapter.iface)
 
         m.submodules.precommit = self.precommit = TestbenchIO(
             Adapter(o=self.gen.get(RetirementLayouts).precommit, nonexclusive=True)
         )
-        self.gen.get(DependencyManager).add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
+        DependencyContext.get().add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
 
         m.submodules.func_unit = func_unit = LSUDummy(self.gen, self.bus_master_adapter)
 

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -12,7 +12,7 @@ from coreblocks.func_blocks.fu.common.rs_func_block import RSBlockComponent
 
 from transactron.core import Method
 from transactron.lib import FIFO, AdapterTrans, Adapter
-from transactron.utils.dependencies import DependencyManager
+from transactron.utils.dependencies import DependencyContext
 from coreblocks.scheduler.scheduler import Scheduler
 from coreblocks.core_structs.rf import RegisterFile
 from coreblocks.core_structs.rat import FRAT
@@ -91,7 +91,7 @@ class SchedulerTestCircuit(Elaboratable):
         m.submodules.core_state = self.core_state = TestbenchIO(
             Adapter(o=self.gen_params.get(RetirementLayouts).core_state)
         )
-        self.gen_params.get(DependencyManager).add_dependency(CoreStateKey(), self.core_state.adapter.iface)
+        DependencyContext.get().add_dependency(CoreStateKey(), self.core_state.adapter.iface)
 
         # main scheduler
         m.submodules.scheduler = self.scheduler = Scheduler(


### PR DESCRIPTION
This PR removes the `DependencyManager` stored in `GenParams`, it is now received from `DependencyContext` instead.