### PR TITLE
Support loading initialized data memory from asm tests

### DIFF
--- a/test/asm/exception_mem.asm
+++ b/test/asm/exception_mem.asm
@@ -9,3 +9,5 @@ sw x2, 4(x0)
 sw x1, 4(x0)  /* TODO: actually check the side fx */
 li x2, 9
 
+.section .bss
+.skip 0x8

--- a/test/asm/fibonacci_mem.asm
+++ b/test/asm/fibonacci_mem.asm
@@ -24,3 +24,6 @@ loop:
     bne x3, x4, loop
 infloop:
     j infloop
+
+.section .bss
+.skip 0xC

--- a/test/asm/init_regs.s
+++ b/test/asm/init_regs.s
@@ -1,3 +1,4 @@
+.macro INIT_REGS_LOAD
 # load the initial states of registers
 # the value of a register `n` is assumed to be stored under address `0x100 + n * 4`.
     lw  x1, 0x104(x0)
@@ -31,3 +32,9 @@
     lw  x29,0x174(x0)
     lw  x30,0x178(x0)
     lw  x31,0x17c(x0)
+.endm
+
+.macro INIT_REGS_ALLOCATION
+.org 0x100
+.skip 0x80
+.endm

--- a/test/asm/init_regs.s
+++ b/test/asm/init_regs.s
@@ -35,6 +35,7 @@
 .endm
 
 .macro INIT_REGS_ALLOCATION
-.org 0x100
+.section .init_regs, "a", @nobits
 .skip 0x80
+.previous
 .endm

--- a/test/asm/interrupt.asm
+++ b/test/asm/interrupt.asm
@@ -1,7 +1,9 @@
- _start:
-    .include "init_regs.s"
+.include "init_regs.s"
 
-# fibonacci spiced with interrupt handler (also with fibonacci)
+_start:
+    INIT_REGS_LOAD
+
+    # fibonacci spiced with interrupt handler (also with fibonacci)
     li x1, 0x200
     csrw mtvec, x1
     li x27, 0     # handler count
@@ -98,3 +100,6 @@ fail:
 .org 0x200
     j int_handler
     li x31, 0xae  # should never happen
+
+.bss
+    INIT_REGS_ALLOCATION

--- a/test/asm/interrupt.asm
+++ b/test/asm/interrupt.asm
@@ -101,5 +101,4 @@ fail:
     j int_handler
     li x31, 0xae  # should never happen
 
-.bss
-    INIT_REGS_ALLOCATION
+INIT_REGS_ALLOCATION

--- a/test/asm/link.ld
+++ b/test/asm/link.ld
@@ -6,7 +6,6 @@ SECTIONS
 {
   .text : { *(.text) }
   . = 0x100000000; /* start from 2**32 - trick to emulate Harvard architecture (memory addresses will start from 0) */
-  .data : { *(.data) }
-  .bss : { *(.bss) }
+  .data : { *(.data) *(.bss) }
   _end = .;
 }

--- a/test/asm/link.ld
+++ b/test/asm/link.ld
@@ -6,6 +6,12 @@ SECTIONS
 {
   .text : { *(.text) }
   . = 0x100000000; /* start from 2**32 - trick to emulate Harvard architecture (memory addresses will start from 0) */
-  .data : { *(.data) *(.bss) }
-  _end = .;
+  .data : {
+      *(.data)
+      *(.bss)
+
+      . =  _end_init_regs > . ? 0x1000 : .;  /* skip .init_regs origin allocation if not used */
+      *(.init_regs)
+      _end_init_regs = .;
+   }
 }

--- a/test/asm/link.ld
+++ b/test/asm/link.ld
@@ -5,7 +5,8 @@ start = 0;
 SECTIONS
 {
   .text : { *(.text) }
-  . = 0x100000000; /* start from 2**32 - trick to emulate Harvard architecture (.bss addresses will start from 0) */
+  . = 0x100000000; /* start from 2**32 - trick to emulate Harvard architecture (memory addresses will start from 0) */
+  .data : { *(.data) }
   .bss : { *(.bss) }
   _end = .;
 }

--- a/test/asm/wfi_int.asm
+++ b/test/asm/wfi_int.asm
@@ -1,5 +1,7 @@
+.include "init_regs.s"
+
 _start:
-    .include "init_regs.s"
+    INIT_REGS_LOAD
 
     li x1, 0x100 # set handler vector
     csrw mtvec, x1
@@ -26,3 +28,6 @@ skip:
 
 .org 0x100
     j handler
+
+.data
+    INIT_REGS_ALLOCATION

--- a/test/asm/wfi_int.asm
+++ b/test/asm/wfi_int.asm
@@ -29,5 +29,4 @@ skip:
 .org 0x100
     j handler
 
-.data
-    INIT_REGS_ALLOCATION
+INIT_REGS_ALLOCATION

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -110,8 +110,6 @@ class TestCoreAsmSourceBase(TestCoreBase):
                             "binary",
                             "-j",
                             section,
-                            "--set-section-flags",
-                            f"{section}=alloc,load,contents",
                             ld_tmp.name,
                             bin_tmp.name,
                         ]
@@ -124,10 +122,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
 
                     return bin
 
-            return {
-                "text": load_section(".text"),
-                "data": load_section(".data") + load_section(".bss"),
-            }
+            return {"text": load_section(".text"), "data": load_section(".data")}
 
 
 @parameterized_class(


### PR DESCRIPTION
Initialized data can be now declared in internal asm tests. Data memory size (also with `.bss`) is now determined from asm source file, instead of default fixed value. 