### PR TITLE
Update Amaranth to after RFC 58

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -70,7 +70,7 @@ class Retirement(Elaboratable):
         m_csr = self.dependency_manager.get_dependency(GenericCSRRegistersKey()).m_mode
         m.submodules.instret_csr = self.instret_csr
 
-        side_fx = Signal(reset=1)
+        side_fx = Signal(init=1)
 
         def free_phys_reg(rp_dst: Value):
             # mark reg in Register File as free
@@ -129,7 +129,7 @@ class Retirement(Elaboratable):
 
                         cause_entry = Signal(self.gen_params.isa.xlen)
 
-                        arch_trap = Signal(reset=1)
+                        arch_trap = Signal(init=1)
 
                         with m.If(cause_register.cause == ExceptionCause._COREBLOCKS_ASYNC_INTERRUPT):
                             # Async interrupts are inserted only by JumpBranchUnit and conditionally by MRET and CSR

--- a/coreblocks/cache/icache.py
+++ b/coreblocks/cache/icache.py
@@ -3,7 +3,7 @@ import operator
 
 from amaranth import *
 from amaranth.lib.data import View
-from amaranth.lib.memory import Memory
+import amaranth.lib.memory as memory
 from amaranth.utils import exact_log2
 
 from transactron.core import def_method, Priority, TModule
@@ -330,7 +330,7 @@ class ICacheMemory(Elaboratable):
         for i in range(self.params.num_of_ways):
             way_wr = self.way_wr_en[i]
 
-            tag_mem = Memory(shape=self.tag_data_layout, depth=self.params.num_of_sets, init=[])
+            tag_mem = memory.Memory(shape=self.tag_data_layout, depth=self.params.num_of_sets, init=[])
             tag_mem_wp = tag_mem.write_port()
             tag_mem_rp = tag_mem.read_port(transparent_for=[tag_mem_wp])
             m.submodules[f"tag_mem_{i}"] = tag_mem
@@ -343,7 +343,7 @@ class ICacheMemory(Elaboratable):
                 tag_mem_wp.en.eq(self.tag_wr_en & way_wr),
             ]
 
-            data_mem = Memory(
+            data_mem = memory.Memory(
                 shape=self.fetch_block_bits, depth=self.params.num_of_sets * self.params.fetch_blocks_in_line, init=[]
             )
             data_mem_wp = data_mem.write_port()

--- a/coreblocks/cache/icache.py
+++ b/coreblocks/cache/icache.py
@@ -156,7 +156,7 @@ class ICache(Elaboratable, CacheInterface):
         with Transaction().body(m):
             self.perf_flushes.incr(m, cond=flush_finish)
 
-        with m.FSM(reset="FLUSH") as fsm:
+        with m.FSM(init="FLUSH") as fsm:
             with m.State("FLUSH"):
                 with m.If(flush_finish):
                     m.next = "LOOKUP"
@@ -172,7 +172,7 @@ class ICache(Elaboratable, CacheInterface):
                     m.next = "LOOKUP"
 
         # Replacement policy
-        way_selector = Signal(self.params.num_of_ways, reset=1)
+        way_selector = Signal(self.params.num_of_ways, init=1)
         with m.If(refill_finish):
             m.d.sync += way_selector.eq(way_selector.rotate_left(1))
 

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -161,7 +161,7 @@ class Core(Component):
         )
 
         # push all registers to FreeRF at reset. r0 should be skipped, stop when counter overflows to 0
-        free_rf_reg = Signal(self.gen_params.phys_regs_bits, reset=1)
+        free_rf_reg = Signal(self.gen_params.phys_regs_bits, init=1)
         with Transaction(name="InitFreeRFFifo").body(m, request=(free_rf_reg.bool())):
             free_rf_fifo.write(m, free_rf_reg)
             m.d.sync += free_rf_reg.eq(free_rf_reg + 1)

--- a/coreblocks/core_structs/rob.py
+++ b/coreblocks/core_structs/rob.py
@@ -1,5 +1,6 @@
 from amaranth import *
 from amaranth.lib.data import View
+from amaranth.lib.memory import Memory
 from transactron import Method, Transaction, def_method, TModule
 from transactron.lib.metrics import *
 from coreblocks.interface.layouts import ROBLayouts
@@ -18,7 +19,7 @@ class ReorderBuffer(Elaboratable):
         self.retire = Method()
         self.done = Array(Signal() for _ in range(2**self.params.rob_entries_bits))
         self.exception = Array(Signal() for _ in range(2**self.params.rob_entries_bits))
-        self.data = Memory(width=layouts.data_layout.size, depth=2**self.params.rob_entries_bits)
+        self.data = Memory(shape=layouts.data_layout.size, depth=2**self.params.rob_entries_bits, init=[])
         self.get_indices = Method(o=layouts.get_indices, nonexclusive=True)
 
         self.perf_rob_wait_time = FIFOLatencyMeasurer(
@@ -45,8 +46,9 @@ class ReorderBuffer(Elaboratable):
         peek_possible = start_idx != end_idx
         put_possible = (end_idx + 1)[0 : len(end_idx)] != start_idx
 
-        m.submodules.read_port = read_port = self.data.read_port()
-        m.submodules.write_port = write_port = self.data.write_port()
+        m.submodules.data = self.data
+        write_port = self.data.write_port()
+        read_port = self.data.read_port(transparent_for=[write_port])
 
         m.d.comb += read_port.addr.eq(start_idx)
 

--- a/coreblocks/core_structs/rob.py
+++ b/coreblocks/core_structs/rob.py
@@ -48,7 +48,7 @@ class ReorderBuffer(Elaboratable):
 
         m.submodules.data = self.data
         write_port = self.data.write_port()
-        read_port = self.data.read_port()
+        read_port = self.data.read_port(transparent_for=[write_port])
 
         m.d.comb += read_port.addr.eq(start_idx)
 

--- a/coreblocks/core_structs/rob.py
+++ b/coreblocks/core_structs/rob.py
@@ -48,7 +48,7 @@ class ReorderBuffer(Elaboratable):
 
         m.submodules.data = self.data
         write_port = self.data.write_port()
-        read_port = self.data.read_port(transparent_for=[write_port])
+        read_port = self.data.read_port()
 
         m.d.comb += read_port.addr.eq(start_idx)
 

--- a/coreblocks/core_structs/rob.py
+++ b/coreblocks/core_structs/rob.py
@@ -1,6 +1,6 @@
 from amaranth import *
 from amaranth.lib.data import View
-from amaranth.lib.memory import Memory
+import amaranth.lib.memory as memory
 from transactron import Method, Transaction, def_method, TModule
 from transactron.lib.metrics import *
 from coreblocks.interface.layouts import ROBLayouts
@@ -19,7 +19,7 @@ class ReorderBuffer(Elaboratable):
         self.retire = Method()
         self.done = Array(Signal() for _ in range(2**self.params.rob_entries_bits))
         self.exception = Array(Signal() for _ in range(2**self.params.rob_entries_bits))
-        self.data = Memory(shape=layouts.data_layout.size, depth=2**self.params.rob_entries_bits, init=[])
+        self.data = memory.Memory(shape=layouts.data_layout.size, depth=2**self.params.rob_entries_bits, init=[])
         self.get_indices = Method(o=layouts.get_indices, nonexclusive=True)
 
         self.perf_rob_wait_time = FIFOLatencyMeasurer(

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -93,7 +93,7 @@ class FetchUnit(Elaboratable):
         def flush():
             m.d.comb += flush_now.eq(1)
 
-        current_pc = Signal(self.gen_params.isa.xlen, reset=self.gen_params.start_pc)
+        current_pc = Signal(self.gen_params.isa.xlen, init=self.gen_params.start_pc)
 
         stalled_unsafe = Signal()
         stalled_exception = Signal()

--- a/coreblocks/func_blocks/csr/csr.py
+++ b/coreblocks/func_blocks/csr/csr.py
@@ -129,7 +129,7 @@ class CSRUnit(FuncBlock, Elaboratable):
         )
 
         # Temporary, until privileged spec is implemented
-        priv_level = Signal(PrivilegeLevel, reset=PrivilegeLevel.MACHINE)
+        priv_level = Signal(PrivilegeLevel, init=PrivilegeLevel.MACHINE)
 
         exe_side_fx = Signal()
 

--- a/coreblocks/func_blocks/csr/csr.py
+++ b/coreblocks/func_blocks/csr/csr.py
@@ -186,10 +186,11 @@ class CSRUnit(FuncBlock, Elaboratable):
         @def_method(m, self.insert)
         def _(rs_entry_id, rs_data):
             m.d.sync += assign(instr, rs_data)
-            m.d.sync += instr.valid.eq(1)
 
             with m.If(rs_data.exec_fn.op_type == OpType.CSR_IMM):  # Pass immediate as first operand
                 m.d.sync += instr.s1_val.eq(rs_data.imm)
+
+            m.d.sync += instr.valid.eq(1)
 
         @def_method(m, self.update)
         def _(reg_id, reg_val):

--- a/coreblocks/func_blocks/csr/csr.py
+++ b/coreblocks/func_blocks/csr/csr.py
@@ -186,11 +186,10 @@ class CSRUnit(FuncBlock, Elaboratable):
         @def_method(m, self.insert)
         def _(rs_entry_id, rs_data):
             m.d.sync += assign(instr, rs_data)
+            m.d.sync += instr.valid.eq(1)
 
             with m.If(rs_data.exec_fn.op_type == OpType.CSR_IMM):  # Pass immediate as first operand
                 m.d.sync += instr.s1_val.eq(rs_data.imm)
-
-            m.d.sync += instr.valid.eq(1)
 
         @def_method(m, self.update)
         def _(reg_id, reg_val):

--- a/coreblocks/func_blocks/fu/common/rs.py
+++ b/coreblocks/func_blocks/fu/common/rs.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from collections.abc import Iterable
 from typing import Optional
 from amaranth import *
@@ -58,6 +59,10 @@ class RSBase(Elaboratable):
             bucket_count=self.rs_entries_bits + 1,
             sample_width=self.rs_entries_bits + 1,
         )
+
+    @abstractmethod
+    def elaborate(self, platform) -> TModule:
+        raise NotImplementedError
 
     def _elaborate(self, m: TModule, selected_id: Value, select_possible: Value, take_vector: Value):
         m.submodules += [self.perf_rs_wait_time, self.perf_num_full]

--- a/coreblocks/func_blocks/fu/division/long_division.py
+++ b/coreblocks/func_blocks/fu/division/long_division.py
@@ -87,16 +87,15 @@ class RecursiveDivison(Elaboratable):
         m.d.comb += rec_div.divisor.eq(self.divisor)
 
         # Single step as described in article
-        quotient_msb = Signal()
         with m.If(concat >= self.divisor):
-            m.d.comb += quotient_msb.eq(1)
+            m.d.comb += self.quotient[self.step_count - 1].eq(1)
             m.d.comb += rec_div.input_remainder.eq(concat - self.divisor)
         with m.Else():
-            m.d.comb += quotient_msb.eq(0)
+            m.d.comb += self.quotient[self.step_count - 1].eq(0)
             m.d.comb += rec_div.input_remainder.eq(concat)
 
         # wiring up rest of result from recursive module
-        m.d.comb += self.quotient.eq(Cat(rec_div.quotient[: (self.step_count - 1)], quotient_msb))
+        m.d.comb += self.quotient[: (self.step_count - 1)].eq(rec_div.quotient)
         m.d.comb += self.remainder.eq(rec_div.remainder)
 
         # partial remainder

--- a/coreblocks/func_blocks/fu/division/long_division.py
+++ b/coreblocks/func_blocks/fu/division/long_division.py
@@ -144,7 +144,7 @@ class LongDivider(DividerBase):
             self.ipc, xlen, partial_remainder_count=self.partial_remainder_count
         )
 
-        ready = Signal(1, reset=1)
+        ready = Signal(1, init=1)
 
         dividend = Signal(unsigned(xlen))
         divisor = Signal(unsigned(xlen))

--- a/coreblocks/func_blocks/fu/division/long_division.py
+++ b/coreblocks/func_blocks/fu/division/long_division.py
@@ -87,15 +87,16 @@ class RecursiveDivison(Elaboratable):
         m.d.comb += rec_div.divisor.eq(self.divisor)
 
         # Single step as described in article
+        quotient_msb = Signal()
         with m.If(concat >= self.divisor):
-            m.d.comb += self.quotient[self.step_count - 1].eq(1)
+            m.d.comb += quotient_msb.eq(1)
             m.d.comb += rec_div.input_remainder.eq(concat - self.divisor)
         with m.Else():
-            m.d.comb += self.quotient[self.step_count - 1].eq(0)
+            m.d.comb += quotient_msb.eq(0)
             m.d.comb += rec_div.input_remainder.eq(concat)
 
         # wiring up rest of result from recursive module
-        m.d.comb += self.quotient[: (self.step_count - 1)].eq(rec_div.quotient)
+        m.d.comb += self.quotient.eq(Cat(rec_div.quotient[: (self.step_count - 1)], quotient_msb))
         m.d.comb += self.remainder.eq(rec_div.remainder)
 
         # partial remainder

--- a/coreblocks/func_blocks/fu/unsigned_multiplication/common.py
+++ b/coreblocks/func_blocks/fu/unsigned_multiplication/common.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from amaranth import *
 
 from coreblocks.params import GenParams
@@ -34,6 +35,10 @@ class MulBaseUnsigned(Elaboratable):
 
         self.issue = Method(i=layout.issue)
         self.accept = Method(o=layout.accept)
+
+    @abstractmethod
+    def elaborate(self, platform) -> TModule:
+        raise NotImplementedError()
 
 
 class DSPMulUnit(Elaboratable):

--- a/coreblocks/func_blocks/fu/unsigned_multiplication/pipelined.py
+++ b/coreblocks/func_blocks/fu/unsigned_multiplication/pipelined.py
@@ -47,7 +47,7 @@ class PipelinedMul(Elaboratable):
 
         self.ready = Signal()
         self.issue = Signal()
-        self.step = Signal(range(self.number_of_steps + 1), reset=self.number_of_steps)
+        self.step = Signal(range(self.number_of_steps + 1), init=self.number_of_steps)
         self.i1 = Signal(self.n_padding)
         self.i2 = Signal(self.n_padding)
         self.result = Signal(2 * n)

--- a/coreblocks/func_blocks/fu/unsigned_multiplication/sequence.py
+++ b/coreblocks/func_blocks/fu/unsigned_multiplication/sequence.py
@@ -42,7 +42,7 @@ class RecursiveWithSingleDSPMul(Elaboratable):
         self.i1 = Signal(unsigned(n))
         self.i2 = Signal(unsigned(n))
         self.result = Signal(unsigned(n * 2))
-        self.confirm = Signal(reset=0)
+        self.confirm = Signal()
         self.reset = Signal()
 
     def elaborate(self, platform) -> TModule:
@@ -135,7 +135,7 @@ class SequentialUnsignedMul(MulBaseUnsigned):
         m.submodules.dsp = dsp = DSPMulUnit(self.dsp_width)
         m.submodules.multiplier = multiplier = RecursiveWithSingleDSPMul(dsp, self.gen_params.isa.xlen)
 
-        accepted = Signal(1, reset=1)
+        accepted = Signal(1, init=1)
         m.d.sync += multiplier.reset.eq(0)
 
         @def_method(m, self.issue, ready=accepted)

--- a/coreblocks/func_blocks/fu/unsigned_multiplication/shift.py
+++ b/coreblocks/func_blocks/fu/unsigned_multiplication/shift.py
@@ -22,7 +22,7 @@ class ShiftUnsignedMul(MulBaseUnsigned):
 
         i1 = Signal(unsigned(self.gen_params.isa.xlen * 2))
         i2 = Signal(unsigned(self.gen_params.isa.xlen))
-        accepted = Signal(1, reset=1)
+        accepted = Signal(1, init=1)
 
         @def_method(m, self.issue, ready=accepted)
         def _(arg):

--- a/coreblocks/params/instr.py
+++ b/coreblocks/params/instr.py
@@ -139,7 +139,6 @@ class RISCVInstr(ABC, ValueCastable):
         const = Const.cast(self.as_value())
         return const.value  # type: ignore
 
-    @ValueCastable.lowermethod
     def as_value(self) -> Value:
         parts: list[tuple[int, Value]] = []
 

--- a/coreblocks/peripherals/wishbone.py
+++ b/coreblocks/peripherals/wishbone.py
@@ -1,4 +1,5 @@
 from amaranth import *
+from amaranth.lib.memory import Memory
 from amaranth.lib.wiring import PureInterface, Signature, In, Out, Component
 from functools import reduce
 from typing import Protocol, cast
@@ -516,10 +517,10 @@ class WishboneMemorySlave(Component):
 
     def __init__(self, wb_params: WishboneParameters, **kwargs):
         super().__init__({"bus": In(WishboneSignature(wb_params))})
-        if "width" not in kwargs:
-            kwargs["width"] = wb_params.data_width
-        if kwargs["width"] not in (8, 16, 32, 64):
-            raise RuntimeError("Memory width has to be one of: 8, 16, 32, 64")
+        if "shape" not in kwargs:
+            kwargs["shape"] = wb_params.data_width
+        if kwargs["shape"] not in (8, 16, 32, 64):
+            raise RuntimeError("Memory shape has to be one of: 8, 16, 32, 64")
         if "depth" not in kwargs:
             kwargs["depth"] = 2**wb_params.addr_width
         self.granularity = wb_params.granularity
@@ -531,8 +532,9 @@ class WishboneMemorySlave(Component):
     def elaborate(self, platform):
         m = TModule()
 
-        m.submodules.rdport = rdport = self.mem.read_port()
-        m.submodules.wrport = wrport = self.mem.write_port(granularity=self.granularity)
+        m.submodules.mem = self.mem
+        wrport = self.mem.write_port(granularity=self.granularity)
+        rdport = self.mem.read_port()
 
         with m.FSM():
             with m.State("Start"):

--- a/coreblocks/peripherals/wishbone.py
+++ b/coreblocks/peripherals/wishbone.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from amaranth.lib.memory import Memory
+import amaranth.lib.memory as memory
 from amaranth.lib.wiring import PureInterface, Signature, In, Out, Component
 from functools import reduce
 from typing import Protocol, cast
@@ -527,7 +527,7 @@ class WishboneMemorySlave(Component):
         if self.granularity not in (8, 16, 32, 64):
             raise RuntimeError("Granularity has to be one of: 8, 16, 32, 64")
 
-        self.mem = Memory(**kwargs)
+        self.mem = memory.Memory(**kwargs)
 
     def elaborate(self, platform):
         m = TModule()

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -60,12 +60,12 @@ class DoubleCounterCSR(Elaboratable):
 
 class MachineModeCSRRegisters(Elaboratable):
     def __init__(self, gen_params: GenParams):
-        self.mvendorid = CSRRegister(CSRAddress.MVENDORID, gen_params, reset=0)
-        self.marchid = CSRRegister(CSRAddress.MARCHID, gen_params, reset=gen_params.marchid)
-        self.mimpid = CSRRegister(CSRAddress.MIMPID, gen_params, reset=gen_params.mimpid)
-        self.mhartid = CSRRegister(CSRAddress.MHARTID, gen_params, reset=0)
+        self.mvendorid = CSRRegister(CSRAddress.MVENDORID, gen_params, init=0)
+        self.marchid = CSRRegister(CSRAddress.MARCHID, gen_params, init=gen_params.marchid)
+        self.mimpid = CSRRegister(CSRAddress.MIMPID, gen_params, init=gen_params.mimpid)
+        self.mhartid = CSRRegister(CSRAddress.MHARTID, gen_params, init=0)
         self.mscratch = CSRRegister(CSRAddress.MSCRATCH, gen_params)
-        self.mconfigptr = CSRRegister(CSRAddress.MCONFIGPTR, gen_params, reset=0)
+        self.mconfigptr = CSRRegister(CSRAddress.MCONFIGPTR, gen_params, init=0)
 
         self.mstatus = AliasedCSR(CSRAddress.MSTATUS, gen_params)
 

--- a/coreblocks/priv/csr/csr_register.py
+++ b/coreblocks/priv/csr/csr_register.py
@@ -61,7 +61,7 @@ class CSRRegister(Elaboratable):
         *,
         width: Optional[int] = None,
         ro_bits: int = 0,
-        reset: int | Enum = 0,
+        init: int | Enum = 0,
         fu_write_priority: bool = True,
         fu_write_filtermap: Optional[Callable[[TModule, Value], tuple[ValueLike, ValueLike]]] = None,
         fu_read_map: Optional[Callable[[TModule, Value], ValueLike]] = None,
@@ -83,7 +83,7 @@ class CSRRegister(Elaboratable):
             Note that this parameter is only required if there are some read-only
             bits in read-write register. Writes to read-only registers specified
             by upper 2 bits of CSR address set to `0b11` are discarded by `CSRUnit`.
-        reset: int | Enum
+        init: int | Enum
             Reset value of CSR.
         fu_write_priority: bool
             Priority of CSR instruction write over `write` method, if both are called at the same cycle.
@@ -131,7 +131,7 @@ class CSRRegister(Elaboratable):
         self._fu_read = self.fu_read_map.method
         self._fu_write = self.fu_write_filter.method
 
-        self.value = Signal(self.width, reset=reset)
+        self.value = Signal(self.width, init=init)
         self.side_effects = Signal(StructLayout({"read": 1, "write": 1}))
 
         # append to global CSR list

--- a/coreblocks/priv/traps/interrupt_controller.py
+++ b/coreblocks/priv/traps/interrupt_controller.py
@@ -66,7 +66,7 @@ class InternalInterruptController(Component):
         # MPIE bit - previous MIE - part of mstatus
         self.mstatus_mpie = CSRRegister(None, gen_params, width=1)
         # MPP bit - previous priv mode - part of mstatus
-        self.mstatus_mpp = CSRRegister(None, gen_params, width=2, ro_bits=0b11, reset=PrivilegeLevel.MACHINE)
+        self.mstatus_mpp = CSRRegister(None, gen_params, width=2, ro_bits=0b11, init=PrivilegeLevel.MACHINE)
         # TODO: filter xPP for only legal modes (when not read-only)
         mstatus = dm.get_dependency(GenericCSRRegistersKey()).m_mode.mstatus
         mstatus.add_field(3, self.mstatus_mie)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ needs_sphinx = "5.1.0"
 # Add any extenstions here. These could be both Sphinx or custom ones.
 extensions = [
     "myst_parser",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.ifconfig",
     "sphinx.ext.extlinks",
@@ -104,3 +105,14 @@ autodoc_class_signature = "separated"
 
 # Auto generate anchors for # - ### headers
 myst_heading_anchors = 3
+
+# Compatibility with Amaranth docstrings
+rst_prolog = """
+.. role:: py(code)
+   :language: python
+"""
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "amaranth": ("https://amaranth-lang.org/docs/amaranth/latest/", None),
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ./amaranth-stubs/  # can't use -e -- pyright doesn't see the stubs then :(
-amaranth-yosys==0.38.0.0.post88
-git+https://github.com/amaranth-lang/amaranth@6d65dc1366da2313e8e6a77d5093ddd6acdec8aa
+amaranth-yosys==0.40.0.0.post100
+git+https://github.com/amaranth-lang/amaranth@9bd536bbf96b07720d6e4a8709b30492af8ddd13
 dataclasses-json==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ./amaranth-stubs/  # can't use -e -- pyright doesn't see the stubs then :(
 amaranth-yosys==0.35.0.0.post81
-git+https://github.com/amaranth-lang/amaranth@115954b4d957b4ba642ad056ab1670bf5d185fb6
+git+https://github.com/amaranth-lang/amaranth@f48b8650c4df42b3260c4791b18fad7991af0541
 dataclasses-json==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ./amaranth-stubs/  # can't use -e -- pyright doesn't see the stubs then :(
 amaranth-yosys==0.35.0.0.post81
-git+https://github.com/amaranth-lang/amaranth@f48b8650c4df42b3260c4791b18fad7991af0541
+git+https://github.com/amaranth-lang/amaranth@6d65dc1366da2313e8e6a77d5093ddd6acdec8aa
 dataclasses-json==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ./amaranth-stubs/  # can't use -e -- pyright doesn't see the stubs then :(
-amaranth-yosys==0.35.0.0.post81
+amaranth-yosys==0.38.0.0.post88
 git+https://github.com/amaranth-lang/amaranth@6d65dc1366da2313e8e6a77d5093ddd6acdec8aa
 dataclasses-json==0.6.3

--- a/scripts/synthesize.py
+++ b/scripts/synthesize.py
@@ -6,6 +6,7 @@ import sys
 import argparse
 
 from amaranth.build import Platform
+from amaranth.build.res import PortGroup
 from amaranth import *
 from amaranth.lib.wiring import Component, Flow, Out, connect, flipped
 
@@ -61,7 +62,7 @@ class InterfaceConnector(Elaboratable):
         m = Module()
 
         pins = platform.request(self.name, self.number)
-        assert isinstance(pins, Record)
+        assert isinstance(pins, PortGroup)
 
         for hier_name, member, v in self.interface.signature.flatten(self.interface):
             name = "__".join(str(x) for x in hier_name)

--- a/test/backend/test_annoucement.py
+++ b/test/backend/test_annoucement.py
@@ -150,14 +150,14 @@ class TestBackend(TestCaseWithSimulator):
         self.fu_count = 1
         self.initialize()
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.consumer)
+            sim.add_process(self.consumer)
             for i in range(self.fu_count):
-                sim.add_sync_process(self.generate_producer(i))
+                sim.add_process(self.generate_producer(i))
 
     def test_many_out(self):
         self.fu_count = 4
         self.initialize()
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.consumer)
+            sim.add_process(self.consumer)
             for i in range(self.fu_count):
-                sim.add_sync_process(self.generate_producer(i))
+                sim.add_process(self.generate_producer(i))

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -142,14 +142,14 @@ class TestRetirement(TestCaseWithSimulator):
                 wait_cycles += 1
                 if wait_cycles >= self.cycles + 10:
                     assert False, "RAT entry was not updated"
-                yield
+                yield Tick()
         assert not self.submit_q
         assert not self.rf_free_q
 
     def precommit_process(self):
         yield from self.retc.precommit_adapter.call_init()
         while self.precommit_q:
-            yield
+            yield Tick()
             info = yield from self.retc.precommit_adapter.call_result()
             assert info is not None
             assert info["side_fx"]

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -187,6 +187,6 @@ class TestRetirement(TestCaseWithSimulator):
     def test_rand(self):
         self.retc = RetirementTestCircuit(self.gen_params)
         with self.run_simulation(self.retc) as sim:
-            sim.add_sync_process(self.free_reg_process)
-            sim.add_sync_process(self.rat_process)
-            sim.add_sync_process(self.precommit_process)
+            sim.add_process(self.free_reg_process)
+            sim.add_process(self.rat_process)
+            sim.add_process(self.precommit_process)

--- a/test/cache/test_icache.py
+++ b/test/cache/test_icache.py
@@ -149,8 +149,8 @@ class TestSimpleCommonBusCacheRefiller(TestCaseWithSimulator):
 
     def test(self):
         with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.wishbone_slave)
-            sim.add_sync_process(self.refiller_process)
+            sim.add_process(self.wishbone_slave)
+            sim.add_process(self.refiller_process)
 
 
 class ICacheBypassTestCircuit(Elaboratable):
@@ -267,8 +267,8 @@ class TestICacheBypass(TestCaseWithSimulator):
 
     def test(self):
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.wishbone_slave)
-            sim.add_sync_process(self.user_process)
+            sim.add_process(self.wishbone_slave)
+            sim.add_process(self.user_process)
 
 
 class MockedCacheRefiller(Elaboratable, CacheRefillerInterface):
@@ -459,7 +459,7 @@ class TestICache(TestCaseWithSimulator):
             assert len(self.refill_requests) == 0
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(cache_user_process)
+            sim.add_process(cache_user_process)
 
     def test_2_way(self):
         self.init_module(2, 4)
@@ -477,7 +477,7 @@ class TestICache(TestCaseWithSimulator):
             assert len(self.refill_requests) == 0
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(cache_process)
+            sim.add_process(cache_process)
 
     # Tests whether the cache is fully pipelined and the latency between requests and response is exactly one cycle.
     def test_pipeline(self):
@@ -573,7 +573,7 @@ class TestICache(TestCaseWithSimulator):
             yield from self.m.accept_res.disable()
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(cache_process)
+            sim.add_process(cache_process)
 
     def test_flush(self):
         self.init_module(2, 4)
@@ -656,7 +656,7 @@ class TestICache(TestCaseWithSimulator):
             self.expect_refill(0x00010000)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(cache_process)
+            sim.add_process(cache_process)
 
     def test_errors(self):
         self.init_module(1, 4)
@@ -753,7 +753,7 @@ class TestICache(TestCaseWithSimulator):
             yield from self.expect_resp(wait=True)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(cache_process)
+            sim.add_process(cache_process)
 
     def test_random(self):
         self.init_module(4, 8)
@@ -793,6 +793,6 @@ class TestICache(TestCaseWithSimulator):
                     yield Tick()
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(sender)
-            sim.add_sync_process(receiver)
-            sim.add_sync_process(refiller_ctrl)
+            sim.add_process(sender)
+            sim.add_process(receiver)
+            sim.add_process(refiller_ctrl)

--- a/test/core_structs/test_rat.py
+++ b/test/core_structs/test_rat.py
@@ -44,7 +44,7 @@ class TestFrontendRegisterAliasTable(TestCaseWithSimulator):
 
         self.gen_input()
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(self.do_rename)
+            sim.add_process(self.do_rename)
 
 
 class TestRetirementRegisterAliasTable(TestCaseWithSimulator):
@@ -81,4 +81,4 @@ class TestRetirementRegisterAliasTable(TestCaseWithSimulator):
 
         self.gen_input()
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(self.do_commit)
+            sim.add_process(self.do_commit)

--- a/test/core_structs/test_reorder_buffer.py
+++ b/test/core_structs/test_reorder_buffer.py
@@ -82,9 +82,9 @@ class TestReorderBuffer(TestCaseWithSimulator):
         self.log_regs = self.gen_params.isa.reg_cnt
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(self.gen_input)
-            sim.add_sync_process(self.do_updates)
-            sim.add_sync_process(self.do_retire)
+            sim.add_process(self.gen_input)
+            sim.add_process(self.do_updates)
+            sim.add_process(self.do_retire)
 
 
 class TestFullDoneCase(TestCaseWithSimulator):
@@ -130,5 +130,5 @@ class TestFullDoneCase(TestCaseWithSimulator):
         self.phys_regs = 2**self.gen_params.phys_regs_bits
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(self.gen_input)
-            sim.add_sync_process(self.do_retire)
+            sim.add_process(self.gen_input)
+            sim.add_process(self.do_retire)

--- a/test/core_structs/test_reorder_buffer.py
+++ b/test/core_structs/test_reorder_buffer.py
@@ -1,4 +1,4 @@
-from amaranth.sim import Passive, Settle
+from amaranth.sim import Passive, Settle, Tick
 
 from transactron.testing import TestCaseWithSimulator, SimpleTestCircuit
 
@@ -14,7 +14,7 @@ class TestReorderBuffer(TestCaseWithSimulator):
     def gen_input(self):
         for _ in range(self.test_steps):
             while self.regs_left_queue.empty():
-                yield
+                yield Tick()
 
             while self.rand.random() < 0.5:
                 yield  # to slow down puts
@@ -31,7 +31,7 @@ class TestReorderBuffer(TestCaseWithSimulator):
             while self.rand.random() < 0.5:
                 yield  # to slow down execution
             if len(self.to_execute_list) == 0:
-                yield
+                yield Tick()
             else:
                 idx = self.rand.randint(0, len(self.to_execute_list) - 1)
                 rob_id, executed = self.to_execute_list.pop(idx)
@@ -43,7 +43,7 @@ class TestReorderBuffer(TestCaseWithSimulator):
         while True:
             if self.retire_queue.empty():
                 self.m.retire.enable()
-                yield
+                yield Tick()
                 is_ready = yield self.m.retire.adapter.done
                 assert is_ready == 0  # transaction should not be ready if there is nothing to retire
             else:
@@ -97,7 +97,7 @@ class TestFullDoneCase(TestCaseWithSimulator):
 
     def do_single_update(self):
         while len(self.to_execute_list) == 0:
-            yield
+            yield Tick()
 
         rob_id = self.to_execute_list.pop(0)
         yield from self.m.mark_done.call(rob_id)
@@ -113,7 +113,7 @@ class TestFullDoneCase(TestCaseWithSimulator):
             yield from self.m.retire.call()
 
         yield from self.m.retire.enable()
-        yield
+        yield Tick()
         res = yield self.m.retire.adapter.done
         assert res == 0  # should be disabled, since we have read all elements
 

--- a/test/frontend/test_decode_stage.py
+++ b/test/frontend/test_decode_stage.py
@@ -79,4 +79,4 @@ class TestDecode(TestCaseWithSimulator):
 
     def test(self):
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.decode_test_proc)
+            sim.add_process(self.decode_test_proc)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -209,8 +209,8 @@ class TestFetchUnit(TestCaseWithSimulator):
 
     def run_sim(self):
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.cache_process)
-            sim.add_sync_process(self.fetch_out_check)
+            sim.add_process(self.cache_process)
+            sim.add_process(self.fetch_out_check)
 
     def test_simple_no_jumps(self):
         for _ in range(50):
@@ -389,8 +389,8 @@ class TestFetchUnit(TestCaseWithSimulator):
                     self.gen_branch(offset, taken=random.randrange(2) == 0)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.cache_process)
-            sim.add_sync_process(self.fetch_out_check)
+            sim.add_process(self.cache_process)
+            sim.add_process(self.fetch_out_check)
 
 
 @dataclass(frozen=True)
@@ -636,7 +636,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
             self.assert_resp(ret, mispredicted=False)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(proc)
+            sim.add_process(proc)
 
     def test_preceding_redirection(self):
         instr_width = self.gen_params.min_instr_width_bytes
@@ -735,7 +735,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
             )
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(proc)
+            sim.add_process(proc)
 
     def test_mispredicted_cfi_type(self):
         instr_width = self.gen_params.min_instr_width_bytes
@@ -781,7 +781,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
             )
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(proc)
+            sim.add_process(proc)
 
     def test_mispredicted_cfi_target(self):
         instr_width = self.gen_params.min_instr_width_bytes
@@ -825,4 +825,4 @@ class TestPredictionChecker(TestCaseWithSimulator):
             )
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(proc)
+            sim.add_process(proc)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -6,7 +6,7 @@ from parameterized import parameterized_class
 import random
 
 from amaranth import Elaboratable, Module
-from amaranth.sim import Passive
+from amaranth.sim import Passive, Tick
 from coreblocks.interface.keys import FetchResumeKey
 
 from transactron.core import Method
@@ -138,10 +138,10 @@ class TestFetchUnit(TestCaseWithSimulator):
 
         while True:
             while len(self.input_q) == 0:
-                yield
+                yield Tick()
 
             while random.random() < 0.5:
-                yield
+                yield Tick()
 
             req_addr = self.input_q.popleft() & ~(self.gen_params.fetch_block_bytes - 1)
 
@@ -194,7 +194,7 @@ class TestFetchUnit(TestCaseWithSimulator):
 
                 # Empty the pipeline
                 yield from self.clean_fifo.call_try()
-                yield
+                yield Tick()
 
                 resume_pc = instr["next_pc"]
                 if access_fault:

--- a/test/frontend/test_rvc.py
+++ b/test/frontend/test_rvc.py
@@ -1,6 +1,6 @@
 from parameterized import parameterized_class
 
-from amaranth.sim import Settle
+from amaranth.sim import Settle, Tick
 from amaranth import *
 
 from coreblocks.frontend.decoder.rvc import InstrDecompress
@@ -291,7 +291,7 @@ class TestInstrDecompress(TestCaseWithSimulator):
                 yield Settle()
 
                 assert (yield self.m.instr_out) == (yield expected)
-                yield
+                yield Tick()
 
         with self.run_simulation(self.m) as sim:
             sim.add_sync_process(process)

--- a/test/frontend/test_rvc.py
+++ b/test/frontend/test_rvc.py
@@ -294,4 +294,4 @@ class TestInstrDecompress(TestCaseWithSimulator):
                 yield Tick()
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)

--- a/test/func_blocks/csr/test_csr.py
+++ b/test/func_blocks/csr/test_csr.py
@@ -153,7 +153,7 @@ class TestCSRUnit(TestCaseWithSimulator):
         self.dut = CSRUnitTestCircuit(self.gen_params, self.csr_count)
 
         with self.run_simulation(self.dut) as sim:
-            sim.add_sync_process(self.process_test)
+            sim.add_process(self.process_test)
 
     exception_csr_numbers = [
         0xC00,  # read_only
@@ -201,7 +201,7 @@ class TestCSRUnit(TestCaseWithSimulator):
         self.dut = CSRUnitTestCircuit(self.gen_params, 0, only_legal=False)
 
         with self.run_simulation(self.dut) as sim:
-            sim.add_sync_process(self.process_exception_test)
+            sim.add_process(self.process_exception_test)
 
 
 class TestCSRRegister(TestCaseWithSimulator):
@@ -266,7 +266,7 @@ class TestCSRRegister(TestCaseWithSimulator):
         self.dut = SimpleTestCircuit(CSRRegister(0, self.gen_params, ro_bits=self.ro_mask))
 
         with self.run_simulation(self.dut) as sim:
-            sim.add_sync_process(self.randomized_process_test)
+            sim.add_process(self.randomized_process_test)
 
     def filtermap_process_test(self):
         prev_value = 0
@@ -318,7 +318,7 @@ class TestCSRRegister(TestCaseWithSimulator):
         )
 
         with self.run_simulation(self.dut) as sim:
-            sim.add_sync_process(self.filtermap_process_test)
+            sim.add_process(self.filtermap_process_test)
 
     def comb_process_test(self):
         yield from self.dut.read.enable()
@@ -357,7 +357,7 @@ class TestCSRRegister(TestCaseWithSimulator):
 
         random.seed(4326)
 
-        self.dut = SimpleTestCircuit(CSRRegister(None, gen_params, ro_bits=0b1111, fu_write_priority=False, reset=0xAB))
+        self.dut = SimpleTestCircuit(CSRRegister(None, gen_params, ro_bits=0b1111, fu_write_priority=False, init=0xAB))
 
         with self.run_simulation(self.dut) as sim:
-            sim.add_sync_process(self.comb_process_test)
+            sim.add_process(self.comb_process_test)

--- a/test/func_blocks/csr/test_csr.py
+++ b/test/func_blocks/csr/test_csr.py
@@ -234,7 +234,7 @@ class TestCSRRegister(TestCaseWithSimulator):
                 fu_read = True
                 yield from self.dut._fu_read.enable()
 
-            yield
+            yield Tick()
             yield Settle()
 
             exp_read_data = exp_write_data if fu_write or write else previous_data
@@ -329,19 +329,19 @@ class TestCSRRegister(TestCaseWithSimulator):
         yield from self.dut._fu_write.call_do()
         assert (yield from self.dut.read_comb.call_result())["data"] == 0xFFFF
         assert (yield from self.dut._fu_read.call_result())["data"] == 0xAB
-        yield
+        yield Tick()
         assert (yield from self.dut.read.call_result())["data"] == 0xFFFB
         assert (yield from self.dut._fu_read.call_result())["data"] == 0xFFFB
-        yield
+        yield Tick()
 
         yield from self.dut._fu_write.call_init({"data": 0x0FFF})
         yield from self.dut.write.call_init({"data": 0xAAAA})
         yield from self.dut._fu_write.call_do()
         yield from self.dut.write.call_do()
         assert (yield from self.dut.read_comb.call_result()) == {"data": 0x0FFF, "read": 1, "written": 1}
-        yield
+        yield Tick()
         assert (yield from self.dut._fu_read.call_result())["data"] == 0xAAAA
-        yield
+        yield Tick()
 
         # single cycle
         yield from self.dut._fu_write.call_init({"data": 0x0BBB})
@@ -349,7 +349,7 @@ class TestCSRRegister(TestCaseWithSimulator):
         update_val = (yield from self.dut.read_comb.call_result())["data"] | 0xD000
         yield from self.dut.write.call_init({"data": update_val})
         yield from self.dut.write.call_do()
-        yield
+        yield Tick()
         assert (yield from self.dut._fu_read.call_result())["data"] == 0xDBBB
 
     def test_comb(self):

--- a/test/func_blocks/fu/common/test_rs.py
+++ b/test/func_blocks/fu/common/test_rs.py
@@ -75,10 +75,10 @@ class TestRS(TestCaseWithSimulator):
         self.finished = False
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.select_process)
-            sim.add_sync_process(self.insert_process)
-            sim.add_sync_process(self.update_process)
-            sim.add_sync_process(self.take_process)
+            sim.add_process(self.select_process)
+            sim.add_process(self.insert_process)
+            sim.add_process(self.update_process)
+            sim.add_process(self.take_process)
 
     def select_process(self):
         for k in range(len(self.data_list)):
@@ -171,7 +171,7 @@ class TestRSMethodInsert(TestCaseWithSimulator):
         self.check_list = create_check_list(self.rs_entries_bits, self.insert_list)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.simulation_process)
+            sim.add_process(self.simulation_process)
 
     def simulation_process(self):
         # After each insert, entry should be marked as full
@@ -216,7 +216,7 @@ class TestRSMethodSelect(TestCaseWithSimulator):
         self.check_list = create_check_list(self.rs_entries_bits, self.insert_list)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.simulation_process)
+            sim.add_process(self.simulation_process)
 
     def simulation_process(self):
         # In the beginning the select method should be ready and id should be selectable
@@ -279,7 +279,7 @@ class TestRSMethodUpdate(TestCaseWithSimulator):
         self.check_list = create_check_list(self.rs_entries_bits, self.insert_list)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.simulation_process)
+            sim.add_process(self.simulation_process)
 
     def simulation_process(self):
         # Insert all reacords
@@ -370,7 +370,7 @@ class TestRSMethodTake(TestCaseWithSimulator):
         self.check_list = create_check_list(self.rs_entries_bits, self.insert_list)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.simulation_process)
+            sim.add_process(self.simulation_process)
 
     def simulation_process(self):
         # After each insert, entry should be marked as full
@@ -469,7 +469,7 @@ class TestRSMethodGetReadyList(TestCaseWithSimulator):
         self.check_list = create_check_list(self.rs_entries_bits, self.insert_list)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.simulation_process)
+            sim.add_process(self.simulation_process)
 
     def simulation_process(self):
         # After each insert, entry should be marked as full
@@ -525,7 +525,7 @@ class TestRSMethodTwoGetReadyLists(TestCaseWithSimulator):
         self.check_list = create_check_list(self.rs_entries_bits, self.insert_list)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.simulation_process)
+            sim.add_process(self.simulation_process)
 
     def simulation_process(self):
         # After each insert, entry should be marked as full

--- a/test/func_blocks/fu/functional_common.py
+++ b/test/func_blocks/fu/functional_common.py
@@ -186,8 +186,8 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
             self.max_wait = 10
 
         with self.run_simulation(self.circ) as sim:
-            sim.add_sync_process(self.producer)
-            sim.add_sync_process(self.consumer)
-            sim.add_sync_process(self.exception_consumer)
+            sim.add_process(self.producer)
+            sim.add_process(self.consumer)
+            sim.add_process(self.exception_consumer)
             if pipeline_test:
-                sim.add_sync_process(self.pipeline_verifier)
+                sim.add_process(self.pipeline_verifier)

--- a/test/func_blocks/fu/functional_common.py
+++ b/test/func_blocks/fu/functional_common.py
@@ -6,7 +6,7 @@ from collections import deque
 from typing import Generic, TypeVar
 
 from amaranth import Elaboratable, Signal
-from amaranth.sim import Passive
+from amaranth.sim import Passive, Tick
 
 from coreblocks.params import GenParams
 from coreblocks.params.configurations import test_core_config
@@ -177,7 +177,7 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
         while True:
             assert (yield self.m.issue.adapter.iface.ready)
             assert (yield self.m.issue.adapter.en) == (yield self.m.issue.adapter.done)
-            yield
+            yield Tick()
 
     def run_standard_fu_test(self, pipeline_test=False):
         if pipeline_test:

--- a/test/func_blocks/fu/test_pipelined_mul_unit.py
+++ b/test/func_blocks/fu/test_pipelined_mul_unit.py
@@ -80,5 +80,5 @@ class TestPipelinedUnsignedMul(TestCaseWithSimulator):
                 yield from self.m.issue.call(req)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(producer)
-            sim.add_sync_process(consumer)
+            sim.add_process(producer)
+            sim.add_process(consumer)

--- a/test/func_blocks/fu/test_unsigned_mul_unit.py
+++ b/test/func_blocks/fu/test_unsigned_mul_unit.py
@@ -83,5 +83,5 @@ class TestUnsignedMultiplicationUnit(TestCaseWithSimulator):
                 yield from self.random_wait(self.waiting_time)
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(producer)
-            sim.add_sync_process(consumer)
+            sim.add_process(producer)
+            sim.add_process(consumer)

--- a/test/func_blocks/lsu/test_dummylsu.py
+++ b/test/func_blocks/lsu/test_dummylsu.py
@@ -248,9 +248,9 @@ class TestDummyLSULoads(TestCaseWithSimulator):
             assert arg == self.exception_queue.pop()
 
         with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.wishbone_slave)
-            sim.add_sync_process(self.inserter)
-            sim.add_sync_process(self.consumer)
+            sim.add_process(self.wishbone_slave)
+            sim.add_process(self.inserter)
+            sim.add_process(self.consumer)
 
 
 class TestDummyLSULoadsCycles(TestCaseWithSimulator):
@@ -305,7 +305,7 @@ class TestDummyLSULoadsCycles(TestCaseWithSimulator):
             assert False
 
         with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.one_instr_test)
+            sim.add_process(self.one_instr_test)
 
 
 class TestDummyLSUStores(TestCaseWithSimulator):
@@ -410,10 +410,10 @@ class TestDummyLSUStores(TestCaseWithSimulator):
             assert False
 
         with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.wishbone_slave)
-            sim.add_sync_process(self.inserter)
-            sim.add_sync_process(self.get_resulter)
-            sim.add_sync_process(self.precommiter)
+            sim.add_process(self.wishbone_slave)
+            sim.add_process(self.inserter)
+            sim.add_process(self.get_resulter)
+            sim.add_process(self.precommiter)
 
 
 class TestDummyLSUFence(TestCaseWithSimulator):
@@ -448,4 +448,4 @@ class TestDummyLSUFence(TestCaseWithSimulator):
             assert False
 
         with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.process)
+            sim.add_process(self.process)

--- a/test/func_blocks/lsu/test_dummylsu.py
+++ b/test/func_blocks/lsu/test_dummylsu.py
@@ -1,7 +1,7 @@
 import random
 from collections import deque
 
-from amaranth.sim import Settle, Passive
+from amaranth.sim import Settle, Passive, Tick
 
 from transactron.lib import Adapter
 from transactron.utils import int_to_signed, signed_to_int
@@ -222,7 +222,7 @@ class TestDummyLSULoads(TestCaseWithSimulator):
         for i in range(self.tests_number):
             req = self.instr_queue.pop()
             while req["rob_id"] not in self.free_rob_id:
-                yield
+                yield Tick()
             self.free_rob_id.remove(req["rob_id"])
             yield from self.test_module.issue.call(req)
             yield from self.random_wait(self.max_wait)
@@ -400,7 +400,7 @@ class TestDummyLSUStores(TestCaseWithSimulator):
         yield Passive()
         while True:
             while len(self.precommit_data) == 0:
-                yield
+                yield Tick()
             rob_id = self.precommit_data[-1]  # precommit is called continously until instruction is retired
             yield from self.test_module.precommit.call(rob_id=rob_id, side_fx=1)
 

--- a/test/func_blocks/lsu/test_pma.py
+++ b/test/func_blocks/lsu/test_pma.py
@@ -40,7 +40,7 @@ class TestPMADirect(TestCaseWithSimulator):
         self.test_module = PMAChecker(self.gen_params)
 
         with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.process)
+            sim.add_process(self.process)
 
 
 class PMAIndirectTestCircuit(Elaboratable):
@@ -127,4 +127,4 @@ class TestPMAIndirect(TestCaseWithSimulator):
             assert False
 
         with self.run_simulation(self.test_module) as sim:
-            sim.add_sync_process(self.process)
+            sim.add_process(self.process)

--- a/test/peripherals/test_axi_lite.py
+++ b/test/peripherals/test_axi_lite.py
@@ -14,7 +14,7 @@ class AXILiteInterfaceWrapper:
 
     def slave_ra_wait(self):
         while not (yield self.axi_lite.read_address.valid):
-            yield
+            yield Tick()
 
     def slave_ra_verify(self, exp_addr, prot):
         assert (yield self.axi_lite.read_address.valid)
@@ -23,14 +23,14 @@ class AXILiteInterfaceWrapper:
 
     def slave_rd_wait(self):
         while not (yield self.axi_lite.read_data.rdy):
-            yield
+            yield Tick()
 
     def slave_rd_respond(self, data, resp=0):
         assert (yield self.axi_lite.read_data.rdy)
         yield self.axi_lite.read_data.data.eq(data)
         yield self.axi_lite.read_data.resp.eq(resp)
         yield self.axi_lite.read_data.valid.eq(1)
-        yield
+        yield Tick()
         yield self.axi_lite.read_data.valid.eq(0)
 
     def slave_wa_ready(self, rdy=1):
@@ -38,7 +38,7 @@ class AXILiteInterfaceWrapper:
 
     def slave_wa_wait(self):
         while not (yield self.axi_lite.write_address.valid):
-            yield
+            yield Tick()
 
     def slave_wa_verify(self, exp_addr, prot):
         assert (yield self.axi_lite.write_address.valid)
@@ -50,7 +50,7 @@ class AXILiteInterfaceWrapper:
 
     def slave_wd_wait(self):
         while not (yield self.axi_lite.write_data.valid):
-            yield
+            yield Tick()
 
     def slave_wd_verify(self, exp_data, strb):
         assert (yield self.axi_lite.write_data.valid)
@@ -59,13 +59,13 @@ class AXILiteInterfaceWrapper:
 
     def slave_wr_wait(self):
         while not (yield self.axi_lite.write_response.rdy):
-            yield
+            yield Tick()
 
     def slave_wr_respond(self, resp=0):
         assert (yield self.axi_lite.write_response.rdy)
         yield self.axi_lite.write_response.resp.eq(resp)
         yield self.axi_lite.write_response.valid.eq(1)
-        yield
+        yield Tick()
         yield self.axi_lite.write_response.valid.eq(0)
 
 
@@ -201,12 +201,12 @@ class TestAXILiteMaster(TestCaseWithSimulator):
 
             yield from slave.slave_ra_wait()
             for _ in range(2):
-                yield
+                yield Tick()
             yield from slave.slave_ra_ready(1)
             yield from slave.slave_ra_verify(1, 1)
             # wait for next rising edge
-            yield
-            yield
+            yield Tick()
+            yield Tick()
 
             yield from slave.slave_ra_wait()
             yield from slave.slave_ra_verify(2, 1)
@@ -247,7 +247,7 @@ class TestAXILiteMaster(TestCaseWithSimulator):
             assert resp["resp"] == 0
 
             for _ in range(5):
-                yield
+                yield Tick()
 
             resp = yield from almt.read_data_response_adapter.call()
             assert resp["data"] == 3

--- a/test/peripherals/test_axi_lite.py
+++ b/test/peripherals/test_axi_lite.py
@@ -258,6 +258,6 @@ class TestAXILiteMaster(TestCaseWithSimulator):
             assert resp["resp"] == 1
 
         with self.run_simulation(almt) as sim:
-            sim.add_sync_process(master_process)
-            sim.add_sync_process(slave_process)
-            sim.add_sync_process(result_process)
+            sim.add_process(master_process)
+            sim.add_process(slave_process)
+            sim.add_process(result_process)

--- a/test/peripherals/test_wishbone.py
+++ b/test/peripherals/test_wishbone.py
@@ -137,9 +137,9 @@ class TestWishboneMaster(TestCaseWithSimulator):
             yield from wwb.slave_respond(1, ack=1, err=1, rty=0)
 
         with self.run_simulation(twbm) as sim:
-            sim.add_sync_process(process)
-            sim.add_sync_process(result_process)
-            sim.add_sync_process(slave)
+            sim.add_process(process)
+            sim.add_process(result_process)
+            sim.add_process(slave)
 
 
 class TestWishboneMuxer(TestCaseWithSimulator):
@@ -180,7 +180,7 @@ class TestWishboneMuxer(TestCaseWithSimulator):
             yield from wb_master.master_verify(1)
 
         with self.run_simulation(mux) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class TestWishboneAribiter(TestCaseWithSimulator):
@@ -239,7 +239,7 @@ class TestWishboneAribiter(TestCaseWithSimulator):
             yield from masters[1].master_verify()
 
         with self.run_simulation(arb) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class TestPipelinedWishboneMaster(TestCaseWithSimulator):
@@ -303,9 +303,9 @@ class TestPipelinedWishboneMaster(TestCaseWithSimulator):
                 yield Tick()
 
         with self.run_simulation(pwbm) as sim:
-            sim.add_sync_process(request_process)
-            sim.add_sync_process(verify_process)
-            sim.add_sync_process(slave_process)
+            sim.add_process(request_process)
+            sim.add_process(verify_process)
+            sim.add_process(slave_process)
 
 
 class WishboneMemorySlaveCircuit(Elaboratable):
@@ -389,6 +389,6 @@ class TestWishboneMemorySlave(TestCaseWithSimulator):
                     assert (yield self.m.mem_slave.mem[req["addr"]]) == mem_state[req["addr"]]
 
         with self.run_simulation(self.m, max_cycles=3000) as sim:
-            sim.add_sync_process(request_process)
-            sim.add_sync_process(result_process)
-            sim.add_sync_process(write_process)
+            sim.add_process(request_process)
+            sim.add_process(result_process)
+            sim.add_process(write_process)

--- a/test/peripherals/test_wishbone.py
+++ b/test/peripherals/test_wishbone.py
@@ -32,7 +32,7 @@ class WishboneInterfaceWrapper:
 
     def slave_wait(self):
         while not ((yield self.wb.stb) and (yield self.wb.cyc)):
-            yield
+            yield Tick()
 
     def slave_verify(self, exp_addr, exp_data, exp_we, exp_sel=0):
         assert (yield self.wb.stb) and (yield self.wb.cyc)
@@ -50,14 +50,14 @@ class WishboneInterfaceWrapper:
         yield self.wb.ack.eq(ack)
         yield self.wb.err.eq(err)
         yield self.wb.rty.eq(rty)
-        yield
+        yield Tick()
         yield self.wb.ack.eq(0)
         yield self.wb.err.eq(0)
         yield self.wb.rty.eq(0)
 
     def wait_ack(self):
         while not ((yield self.wb.stb) and (yield self.wb.cyc) and (yield self.wb.ack)):
-            yield
+            yield Tick()
 
 
 class TestWishboneMaster(TestCaseWithSimulator):
@@ -80,8 +80,8 @@ class TestWishboneMaster(TestCaseWithSimulator):
             yield from twbm.requestAdapter.call(addr=2, data=0, we=0, sel=1)
 
             # read request after delay
-            yield
-            yield
+            yield Tick()
+            yield Tick()
             yield from twbm.requestAdapter.call(addr=1, data=0, we=0, sel=1)
 
             # write request
@@ -124,7 +124,7 @@ class TestWishboneMaster(TestCaseWithSimulator):
             yield  # consecutive request
             yield from wwb.slave_verify(3, 5, 1, 0)
             yield from wwb.slave_respond(0)
-            yield
+            yield Tick()
 
             yield  # consecutive request
             yield from wwb.slave_verify(2, 0, 0, 0)
@@ -153,28 +153,28 @@ class TestWishboneMuxer(TestCaseWithSimulator):
             # check full communiaction
             yield from wb_master.master_set(2, 0, 1)
             yield mux.sselTGA.eq(0b0001)
-            yield
+            yield Tick()
             yield from slaves[0].slave_verify(2, 0, 1)
             assert not (yield slaves[1].wb.stb)
             yield from slaves[0].slave_respond(4)
             yield from wb_master.master_verify(4)
             yield from wb_master.master_release(release_cyc=0)
-            yield
+            yield Tick()
             # select without releasing cyc (only on stb)
             yield from wb_master.master_set(3, 0, 0)
             yield mux.sselTGA.eq(0b0010)
-            yield
+            yield Tick()
             assert not (yield slaves[0].wb.stb)
             yield from slaves[1].slave_verify(3, 0, 0)
             yield from slaves[1].slave_respond(5)
             yield from wb_master.master_verify(5)
             yield from wb_master.master_release()
-            yield
+            yield Tick()
 
             # normal selection
             yield from wb_master.master_set(6, 0, 0)
             yield mux.sselTGA.eq(0b1000)
-            yield
+            yield Tick()
             yield from slaves[3].slave_verify(6, 0, 0)
             yield from slaves[3].slave_respond(1)
             yield from wb_master.master_verify(1)
@@ -199,7 +199,7 @@ class TestWishboneAribiter(TestCaseWithSimulator):
             yield from masters[0].master_verify()
             assert not (yield masters[1].wb.ack)
             yield from masters[0].master_release()
-            yield
+            yield Tick()
 
             # check if bus is granted to next master if previous ends cycle
             yield from slave.slave_wait()
@@ -208,7 +208,7 @@ class TestWishboneAribiter(TestCaseWithSimulator):
             yield from masters[1].master_verify()
             assert not (yield masters[0].wb.ack)
             yield from masters[1].master_release()
-            yield
+            yield Tick()
 
             # check round robin behaviour (2 masters requesting *2)
             yield from masters[0].master_set(1, 0, 0)
@@ -219,7 +219,7 @@ class TestWishboneAribiter(TestCaseWithSimulator):
             yield from masters[0].master_verify(3)
             yield from masters[0].master_release()
             yield from masters[1].master_release()
-            yield
+            yield Tick()
             assert not (yield slave.wb.cyc)
 
             yield from masters[0].master_set(1, 0, 0)
@@ -231,7 +231,7 @@ class TestWishboneAribiter(TestCaseWithSimulator):
 
             # check if releasing stb keeps grant
             yield from masters[1].master_release(release_cyc=0)
-            yield
+            yield Tick()
             yield from masters[1].master_set(3, 0, 0)
             yield from slave.slave_wait()
             yield from slave.slave_verify(3, 0, 0)
@@ -268,7 +268,7 @@ class TestPipelinedWishboneMaster(TestCaseWithSimulator):
         def verify_process():
             for _ in range(requests):
                 while random.random() < 0.8:
-                    yield
+                    yield Tick()
 
                 result = yield from pwbm.result.call()
                 cres = res_queue.pop()
@@ -300,7 +300,7 @@ class TestPipelinedWishboneMaster(TestCaseWithSimulator):
 
                 yield wbw.stall.eq(random.random() < 0.3)
 
-                yield
+                yield Tick()
 
         with self.run_simulation(pwbm) as sim:
             sim.add_sync_process(request_process)
@@ -357,13 +357,13 @@ class TestWishboneMemorySlave(TestCaseWithSimulator):
                 wr_queue.appendleft(req)
 
                 while random.random() < 0.2:
-                    yield
+                    yield Tick()
                 yield from self.m.request.call(req)
 
         def result_process():
             for _ in range(self.iters):
                 while random.random() < 0.2:
-                    yield
+                    yield Tick()
                 res = yield from self.m.result.call()
                 req = req_queue.pop()
 
@@ -383,7 +383,7 @@ class TestWishboneMemorySlave(TestCaseWithSimulator):
                             mem_state[req["addr"]] &= ~granularity_mask
                             mem_state[req["addr"]] |= req["data"] & granularity_mask
 
-                yield
+                yield Tick()
 
                 if req["we"]:
                     assert (yield self.m.mem_slave.mem[req["addr"]]) == mem_state[req["addr"]]

--- a/test/peripherals/test_wishbone.py
+++ b/test/peripherals/test_wishbone.py
@@ -333,7 +333,7 @@ class TestWishboneMemorySlave(TestCaseWithSimulator):
 
         self.addr_width = (self.memsize - 1).bit_length()  # nearest log2 >= log2(memsize)
         self.wb_params = WishboneParameters(data_width=32, addr_width=self.addr_width, granularity=16)
-        self.m = WishboneMemorySlaveCircuit(wb_params=self.wb_params, mem_args={"depth": self.memsize})
+        self.m = WishboneMemorySlaveCircuit(wb_params=self.wb_params, mem_args={"depth": self.memsize, "init": []})
 
         self.sel_width = self.wb_params.data_width // self.wb_params.granularity
 
@@ -386,7 +386,7 @@ class TestWishboneMemorySlave(TestCaseWithSimulator):
                 yield Tick()
 
                 if req["we"]:
-                    assert (yield self.m.mem_slave.mem[req["addr"]]) == mem_state[req["addr"]]
+                    assert (yield self.m.mem_slave.mem.data[req["addr"]]) == mem_state[req["addr"]]
 
         with self.run_simulation(self.m, max_cycles=3000) as sim:
             sim.add_process(request_process)

--- a/test/peripherals/test_wishbone.py
+++ b/test/peripherals/test_wishbone.py
@@ -386,7 +386,7 @@ class TestWishboneMemorySlave(TestCaseWithSimulator):
                 yield Tick()
 
                 if req["we"]:
-                    assert (yield self.m.mem_slave.mem.data[req["addr"]]) == mem_state[req["addr"]]
+                    assert (yield Value.cast(self.m.mem_slave.mem.data[req["addr"]])) == mem_state[req["addr"]]
 
         with self.run_simulation(self.m, max_cycles=3000) as sim:
             sim.add_process(request_process)

--- a/test/priv/traps/test_exception.py
+++ b/test/priv/traps/test_exception.py
@@ -76,4 +76,4 @@ class TestExceptionCauseRegister(TestCaseWithSimulator):
             return {"start": self.rob_id, "end": 0}
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(process_test)
+            sim.add_process(process_test)

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -159,7 +159,6 @@ class CocotbSimulation(SimulationBackend):
                 elif component[0] == "\\":
                     obj = obj._id(component[1:], extended=False)
                 else:
-                    print(dir(obj))
                     raise
 
         return obj

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -153,10 +153,13 @@ class CocotbSimulation(SimulationBackend):
                 # function instead of 'getattr' - this is required by cocotb.
                 obj = obj._id(component, extended=False)
             except AttributeError:
-                # Try with escaped name
+                # Try with escaped or unescaped name
                 if component[0] != "\\" and component[-1] != " ":
                     obj = obj._id("\\" + component + " ", extended=False)
+                elif component[0] == "\\":
+                    obj = obj._id(component[1:], extended=False)
                 else:
+                    print(dir(obj))
                     raise
 
         return obj

--- a/test/regression/cocotb/benchmark.Makefile
+++ b/test/regression/cocotb/benchmark.Makefile
@@ -14,7 +14,7 @@ SIM_BUILD = build/benchmark
 
 # Yosys/Amaranth borkedness workaround
 ifeq ($(SIM),verilator)
-  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST
+  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN
   BUILD_ARGS += -j`nproc`
 endif
 

--- a/test/regression/cocotb/signature.Makefile
+++ b/test/regression/cocotb/signature.Makefile
@@ -14,7 +14,7 @@ SIM_BUILD = build/signature
 
 # Yosys/Amaranth borkedness workaround
 ifeq ($(SIM),verilator)
-  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST
+  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN
   BUILD_ARGS += -j`nproc`
 endif
 

--- a/test/regression/cocotb/test.Makefile
+++ b/test/regression/cocotb/test.Makefile
@@ -14,7 +14,7 @@ SIM_BUILD = build/test
 
 # Yosys/Amaranth borkedness workaround
 ifeq ($(SIM),verilator)
-  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST
+  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN
   BUILD_ARGS += -j`nproc`
 endif
 

--- a/test/regression/pysim.py
+++ b/test/regression/pysim.py
@@ -2,7 +2,7 @@ import re
 import os
 import logging
 
-from amaranth.sim import Passive, Settle
+from amaranth.sim import Passive, Settle, Tick
 from amaranth.utils import exact_log2
 from amaranth import *
 
@@ -83,7 +83,7 @@ class PySimulation(SimulationBackend):
                         rty = 1
 
                 for _ in range(delay):
-                    yield
+                    yield Tick()
 
                 yield from wb_ctrl.slave_respond(resp_data, ack=ack, err=err, rty=rty)
 
@@ -95,7 +95,7 @@ class PySimulation(SimulationBackend):
         def f():
             while self.running:
                 self.cycle_cnt += 1
-                yield
+                yield Tick()
 
             yield from on_finish()
 

--- a/test/regression/pysim.py
+++ b/test/regression/pysim.py
@@ -149,6 +149,10 @@ class PySimulation(SimulationBackend):
 
             sim.add_process(make_logging_process(self.log_level, self.log_filter, on_error))
 
+            # This enables logging in benchmarks. TODO: after unifying regression testing, remove.
+            logging.basicConfig()
+            logging.getLogger().setLevel(self.log_level)
+
             profile = None
             if "__TRANSACTRON_PROFILE" in os.environ:
                 transaction_manager = DependencyContext.get().get_dependency(TransactionManagerKey())

--- a/test/regression/pysim.py
+++ b/test/regression/pysim.py
@@ -141,19 +141,19 @@ class PySimulation(SimulationBackend):
             self.cycle_cnt = 0
 
             sim = PysimSimulator(core, max_cycles=timeout_cycles, traces_file=self.traces_file)
-            sim.add_sync_process(self._wishbone_slave(mem_model, wb_instr_ctrl, is_instr_bus=True))
-            sim.add_sync_process(self._wishbone_slave(mem_model, wb_data_ctrl, is_instr_bus=False))
+            sim.add_process(self._wishbone_slave(mem_model, wb_instr_ctrl, is_instr_bus=True))
+            sim.add_process(self._wishbone_slave(mem_model, wb_data_ctrl, is_instr_bus=False))
 
             def on_error():
                 raise RuntimeError("Simulation finished due to an error")
 
-            sim.add_sync_process(make_logging_process(self.log_level, self.log_filter, on_error))
+            sim.add_process(make_logging_process(self.log_level, self.log_filter, on_error))
 
             profile = None
             if "__TRANSACTRON_PROFILE" in os.environ:
                 transaction_manager = DependencyContext.get().get_dependency(TransactionManagerKey())
                 profile = Profile()
-                sim.add_sync_process(profiler_process(transaction_manager, profile))
+                sim.add_process(profiler_process(transaction_manager, profile))
 
             metric_values: dict[str, dict[str, int]] = {}
 
@@ -167,7 +167,7 @@ class PySimulation(SimulationBackend):
                             metric_name, reg_name
                         )
 
-            sim.add_sync_process(self._waiter(on_finish=on_sim_finish))
+            sim.add_process(self._waiter(on_finish=on_sim_finish))
             success = sim.run()
 
             self.pretty_dump_metrics(metric_values)

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -135,10 +135,10 @@ class TestRSSelect(TestCaseWithSimulator):
         """
 
         with self.run_simulation(self.m, max_cycles=1500) as sim:
-            sim.add_sync_process(self.create_instr_input_process(100, _rs1_optypes.union(_rs2_optypes)))
-            sim.add_sync_process(self.create_rs_alloc_process(self.m.rs1_alloc, rs_id=0, rs_optypes=_rs1_optypes))
-            sim.add_sync_process(self.create_rs_alloc_process(self.m.rs2_alloc, rs_id=1, rs_optypes=_rs2_optypes))
-            sim.add_sync_process(self.create_output_process(100))
+            sim.add_process(self.create_instr_input_process(100, _rs1_optypes.union(_rs2_optypes)))
+            sim.add_process(self.create_rs_alloc_process(self.m.rs1_alloc, rs_id=0, rs_optypes=_rs1_optypes))
+            sim.add_process(self.create_rs_alloc_process(self.m.rs2_alloc, rs_id=1, rs_optypes=_rs2_optypes))
+            sim.add_process(self.create_output_process(100))
 
     def test_only_rs1(self):
         """
@@ -147,9 +147,9 @@ class TestRSSelect(TestCaseWithSimulator):
         """
 
         with self.run_simulation(self.m, max_cycles=1500) as sim:
-            sim.add_sync_process(self.create_instr_input_process(100, _rs1_optypes.intersection(_rs2_optypes)))
-            sim.add_sync_process(self.create_rs_alloc_process(self.m.rs1_alloc, rs_id=0, rs_optypes=_rs1_optypes))
-            sim.add_sync_process(self.create_output_process(100))
+            sim.add_process(self.create_instr_input_process(100, _rs1_optypes.intersection(_rs2_optypes)))
+            sim.add_process(self.create_rs_alloc_process(self.m.rs1_alloc, rs_id=0, rs_optypes=_rs1_optypes))
+            sim.add_process(self.create_output_process(100))
 
     def test_only_rs2(self):
         """
@@ -158,9 +158,9 @@ class TestRSSelect(TestCaseWithSimulator):
         """
 
         with self.run_simulation(self.m, max_cycles=1500) as sim:
-            sim.add_sync_process(self.create_instr_input_process(100, _rs1_optypes.intersection(_rs2_optypes)))
-            sim.add_sync_process(self.create_rs_alloc_process(self.m.rs2_alloc, rs_id=1, rs_optypes=_rs2_optypes))
-            sim.add_sync_process(self.create_output_process(100))
+            sim.add_process(self.create_instr_input_process(100, _rs1_optypes.intersection(_rs2_optypes)))
+            sim.add_process(self.create_rs_alloc_process(self.m.rs2_alloc, rs_id=1, rs_optypes=_rs2_optypes))
+            sim.add_process(self.create_output_process(100))
 
     def test_delays(self):
         """
@@ -169,11 +169,11 @@ class TestRSSelect(TestCaseWithSimulator):
         """
 
         with self.run_simulation(self.m, max_cycles=5000) as sim:
-            sim.add_sync_process(self.create_instr_input_process(300, _rs1_optypes.union(_rs2_optypes), random_wait=4))
-            sim.add_sync_process(
+            sim.add_process(self.create_instr_input_process(300, _rs1_optypes.union(_rs2_optypes), random_wait=4))
+            sim.add_process(
                 self.create_rs_alloc_process(self.m.rs1_alloc, rs_id=0, rs_optypes=_rs1_optypes, random_wait=12)
             )
-            sim.add_sync_process(
+            sim.add_process(
                 self.create_rs_alloc_process(self.m.rs2_alloc, rs_id=1, rs_optypes=_rs2_optypes, random_wait=12)
             )
-            sim.add_sync_process(self.create_output_process(300, random_wait=12))
+            sim.add_process(self.create_output_process(300, random_wait=12))

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -270,7 +270,7 @@ class TestScheduler(TestCaseWithSimulator):
         def check(got, expected):
             rl_dst = yield View(
                 self.gen_params.get(ROBLayouts).data_layout,
-                C((yield self.m.rob.data[got["rs_data"]["rob_id"]]), self.gen_params.get(ROBLayouts).data_layout.size),
+                C((yield self.m.rob.data.data[got["rs_data"]["rob_id"]]), self.gen_params.get(ROBLayouts).data_layout.size),
             ).rl_dst
             s1 = self.rf_state[expected["rp_s1"]]
             s2 = self.rf_state[expected["rp_s2"]]

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -380,12 +380,10 @@ class TestScheduler(TestCaseWithSimulator):
 
         with self.run_simulation(self.m, max_cycles=1500) as sim:
             for i in range(self.rs_count):
-                sim.add_sync_process(
+                sim.add_process(
                     self.make_output_process(io=self.m.rs_insert[i], output_queues=[self.expected_rs_entry_queue[i]])
                 )
-                sim.add_sync_process(rs_alloc_process(self.m.rs_alloc[i], i))
-            sim.add_sync_process(
-                self.make_queue_process(io=self.m.rob_done, input_queues=[self.free_ROB_entries_queue])
-            )
-            sim.add_sync_process(self.make_queue_process(io=self.m.free_rf_inp, input_queues=[self.free_regs_queue]))
-            sim.add_sync_process(instr_input_process)
+                sim.add_process(rs_alloc_process(self.m.rs_alloc[i], i))
+            sim.add_process(self.make_queue_process(io=self.m.rob_done, input_queues=[self.free_ROB_entries_queue]))
+            sim.add_process(self.make_queue_process(io=self.m.free_rf_inp, input_queues=[self.free_regs_queue]))
+            sim.add_process(instr_input_process)

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -270,7 +270,10 @@ class TestScheduler(TestCaseWithSimulator):
         def check(got, expected):
             rl_dst = yield View(
                 self.gen_params.get(ROBLayouts).data_layout,
-                C((yield self.m.rob.data.data[got["rs_data"]["rob_id"]]), self.gen_params.get(ROBLayouts).data_layout.size),
+                C(
+                    (yield Value.cast(self.m.rob.data.data[got["rs_data"]["rob_id"]])),
+                    self.gen_params.get(ROBLayouts).data_layout.size,
+                ),
             ).rl_dst
             s1 = self.rf_state[expected["rp_s1"]]
             s2 = self.rf_state[expected["rp_s2"]]

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -269,7 +269,8 @@ class TestScheduler(TestCaseWithSimulator):
     def make_output_process(self, io: TestbenchIO, output_queues: Iterable[deque]):
         def check(got, expected):
             rl_dst = yield View(
-                self.gen_params.get(ROBLayouts).data_layout, self.m.rob.data[got["rs_data"]["rob_id"]]
+                self.gen_params.get(ROBLayouts).data_layout,
+                C((yield self.m.rob.data[got["rs_data"]["rob_id"]]), self.gen_params.get(ROBLayouts).data_layout.size),
             ).rl_dst
             s1 = self.rf_state[expected["rp_s1"]]
             s2 = self.rf_state[expected["rp_s2"]]

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -4,7 +4,7 @@ from collections import namedtuple, deque
 from typing import Callable, Optional, Iterable
 from amaranth import *
 from amaranth.lib.data import View
-from amaranth.sim import Settle
+from amaranth.sim import Settle, Tick
 from parameterized import parameterized_class
 from coreblocks.interface.keys import CoreStateKey
 from coreblocks.interface.layouts import ROBLayouts, RetirementLayouts
@@ -173,7 +173,7 @@ class TestScheduler(TestCaseWithSimulator):
                         return None
                 else:
                     # if no element available, wait and retry on the next clock cycle
-                    yield
+                    yield Tick()
 
             # merge queue element with all previous ones (dict merge)
             item = item | partial_item

--- a/test/scheduler/test_wakeup_select.py
+++ b/test/scheduler/test_wakeup_select.py
@@ -118,4 +118,4 @@ class TestWakeupSelect(TestCaseWithSimulator):
 
     def test(self):
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.process)
+            sim.add_process(self.process)

--- a/test/scheduler/test_wakeup_select.py
+++ b/test/scheduler/test_wakeup_select.py
@@ -1,7 +1,7 @@
 from typing import Optional, cast
 from amaranth import *
 from amaranth.lib.data import StructLayout
-from amaranth.sim import Settle
+from amaranth.sim import Settle, Tick
 
 from collections import deque
 from enum import Enum
@@ -112,7 +112,7 @@ class TestWakeupSelect(TestCaseWithSimulator):
                 if issued is not None:
                     assert issued == self.taken.popleft()
                     issued_count += 1
-            yield
+            yield Tick()
         assert inserted_count != 0
         assert inserted_count == issued_count
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -158,7 +158,7 @@ class TestCoreBasicAsm(TestCoreAsmSourceBase):
         self.m = CoreTestElaboratable(self.gen_params, instr_mem=bin_src["text"], data_mem=bin_src["data"])
 
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.run_and_check)
+            sim.add_process(self.run_and_check)
 
 
 # test interrupts with varying triggering frequency (parametrizable amount of cycles between
@@ -283,5 +283,5 @@ class TestCoreInterrupt(TestCoreAsmSourceBase):
             bin_src["data"][self.reg_init_mem_offset // 4 + reg_id] = val
         self.m = CoreTestElaboratable(self.gen_params, instr_mem=bin_src["text"], data_mem=bin_src["data"])
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.run_with_interrupt_process)
-            sim.add_sync_process(self.clear_level_interrupt_procsess)
+            sim.add_process(self.run_with_interrupt_process)
+            sim.add_process(self.clear_level_interrupt_procsess)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -30,10 +30,10 @@ class CoreTestElaboratable(Elaboratable):
         # Align the size of the memory to the length of a cache line.
         instr_mem_depth = align_to_power_of_two(len(self.instr_mem), self.gen_params.icache_params.line_bytes_log)
         self.wb_mem_slave = WishboneMemorySlave(
-            wb_params=self.gen_params.wb_params, width=32, depth=instr_mem_depth, init=self.instr_mem
+            wb_params=self.gen_params.wb_params, shape=32, depth=instr_mem_depth, init=self.instr_mem
         )
         self.wb_mem_slave_data = WishboneMemorySlave(
-            wb_params=self.gen_params.wb_params, width=32, depth=len(self.data_mem), init=self.data_mem
+            wb_params=self.gen_params.wb_params, shape=32, depth=len(self.data_mem), init=self.data_mem
         )
 
         self.core = Core(gen_params=self.gen_params)

--- a/test/transactron/core/test_transactions.py
+++ b/test/transactron/core/test_transactions.py
@@ -76,7 +76,7 @@ class TestScheduler(TestCaseWithSimulator):
             yield from self.sim_step(sched, 0, 0)
 
         with self.run_simulation(sched) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
     def test_multi(self):
         sched = Scheduler(4)
@@ -100,7 +100,7 @@ class TestScheduler(TestCaseWithSimulator):
             yield from self.sim_step(sched, 0b0010, 0b0010)
 
         with self.run_simulation(sched) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class TransactionConflictTestCircuit(Elaboratable):
@@ -192,9 +192,9 @@ class TestTransactionConflict(TestCaseWithSimulator):
         self.m = TransactionConflictTestCircuit(self.__class__.scheduler)
 
         with self.run_simulation(self.m, add_transaction_module=False) as sim:
-            sim.add_sync_process(self.make_in1_process(prob1))
-            sim.add_sync_process(self.make_in2_process(prob2))
-            sim.add_sync_process(self.make_out_process(probout))
+            sim.add_process(self.make_in1_process(prob1))
+            sim.add_process(self.make_in2_process(prob2))
+            sim.add_process(self.make_out_process(probout))
 
         assert not self.in_expected
         assert not self.out1_expected
@@ -374,7 +374,7 @@ class TestNested(TestCaseWithSimulator):
                 assert (yield m.t2) == r1 * r2
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class ScheduleBeforeTestCircuit(SchedulingTestCircuit):
@@ -420,7 +420,7 @@ class TestScheduleBefore(TestCaseWithSimulator):
                 assert not (yield m.t2)
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class SingleCallerTestCircuit(Elaboratable):

--- a/test/transactron/core/test_transactions.py
+++ b/test/transactron/core/test_transactions.py
@@ -57,7 +57,7 @@ class TestScheduler(TestCaseWithSimulator):
 
     def sim_step(self, sched, request, expected_grant):
         yield sched.requests.eq(request)
-        yield
+        yield Tick()
 
         if request == 0:
             assert not (yield sched.valid)
@@ -136,7 +136,7 @@ class TestTransactionConflict(TestCaseWithSimulator):
         def process():
             for i in src:
                 while random.random() >= prob:
-                    yield
+                    yield Tick()
                 tgt(i)
                 r = yield from io.call(data=i)
                 chk(r["data"])
@@ -369,7 +369,7 @@ class TestNested(TestCaseWithSimulator):
             for r1, r2 in to_do:
                 yield m.r1.eq(r1)
                 yield m.r2.eq(r2)
-                yield
+                yield Tick()
                 assert (yield m.t1) == r1
                 assert (yield m.t2) == r1 * r2
 
@@ -415,7 +415,7 @@ class TestScheduleBefore(TestCaseWithSimulator):
             for r1, r2 in to_do:
                 yield m.r1.eq(r1)
                 yield m.r2.eq(r2)
-                yield
+                yield Tick()
                 assert (yield m.t1) == r1
                 assert not (yield m.t2)
 

--- a/test/transactron/core/test_transactions.py
+++ b/test/transactron/core/test_transactions.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from unittest.case import TestCase
 import pytest
 from amaranth import *
@@ -207,6 +208,10 @@ class SchedulingTestCircuit(Elaboratable):
         self.r2 = Signal()
         self.t1 = Signal()
         self.t2 = Signal()
+
+    @abstractmethod
+    def elaborate(self, platform) -> TModule:
+        raise NotImplementedError
 
 
 class PriorityTestCircuit(SchedulingTestCircuit):

--- a/test/transactron/lib/test_fifo.py
+++ b/test/transactron/lib/test_fifo.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from amaranth.sim import Settle
+from amaranth.sim import Settle, Tick
 
 from transactron.lib import AdapterTrans, BasicFifo
 
@@ -63,10 +63,10 @@ class TestBasicFifo(TestCaseWithSimulator):
         def target():
             while not self.done or expq:
                 if random.randint(0, 1):
-                    yield
+                    yield Tick()
 
                 yield from fifoc.fifo_read.call_init()
-                yield
+                yield Tick()
 
                 v = yield from fifoc.fifo_read.call_result()
                 if v is not None:

--- a/test/transactron/lib/test_fifo.py
+++ b/test/transactron/lib/test_fifo.py
@@ -75,5 +75,5 @@ class TestBasicFifo(TestCaseWithSimulator):
                 yield from fifoc.fifo_read.disable()
 
         with self.run_simulation(fifoc) as sim:
-            sim.add_sync_process(source)
-            sim.add_sync_process(target)
+            sim.add_process(source)
+            sim.add_process(target)

--- a/test/transactron/lib/test_transaction_lib.py
+++ b/test/transactron/lib/test_transaction_lib.py
@@ -56,8 +56,8 @@ class TestFifoBase(TestCaseWithSimulator):
                 yield from self.random_wait(reader_rand)
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(reader)
-            sim.add_sync_process(writer)
+            sim.add_process(reader)
+            sim.add_process(writer)
 
 
 class TestFIFO(TestFifoBase):
@@ -125,7 +125,7 @@ class TestForwarder(TestFifoBase):
                 yield from forward_check(x)
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class TestPipe(TestFifoBase):
@@ -193,9 +193,9 @@ class TestMemoryBank(TestCaseWithSimulator):
         max_cycles = test_count + 2 if pipeline_test else 100000
 
         with self.run_simulation(m, max_cycles=max_cycles) as sim:
-            sim.add_sync_process(reader_req)
-            sim.add_sync_process(reader_resp)
-            sim.add_sync_process(writer)
+            sim.add_process(reader_req)
+            sim.add_process(reader_resp)
+            sim.add_process(writer)
 
 
 class TestAsyncMemoryBank(TestCaseWithSimulator):
@@ -231,8 +231,8 @@ class TestAsyncMemoryBank(TestCaseWithSimulator):
                 yield from self.random_wait(reader_rand, min_cycle_cnt=1)
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(reader)
-            sim.add_sync_process(writer)
+            sim.add_process(reader)
+            sim.add_process(writer)
 
 
 class ManyToOneConnectTransTestCircuit(Elaboratable):
@@ -326,17 +326,17 @@ class TestManyToOneConnectTrans(TestCaseWithSimulator):
         self.count = 1
         self.initialize()
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.consumer)
+            sim.add_process(self.consumer)
             for i in range(self.count):
-                sim.add_sync_process(self.generate_producer(i))
+                sim.add_process(self.generate_producer(i))
 
     def test_many_out(self):
         self.count = 4
         self.initialize()
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.consumer)
+            sim.add_process(self.consumer)
             for i in range(self.count):
-                sim.add_sync_process(self.generate_producer(i))
+                sim.add_process(self.generate_producer(i))
 
 
 class MethodMapTestCircuit(Elaboratable):
@@ -416,18 +416,18 @@ class TestMethodTransformer(TestCaseWithSimulator):
     def test_method_transformer(self):
         self.m = MethodMapTestCircuit(4, False, False)
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.source)
-            sim.add_sync_process(self.target)
+            sim.add_process(self.source)
+            sim.add_process(self.target)
 
     def test_method_transformer_dicts(self):
         self.m = MethodMapTestCircuit(4, False, True)
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.source)
+            sim.add_process(self.source)
 
     def test_method_transformer_with_methods(self):
         self.m = MethodMapTestCircuit(4, True, True)
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.source)
+            sim.add_process(self.source)
 
 
 class TestMethodFilter(TestCaseWithSimulator):
@@ -461,7 +461,7 @@ class TestMethodFilter(TestCaseWithSimulator):
         )
         m = ModuleConnector(test_circuit=self.tc, target=self.target, cmeth=self.cmeth)
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(self.source)
+            sim.add_process(self.source)
 
     @parameterized.expand([(True,), (False,)])
     def test_method_filter(self, use_condition):
@@ -473,7 +473,7 @@ class TestMethodFilter(TestCaseWithSimulator):
         self.tc = SimpleTestCircuit(MethodFilter(self.target.adapter.iface, condition, use_condition=use_condition))
         m = ModuleConnector(test_circuit=self.tc, target=self.target, cmeth=self.cmeth)
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(self.source)
+            sim.add_process(self.source)
 
 
 class MethodProductTestCircuit(Elaboratable):
@@ -546,9 +546,9 @@ class TestMethodProduct(TestCaseWithSimulator):
                 assert val == data
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(method_process)
+            sim.add_process(method_process)
             for k in range(targets):
-                sim.add_sync_process(target_process(k))
+                sim.add_process(target_process(k))
 
 
 class TestSerializer(TestCaseWithSimulator):
@@ -615,8 +615,8 @@ class TestSerializer(TestCaseWithSimulator):
     def test_serial(self):
         with self.run_simulation(self.m) as sim:
             for i in range(self.port_count):
-                sim.add_sync_process(self.requestor(i))
-                sim.add_sync_process(self.responder(i))
+                sim.add_process(self.requestor(i))
+                sim.add_process(self.responder(i))
 
 
 class TestMethodTryProduct(TestCaseWithSimulator):
@@ -654,9 +654,9 @@ class TestMethodTryProduct(TestCaseWithSimulator):
                     assert val == {}
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(method_process)
+            sim.add_process(method_process)
             for k in range(targets):
-                sim.add_sync_process(target_process(k))
+                sim.add_process(target_process(k))
 
 
 class MethodTryProductTestCircuit(Elaboratable):
@@ -758,4 +758,4 @@ class TestCondition(TestCaseWithSimulator):
                     assert selection in [c1, 2 * c2, 3 * c3]
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)

--- a/test/transactron/test_adapter.py
+++ b/test/transactron/test_adapter.py
@@ -59,4 +59,4 @@ class TestAdapterTrans(TestCaseWithSimulator):
         self.m = ModuleConnector(echo=self.echo, consumer=self.consumer)
 
         with self.run_simulation(self.m, max_cycles=100) as sim:
-            sim.add_sync_process(self.proc)
+            sim.add_process(self.proc)

--- a/test/transactron/test_assign.py
+++ b/test/transactron/test_assign.py
@@ -3,7 +3,7 @@ from typing import Callable
 from amaranth import *
 from amaranth.lib import data
 from amaranth.lib.enum import Enum
-from amaranth.hdl._ast import ArrayProxy, Slice
+from amaranth.hdl._ast import ArrayProxy, SwitchValue, Slice
 
 from transactron.utils._typing import MethodLayout
 from transactron.utils import AssignType, assign
@@ -143,11 +143,14 @@ class TestAssign(TestCase):
         self.assertIs_AP(alist[0].rhs, self.extrr(rhs).a)
 
     def assertIs_AP(self, expr1, expr2):  # noqa: N802
-        if isinstance(expr1, ArrayProxy) and isinstance(expr2, ArrayProxy):
+        expr1 = Value.cast(expr1)
+        expr2 = Value.cast(expr2)
+        if isinstance(expr1, SwitchValue) and isinstance(expr2, SwitchValue):
             # new proxies are created on each index, structural equality is needed
-            self.assertIs(expr1.index, expr2.index)
-            assert len(expr1.elems) == len(expr2.elems)
-            for x, y in zip(expr1.elems, expr2.elems):
+            self.assertIs(expr1.test, expr2.test)
+            assert len(expr1.cases) == len(expr2.cases)
+            for (px, x), (py, y) in zip(expr1.cases, expr2.cases):
+                self.assertEqual(px, py)
                 self.assertIs_AP(x, y)
         elif isinstance(expr1, Slice) and isinstance(expr2, Slice):
             self.assertIs_AP(expr1.value, expr2.value)

--- a/test/transactron/test_connectors.py
+++ b/test/transactron/test_connectors.py
@@ -43,4 +43,4 @@ class TestStableSelectingNetwork(TestCaseWithSimulator):
                 yield Tick()
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)

--- a/test/transactron/test_connectors.py
+++ b/test/transactron/test_connectors.py
@@ -1,7 +1,7 @@
 import random
 from parameterized import parameterized_class
 
-from amaranth.sim import Settle
+from amaranth.sim import Settle, Tick
 
 from transactron.lib import StableSelectingNetwork
 from transactron.testing import TestCaseWithSimulator
@@ -40,7 +40,7 @@ class TestStableSelectingNetwork(TestCaseWithSimulator):
                     assert out == expected_output_prefix[i]
 
                 assert (yield m.output_cnt) == total
-                yield
+                yield Tick()
 
         with self.run_simulation(m) as sim:
             sim.add_sync_process(process)

--- a/test/transactron/test_methods.py
+++ b/test/transactron/test_methods.py
@@ -161,7 +161,7 @@ class TestDefMethods(TestCaseWithSimulator):
                 assert ret["foo"] == (val + k) % 2**3
 
         with self.run_simulation(circuit) as sim:
-            sim.add_sync_process(test_process)
+            sim.add_process(test_process)
 
 
 class AdapterCircuit(Elaboratable):
@@ -398,7 +398,7 @@ class TestQuadrupleCircuits(TestCaseWithSimulator):
                 assert out["data"] == n * 4
 
         with self.run_simulation(circ) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class ConditionalCallCircuit(Elaboratable):
@@ -507,7 +507,7 @@ class TestConditionals(TestCaseWithSimulator):
             assert not (yield from circ.tb.done())
 
         with self.run_simulation(circ) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
     @parameterized.expand(
         [
@@ -531,7 +531,7 @@ class TestConditionals(TestCaseWithSimulator):
             assert (yield from circ.tb.done())
 
         with self.run_simulation(circ) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class NonexclusiveMethodCircuit(Elaboratable):
@@ -594,7 +594,7 @@ class TestNonexclusiveMethod(TestCaseWithSimulator):
                     assert (yield from circ.t2.get_outputs()) == {"data": x}
 
         with self.run_simulation(circ) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class TwoNonexclusiveConflictCircuit(Elaboratable):
@@ -646,7 +646,7 @@ class TestConflicting(TestCaseWithSimulator):
             assert not (yield circ.running1) or not (yield circ.running2)
 
         with self.run_simulation(circ) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class CustomCombinerMethodCircuit(Elaboratable):
@@ -721,7 +721,7 @@ class TestCustomCombinerMethod(TestCaseWithSimulator):
                     assert (yield from circ.t2.get_outputs()) == {"data": val1e ^ val2e}
 
         with self.run_simulation(circ) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class DataDependentConditionalCircuit(Elaboratable):
@@ -803,7 +803,7 @@ class TestDataDependentConditionalMethod(TestCaseWithSimulator):
                 yield Tick()
 
         with self.run_simulation(self.circ, 100) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
     def test_random_arg(self):
         self.base_random(lambda arg: arg.data != self.bad_number)

--- a/test/transactron/test_methods.py
+++ b/test/transactron/test_methods.py
@@ -158,7 +158,7 @@ class TestDefMethods(TestCaseWithSimulator):
             for k, method in enumerate(circuit.methods):
                 val = random.randrange(0, 2**3)
                 ret = yield from method.call(foo=val)
-                assert ret["foo"] == val + k % 2**3
+                assert ret["foo"] == (val + k) % 2**3
 
         with self.run_simulation(circuit) as sim:
             sim.add_sync_process(test_process)

--- a/test/transactron/test_methods.py
+++ b/test/transactron/test_methods.py
@@ -800,7 +800,7 @@ class TestDataDependentConditionalMethod(TestCaseWithSimulator):
                 assert in1 != self.bad_number or not out_t1
                 assert in2 != self.bad_number or not out_t2
 
-                yield
+                yield Tick()
 
         with self.run_simulation(self.circ, 100) as sim:
             sim.add_sync_process(process)

--- a/test/transactron/test_metrics.py
+++ b/test/transactron/test_metrics.py
@@ -92,7 +92,7 @@ class TestHwCounter(TestCaseWithSimulator):
                     called_cnt += 1
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(test_process)
+            sim.add_process(test_process)
 
     def test_counter_with_condition_in_method(self):
         m = SimpleTestCircuit(CounterWithConditionInMethodCircuit())
@@ -117,7 +117,7 @@ class TestHwCounter(TestCaseWithSimulator):
                     called_cnt += 1
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(test_process)
+            sim.add_process(test_process)
 
     def test_counter_with_condition_without_method(self):
         m = CounterWithoutMethodCircuit()
@@ -139,7 +139,7 @@ class TestHwCounter(TestCaseWithSimulator):
                     called_cnt += 1
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(test_process)
+            sim.add_process(test_process)
 
 
 class OneHotEnum(IntFlag):
@@ -200,7 +200,7 @@ class TestTaggedCounter(TestCaseWithSimulator):
                 counts[tag] += 1
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(test_process)
+            sim.add_process(test_process)
 
     def test_one_hot_enum(self):
         self.do_test_enum(OneHotEnum, [e.value for e in OneHotEnum])
@@ -306,7 +306,7 @@ class TestHwHistogram(TestCaseWithSimulator):
                 assert total_count == (yield histogram.count.value)
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(test_process)
+            sim.add_process(test_process)
 
 
 class TestLatencyMeasurerBase(TestCaseWithSimulator):
@@ -379,8 +379,8 @@ class TestFIFOLatencyMeasurer(TestLatencyMeasurerBase):
             self.check_latencies(m, latencies)
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(producer)
-            sim.add_sync_process(consumer)
+            sim.add_process(producer)
+            sim.add_process(consumer)
 
 
 @parameterized_class(
@@ -458,8 +458,8 @@ class TestIndexedLatencyMeasurer(TestLatencyMeasurerBase):
             self.check_latencies(m, latencies)
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(producer)
-            sim.add_sync_process(consumer)
+            sim.add_process(producer)
+            sim.add_process(consumer)
 
 
 class MetricManagerTestCircuit(Elaboratable):
@@ -544,4 +544,4 @@ class TestMetricsManager(TestCaseWithSimulator):
                 assert counters[2] == (yield metrics_manager.get_register_value("bar.baz.counter3", "count"))
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(test_process)
+            sim.add_process(test_process)

--- a/test/transactron/test_metrics.py
+++ b/test/transactron/test_metrics.py
@@ -7,7 +7,7 @@ from enum import IntFlag, IntEnum, auto, Enum
 from parameterized import parameterized_class
 
 from amaranth import *
-from amaranth.sim import Settle
+from amaranth.sim import Settle, Tick
 
 from transactron.lib.metrics import *
 from transactron import *
@@ -82,7 +82,7 @@ class TestHwCounter(TestCaseWithSimulator):
                 if call_now:
                     yield from m.method.call()
                 else:
-                    yield
+                    yield Tick()
 
                 # Note that it takes one cycle to update the register value, so here
                 # we are comparing the "previous" values.
@@ -107,7 +107,7 @@ class TestHwCounter(TestCaseWithSimulator):
                 if call_now:
                     yield from m.method.call(cond=condition)
                 else:
-                    yield
+                    yield Tick()
 
                 # Note that it takes one cycle to update the register value, so here
                 # we are comparing the "previous" values.
@@ -129,7 +129,7 @@ class TestHwCounter(TestCaseWithSimulator):
                 condition = random.randint(0, 1)
 
                 yield m.cond.eq(condition)
-                yield
+                yield Tick()
 
                 # Note that it takes one cycle to update the register value, so here
                 # we are comparing the "previous" values.
@@ -193,9 +193,9 @@ class TestTaggedCounter(TestCaseWithSimulator):
 
                 yield m.cond.eq(1)
                 yield m.tag.eq(tag)
-                yield
+                yield Tick()
                 yield m.cond.eq(0)
-                yield
+                yield Tick()
 
                 counts[tag] += 1
 
@@ -283,9 +283,9 @@ class TestHwHistogram(TestCaseWithSimulator):
                             buckets[i] += 1
                             break
                     yield from m.method.call(data=value)
-                    yield
+                    yield Tick()
                 else:
-                    yield
+                    yield Tick()
 
                 histogram = m._dut.histogram
                 # Skip the assertion if the min is still uninitialized
@@ -417,7 +417,7 @@ class TestIndexedLatencyMeasurer(TestLatencyMeasurerBase):
 
             for _ in range(200):
                 while not free_slots:
-                    yield
+                    yield Tick()
                     continue
                 yield Settle()
 
@@ -437,7 +437,7 @@ class TestIndexedLatencyMeasurer(TestLatencyMeasurerBase):
         def consumer():
             while not finish:
                 while not used_slots:
-                    yield
+                    yield Tick()
                     continue
 
                 slot_id = random.choice(used_slots)
@@ -533,7 +533,7 @@ class TestMetricsManager(TestCaseWithSimulator):
                 rand = [random.randint(0, 1) for _ in range(3)]
 
                 yield from m.incr_counters.call(counter1=rand[0], counter2=rand[1], counter3=rand[2])
-                yield
+                yield Tick()
 
                 for i in range(3):
                     if rand[i] == 1:

--- a/test/transactron/test_simultaneous.py
+++ b/test/transactron/test_simultaneous.py
@@ -66,7 +66,7 @@ class TestSimultaneousDiamond(TestCaseWithSimulator):
                     assert not any(dones.values())
 
         with self.run_simulation(circ) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)
 
 
 class UnsatisfiableTriangleTestCircuit(Elaboratable):
@@ -169,4 +169,4 @@ class TestTransitivity(TestCaseWithSimulator):
                     assert result in possibles
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(process)
+            sim.add_process(process)

--- a/test/transactron/test_simultaneous.py
+++ b/test/transactron/test_simultaneous.py
@@ -51,7 +51,7 @@ class TestSimultaneousDiamond(TestCaseWithSimulator):
                 for k, n in enumerate(methods):
                     enables[n] = bool(i & (1 << k))
                     yield from methods[n].set_enable(enables[n])
-                yield
+                yield Tick()
                 dones: dict[str, bool] = {}
                 for n in methods:
                     dones[n] = bool((yield from methods[n].done()))

--- a/test/transactron/test_transactron_lib_storage.py
+++ b/test/transactron/test_transactron_lib_storage.py
@@ -37,10 +37,10 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
                 yield from self.multi_settle(4)
                 elem = input_lst.pop()
                 if isinstance(elem, OpNOP):
-                    yield
+                    yield Tick()
                     continue
                 if input_verification is not None and not input_verification(elem):
-                    yield
+                    yield Tick()
                     continue
                 response = yield from method.call(**elem)
                 yield from self.multi_settle(settle_count)
@@ -52,7 +52,7 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
                 if state_change is not None:
                     # It is standard python function by purpose to don't allow accessing circuit
                     state_change(elem, response)
-                yield
+                yield Tick()
 
         return f
 

--- a/test/transactron/test_transactron_lib_storage.py
+++ b/test/transactron/test_transactron_lib_storage.py
@@ -129,7 +129,7 @@ class TestContentAddressableMemory(TestCaseWithSimulator):
         with self.reinitialize_fixtures():
             self.setUp()
             with self.run_simulation(self.circ, max_cycles=500) as sim:
-                sim.add_sync_process(self.push_process(in_push))
-                sim.add_sync_process(self.read_process(in_read))
-                sim.add_sync_process(self.write_process(in_write))
-                sim.add_sync_process(self.remove_process(in_remove))
+                sim.add_process(self.push_process(in_push))
+                sim.add_process(self.read_process(in_read))
+                sim.add_process(self.write_process(in_write))
+                sim.add_process(self.remove_process(in_remove))

--- a/test/transactron/testing/test_infrastructure.py
+++ b/test/transactron/testing/test_infrastructure.py
@@ -28,4 +28,4 @@ class TestNow(TestCaseWithSimulator):
 
     def test_random(self):
         with self.run_simulation(self.m, 50) as sim:
-            sim.add_sync_process(self.process)
+            sim.add_process(self.process)

--- a/test/transactron/testing/test_infrastructure.py
+++ b/test/transactron/testing/test_infrastructure.py
@@ -24,7 +24,7 @@ class TestNow(TestCaseWithSimulator):
             now = yield Now()
             assert k == now
 
-            yield
+            yield Tick()
 
     def test_random(self):
         with self.run_simulation(self.m, 50) as sim:

--- a/test/transactron/testing/test_log.py
+++ b/test/transactron/testing/test_log.py
@@ -76,7 +76,7 @@ class TestLog(TestCaseWithSimulator):
                 yield m.input.eq(i)
 
         with self.run_simulation(m) as sim:
-            sim.add_sync_process(proc)
+            sim.add_process(proc)
 
         assert re.search(
             r"WARNING  test_logger:logging\.py:\d+ \[test/transactron/testing/test_log\.py:\d+\] "
@@ -86,7 +86,7 @@ class TestLog(TestCaseWithSimulator):
         for i in range(0, 50, 2):
             assert re.search(
                 r"WARNING  test_logger:logging\.py:\d+ \[test/transactron/testing/test_log\.py:\d+\] "
-                + f"Input is even! input={i}, counter={i + 2}",
+                + f"Input is even! input={i}, counter={i + 1}",
                 caplog.text,
             )
 
@@ -99,7 +99,7 @@ class TestLog(TestCaseWithSimulator):
 
         with pytest.raises(AssertionError):
             with self.run_simulation(m) as sim:
-                sim.add_sync_process(proc)
+                sim.add_process(proc)
 
         assert re.search(
             r"ERROR    test_logger:logging\.py:\d+ \[test/transactron/testing/test_log\.py:\d+\] "
@@ -116,7 +116,7 @@ class TestLog(TestCaseWithSimulator):
 
         with pytest.raises(AssertionError):
             with self.run_simulation(m) as sim:
-                sim.add_sync_process(proc)
+                sim.add_process(proc)
 
         assert re.search(
             r"ERROR    test_logger:logging\.py:\d+ \[test/transactron/testing/test_log\.py:\d+\] Output differs",

--- a/test/transactron/testing/test_log.py
+++ b/test/transactron/testing/test_log.py
@@ -1,5 +1,7 @@
 import pytest
+import re
 from amaranth import *
+from amaranth.sim import Tick
 
 from transactron import *
 from transactron.testing import TestCaseWithSimulator
@@ -70,51 +72,53 @@ class TestLog(TestCaseWithSimulator):
 
         def proc():
             for i in range(50):
-                yield
+                yield Tick()
                 yield m.input.eq(i)
 
         with self.run_simulation(m) as sim:
             sim.add_sync_process(proc)
 
-        assert (
-            "WARNING  test_logger:logging.py:83 [test/transactron/testing/test_log.py:22] "
-            + "Log triggered under Amaranth If value+3=0x2d"
-            in caplog.text
+        assert re.search(
+            r"WARNING  test_logger:logging\.py:\d+ \[test/transactron/testing/test_log\.py:\d+\] "
+            + r"Log triggered under Amaranth If value\+3=0x2d",
+            caplog.text,
         )
         for i in range(0, 50, 2):
-            expected_msg = (
-                "WARNING  test_logger:logging.py:83 [test/transactron/testing/test_log.py:24] "
-                + f"Input is even! input={i}, counter={i + 2}"
+            assert re.search(
+                r"WARNING  test_logger:logging\.py:\d+ \[test/transactron/testing/test_log\.py:\d+\] "
+                + f"Input is even! input={i}, counter={i + 2}",
+                caplog.text,
             )
-            assert expected_msg in caplog.text
 
     def test_error_log(self, caplog):
         m = ErrorLogTest()
 
         def proc():
-            yield
+            yield Tick()
             yield m.input.eq(1)
 
         with pytest.raises(AssertionError):
             with self.run_simulation(m) as sim:
                 sim.add_sync_process(proc)
 
-        extected_out = (
-            "ERROR    test_logger:logging.py:83 [test/transactron/testing/test_log.py:41] "
-            + "Input is different than output! input=0x1 output=0x0"
+        assert re.search(
+            r"ERROR    test_logger:logging\.py:\d+ \[test/transactron/testing/test_log\.py:\d+\] "
+            + "Input is different than output! input=0x1 output=0x0",
+            caplog.text,
         )
-        assert extected_out in caplog.text
 
     def test_assertion(self, caplog):
         m = AssertionTest()
 
         def proc():
-            yield
+            yield Tick()
             yield m.input.eq(1)
 
         with pytest.raises(AssertionError):
             with self.run_simulation(m) as sim:
                 sim.add_sync_process(proc)
 
-        extected_out = "ERROR    test_logger:logging.py:83 [test/transactron/testing/test_log.py:62] Output differs"
-        assert extected_out in caplog.text
+        assert re.search(
+            r"ERROR    test_logger:logging\.py:\d+ \[test/transactron/testing/test_log\.py:\d+\] Output differs",
+            caplog.text,
+        )

--- a/test/transactron/testing/test_validate_arguments.py
+++ b/test/transactron/testing/test_validate_arguments.py
@@ -54,6 +54,6 @@ class TestValidateArguments(TestCaseWithSimulator):
         self.m = ValidateArgumentsTestCircuit()
         self.accepted_val = 0
         with self.run_simulation(self.m) as sim:
-            sim.add_sync_process(self.changer)
-            sim.add_sync_process(self.control_caller(self.m.caller1, self.m.method))
-            sim.add_sync_process(self.control_caller(self.m.caller2, self.m.method))
+            sim.add_process(self.changer)
+            sim.add_process(self.control_caller(self.m.caller1, self.m.method))
+            sim.add_process(self.control_caller(self.m.caller2, self.m.method))

--- a/transactron/core/manager.py
+++ b/transactron/core/manager.py
@@ -6,6 +6,8 @@ from amaranth import *
 from amaranth.lib.wiring import Component, connect, flipped
 from itertools import chain, filterfalse, product
 
+from amaranth_types import AbstractComponent
+
 from transactron.utils import *
 from transactron.utils.transactron_helpers import _graph_ccs
 from transactron.graph import OwnershipGraph, Direction
@@ -506,7 +508,7 @@ class TransactionComponent(TransactionModule, Component):
 
     def __init__(
         self,
-        component: Component,
+        component: AbstractComponent,
         dependency_manager: Optional[DependencyManager] = None,
         transaction_manager: Optional[TransactionManager] = None,
     ):

--- a/transactron/core/tmodule.py
+++ b/transactron/core/tmodule.py
@@ -242,9 +242,9 @@ class TModule(ModuleLike, Elaboratable):
                     yield
 
     @contextmanager
-    def FSM(self, reset: Optional[str] = None, domain: str = "sync", name: str = "fsm"):  # noqa: N802
+    def FSM(self, init: Optional[str] = None, domain: str = "sync", name: str = "fsm"):  # noqa: N802
         old_fsm = self.fsm
-        with self.main_module.FSM(reset, domain, name) as fsm:
+        with self.main_module.FSM(init, domain, name) as fsm:
             self.fsm = fsm
             with self.path_builder.enter(EnterType.PUSH):
                 yield fsm

--- a/transactron/graph.py
+++ b/transactron/graph.py
@@ -58,7 +58,7 @@ class OwnershipGraph:
                         self.remember_field(owner_id, field, obj)
                 if isinstance(owner, Fragment):
                     assert isinstance(owner, TracingFragment)
-                    for obj, field in owner.subfragments:
+                    for obj, field, _ in owner.subfragments:
                         self.remember_field(owner_id, field, obj)
                 try:
                     owner = owner._elaborated  # type: ignore

--- a/transactron/lib/adapters.py
+++ b/transactron/lib/adapters.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Optional
 from amaranth import *
 from amaranth.lib.wiring import Component, In, Out
@@ -26,6 +27,10 @@ class AdapterBase(Component):
 
     def debug_signals(self) -> SignalBundle:
         return [self.en, self.done, self.data_in, self.data_out]
+
+    @abstractmethod
+    def elaborate(self, platform) -> TModule:
+        raise NotImplementedError()
 
 
 class AdapterTrans(AdapterBase):

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -1,4 +1,5 @@
 from amaranth import *
+from amaranth.lib.memory import Memory
 from transactron import Method, def_method, Priority, TModule
 from transactron.utils._typing import ValueLike, MethodLayout, SrcLoc, MethodStruct
 from transactron.utils.amaranth_ext import mod_incr
@@ -48,7 +49,7 @@ class BasicFifo(Elaboratable):
         self.clear = Method(src_loc=src_loc)
         self.head = Signal(from_method_layout(layout))
 
-        self.buff = Memory(width=self.width, depth=self.depth)
+        self.buff = Memory(shape=self.width, depth=self.depth, init=[])
 
         self.write_ready = Signal()
         self.read_ready = Signal()
@@ -68,8 +69,9 @@ class BasicFifo(Elaboratable):
         next_read_idx = Signal.like(self.read_idx)
         m.d.comb += next_read_idx.eq(mod_incr(self.read_idx, self.depth))
 
-        m.submodules.buff_rdport = self.buff_rdport = self.buff.read_port(domain="sync", transparent=True)
-        m.submodules.buff_wrport = self.buff_wrport = self.buff.write_port()
+        m.submodules.buff = self.buff
+        self.buff_wrport = self.buff.write_port()
+        self.buff_rdport = self.buff.read_port(domain="sync", transparent_for=[self.buff_wrport])
 
         m.d.comb += self.read_ready.eq(self.level != 0)
         m.d.comb += self.write_ready.eq(self.level != self.depth)

--- a/transactron/lib/fifo.py
+++ b/transactron/lib/fifo.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from amaranth.lib.memory import Memory
+import amaranth.lib.memory as memory
 from transactron import Method, def_method, Priority, TModule
 from transactron.utils._typing import ValueLike, MethodLayout, SrcLoc, MethodStruct
 from transactron.utils.amaranth_ext import mod_incr
@@ -49,7 +49,7 @@ class BasicFifo(Elaboratable):
         self.clear = Method(src_loc=src_loc)
         self.head = Signal(from_method_layout(layout))
 
-        self.buff = Memory(shape=self.width, depth=self.depth, init=[])
+        self.buff = memory.Memory(shape=self.width, depth=self.depth, init=[])
 
         self.write_ready = Signal()
         self.read_ready = Signal()

--- a/transactron/lib/metrics.py
+++ b/transactron/lib/metrics.py
@@ -175,6 +175,10 @@ class HwMetric(ABC, MetricModel):
     def metrics_enabled(self) -> bool:
         return DependencyContext.get().get_dependency(HwMetricsEnabledKey())
 
+    # To restore hashability lost by dataclass subclassing
+    def __hash__(self):
+        return object.__hash__(self)
+
 
 class HwCounter(Elaboratable, HwMetric):
     """Hardware Counter

--- a/transactron/lib/metrics.py
+++ b/transactron/lib/metrics.py
@@ -85,7 +85,7 @@ class HwMetricRegister(MetricRegisterModel):
         Amaranth signal representing the value of the register.
     """
 
-    def __init__(self, name: str, width_bits: int, description: str = "", reset: int = 0):
+    def __init__(self, name: str, width_bits: int, description: str = "", init: int = 0):
         """
         Parameters
         ----------
@@ -96,12 +96,12 @@ class HwMetricRegister(MetricRegisterModel):
             The bit-width of the register.
         description: str
             A brief description of the metric's purpose.
-        reset: int
+        init: int
             The reset value of the register.
         """
         super().__init__(name, description, width_bits)
 
-        self.value = Signal(width_bits, reset=reset, name=name)
+        self.value = Signal(width_bits, init=init, name=name)
 
 
 @dataclass(frozen=True)
@@ -399,7 +399,7 @@ class HwExpHistogram(Elaboratable, HwMetric):
             "min",
             self.sample_width,
             "the minimum of all observed values",
-            reset=(1 << self.sample_width) - 1,
+            init=(1 << self.sample_width) - 1,
         )
         self.max = HwMetricRegister("max", self.sample_width, "the maximum of all observed values")
 

--- a/transactron/lib/storage.py
+++ b/transactron/lib/storage.py
@@ -1,6 +1,6 @@
 from amaranth import *
 from amaranth.utils import *
-from amaranth.lib.memory import Memory
+import amaranth.lib.memory as memory
 
 from transactron.utils.transactron_helpers import from_method_layout, make_layout
 from ..core import *
@@ -79,7 +79,7 @@ class MemoryBank(Elaboratable):
     def elaborate(self, platform) -> TModule:
         m = TModule()
 
-        m.submodules.mem = mem = Memory(shape=self.width, depth=self.elem_count, init=[])
+        m.submodules.mem = mem = memory.Memory(shape=self.width, depth=self.elem_count, init=[])
         write_port = mem.write_port()
         read_port = mem.read_port(transparent_for=[write_port] if self.transparent else [])
         read_output_valid = Signal()
@@ -272,7 +272,7 @@ class AsyncMemoryBank(Elaboratable):
     def elaborate(self, platform) -> TModule:
         m = TModule()
 
-        mem = Memory(shape=self.width, depth=self.elem_count, init=[])
+        mem = memory.Memory(shape=self.width, depth=self.elem_count, init=[])
         m.submodules.mem = mem
         write_port = mem.write_port()
         read_port = mem.read_port(domain="comb")

--- a/transactron/lib/storage.py
+++ b/transactron/lib/storage.py
@@ -1,5 +1,6 @@
 from amaranth import *
 from amaranth.utils import *
+from amaranth.lib.memory import Memory
 
 from transactron.utils.transactron_helpers import from_method_layout, make_layout
 from ..core import *
@@ -78,9 +79,9 @@ class MemoryBank(Elaboratable):
     def elaborate(self, platform) -> TModule:
         m = TModule()
 
-        mem = Memory(width=self.width, depth=self.elem_count)
-        m.submodules.read_port = read_port = mem.read_port(transparent=self.transparent)
-        m.submodules.write_port = write_port = mem.write_port()
+        m.submodules.mem = mem = Memory(shape=self.width, depth=self.elem_count, init=[])
+        write_port = mem.write_port()
+        read_port = mem.read_port(transparent_for=[write_port] if self.transparent else [])
         read_output_valid = Signal()
         overflow_valid = Signal()
         overflow_data = Signal(self.width)
@@ -271,9 +272,10 @@ class AsyncMemoryBank(Elaboratable):
     def elaborate(self, platform) -> TModule:
         m = TModule()
 
-        mem = Memory(width=self.width, depth=self.elem_count)
-        m.submodules.read_port = read_port = mem.read_port(domain="comb")
-        m.submodules.write_port = write_port = mem.write_port()
+        mem = Memory(shape=self.width, depth=self.elem_count, init=[])
+        m.submodules.mem = mem
+        write_port = mem.write_port()
+        read_port = mem.read_port(domain="comb")
 
         @def_method(m, self.read)
         def _(addr):

--- a/transactron/testing/gtkw_extension.py
+++ b/transactron/testing/gtkw_extension.py
@@ -2,6 +2,7 @@ from typing import Iterable, Mapping
 from contextlib import contextmanager
 from amaranth.lib.data import View
 from amaranth.sim.pysim import _VCDWriter
+from amaranth.sim import Tick
 from amaranth import *
 from transactron.utils import flatten_signals
 
@@ -64,7 +65,7 @@ def write_vcd_ext(engine, vcd_file, gtkw_file, traces):
     vcd_writer = _VCDWriterExt(engine._fragment, vcd_file=vcd_file, gtkw_file=gtkw_file, traces=traces)
     try:
         engine._vcd_writers.append(vcd_writer)
-        yield
+        yield Tick()
     finally:
         vcd_writer.close(engine.now)
         engine._vcd_writers.remove(vcd_writer)

--- a/transactron/testing/gtkw_extension.py
+++ b/transactron/testing/gtkw_extension.py
@@ -8,10 +8,8 @@ from transactron.utils import flatten_signals
 
 
 class _VCDWriterExt(_VCDWriter):
-    def __init__(self, fragment, *, vcd_file, gtkw_file, traces):
-        super().__init__(
-            fragment=fragment, vcd_file=vcd_file, gtkw_file=gtkw_file, traces=list(flatten_signals(traces))
-        )
+    def __init__(self, design, *, vcd_file, gtkw_file, traces):
+        super().__init__(design=design, vcd_file=vcd_file, gtkw_file=gtkw_file, traces=list(flatten_signals(traces)))
         self._tree_traces = traces
 
     def close(self, timestamp):
@@ -62,7 +60,7 @@ class _VCDWriterExt(_VCDWriter):
 
 @contextmanager
 def write_vcd_ext(engine, vcd_file, gtkw_file, traces):
-    vcd_writer = _VCDWriterExt(engine._fragment, vcd_file=vcd_file, gtkw_file=gtkw_file, traces=traces)
+    vcd_writer = _VCDWriterExt(engine._design, vcd_file=vcd_file, gtkw_file=gtkw_file, traces=traces)
     try:
         engine._vcd_writers.append(vcd_writer)
         yield Tick()

--- a/transactron/testing/gtkw_extension.py
+++ b/transactron/testing/gtkw_extension.py
@@ -17,8 +17,8 @@ class _VCDWriterExt(_VCDWriter):
     def close(self, timestamp):
         def save_signal(value: Value):
             for signal in value._rhs_signals():  # type: ignore
-                if signal in self.gtkw_names:
-                    for name in self.gtkw_names[signal]:
+                if signal in self.gtkw_signal_names:
+                    for name in self.gtkw_signal_names[signal]:
                         self.gtkw_save.trace(name)
 
         def gtkw_traces(traces):

--- a/transactron/testing/infrastructure.py
+++ b/transactron/testing/infrastructure.py
@@ -184,7 +184,7 @@ class PysimSimulator(Simulator):
             # TODO: try to merge with Amaranth.
             if isinstance(extra_signals, Callable):
                 extra_signals = extra_signals()
-            clocks = [d.clk for d in cast(Any, self)._fragment.domains.values()]
+            clocks = [d.clk for d in cast(Any, self)._design.fragment.domains.values()]
 
             self.ctx = write_vcd_ext(
                 cast(Any, self)._engine,

--- a/transactron/testing/logging.py
+++ b/transactron/testing/logging.py
@@ -99,7 +99,7 @@ def make_logging_process(level: tlog.LogLevel, namespace_regexp: str, on_error: 
         while True:
             yield Tick("sync_neg")
             yield from handle_logs()
-            yield
+            yield Tick()
             _sim_cycle += 1
 
     return log_process

--- a/transactron/testing/profiler.py
+++ b/transactron/testing/profiler.py
@@ -32,6 +32,6 @@ def profiler_process(transaction_manager: TransactionManager, profile: Profile):
             cprof = CycleProfile.make(samples, profile_data)
             profile.cycles.append(cprof)
 
-            yield
+            yield Tick()
 
     return process

--- a/transactron/tracing.py
+++ b/transactron/tracing.py
@@ -7,6 +7,7 @@ import warnings
 from amaranth.hdl import Elaboratable, Fragment, Instance
 from amaranth.hdl._xfrm import FragmentTransformer
 from amaranth.hdl import _dsl, _ir, _mem, _xfrm
+from amaranth_types import SrcLoc
 from transactron.utils import HasElaborate
 from . import core
 
@@ -79,7 +80,7 @@ class TracingFragmentTransformer(FragmentTransformer):
 
 class TracingFragment(Fragment):
     _tracing_original: Elaboratable
-    subfragments: list[tuple[Elaboratable, str]]
+    subfragments: list[tuple[Elaboratable, str, SrcLoc]]
 
     if DIAGNOSTICS:
 

--- a/transactron/tracing.py
+++ b/transactron/tracing.py
@@ -7,6 +7,7 @@ import warnings
 from amaranth.hdl import Elaboratable, Fragment, Instance
 from amaranth.hdl._xfrm import FragmentTransformer
 from amaranth.hdl import _dsl, _ir, _mem, _xfrm
+from amaranth.lib import memory  # type: ignore
 from amaranth_types import SrcLoc
 from transactron.utils import HasElaborate
 from . import core
@@ -17,7 +18,7 @@ modules_with_fragment: tuple = core, _ir, _dsl, _mem, _xfrm
 # List of Fragment subclasses which should be patched to inherit from TracingFragment.
 # The first element of the tuple is a subclass name to patch, and the second element
 # of the tuple is tuple with modules in which the patched subclass should be installed.
-fragment_subclasses_to_patch = [("MemoryInstance", (_mem, _xfrm))]
+fragment_subclasses_to_patch = [("MemoryInstance", (memory, _mem, _xfrm))]
 
 DIAGNOSTICS = False
 orig_on_fragment = FragmentTransformer.on_fragment

--- a/transactron/utils/amaranth_ext/elaboratables.py
+++ b/transactron/utils/amaranth_ext/elaboratables.py
@@ -162,7 +162,7 @@ class Scheduler(Elaboratable):
         self.count = count
 
         self.requests = Signal(count)
-        self.grant = Signal(count, reset=1)
+        self.grant = Signal(count, init=1)
         self.valid = Signal()
 
     def elaborate(self, platform):

--- a/transactron/utils/assign.py
+++ b/transactron/utils/assign.py
@@ -217,7 +217,7 @@ def assign(
             if valuelike_shape(lhs) != valuelike_shape(rhs):
                 raise ValueError(
                     "Shapes not matching: lhs: {} {} rhs: {} {}".format(
-                        valuelike_shape(lhs), lhs, valuelike_shape(rhs), rhs
+                        valuelike_shape(lhs), repr(lhs), valuelike_shape(rhs), repr(rhs)
                     )
                 )
 


### PR DESCRIPTION
Amaranth update. It includes, among others:

* RFC 58 - ValueCastable formatting.
* RFC 51 - from_bits and data.Const.
* RFC 50 - Print statement.
* RFC 45 - lib.memory.
* RFC 43 - reset= to init=.
* RFC 27 - testbench functions. For now, I've avoided the `Settle` issue by silencing a deprecation warning. I've fixed all the other deprecation warnings however.

I intend to do Amaranth version updates in parts, so that the pull requests will be manageable. This PR unfortunately turned out to be quite large because of an Amaranth bug - see history below.

Somehow, synthesis results are better, and the reasons for that are unknown. Is this a result of Yosys or Amaranth upgrade? Is this a bug? I don't know.

Disclaimer: a lot of the new type stubs are untested, and some of them will probably need to be corrected in the future.