### PR TITLE
Fix WFI resume on mstatus.MIE disabled

### DIFF
--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -68,6 +68,11 @@ class AsyncInterruptInsertSignalKey(SimpleKey[Signal]):
 
 
 @dataclass(frozen=True)
+class WaitForInterruptResumeKey(SimpleKey[Signal]):
+    pass
+
+
+@dataclass(frozen=True)
 class MretKey(SimpleKey[Method]):
     pass
 

--- a/test/asm/user_mode.asm
+++ b/test/asm/user_mode.asm
@@ -68,7 +68,7 @@ case0:
     li x1, 1<<17
     csrs mie, x1 # enable fixed level interrupt
 
-    # MIE = 0, but interrupts are active in U-MODE (when enabled in mie)
+    # mstatus.MIE = 0, but interrupts are active in U-MODE (when enabled in mie)
 
     la x1, user_code2
     csrw mepc, x1

--- a/test/asm/wfi_no_mie.asm
+++ b/test/asm/wfi_no_mie.asm
@@ -1,0 +1,27 @@
+_start:
+    li x4, 0
+
+    la x1, trap_handler
+    csrw mtvec, x1
+
+    li x1, 1<<17
+    csrs mie, x1 # enable fixed level interrupt
+    # but keep mstatus.MIE disabled
+
+    li x2, 1
+    loop:
+        wfi
+        addi x2, x2, -1
+        bnez x2, loop
+
+    j pass
+
+fail:
+    j fail
+
+pass:
+    li x8, 8
+    j pass
+
+trap_handler:
+    j fail


### PR DESCRIPTION
~~Depends on #729 (see last commit for diff)~~

WFI should continue to next instruction if interrupt is pending and unmasked via `mie`, but global interrupt enable `mstatus.MIE` bit is disabled.
[Priv spec 3.3.3]

Previously it only triggers interrupt handler when `mstatus.MIE` is set, and waits otherwise.