### PR TITLE
Add Lookup3 and Sip hashes

### DIFF
--- a/test/transactron/utils/test_hw_hash.py
+++ b/test/transactron/utils/test_hw_hash.py
@@ -1,0 +1,95 @@
+import math
+from transactron.testing import *
+import random
+from transactron.utils.amaranth_ext.hw_hash import *
+import pytest
+
+
+def rot(x, k) -> int:
+    return ((x) << (k)) | ((x) >> (32 - (k)))
+
+
+def lookup3(value, seed):
+    if seed is None:
+        seed = 0xDEADBEEF
+    a = (value & ((1 << 32) - 1)) + seed
+    b = ((value >> 32) & ((1 << 32) - 1)) + seed
+    c = ((value >> 64) & ((1 << 32) - 1)) + seed
+
+    a &= 0xFFFFFFFF
+    b &= 0xFFFFFFFF
+    c &= 0xFFFFFFFF
+    c ^= b
+    c &= 0xFFFFFFFF
+    c -= rot(b, 14)
+    c &= 0xFFFFFFFF
+    a ^= c
+    a &= 0xFFFFFFFF
+    a -= rot(c, 11)
+    a &= 0xFFFFFFFF
+    b ^= a
+    b &= 0xFFFFFFFF
+    b -= rot(a, 25)
+    b &= 0xFFFFFFFF
+    c ^= b
+    c &= 0xFFFFFFFF
+    c -= rot(b, 16)
+    c &= 0xFFFFFFFF
+    a ^= c
+    a &= 0xFFFFFFFF
+    a -= rot(c, 4)
+    a &= 0xFFFFFFFF
+    b ^= a
+    b &= 0xFFFFFFFF
+    b -= rot(a, 14)
+    b &= 0xFFFFFFFF
+    c ^= b
+    c &= 0xFFFFFFFF
+    c -= rot(b, 24)
+    c &= 0xFFFFFFFF
+    return c
+
+
+@pytest.mark.parametrize("model", [JenkinsHash96Bits, lambda: SipHash64Bits(2, 4), lambda: SipHash64Bits(1, 3)])
+@pytest.mark.parametrize("bits", [16, 32, 64, 96])
+@pytest.mark.parametrize("seed", [None, 0x573A8CF])
+class TestHash(TestCaseWithSimulator):
+    test_number = 800
+    modulo = 16
+
+    def process(self):
+        hash_mod_list = [0] * self.modulo
+        if self.seed is not None:
+            yield self.circ.seed.eq(self.seed)
+        for i in range(self.test_number):
+            in_val = random.randrange(1 << self.bits)
+            yield self.circ.value.eq(in_val)
+            yield Settle()
+            yield Delay(1e-9)  # pretty print
+            hash_mod_list[(yield self.circ.out_hash) % self.modulo] += 1
+        #            hash_mod_list[lookup3(in_val, self.seed) % self.modulo] += 1
+        print(hash_mod_list)
+
+        # Chi squere test
+        # stat = sum([(count - self.test_number/self.modulo)**2/count for count in hash_mod_list])
+        # Chi(15) for p=0.01
+        # assert stat < 30.5779
+
+        for count in hash_mod_list:
+            p_test = count / self.test_number
+            p_expected = 1 / self.modulo
+
+            # Test of proportion
+            stat = (p_test - p_expected) / (math.sqrt(p_expected * (1 - p_expected))) * math.sqrt(self.test_number)
+
+            # Assumimg p=0.05 of the whole test and Bonfferoni correction k=16, we need the used p=0.003.
+            # For N(0,1) this is circa 3*standard deviation
+            # Sadly these hash algorithms have problems for the small input data sizes, so threshold is set on 4
+            assert stat < 4 and stat > -4
+
+    def test_random(self, seed, bits, model):
+        self.seed = seed
+        self.bits = bits
+        self.circ = model()
+        with self.run_simulation(self.circ) as sim:
+            sim.add_process(self.process)

--- a/transactron/utils/amaranth_ext/hw_hash.py
+++ b/transactron/utils/amaranth_ext/hw_hash.py
@@ -1,0 +1,121 @@
+from amaranth import *
+
+__all__ = ["JenkinsHash96Bits", "SipHash64Bits"]
+
+
+class JenkinsHash96Bits(Elaboratable):
+    """
+    Simplified implementation of Lookup3 hash function which assumes that input to be hashed is no longer than 96 bits.
+
+    Lookup3 function is a non-cryptographic hash function, which can be used in hash tables and sketches.
+    By default it supports input of arbitrary length, but this implementation is simplified and
+    only the last step of lookup3 is implemented, what implies that no more than 96 bits can be hashed.
+    Provided implementation is combinational it works in one cycle.
+    All not used bits should be bound to 0.
+
+    Implementation based on:
+    https://chromium.googlesource.com/external/smhasher/+/5b8fd3c31a58b87b80605dca7a64fad6cb3f8a0f/lookup3.cpp
+
+    Parameters
+    ----------
+    seed : Signal(32)
+        The seed to be used during hashing. By default it is a constant chosen randomly.
+        You can overwrite it, to have different hash values using the same algorithm.
+    value : Signal(96)
+        Input value to be hashed. Not used bits should be 0.
+    out_hash : Signal(32)
+        Calculated hash.
+    """
+
+    def __init__(self):
+        self.seed = Signal(32, reset=0x70736575)  # Default value chosen randomly
+        self.seed2 = Signal(32, reset=0xA8DE8DED)  # Default value chosen randomly
+        self.seed3 = Signal(32, reset=0xAFDB5A9E)  # Default value chosen randomly
+        self.value = Signal(96)
+        self.out_hash = Signal(32)
+
+    def _finalize(self, m: Module, a: Value, b: Value, c: Value):
+        a_tmp1 = Signal(32)
+        b_tmp1 = Signal(32)
+        c_tmp1 = Signal(32)
+        a_tmp2 = Signal(32)
+        b_tmp2 = Signal(32)
+        c_tmp2 = Signal(32)
+        c_tmp3 = Signal(32)
+
+        m.d.comb += [
+            c_tmp1.eq((c ^ b) - b.rotate_left(14)),
+            a_tmp1.eq((a ^ c_tmp1) - c_tmp1.rotate_left(11)),
+            b_tmp1.eq((b ^ a_tmp1) - a_tmp1.rotate_left(25)),
+            c_tmp2.eq((c_tmp1 ^ b_tmp1) - b_tmp1.rotate_left(16)),
+            a_tmp2.eq((a_tmp1 ^ c_tmp2) - c_tmp2.rotate_left(4)),
+            b_tmp2.eq((b_tmp1 ^ a_tmp2) - a_tmp2.rotate_left(14)),
+            c_tmp3.eq((c_tmp2 ^ b_tmp2) - b_tmp2.rotate_left(24)),
+        ]
+        return c_tmp3
+
+    def elaborate(self, platform):
+        m = Module()
+
+        a = Signal(32)
+        b = Signal(32)
+        c = Signal(32)
+        m.d.comb += a.eq(self.value[0:32] + self.seed)
+        m.d.comb += b.eq(self.value[32:64] + self.seed2)
+        m.d.comb += c.eq(self.value[64:96] + self.seed3)
+
+        m.d.comb += self.out_hash.eq(self._finalize(m, a, b, c))
+
+        return m
+
+
+class SipHash64Bits(Elaboratable):
+    def __init__(self, c: int = 2, d: int = 4):
+        self.seed = Signal(128)
+        self.value = Signal(64)
+        self.out_hash = Signal(64)
+        self.mixing_layers = c
+        self.finalize_layers = d
+
+    def _sip_round(self, m, v0, v1, v2, v3):
+        v0_tmp1 = Signal(64)
+        v1_tmp1 = Signal(64)
+        v2_tmp1 = Signal(64)
+        v3_tmp1 = Signal(64)
+        v0_tmp2 = Signal(64)
+        v1_tmp2 = Signal(64)
+        v2_tmp2 = Signal(64)
+        v3_tmp2 = Signal(64)
+
+        m.d.comb += [
+            v0_tmp1.eq(v0 + v1),
+            v1_tmp1.eq(v0_tmp1 ^ v1.rotate_left(13)),
+            v2_tmp1.eq(v2 + v3),
+            v3_tmp1.eq(v2_tmp1 ^ v3.rotate_left(16)),
+            v0_tmp2.eq(v0_tmp1.rotate_left(32) + v3_tmp1),
+            v2_tmp2.eq(v2_tmp1 + v1_tmp1),
+            v1_tmp2.eq(v1_tmp1.rotate_left(17) ^ v2_tmp2),
+            v3_tmp2.eq(v3_tmp1.rotate_left(21) ^ v0_tmp2),
+        ]
+
+        return v0_tmp2, v1_tmp2, v2_tmp2.rotate_left(32), v3_tmp2
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        v0 = self.seed[0:64] ^ 0x736F6D6570736575
+        v1 = self.seed[64:128] ^ 0x646F72616E646F6D
+        v2 = self.seed[0:64] ^ 0x6C7967656E657261
+        v3 = self.seed[64:128] ^ 0x7465646279746573 ^ self.value
+
+        for i in range(self.mixing_layers):
+            v0, v1, v2, v3 = self._sip_round(m, v0, v1, v2, v3)
+
+        v0 = v0 ^ self.value
+        v2 = v2 ^ 0xFF
+
+        for i in range(self.finalize_layers):
+            v0, v1, v2, v3 = self._sip_round(m, v0, v1, v2, v3)
+        m.d.comb += self.out_hash.eq(v0 ^ v1 ^ v2 ^ v3)
+
+        return m


### PR DESCRIPTION
Here is a draft pull request of implementation of two non-cryptographic hashes:
- Lookup3 (http://www.burtleburtle.net/bob/hash/doobs.html)
- SipHash (https://eprint.iacr.org/2012/351.pdf)

I had an idea to test them using statistical test to check if they hash into uniform distribution, but sadly for small input data (from range [0,1023]) there is some bias and statistical tests fails... Whats more I am not sure if we want to have tests based on statistics, because this can cause instability.