### PR TITLE
Add `def_methods`

### DIFF
--- a/test/transactron/test_methods.py
+++ b/test/transactron/test_methods.py
@@ -7,6 +7,7 @@ from amaranth.sim import *
 from transactron.testing import TestCaseWithSimulator, TestbenchIO, data_layout
 
 from transactron import *
+from transactron.testing.infrastructure import SimpleTestCircuit
 from transactron.utils import MethodStruct
 from transactron.lib import *
 
@@ -124,6 +125,43 @@ class TestDefMethod(TestCaseWithSimulator):
 
         with pytest.raises(TypeError):
             self.do_test_definition(definition)
+
+
+class TestDefMethods(TestCaseWithSimulator):
+    class CircuitTestModule(Elaboratable):
+        def __init__(self, method_definition):
+            self.methods = [
+                Method(
+                    i=[("foo", 3)],
+                    o=[("foo", 3)],
+                )
+                for _ in range(4)
+            ]
+
+            self.method_definition = method_definition
+
+        def elaborate(self, platform):
+            m = TModule()
+            m._MustUse__silence = True  # type: ignore
+
+            def_methods(m, self.methods)(self.method_definition)
+
+            return m
+
+    def test_basic_methods(self):
+        def definition(idx: int, foo: Value):
+            return {"foo": foo + idx}
+
+        circuit = SimpleTestCircuit(TestDefMethods.CircuitTestModule(definition))
+
+        def test_process():
+            for k, method in enumerate(circuit.methods):
+                val = random.randrange(0, 2**3)
+                ret = yield from method.call(foo=val)
+                assert ret["foo"] == val + k % 2**3
+
+        with self.run_simulation(circuit) as sim:
+            sim.add_sync_process(test_process)
 
 
 class AdapterCircuit(Elaboratable):

--- a/transactron/core/sugar.py
+++ b/transactron/core/sugar.py
@@ -1,13 +1,18 @@
+from collections.abc import Sequence, Callable
 from amaranth import *
-from typing import TYPE_CHECKING, Optional, Callable
+from typing import TYPE_CHECKING, Optional, Concatenate, ParamSpec
 from transactron.utils import *
 from transactron.utils.assign import AssignArg
+from functools import partial
 
 if TYPE_CHECKING:
     from .tmodule import TModule
     from .method import Method
 
-__all__ = ["def_method"]
+__all__ = ["def_method", "def_methods"]
+
+
+P = ParamSpec("P")
 
 
 def def_method(
@@ -86,5 +91,90 @@ def def_method(
 
         if ret_out is not None:
             m.d.top_comb += assign(out, ret_out, fields=AssignType.ALL)
+
+    return decorator
+
+
+def def_methods(
+    m: "TModule",
+    methods: Sequence["Method"],
+    ready: Callable[[int], ValueLike] = lambda _: C(1),
+    validate_arguments: Optional[Callable[..., ValueLike]] = None,
+):
+    """Decorator for defining similar methods
+
+    This decorator is a wrapper over `def_method`, which allows you to easily
+    define multiple similar methods in a loop.
+
+    The function over which this decorator is applied, should always expect
+    at least one argument, as the index of the method will be passed as the
+    first argument to the function.
+
+    This is a syntax sugar equivalent to:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        for i in range(len(my_methods)):
+            @def_method(m, my_methods[i])
+            def _(arg):
+                ...
+
+    Parameters
+    ----------
+    m: TModule
+        Module in which operations on signals should be executed.
+    methods: Sequence[Method]
+        The methods whose body is going to be defined.
+    ready: Callable[[int], Value]
+        A `Callable` that takes the index in the form of an `int` of the currently defined method
+        and produces a `Value` describing whether the method is ready to be run.
+        When omitted, each defined method is always ready. Assigned combinationally to the `ready` attribute.
+    validate_arguments: Optional[Callable[Concatenate[int, ...], ValueLike]]
+        Function that takes input arguments used to call the method
+        and checks whether the method can be called with those arguments.
+        It instantiates a combinational circuit for each
+        method caller. By default, there is no function, so all arguments
+        are accepted.
+
+    Examples
+    --------
+    Define three methods with the same body:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        m = TModule()
+        my_sum_methods = [Method(i=[("arg1",8),("arg2",8)], o=[("res",8)]) for _ in range(3)]
+        @def_methods(m, my_sum_methods)
+        def _(_, arg1, arg2):
+            return arg1 + arg2
+
+    Define three methods with different bodies parametrized with the index of the method:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        m = TModule()
+        my_sum_methods = [Method(i=[("arg1",8),("arg2",8)], o=[("res",8)]) for _ in range(3)]
+        @def_methods(m, my_sum_methods)
+        def _(index : int, arg1, arg2):
+            return arg1 + arg2 + index
+
+    Define three methods with different ready signals:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        @def_methods(m, my_filter_read_methods, ready_list=lambda i: fifo.head == i)
+        def _(_):
+            return fifo.read(m)
+    """
+
+    def decorator(func: Callable[Concatenate[int, P], Optional[RecordDict]]):
+        for i in range(len(methods)):
+            partial_f = partial(func, i)
+            partial_vargs = partial(validate_arguments, i) if validate_arguments is not None else None
+            def_method(m, methods[i], ready(i), partial_vargs)(partial_f)
 
     return decorator


### PR DESCRIPTION
This PR contains basically the `def_method_loop` decorator from #395. Changes:

- Renamed to `def_methods`.
- Only callables allowed as `ready` - as this is the more general of the two possibilities allowed in the original implementation.
- Adapted to current Transactron.
- Minimal testbench added.

This will be useful when working on superscalarity.