### PR TITLE
Synchronous register file using MemoryBank

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -132,8 +132,10 @@ class Core(Component):
             get_free_reg=free_rf_fifo.read,
             rat_rename=frat.rename,
             rob_put=rob.put,
-            rf_read1=rf.read1,
-            rf_read2=rf.read2,
+            rf_read_req1=rf.read_req1,
+            rf_read_req2=rf.read_req2,
+            rf_read_resp1=rf.read_resp1,
+            rf_read_resp2=rf.read_resp2,
             reservation_stations=self.func_blocks_unifier.rs_blocks,
             gen_params=self.gen_params,
         )

--- a/coreblocks/core_structs/rf.py
+++ b/coreblocks/core_structs/rf.py
@@ -1,9 +1,9 @@
 from amaranth import *
-import amaranth.lib.memory as memory
 from transactron import Method, Transaction, def_method, TModule
 from coreblocks.interface.layouts import RFLayouts
 from coreblocks.params import GenParams
 from transactron.lib.metrics import HwExpHistogram, TaggedLatencyMeasurer
+from transactron.lib.storage import AsyncMemoryBank
 from transactron.utils.amaranth_ext.functions import popcount
 
 __all__ = ["RegisterFile"]
@@ -14,7 +14,9 @@ class RegisterFile(Elaboratable):
         self.gen_params = gen_params
         layouts = gen_params.get(RFLayouts)
         self.read_layout = layouts.rf_read_out
-        self.entries = memory.Memory(shape=gen_params.isa.xlen, depth=2**gen_params.phys_regs_bits, init=[])
+        self.entries = AsyncMemoryBank(
+            data_layout=[("data", gen_params.isa.xlen)], elem_count=2**gen_params.phys_regs_bits, read_ports=2
+        )
         self.valids = Array(Signal(init=k == 0) for k in range(2**gen_params.phys_regs_bits))
 
         self.read1 = Method(i=layouts.rf_read_in, o=layouts.rf_read_out)
@@ -43,17 +45,12 @@ class RegisterFile(Elaboratable):
         being_written = Signal(self.gen_params.phys_regs_bits)
         written_value = Signal(self.gen_params.isa.xlen)
 
-        write_port = self.entries.write_port()
-        read_port_1 = self.entries.read_port(domain="comb")
-        read_port_2 = self.entries.read_port(domain="comb")
-
         @def_method(m, self.read1)
         def _(reg_id: Value):
             forward = Signal()
             m.d.av_comb += forward.eq((being_written == reg_id) & (reg_id != 0))
-            m.d.av_comb += read_port_1.addr.eq(reg_id)
             return {
-                "reg_val": Mux(forward, written_value, read_port_1.data),
+                "reg_val": Mux(forward, written_value, self.entries.read[0](m, addr=reg_id).data),
                 "valid": Mux(forward, 1, self.valids[reg_id]),
             }
 
@@ -61,9 +58,8 @@ class RegisterFile(Elaboratable):
         def _(reg_id: Value):
             forward = Signal()
             m.d.av_comb += forward.eq((being_written == reg_id) & (reg_id != 0))
-            m.d.av_comb += read_port_2.addr.eq(reg_id)
             return {
-                "reg_val": Mux(forward, written_value, read_port_2.data),
+                "reg_val": Mux(forward, written_value, self.entries.read[1](m, addr=reg_id).data),
                 "valid": Mux(forward, 1, self.valids[reg_id]),
             }
 
@@ -72,10 +68,8 @@ class RegisterFile(Elaboratable):
             zero_reg = reg_id == 0
             m.d.comb += being_written.eq(reg_id)
             m.d.av_comb += written_value.eq(reg_val)
-            m.d.av_comb += write_port.addr.eq(reg_id)
-            m.d.av_comb += write_port.data.eq(reg_val)
             with m.If(~(zero_reg)):
-                m.d.comb += write_port.en.eq(1)
+                self.entries.write(m, addr=reg_id, data={"data": reg_val})
                 m.d.sync += self.valids[reg_id].eq(1)
                 self.perf_rf_valid_time.start(m, slot=reg_id)
 

--- a/coreblocks/core_structs/rf.py
+++ b/coreblocks/core_structs/rf.py
@@ -3,7 +3,7 @@ from transactron import Method, Transaction, def_method, TModule
 from coreblocks.interface.layouts import RFLayouts
 from coreblocks.params import GenParams
 from transactron.lib.metrics import HwExpHistogram, TaggedLatencyMeasurer
-from transactron.lib.storage import AsyncMemoryBank
+from transactron.lib.storage import MemoryBank
 from transactron.utils.amaranth_ext.functions import popcount
 
 __all__ = ["RegisterFile"]
@@ -14,13 +14,18 @@ class RegisterFile(Elaboratable):
         self.gen_params = gen_params
         layouts = gen_params.get(RFLayouts)
         self.read_layout = layouts.rf_read_out
-        self.entries = AsyncMemoryBank(
-            data_layout=[("data", gen_params.isa.xlen)], elem_count=2**gen_params.phys_regs_bits, read_ports=2
+        self.entries = MemoryBank(
+            data_layout=[("data", gen_params.isa.xlen)],
+            elem_count=2**gen_params.phys_regs_bits,
+            read_ports=2,
+            transparent=True,
         )
         self.valids = Array(Signal(init=k == 0) for k in range(2**gen_params.phys_regs_bits))
 
-        self.read1 = Method(i=layouts.rf_read_in, o=layouts.rf_read_out)
-        self.read2 = Method(i=layouts.rf_read_in, o=layouts.rf_read_out)
+        self.read_req1 = Method(i=layouts.rf_read_in)
+        self.read_req2 = Method(i=layouts.rf_read_in)
+        self.read_resp1 = Method(i=layouts.rf_read_in, o=layouts.rf_read_out)
+        self.read_resp2 = Method(i=layouts.rf_read_in, o=layouts.rf_read_out)
         self.write = Method(i=layouts.rf_write)
         self.free = Method(i=layouts.rf_free)
 
@@ -45,21 +50,29 @@ class RegisterFile(Elaboratable):
         being_written = Signal(self.gen_params.phys_regs_bits)
         written_value = Signal(self.gen_params.isa.xlen)
 
-        @def_method(m, self.read1)
+        @def_method(m, self.read_req1)
+        def _(reg_id: Value):
+            self.entries.read_req[0](m, addr=reg_id)
+
+        @def_method(m, self.read_req2)
+        def _(reg_id: Value):
+            self.entries.read_req[1](m, addr=reg_id)
+
+        @def_method(m, self.read_resp1)
         def _(reg_id: Value):
             forward = Signal()
             m.d.av_comb += forward.eq((being_written == reg_id) & (reg_id != 0))
             return {
-                "reg_val": Mux(forward, written_value, self.entries.read[0](m, addr=reg_id).data),
+                "reg_val": Mux(forward, written_value, self.entries.read_resp[0](m).data),
                 "valid": Mux(forward, 1, self.valids[reg_id]),
             }
 
-        @def_method(m, self.read2)
+        @def_method(m, self.read_resp2)
         def _(reg_id: Value):
             forward = Signal()
             m.d.av_comb += forward.eq((being_written == reg_id) & (reg_id != 0))
             return {
-                "reg_val": Mux(forward, written_value, self.entries.read[1](m, addr=reg_id).data),
+                "reg_val": Mux(forward, written_value, self.entries.read_resp[1](m).data),
                 "valid": Mux(forward, 1, self.valids[reg_id]),
             }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@edb302b001433edf4c8568190adc9bd0c0039f45
-transactron @ git+https://github.com/kuznia-rdzeni/transactron.git@82aceee58db05498ffd8c4dd515bcb834bb0cf88
+transactron @ git+https://github.com/kuznia-rdzeni/transactron.git@e38f872b1875a6ca460a7d173e1bf2072c22ddcc
 amaranth-yosys==0.40.0.0.post100
 amaranth==0.5.3
 dataclasses-json==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@edb302b001433edf4c8568190adc9bd0c0039f45
-transactron @ git+https://github.com/kuznia-rdzeni/transactron.git@e38f872b1875a6ca460a7d173e1bf2072c22ddcc
+transactron @ git+https://github.com/kuznia-rdzeni/transactron.git@08fd4baa5bdea7617ace0ab0a9348bda623c4017
 amaranth-yosys==0.40.0.0.post100
 amaranth==0.5.3
 dataclasses-json==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 amaranth-stubs @ git+https://github.com/kuznia-rdzeni/amaranth-stubs.git@edb302b001433edf4c8568190adc9bd0c0039f45
-transactron @ git+https://github.com/kuznia-rdzeni/transactron.git@972047b7bfac3d2e193a428de35c976f9b17c51a
+transactron @ git+https://github.com/kuznia-rdzeni/transactron.git@82aceee58db05498ffd8c4dd515bcb834bb0cf88
 amaranth-yosys==0.40.0.0.post100
 amaranth==0.5.3
 dataclasses-json==0.6.3

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -99,8 +99,10 @@ class SchedulerTestCircuit(Elaboratable):
             get_free_reg=free_rf_fifo.read,
             rat_rename=rat.rename,
             rob_put=self.rob.put,
-            rf_read1=self.rf.read1,
-            rf_read2=self.rf.read2,
+            rf_read_req1=self.rf.read_req1,
+            rf_read_req2=self.rf.read_req2,
+            rf_read_resp1=self.rf.read_resp1,
+            rf_read_resp2=self.rf.read_resp2,
             reservation_stations=rs_blocks,
             gen_params=self.gen_params,
         )

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -3,12 +3,11 @@ from typing import Any
 from amaranth import *
 from amaranth.lib.wiring import connect
 from amaranth_types import ValueLike
-from transactron.lib import AdapterTrans
 from transactron.testing.tick_count import TicksKey
 
 from transactron.utils import align_to_power_of_two
 
-from transactron.testing import TestCaseWithSimulator, ProcessContext, TestbenchContext, TestbenchIO
+from transactron.testing import TestCaseWithSimulator, ProcessContext, TestbenchContext
 
 from coreblocks.arch.isa_consts import PrivilegeLevel
 from coreblocks.core import Core
@@ -56,7 +55,6 @@ class CoreTestElaboratable(Elaboratable):
         m.submodules.wb_mem_slave = self.wb_mem_slave
         m.submodules.wb_mem_slave_data = self.wb_mem_slave_data
         m.submodules.c = self.core
-        m.submodules.rf_read = self.rf_read = TestbenchIO(AdapterTrans(self.core.RF.read1))
 
         connect(m, self.core.wb_instr, self.wb_mem_slave.bus)
         connect(m, self.core.wb_data, self.wb_mem_slave_data.bus)
@@ -71,8 +69,9 @@ class TestCoreBase(TestCaseWithSimulator):
     def get_phys_reg_rrat(self, sim: TestbenchContext, reg_id):
         return sim.get(self.m.core.RRAT.entries[reg_id])
 
-    async def get_arch_reg_val(self, sim: TestbenchContext, reg_id):
-        return (await self.m.rf_read.call(sim, reg_id=self.get_phys_reg_rrat(sim, reg_id))).reg_val
+    def get_arch_reg_val(self, sim: TestbenchContext, reg_id):
+        # TODO: better stubs for memory, remove ignore
+        return sim.get(self.m.core.RF.entries.mem.data[(self.get_phys_reg_rrat(sim, reg_id))])  # type: ignore
 
 
 class TestCoreAsmSourceBase(TestCoreBase):
@@ -162,7 +161,7 @@ class TestCoreBasicAsm(TestCoreAsmSourceBase):
         await self.tick(sim, self.cycle_count)
 
         for reg_id, val in self.expected_regvals.items():
-            assert (await self.get_arch_reg_val(sim, reg_id)) == val
+            assert self.get_arch_reg_val(sim, reg_id) == val
 
     def test_asm_source(self):
         self.gen_params = GenParams(self.configuration)
@@ -277,23 +276,23 @@ class TestCoreInterrupt(TestCoreAsmSourceBase):
             if early_interrupt:
                 # wait until interrupts are cleared, so it won't be missed
                 await sim.tick().until(self.m.core.interrupt_controller.mip.value == 0)
-                assert (await self.get_arch_reg_val(sim, 30)) == int_count
+                assert self.get_arch_reg_val(sim, 30) == int_count
 
                 int_count += await do_interrupt()
             else:
                 await sim.tick().until(self.m.core.interrupt_controller.mip.value == 0)
-                assert (await self.get_arch_reg_val(sim, 30)) == int_count
+                assert self.get_arch_reg_val(sim, 30) == int_count
 
             handler_count += 1
 
             # wait until ISR returns
             await sim.tick().until(self.m.core.interrupt_controller.mstatus_mie.value != 0)
 
-        assert (await self.get_arch_reg_val(sim, 30)) == int_count
-        assert (await self.get_arch_reg_val(sim, 27)) == handler_count
+        assert self.get_arch_reg_val(sim, 30) == int_count
+        assert self.get_arch_reg_val(sim, 27) == handler_count
 
         for reg_id, val in self.expected_regvals.items():
-            assert (await self.get_arch_reg_val(sim, reg_id)) == val
+            assert self.get_arch_reg_val(sim, reg_id) == val
 
     def test_interrupted_prog(self):
         bin_src = self.prepare_source(self.source_file)
@@ -359,7 +358,7 @@ class TestCoreInterruptOnPrivMode(TestCoreAsmSourceBase):
             await self.random_wait(sim, 5)
 
         for reg_id, val in self.expected_regvals.items():
-            assert (await self.get_arch_reg_val(sim, reg_id)) == val
+            assert self.get_arch_reg_val(sim, reg_id) == val
 
     def test_interrupted_prog(self):
         bin_src = self.prepare_source(self.source_file)


### PR DESCRIPTION
This PR implements a synchronous register file. Read requests are done on RS selection, results are read, like previously, on RS insertion. The change will enable using FPGA Block RAMs and multiport RAM structures utilizing block RAMs.

Closes #737.

TODO:
- [x] Merge Transactron PR https://github.com/kuznia-rdzeni/transactron/pull/18, change commit in dependencies.