### PR TITLE
Restore logging handler

### DIFF
--- a/test/transactron/testing/test_log.py
+++ b/test/transactron/testing/test_log.py
@@ -76,7 +76,6 @@ class TestLog(TestCaseWithSimulator):
         with self.run_simulation(m) as sim:
             sim.add_sync_process(proc)
 
-        print(caplog.text)
         assert (
             "WARNING  test_logger:logging.py:83 [test/transactron/testing/test_log.py:22] "
             + "Log triggered under Amaranth If value+3=0x2d"


### PR DESCRIPTION
PR #573 accidentally broke logging by removing `register_logging_handler` from `configure logging`:

```diff
-    @pytest.fixture(autouse=True)
-    def configure_logging(self, fixture_sim_processes_to_add, register_logging_handler):
+    def configure_logging(self):
```

As a result, no logs were printed on the output.

I also found and removed an old `print` statement from `test_log.py`