### PR TITLE
Update Amaranth to just before RFC 27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ./amaranth-stubs/  # can't use -e -- pyright doesn't see the stubs then :(
 amaranth-yosys==0.35.0.0.post81
-git+https://github.com/amaranth-lang/amaranth@115954b4d957b4ba642ad056ab1670bf5d185fb6
+git+https://github.com/amaranth-lang/amaranth@f48b8650c4df42b3260c4791b18fad7991af0541
 dataclasses-json==0.6.3


### PR DESCRIPTION
This small PR adds support for Amaranth RFCs 42 and 46. The next commit in Amaranth implements [RFC 27](https://amaranth-lang.org/rfcs/0027-simulator-testbenches.html), which involves `Settle` in testbenches. I expect trouble, so I would like to work on that in a separate PR.