### PR TITLE
Update RISC-V toolchain

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -80,7 +80,7 @@ jobs:
           (github.event.action == 'labeled' && github.event.label.name == 'benchmark')
         )
       )
-    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2024.03.12
+    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2024.12.07
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
   build-riscof-tests:
     name: Build regression tests (riscv-arch-test)
     runs-on: ubuntu-latest
-    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2024.03.12
+    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2024.12.07
     timeout-minutes: 10
     env:
       PYENV_ROOT: "/root/.pyenv"
@@ -200,7 +200,7 @@ jobs:
   build-regression-tests:
     name: Build regression tests (riscv-tests)
     runs-on: ubuntu-latest
-    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2024.03.12
+    container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2024.12.07
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/docker/riscv-toolchain.Dockerfile
+++ b/docker/riscv-toolchain.Dockerfile
@@ -1,25 +1,25 @@
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
-    autoconf automake autotools-dev curl python3.11 python3.11-venv python3-pip bc lsb-release \
+    autoconf automake autotools-dev curl python3 python3-venv python3-pip bc lsb-release \
     libmpc-dev libmpfr-dev libgmp-dev gawk build-essential \
     bison flex texinfo gperf libtool patchutils zlib1g-dev device-tree-compiler \
     libexpat-dev ninja-build git ca-certificates python-is-python3 \ 
     libssl-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --shallow-since=2023.05.01 https://github.com/riscv/riscv-gnu-toolchain && \
+RUN git clone --shallow-since=2024.11.20 https://github.com/riscv-collab/riscv-gnu-toolchain && \
     cd riscv-gnu-toolchain && \
-    git checkout 2023.12.10 && \
-    ./configure --with-multilib-generator="rv32i-ilp32--a*zifence*zicsr;rv32im-ilp32--a*zifence*zicsr;rv32ic-ilp32--a*zifence*zicsr;rv32imc-ilp32--a*zifence*zicsr;rv32imfc-ilp32f--a*zifence;rv32imc_zba_zbb_zbc_zbs-ilp32--a*zifence*zicsr" && \
+    git checkout 2024.11.22 && \
+    ./configure --with-multilib-generator="rv32i-ilp32--a*zifence*zicsr;rv32im-ilp32--a*zifence*zicsr;rv32ic-ilp32--a*zifence*zicsr;rv32imc-ilp32--a*zifence*zicsr;rv32imfc-ilp32f--a*zifence;rv32imc_zba_zbb_zbc_zbs_zicond-ilp32--a*zifence*zicsr" && \
     make -j$(nproc) && \
     cd / && rm -rf riscv-gnu-toolchain
 
-RUN git clone --shallow-since=2023.10.01 https://github.com/riscv-software-src/riscv-isa-sim.git spike && \
+RUN git clone --shallow-since=2024.10.01 https://github.com/riscv-software-src/riscv-isa-sim.git spike && \
     cd spike && \
-    git checkout eeef09ebb894c3bb7e42b7b47aae98792b8eef79 && \
+    git checkout 7812eabb441eaf2067d07636a382eca622e48814 && \
     mkdir build/ install/  && \
     cd build/ && \
     ../configure --prefix=/spike/install/ && \

--- a/test/external/embench/board_config/coreblocks-sim/board.cfg
+++ b/test/external/embench/board_config/coreblocks-sim/board.cfg
@@ -1,5 +1,5 @@
 cc = 'riscv64-unknown-elf-gcc'
-cflags = (['-c', '-fdata-sections', '-march=rv32imc_zba_zbb_zbc_zbs_zicsr', '-mabi=ilp32'])
-ldflags = (['-Wl,-gc-sections', '-march=rv32imc_zba_zbb_zbc_zbs_zicsr', '-mabi=ilp32', '-nostartfiles', '-T../../../common/link.ld'])
+cflags = (['-c', '-fdata-sections', '-march=rv32imc_zba_zbb_zbc_zbs_zicsr_zicond', '-mabi=ilp32'])
+ldflags = (['-Wl,-gc-sections', '-march=rv32imc_zba_zbb_zbc_zbs_zicsr_zicond', '-mabi=ilp32', '-nostartfiles', '-T../../../common/link.ld'])
 user_libs = (['-lm'])
 cpu_mhz = 0.01


### PR DESCRIPTION
This PR updates the RISC-V toolchain used in the CI builds. This includes updated GCC which can take advantage of the zicond extension. The `riscv-arch-test` dependency also needed to be updated because of a build error.

Benchmarks show some IPC improvements on `crc32` , `minver` and `ud` , minimal IPC improvement on `slre` and `statemate`, and a small decrease on `nettle-sha256`. 

Fixes #748.