### PR TITLE
Add new M-mode CSRs

### DIFF
--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -52,6 +52,10 @@ class _CoreConfigurationDataClass:
         Enables 16-bit Compressed Instructions extension.
     embedded: bool
         Enables Reduced Integer (E) extension.
+    marchid: int
+        The value of the MARCHID CSR.
+    mimpid: int
+        The value of the MIMPID CSR.
     debug_signals: bool
         Enable debug signals (for example hardware metrics etc). If disabled, none of them will be synthesized.
     phys_regs_bits: int
@@ -93,6 +97,9 @@ class _CoreConfigurationDataClass:
 
     compressed: bool = False
     embedded: bool = False
+
+    marchid: int = 44
+    mimpid: int = 0
 
     debug_signals: bool = True
 

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -80,3 +80,6 @@ class GenParams(DependentCache):
         self.extra_verification = cfg.extra_verification
 
         self._toolchain_isa_str = gen_isa_string(extensions, cfg.xlen, skip_internal=True)
+
+        self.marchid = cfg.marchid
+        self.mimpid = cfg.mimpid

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -59,6 +59,13 @@ class DoubleCounterCSR(Elaboratable):
 
 class MachineModeCSRRegisters(Elaboratable):
     def __init__(self, gen_params: GenParams):
+        self.mvendorid = CSRRegister(CSRAddress.MVENDORID, gen_params, reset=0)
+        self.marchid = CSRRegister(CSRAddress.MARCHID, gen_params, reset=gen_params.marchid)
+        self.mimpid = CSRRegister(CSRAddress.MIMPID, gen_params, reset=gen_params.mimpid)
+        self.mhartid = CSRRegister(CSRAddress.MHARTID, gen_params, reset=0)
+        self.mscratch = CSRRegister(CSRAddress.MSCRATCH, gen_params)
+        self.mconfigptr = CSRRegister(CSRAddress.MCONFIGPTR, gen_params, reset=0)
+
         self.mcause = CSRRegister(CSRAddress.MCAUSE, gen_params)
 
         # SPEC: The mtvec register must always be implemented, but can contain a read-only value.
@@ -71,9 +78,9 @@ class MachineModeCSRRegisters(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        m.submodules.mcause = self.mcause
-        m.submodules.mtvec = self.mtvec
-        m.submodules.mepc = self.mepc
+        for name, value in vars(self).items():
+            if isinstance(value, CSRRegister):
+                m.submodules[name] = value
 
         return m
 

--- a/test/asm/csr_mmode.asm
+++ b/test/asm/csr_mmode.asm
@@ -1,0 +1,27 @@
+    li x15, 5 # this many instructions will raise an exception
+    la x6, exception_handler
+    csrw mtvec, x6 # set-up handler
+    # test read-only CSRs
+    csrw mvendorid, 1
+    csrw marchid, 1
+    csrw mimpid, 1
+    csrw mhartid, 1
+    csrw mconfigptr, 1
+    csrr x1, mvendorid
+    csrr x2, marchid
+    csrr x3, mimpid
+    csrr x4, mhartid
+    csrr x5, mconfigptr
+    # test writable CSRs
+    csrw mscratch, 4
+    csrr x6, mscratch
+infloop:
+    j infloop
+
+exception_handler:
+   addi x15, x15, -1 # count exceptions
+
+   csrr x31, mepc    # resume program execution,
+   addi x31, x31, 4   # but skip unimplemented instruction
+   csrw mepc, x31
+   mret

--- a/test/asm/csr_mmode.asm
+++ b/test/asm/csr_mmode.asm
@@ -6,12 +6,12 @@
     csrw marchid, 1
     csrw mimpid, 1
     csrw mhartid, 1
-    csrw mconfigptr, 1
+    csrw 0xf15, 1  # csrw mconfigptr, 1
     csrr x1, mvendorid
     csrr x2, marchid
     csrr x3, mimpid
     csrr x4, mhartid
-    csrr x5, mconfigptr
+    csrr x5, 0xf15  # csrr x5, mconfigptr
     # test writable CSRs
     csrw mscratch, 4
     csrr x6, mscratch

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -137,6 +137,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
         ("fibonacci", "fibonacci.asm", 500, {2: 2971215073}, basic_core_config),
         ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, basic_core_config),
         ("csr", "csr.asm", 200, {1: 1, 2: 4}, full_core_config),
+        ("csr_mmode", "csr_mmode.asm", 1000, {1: 0, 2: 44, 3: 0, 4: 0, 5: 0, 6: 4, 15: 0}, full_core_config),
         ("exception", "exception.asm", 200, {1: 1, 2: 2}, basic_core_config),
         ("exception_mem", "exception_mem.asm", 200, {1: 1, 2: 2}, basic_core_config),
         ("exception_handler", "exception_handler.asm", 2000, {2: 987, 11: 0xAAAA, 15: 16}, full_core_config),


### PR DESCRIPTION
This PR adds the ~`misa`~, `mvendorid`, `marchid`, `mimpid`, `mhartid`, `mscratch` and `mconfigptr`, bringing the completion of #561 a little bit closer. Other than `mscratch`, all of the other added CSRs are read-only.