### PR TITLE
IOInterface typing wrapper for lib.data signatures

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -25,7 +25,7 @@ from coreblocks.scheduler.scheduler import Scheduler
 from coreblocks.backend.annoucement import ResultAnnouncement
 from coreblocks.backend.retirement import Retirement
 from coreblocks.peripherals.bus_adapter import WishboneMasterAdapter
-from coreblocks.peripherals.wishbone import WishboneMaster, WishboneInterface, WishboneSignature
+from coreblocks.peripherals.wishbone import WishboneMaster, WishboneInterface
 from transactron.lib import BasicFifo
 from transactron.lib.metrics import HwMetricsEnabledKey
 
@@ -39,8 +39,8 @@ class Core(Component):
     def __init__(self, *, gen_params: GenParams):
         super().__init__(
             {
-                "wb_instr": Out(WishboneSignature(gen_params.wb_params)),
-                "wb_data": Out(WishboneSignature(gen_params.wb_params)),
+                "wb_instr": Out(WishboneInterface(gen_params.wb_params).signature),
+                "wb_data": Out(WishboneInterface(gen_params.wb_params).signature),
             }
         )
 

--- a/coreblocks/peripherals/wishbone.py
+++ b/coreblocks/peripherals/wishbone.py
@@ -1,16 +1,15 @@
 from amaranth import *
-from amaranth.lib.wiring import PureInterface, Signature, In, Out, Component
+from amaranth.lib.wiring import In, Out, Component
 from functools import reduce
-from typing import Protocol, cast
 import operator
 
 from transactron import Method, def_method, TModule
 from transactron.core import Transaction
 from transactron.lib import AdapterTrans, BasicFifo
 from transactron.utils import OneHotSwitchDynamic, assign, RoundRobin
-from transactron.utils._typing import AbstractInterface, AbstractSignature
 from transactron.lib.connectors import Forwarder
 from transactron.utils.transactron_helpers import make_layout
+from transactron.utils.amaranth_ext.io_interface import *
 from transactron.lib import logging
 
 
@@ -33,45 +32,21 @@ class WishboneParameters:
         self.granularity = granularity
 
 
-class WishboneSignature(Signature):
+class WishboneInterface(IOInterface):
     def __init__(self, wb_params: WishboneParameters):
-        super().__init__(
-            {
-                "dat_r": In(wb_params.data_width),
-                "dat_w": Out(wb_params.data_width),
-                "rst": Out(1),
-                "ack": In(1),
-                "adr": Out(wb_params.addr_width),
-                "cyc": Out(1),
-                "stall": In(1),
-                "err": In(1),
-                "lock": Out(1),
-                "rty": In(1),
-                "sel": Out(wb_params.data_width // wb_params.granularity),
-                "stb": Out(1),
-                "we": Out(1),
-            }
-        )
-
-    def create(self, *, path: tuple[str | int, ...] = (), src_loc_at: int = 0):
-        """Create a WishboneInterface."""  # workaround for Sphinx problem with Amaranth docstring
-        return cast(WishboneInterface, PureInterface(self, path=path, src_loc_at=src_loc_at + 1))
-
-
-class WishboneInterface(AbstractInterface[AbstractSignature], Protocol):
-    dat_r: Signal
-    dat_w: Signal
-    rst: Signal
-    ack: Signal
-    adr: Signal
-    cyc: Signal
-    stall: Signal
-    err: Signal
-    lock: Signal
-    rty: Signal
-    sel: Signal
-    stb: Signal
-    we: Signal
+        self.dat_r = SignalIn(wb_params.data_width)
+        self.dat_w = SignalOut(wb_params.data_width)
+        self.rst = SignalOut(1)
+        self.ack = SignalIn(1)
+        self.adr = SignalOut(wb_params.addr_width)
+        self.cyc = SignalOut(1)
+        self.stall = SignalIn(1)
+        self.err = SignalIn(1)
+        self.lock = SignalOut(1)
+        self.rty = SignalIn(1)
+        self.sel = SignalOut(wb_params.data_width // wb_params.granularity)
+        self.stb = SignalOut(1)
+        self.we = SignalOut(1)
 
 
 class WishboneMasterMethodLayout:
@@ -129,7 +104,8 @@ class WishboneMaster(Component):
     wb_master: WishboneInterface
 
     def __init__(self, wb_params: WishboneParameters, name: str = ""):
-        super().__init__({"wb_master": Out(WishboneSignature(wb_params))})
+        super().__init__({"wb_master": Out(WishboneInterface(wb_params).signature)})
+
         self.name = name
         self.wb_params = wb_params
 
@@ -261,7 +237,7 @@ class PipelinedWishboneMaster(Component):
     wb: WishboneInterface
 
     def __init__(self, wb_params: WishboneParameters, *, max_req: int = 8):
-        super().__init__({"wb": Out(WishboneSignature(wb_params))})
+        super().__init__({"wb": Out(WishboneInterface(wb_params).signature)})
         self.wb_params = wb_params
         self.max_req = max_req
 
@@ -365,8 +341,8 @@ class WishboneMuxer(Component):
     def __init__(self, wb_params: WishboneParameters, num_slaves: int, ssel_tga: Signal):
         super().__init__(
             {
-                "master_wb": Out(WishboneSignature(wb_params)),
-                "slaves": In(WishboneSignature(wb_params)).array(num_slaves),
+                "master_wb": Out(WishboneInterface(wb_params).signature),
+                "slaves": Out(WishboneInterface(wb_params).signature).array(num_slaves),
             }
         )
         self.sselTGA = ssel_tga
@@ -438,8 +414,8 @@ class WishboneArbiter(Component):
     def __init__(self, wb_params: WishboneParameters, num_masters: int):
         super().__init__(
             {
-                "slave_wb": Out(WishboneSignature(wb_params)),
-                "masters": In(WishboneSignature(wb_params)).array(num_masters),
+                "slave_wb": Out(WishboneInterface(wb_params).signature),
+                "masters": In(WishboneInterface(wb_params).signature).array(num_masters),
             }
         )
 
@@ -515,7 +491,7 @@ class WishboneMemorySlave(Component):
     bus: WishboneInterface
 
     def __init__(self, wb_params: WishboneParameters, **kwargs):
-        super().__init__({"bus": In(WishboneSignature(wb_params))})
+        super().__init__({"bus": In(WishboneInterface(wb_params).signature)})
         if "width" not in kwargs:
             kwargs["width"] = wb_params.data_width
         if kwargs["width"] not in (8, 16, 32, 64):

--- a/scripts/synthesize.py
+++ b/scripts/synthesize.py
@@ -28,7 +28,7 @@ from coreblocks.func_blocks.fu.zbc import ZbcComponent
 from coreblocks.func_blocks.fu.zbs import ZbsComponent
 from transactron import TransactionModule
 from transactron.lib import AdapterTrans
-from coreblocks.peripherals.wishbone import WishboneArbiter, WishboneInterface, WishboneSignature
+from coreblocks.peripherals.wishbone import WishboneArbiter, WishboneInterface
 from constants.ecp5_platforms import (
     ResourceBuilder,
     append_resources,
@@ -80,7 +80,7 @@ class SynthesisCore(Component):
     wb: WishboneInterface
 
     def __init__(self, gen_params: GenParams):
-        super().__init__({"wb": Out(WishboneSignature(gen_params.wb_params))})
+        super().__init__({"wb": Out(WishboneInterface(gen_params.wb_params).signature)})
         self.gen_params = gen_params
 
     def elaborate(self, platform):

--- a/transactron/utils/amaranth_ext/__init__.py
+++ b/transactron/utils/amaranth_ext/__init__.py
@@ -1,2 +1,3 @@
 from .functions import *  # noqa: F401
 from .elaboratables import *  # noqa: F401
+from .io_interface import *  # noqa: F401

--- a/transactron/utils/amaranth_ext/io_interface.py
+++ b/transactron/utils/amaranth_ext/io_interface.py
@@ -1,0 +1,112 @@
+from typing import Optional
+from copy import copy
+from amaranth import Shape, ShapeLike, Value, ValueLike, unsigned
+from amaranth.lib.wiring import Signature, Flow, Member
+from amaranth_types import AbstractInterface, AbstractSignature
+
+__all__ = [
+    "IOSignal",
+    "SignalIn",
+    "SignalOut",
+    "IOInterface",
+]
+
+
+class IOSignal(Value):
+    _io_flow: Flow
+    _io_shape: ShapeLike
+
+    def __init__(self, flow: Flow, shape: Optional[ShapeLike] = None):
+        self._io_shape = unsigned(1) if shape is None else shape
+        self._io_flow = flow
+
+    # Value abstract methods
+    def shape(self):
+        return Shape.cast(self._io_shape)
+
+    def _rhs_signals(self):
+        # This method should never be called
+        # IOSignal is going to be substituted by a Component constructor or be used only as a type
+        raise NotImplementedError
+
+    # Signal API compatiblity - Signal cannot be subclassed
+    @staticmethod
+    def like(
+        other: ValueLike, *, name: Optional[str] = None, name_suffix: Optional[str] = None, src_loc_at=None, **kwargs
+    ):
+        raise NotImplementedError
+
+
+class SignalIn(IOSignal):
+    def __init__(self, shape: Optional[ShapeLike] = 0):
+        super().__init__(Flow.In, shape)
+
+
+class SignalOut(IOSignal):
+    def __init__(self, shape: Optional[ShapeLike] = 0):
+        super().__init__(Flow.Out, shape)
+
+
+class IOInterface(AbstractInterface[AbstractSignature]):
+    _is_flipped: bool
+
+    def _get_flipped(self) -> bool:
+        try:
+            return self._is_flipped
+        except AttributeError:
+            return False
+
+    def _to_members_list(self, *, _name_prefix: str = "") -> dict[str, Member]:
+        ret = {}
+        for m_name in dir(self):
+            if m_name == "signature" or m_name == "flipped" or m_name.startswith("_"):
+                continue
+
+            m_val = getattr(self, m_name)
+            if isinstance(m_val, IOSignal):
+                if m_val._io_flow is Flow.In:
+                    ret[m_name] = Flow.In(m_val._io_shape)
+                if m_val._io_flow is Flow.Out:
+                    ret[m_name] = Flow.Out(m_val._io_shape)
+
+            elif isinstance(m_val, IOInterface):
+                flow_direction = Flow.In if m_val._get_flipped() else Flow.Out
+                ret[m_name] = flow_direction(
+                    Signature(m_val._to_members_list(_name_prefix=_name_prefix + m_name + "."))
+                )
+
+            else:
+                raise AttributeError(
+                    f"Illegal attribute `{_name_prefix + m_name}`. "
+                    "Expected IOSignal, SignalIn, SignalOut or IOInterface"
+                )
+
+        return ret
+
+    @property
+    def signature(self) -> Signature:
+        if self._get_flipped():
+            return Signature(Signature(self._to_members_list()).flip().members)
+        else:
+            return Signature(self._to_members_list())
+
+    def flipped(self) -> "IOInterface":
+        x = copy(self)
+        x._is_flipped = not self._get_flipped()
+        return x
+
+
+# class SubInterface(IOInterface):
+#    def __init__(self):
+#        self.i = SignalIn(1)
+#
+# class WishboneInterface(IOInterface):
+#    def __init__(self):
+#        self.i = SignalIn(2)
+#        self.o = SignalOut(2)
+#        self.s = SubInterface()
+#       self.f = SubInterface().flipped()
+#        self.z = 1
+
+
+# print(WishboneInterface().signature)


### PR DESCRIPTION
Using `amaranth.lib.data` Signatures with typing comes with some boilerplate and repetition :(

I came up with a class that can be used both for typing and to get amaranth `Signature` for use in `Component` constructor.

It works by crating a class with `IOSignal` fields declared as `self.` in constructor, so it can be directly for typechecking. `IOSignal` type derives `Value` with additonal shape and direction information. 
`IOInterface` is never used globally, but is intended only for interface typing.  Those signals will be filled with actual objects at `super().__init__(...` `Component` constructor (that gets Signature from generated `IOInterface.signature`). Nested `IOInterfaces` are supported. 
 
It is *a bit* hacky, but what do you think?