### PR TITLE
Support top-level signals in TransactionComponent

### DIFF
--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -529,7 +529,7 @@ class TransactionComponent(TransactionModule, Component):
     def elaborate(self, platform):
         m = super().elaborate(platform)
 
-        for name in self.signature.members:
-            connect(m, flipped(getattr(self, name)), getattr(self.elaboratable, name))
+        assert isinstance(self.elaboratable, Component)  # for typing
+        connect(m, flipped(self), self.elaboratable)
 
         return m


### PR DESCRIPTION
`TransactionComponent` only supports connecting nested `Signatures`. It crashes when connecting plain signals (`In`/`Out`) at top level.
Amaranth `connect` can be used at higher level to support both cases, it also iterates over sub-signatures internally