### PR TITLE
Fix synthesis of some configurations

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -136,10 +136,11 @@ class Core(Component):
 
         m.submodules.exception_information_register = self.exception_information_register
 
-        fetch_resume_fb, fetch_resume_unifiers = self.connections.get_dependency(FetchResumeKey())
-        m.submodules.fetch_resume_unifiers = ModuleConnector(**fetch_resume_unifiers)
+        if self.connections.dependency_provided(FetchResumeKey()):
+            fetch_resume_fb, fetch_resume_unifiers = self.connections.get_dependency(FetchResumeKey())
+            m.submodules.fetch_resume_unifiers = ModuleConnector(**fetch_resume_unifiers)
 
-        m.submodules.fetch_resume_connector = ConnectTrans(fetch_resume_fb, self.frontend.resume_from_unsafe)
+            m.submodules.fetch_resume_connector = ConnectTrans(fetch_resume_fb, self.frontend.resume_from_unsafe)
 
         m.submodules.announcement = self.announcement
         m.submodules.func_blocks_unifier = self.func_blocks_unifier

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -402,7 +402,12 @@ class FetchUnit(Elaboratable):
         if self.gen_params.extra_verification:
             expect_unstall_unsafe = Signal()
             prev_stalled_unsafe = Signal()
-            unifier_ready = DependencyContext.get().get_dependency(FetchResumeKey())[0].ready
+            dependencies = DependencyContext.get()
+            if dependencies.dependency_provided(FetchResumeKey()):
+                unifier_ready = DependencyContext.get().get_dependency(FetchResumeKey())[0].ready
+            else:
+                unifier_ready = C(0)
+
             m.d.sync += prev_stalled_unsafe.eq(stalled_unsafe)
             with m.FSM("running"):
                 with m.State("running"):

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -62,7 +62,7 @@ class CoreFrontend(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        if self.icache_refiller:
+        if self.gen_params.icache_params.enable:
             m.submodules.icache_refiller = self.icache_refiller
         m.submodules.icache = self.icache
 

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -155,12 +155,15 @@ basic_core_config = CoreConfiguration()
 tiny_core_config = CoreConfiguration(
     embedded=True,
     func_units_config=(
-        RSBlockComponent([ALUComponent(), ShiftUnitComponent(), JumpComponent()], rs_entries=2),
+        RSBlockComponent(
+            [ALUComponent(), ShiftUnitComponent(), JumpComponent(), ExceptionUnitComponent()], rs_entries=2
+        ),
         RSBlockComponent([LSUComponent()], rs_entries=2, rs_type=FifoRS),
     ),
     phys_regs_bits=basic_core_config.phys_regs_bits - 1,
     rob_entries_bits=basic_core_config.rob_entries_bits - 1,
-    allow_partial_extensions=True,  # No exception unit
+    icache_enable=False,
+    user_mode=False,
 )
 
 # Core configuration with all supported components

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -28,7 +28,7 @@ class TestConfigurationsISAString(TestCase):
             "rv32imcbzicsr_zifencei_xintmachinemode",
             "rv32imcbzicsr_zifencei_xintmachinemode",
         ),
-        ISAStrTest(tiny_core_config, "rv32e", "rv32", "rv32e"),
+        ISAStrTest(tiny_core_config, "rv32e", "rv32e", "rv32e"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),
     ]
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -10,7 +10,7 @@ from coreblocks.arch.isa_consts import PrivilegeLevel
 from coreblocks.core import Core
 from coreblocks.params import GenParams
 from coreblocks.params.instr import *
-from coreblocks.params.configurations import CoreConfiguration, basic_core_config, full_core_config
+from coreblocks.params.configurations import *
 from coreblocks.peripherals.wishbone import WishboneMemorySlave
 
 import random
@@ -131,6 +131,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
     [
         ("fibonacci", "fibonacci.asm", 500, {2: 2971215073}, basic_core_config),
         ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, basic_core_config),
+        ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, tiny_core_config),
         ("csr", "csr.asm", 200, {1: 1, 2: 4}, full_core_config),
         ("csr_mmode", "csr_mmode.asm", 1000, {1: 0, 2: 44, 3: 0, 4: 0, 5: 0, 6: 4, 15: 0}, full_core_config),
         ("exception", "exception.asm", 200, {1: 1, 2: 2}, basic_core_config),

--- a/transactron/utils/dependencies.py
+++ b/transactron/utils/dependencies.py
@@ -138,6 +138,10 @@ class DependencyManager:
 
         return val
 
+    def dependency_provided(self, key: DependencyKey) -> bool:
+        """Checks if any dependency for a key is provided (ignores `empty_valid` parameter)"""
+        return key in self.dependencies
+
 
 class DependencyContext:
     stack: list[DependencyManager] = []


### PR DESCRIPTION
* After front end refactor `icache=False` was not synthesizing!!
* Disabled icache and user mode in tiny config
* Added check if FetchResumeKey (from unsafe) is provided. Otherwise tiny config that doesn't have any unsafe instructions would not synthesize
* Add run of asm test tiny core config to prevent that kind of errors issues in future 
* Updated tiny core config to implement full I - added ExceptionUnit. Why not? If exception happens it would restart execution to 0x0 (default) instead of hanging up (or worse?) the core in undefined state. CSR Unit is not included so hepefully most of interrupt handling will by optimized away