### PR TITLE
Clean up `MemoryBank`

### DIFF
--- a/test/transactron/lib/test_transaction_lib.py
+++ b/test/transactron/lib/test_transaction_lib.py
@@ -1,10 +1,9 @@
 import pytest
 from itertools import product
 import random
-import itertools
 from operator import and_
 from functools import reduce
-from amaranth.sim import Settle, Passive
+from amaranth.sim import Settle
 from typing import Optional, TypeAlias
 from parameterized import parameterized
 from collections import deque
@@ -141,20 +140,15 @@ class TestPipe(TestFifoBase):
 class TestMemoryBank(TestCaseWithSimulator):
     test_conf = [(9, 3, 3, 3, 14), (16, 1, 1, 3, 15), (16, 1, 1, 1, 16), (12, 3, 1, 1, 17)]
 
-    parametrized_input = [tc + sf for tc, sf in itertools.product(test_conf, [(True,), (False,)])]
-
-    @parameterized.expand(parametrized_input)
-    def test_mem(self, max_addr, writer_rand, reader_req_rand, reader_resp_rand, seed, safe_writes):
+    @parameterized.expand(test_conf)
+    def test_mem(self, max_addr, writer_rand, reader_req_rand, reader_resp_rand, seed):
         test_count = 200
 
         data_width = 6
-        m = SimpleTestCircuit(
-            MemoryBank(data_layout=[("data", data_width)], elem_count=max_addr, safe_writes=safe_writes)
-        )
+        m = SimpleTestCircuit(MemoryBank(data_layout=[("data", data_width)], elem_count=max_addr))
 
         data: list[int] = list(0 for _ in range(max_addr))
         read_req_queue = deque()
-        addr_queue = deque()
 
         random.seed(seed)
 
@@ -166,7 +160,7 @@ class TestMemoryBank(TestCaseWithSimulator):
                 for _ in range(2):
                     yield Settle()
                 data[a] = d
-                yield from self.random_wait(writer_rand, min_cycle_cnt=1)
+                yield from self.random_wait(writer_rand)
 
         def reader_req():
             for cycle in range(test_count):
@@ -174,12 +168,9 @@ class TestMemoryBank(TestCaseWithSimulator):
                 yield from m.read_req.call(addr=a)
                 for _ in range(1):
                     yield Settle()
-                if safe_writes:
-                    d = data[a]
-                    read_req_queue.append(d)
-                else:
-                    addr_queue.append((cycle, a))
-                yield from self.random_wait(reader_req_rand, min_cycle_cnt=1)
+                d = data[a]
+                read_req_queue.append(d)
+                yield from self.random_wait(reader_req_rand)
 
         def reader_resp():
             for cycle in range(test_count):
@@ -189,57 +180,10 @@ class TestMemoryBank(TestCaseWithSimulator):
                 assert (yield from m.read_resp.call()) == {"data": d}
                 yield from self.random_wait(reader_resp_rand, min_cycle_cnt=1)
 
-        def internal_reader_resp():
-            assert m._dut._internal_read_resp_trans is not None
-            yield Passive()
-            while True:
-                if addr_queue:
-                    instr, a = addr_queue[0]
-                else:
-                    yield
-                    continue
-                d = data[a]
-                # check when internal method has been run to capture
-                # memory state for tests purposes
-                if (yield m._dut._internal_read_resp_trans.grant):
-                    addr_queue.popleft()
-                    read_req_queue.append(d)
-                yield
-
         with self.run_simulation(m) as sim:
             sim.add_sync_process(reader_req)
             sim.add_sync_process(reader_resp)
             sim.add_sync_process(writer)
-            if not safe_writes:
-                sim.add_sync_process(internal_reader_resp)
-
-    def test_pipelined(self):
-        data_width = 6
-        max_addr = 9
-        m = SimpleTestCircuit(MemoryBank(data_layout=[("data", data_width)], elem_count=max_addr, safe_writes=False))
-
-        random.seed(14)
-
-        def process():
-            a = 3
-            d1 = random.randrange(2**data_width)
-            yield from m.write.call_init(data=d1, addr=a)
-            yield from m.read_req.call_init(addr=a)
-            yield
-            d2 = random.randrange(2**data_width)
-            yield from m.write.call_init(data=d2, addr=a)
-            yield from m.read_resp.call_init()
-            yield
-            yield from m.write.disable()
-            yield from m.read_req.disable()
-            ret_d1 = (yield from m.read_resp.call_result())["data"]
-            assert d1 == ret_d1
-            yield
-            ret_d2 = (yield from m.read_resp.call_result())["data"]
-            assert d2 == ret_d2
-
-        with self.run_simulation(m) as sim:
-            sim.add_sync_process(process)
 
 
 class TestAsyncMemoryBank(TestCaseWithSimulator):

--- a/test/transactron/lib/test_transaction_lib.py
+++ b/test/transactron/lib/test_transaction_lib.py
@@ -140,7 +140,8 @@ class TestPipe(TestFifoBase):
 class TestMemoryBank(TestCaseWithSimulator):
     test_conf = [(9, 3, 3, 3, 14), (16, 1, 1, 3, 15), (16, 1, 1, 1, 16), (12, 3, 1, 1, 17), (9, 0, 0, 0, 18)]
 
-    @parameterized.expand(tc + tr for tc in test_conf for tr in [(False,), (True,)])
+    @pytest.mark.parametrize("max_addr, writer_rand, reader_req_rand, reader_resp_rand, seed", test_conf)
+    @pytest.mark.parametrize("transparent", [False, True])
     def test_mem(
         self, max_addr: int, writer_rand: int, reader_req_rand: int, reader_resp_rand: int, seed: int, transparent: bool
     ):

--- a/test/transactron/lib/test_transaction_lib.py
+++ b/test/transactron/lib/test_transaction_lib.py
@@ -188,7 +188,10 @@ class TestMemoryBank(TestCaseWithSimulator):
                 assert (yield from m.read_resp.call()) == {"data": d}
                 yield from self.random_wait(reader_resp_rand)
 
-        with self.run_simulation(m) as sim:
+        pipeline_test = writer_rand == 0 and reader_req_rand == 0 and reader_resp_rand == 0
+        max_cycles = test_count + 2 if pipeline_test else 100000
+
+        with self.run_simulation(m, max_cycles=max_cycles) as sim:
             sim.add_sync_process(reader_req)
             sim.add_sync_process(reader_resp)
             sim.add_sync_process(writer)

--- a/test/transactron/lib/test_transaction_lib.py
+++ b/test/transactron/lib/test_transaction_lib.py
@@ -179,11 +179,11 @@ class TestMemoryBank(TestCaseWithSimulator):
 
         def reader_resp():
             for cycle in range(test_count):
-                for _ in range(2):
+                for _ in range(3):
                     yield Settle()
                 while not read_req_queue:
                     yield from self.random_wait(reader_resp_rand or 1, min_cycle_cnt=1)
-                    for _ in range(2):
+                    for _ in range(3):
                         yield Settle()
                 d = read_req_queue.popleft()
                 assert (yield from m.read_resp.call()) == {"data": d}

--- a/transactron/lib/storage.py
+++ b/transactron/lib/storage.py
@@ -5,8 +5,7 @@ from transactron.utils.transactron_helpers import from_method_layout, make_layou
 from ..core import *
 from ..utils import SrcLoc, get_src_loc, MultiPriorityEncoder
 from typing import Optional
-from transactron.utils import assign, AssignType, LayoutList, MethodLayout
-from .reqres import ArgumentsToResultsZipper
+from transactron.utils import LayoutList, MethodLayout
 
 __all__ = ["MemoryBank", "ContentAddressableMemory", "AsyncMemoryBank"]
 
@@ -36,7 +35,6 @@ class MemoryBank(Elaboratable):
         data_layout: LayoutList,
         elem_count: int,
         granularity: Optional[int] = None,
-        safe_writes: bool = True,
         src_loc: int | SrcLoc = 0,
     ):
         """
@@ -49,10 +47,6 @@ class MemoryBank(Elaboratable):
         granularity: Optional[int]
             Granularity of write, forwarded to Amaranth. If `None` the whole structure is always saved at once.
             If not, the width of `data_layout` is split into `granularity` parts, which can be saved independently.
-        safe_writes: bool
-            Set to `False` if an optimisation can be done to increase throughput of writes. This will cause that
-            writes will be reordered with respect to reads eg. in sequence "read A, write A X", read can return
-            "X" even when write was called later. By default `True`, which disable optimisation.
         src_loc: int | SrcLoc
             How many stack frames deep the source location is taken from.
             Alternatively, the source location to use instead of the default.
@@ -63,7 +57,7 @@ class MemoryBank(Elaboratable):
         self.granularity = granularity
         self.width = from_method_layout(self.data_layout).size
         self.addr_width = bits_for(self.elem_count - 1)
-        self.safe_writes = safe_writes
+        self.safe_writes = False
 
         self.read_req_layout: LayoutList = [("addr", self.addr_width)]
         write_layout = [("addr", self.addr_width), ("data", self.data_layout)]
@@ -80,60 +74,45 @@ class MemoryBank(Elaboratable):
         m = TModule()
 
         mem = Memory(width=self.width, depth=self.elem_count)
-        m.submodules.read_port = read_port = mem.read_port()
+        m.submodules.read_port = read_port = mem.read_port(transparent=False)
         m.submodules.write_port = write_port = mem.write_port()
         read_output_valid = Signal()
-        prev_read_addr = Signal(self.addr_width)
-        write_pending = Signal()
-        write_req = Signal()
-        write_args = Signal(self.write_layout)
-        write_args_prev = Signal(self.write_layout)
-        m.d.comb += read_port.addr.eq(prev_read_addr)
+        overflow_valid = Signal()
+        overflow_data = Signal(self.width)
 
-        zipper = ArgumentsToResultsZipper([("valid", 1)], self.data_layout)
-        m.submodules.zipper = zipper
+        # The read request method can be called at most twice when not reading the response.
+        # The first result is stored in the overflow buffer, the second - in the read value buffer of the memory.
+        # If the responses are always read as they arrive, overflow is never written and no stalls occur.
 
-        self._internal_read_resp_trans = Transaction(src_loc=self.src_loc)
-        with self._internal_read_resp_trans.body(m, request=read_output_valid):
+        with m.If(read_output_valid & ~overflow_valid & self.read_req.run & ~self.read_resp.run):
             m.d.sync += read_output_valid.eq(0)
-            zipper.write_results(m, read_port.data)
+            m.d.sync += overflow_valid.eq(1)
+            m.d.sync += overflow_data.eq(read_port.data)
 
-        write_trans = Transaction(src_loc=self.src_loc)
-        with write_trans.body(m, request=write_req | (~read_output_valid & write_pending)):
-            if self.safe_writes:
-                with m.If(write_pending):
-                    m.d.comb += assign(write_args, write_args_prev, fields=AssignType.ALL)
-            m.d.sync += write_pending.eq(0)
-            m.d.comb += write_port.addr.eq(write_args.addr)
-            m.d.comb += write_port.data.eq(write_args.data)
+        @def_method(m, self.read_resp, read_output_valid | overflow_valid)
+        def _():
+            with m.If(overflow_valid):
+                m.d.sync += overflow_valid.eq(0)
+            with m.Else():
+                m.d.sync += read_output_valid.eq(0)
+            return Mux(overflow_valid, overflow_data, read_port.data)
+
+        m.d.comb += read_port.en.eq(0)  # because the init value is 1
+
+        @def_method(m, self.read_req, ~overflow_valid)
+        def _(addr):
+            m.d.sync += read_output_valid.eq(1)
+            m.d.comb += read_port.en.eq(1)
+            m.d.comb += read_port.addr.eq(addr)
+
+        @def_method(m, self.write)
+        def _(arg):
+            m.d.comb += write_port.addr.eq(arg.addr)
+            m.d.comb += write_port.data.eq(arg.data)
             if self.granularity is None:
                 m.d.comb += write_port.en.eq(1)
             else:
-                m.d.comb += write_port.en.eq(write_args.mask)
-
-        @def_method(m, self.read_resp)
-        def _():
-            output = zipper.read(m)
-            return output.results
-
-        @def_method(m, self.read_req, ~write_pending)
-        def _(addr):
-            m.d.sync += read_output_valid.eq(1)
-            m.d.comb += read_port.addr.eq(addr)
-            m.d.sync += prev_read_addr.eq(addr)
-            zipper.write_args(m, valid=1)
-
-        @def_method(m, self.write, ~write_pending)
-        def _(arg):
-            if self.safe_writes:
-                with m.If((arg.addr == read_port.addr) & (read_output_valid | self.read_req.run)):
-                    m.d.sync += write_pending.eq(1)
-                    m.d.sync += assign(write_args_prev, arg, fields=AssignType.ALL)
-                with m.Else():
-                    m.d.comb += write_req.eq(1)
-            else:
-                m.d.comb += write_req.eq(1)
-            m.d.comb += assign(write_args, arg, fields=AssignType.ALL)
+                m.d.comb += write_port.en.eq(arg.mask)
 
         return m
 

--- a/transactron/lib/storage.py
+++ b/transactron/lib/storage.py
@@ -49,7 +49,9 @@ class MemoryBank(Elaboratable):
             Granularity of write, forwarded to Amaranth. If `None` the whole structure is always saved at once.
             If not, the width of `data_layout` is split into `granularity` parts, which can be saved independently.
         transparent: bool
-            Read port transparency, false by default.
+            Read port transparency, false by default. When a read port is transparent, if a given memory address
+            is read and written in the same clock cycle, the read returns the written value instead of the value
+            which was in the memory in that cycle.
         src_loc: int | SrcLoc
             How many stack frames deep the source location is taken from.
             Alternatively, the source location to use instead of the default.

--- a/transactron/lib/storage.py
+++ b/transactron/lib/storage.py
@@ -90,7 +90,6 @@ class MemoryBank(Elaboratable):
         # If the responses are always read as they arrive, overflow is never written and no stalls occur.
 
         with m.If(read_output_valid & ~overflow_valid & self.read_req.run & ~self.read_resp.run):
-            m.d.sync += read_output_valid.eq(0)
             m.d.sync += overflow_valid.eq(1)
             m.d.sync += overflow_data.eq(read_port.data)
 


### PR DESCRIPTION
This PR fixes something which bothered me for a long time. I couldn't wrap my head around why @lekcyjna123's `MemoryBank` implementation is so weird and complex. Finally, I understood the problem: in the version of Amaranth we are using, the read ports are transparent by default (!), and @lekcyjna123 basically tried to make non-transparent reads from a transparent read port.

What was changed:
* The `safe_writes` argument was replaced with `transparent`, which controls the read port transparency.
* The weird use of `ArgumentsToResultsZipper` and the risky use of an internal transaction which should always be able to run was removed. An explicit overflow management was added instead. 
* The test was changed so that it no longer uses implementation details of `MemoryBank` and handles transparency more naturally.
* The test was changed so that it is able to check consecutive reads and consecutive writes.
* Integrated the pipelining check into the main test.