### PR TITLE
Remove func blocks unifier indirections

### DIFF
--- a/coreblocks/backend/annoucement.py
+++ b/coreblocks/backend/annoucement.py
@@ -20,7 +20,7 @@ class ResultAnnouncement(Elaboratable):
     """
 
     def __init__(
-        self, *, gen_params: GenParams, get_result: Method, rob_mark_done: Method, rs_update: Method, rf_write: Method
+        self, *, gen_params: GenParams, get_result: Method, rob_mark_done: Method, announce: Method
     ):
         """
         Parameters
@@ -33,18 +33,14 @@ class ResultAnnouncement(Elaboratable):
             which should be announced in core. This method assumes that results
             from different FUs are already serialized.
         rob_mark_done : Method
-            Method which is invoked to mark that instruction ended without exception.
-        rs_update : Method
-            Method which is invoked to pass value which is an output of finished instruction
-            to RS, so that RS can save it if there are instructions which wait for it.
-        rf_write : Method
-            Method which is invoked to save value which is an output of finished instruction to RF.
+            Method which is invoked to mark that instruction finished execution.
+        announce : Method
+            Method which is invoked to announce the computed register value to RF and RS.
         """
 
         self.m_get_result = get_result
         self.m_rob_mark_done = rob_mark_done
-        self.m_rs_update = rs_update
-        self.m_rf_write_val = rf_write
+        self.m_announce = announce
 
     def debug_signals(self):
         return [self.m_get_result.debug_signals()]
@@ -56,8 +52,7 @@ class ResultAnnouncement(Elaboratable):
             result = self.m_get_result(m)
             self.m_rob_mark_done(m, rob_id=result.rob_id, exception=result.exception)
 
-            self.m_rf_write_val(m, reg_id=result.rp_dst, reg_val=result.result)
             with m.If(result.rp_dst != 0):
-                self.m_rs_update(m, reg_id=result.rp_dst, reg_val=result.result)
+                self.m_announce(m, reg_id=result.rp_dst, reg_val=result.result)
 
         return m

--- a/coreblocks/backend/annoucement.py
+++ b/coreblocks/backend/annoucement.py
@@ -19,9 +19,7 @@ class ResultAnnouncement(Elaboratable):
     `ManyToOneConnectTrans` to a FIFO.
     """
 
-    def __init__(
-        self, *, gen_params: GenParams, get_result: Method, rob_mark_done: Method, announce: Method
-    ):
+    def __init__(self, *, gen_params: GenParams, get_result: Method, rob_mark_done: Method, announce: Method):
         """
         Parameters
         ----------

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -14,6 +14,7 @@ from coreblocks.interface.keys import (
     FetchResumeKey,
     CSRInstancesKey,
     CommonBusDataKey,
+    FuncUnitResultKey,
 )
 from coreblocks.params.genparams import GenParams
 from coreblocks.core_structs.rat import FRAT, RRAT
@@ -80,14 +81,6 @@ class Core(Component):
             blocks=gen_params.func_units_config,
         )
 
-        self.announcement = ResultAnnouncement(
-            gen_params=self.gen_params,
-            get_result=self.func_blocks_unifier.get_result,
-            rob_mark_done=self.ROB.mark_done,
-            rs_update=self.func_blocks_unifier.update,
-            rf_write=self.RF.write,
-        )
-
         self.csr_generic = GenericCSRRegisters(self.gen_params)
         self.connections.add_dependency(CSRInstancesKey(), self.csr_generic)
 
@@ -123,6 +116,17 @@ class Core(Component):
         drop_second_ret_value = (self.gen_params.get(DecodeLayouts).decoded_instr, lambda _, rets: rets[0])
         m.submodules.get_instr = get_instr = MethodProduct(
             [self.frontend.consume_instr, core_counter.increment], combiner=drop_second_ret_value
+        )
+
+        func_get_result, func_unifier = self.connections.get_dependency(FuncUnitResultKey())
+        m.submodules.func_unifiers = ModuleConnector(**func_unifier)
+
+        self.announcement = ResultAnnouncement(
+            gen_params=self.gen_params,
+            get_result=func_get_result,
+            rob_mark_done=self.ROB.mark_done,
+            rs_update=self.func_blocks_unifier.update,
+            rf_write=self.RF.write,
         )
 
         m.submodules.scheduler = Scheduler(

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -126,10 +126,7 @@ class Core(Component):
         m.submodules.announce_unifiers = ModuleConnector(**announce_unifier)
 
         self.announcement = ResultAnnouncement(
-            gen_params=self.gen_params,
-            get_result=func_get_result,
-            rob_mark_done=self.ROB.mark_done,
-            announce=announce
+            gen_params=self.gen_params, get_result=func_get_result, rob_mark_done=self.ROB.mark_done, announce=announce
         )
 
         m.submodules.scheduler = Scheduler(

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -82,7 +82,6 @@ class Core(Component):
             gen_params=gen_params,
             blocks=gen_params.func_units_config,
         )
-        self.connections.add_dependency(AnnounceKey(), self.func_blocks_unifier.update)
 
         self.csr_generic = GenericCSRRegisters(self.gen_params)
         self.connections.add_dependency(CSRInstancesKey(), self.csr_generic)

--- a/coreblocks/func_blocks/csr/csr.py
+++ b/coreblocks/func_blocks/csr/csr.py
@@ -17,6 +17,7 @@ from coreblocks.interface.keys import (
     CSRListKey,
     FetchResumeKey,
     CSRInstancesKey,
+    FuncUnitResultKey,
     InstructionPrecommitKey,
     ExceptionReportKey,
     AsyncInterruptInsertSignalKey,
@@ -268,6 +269,7 @@ class CSRBlockComponent(BlockComponentParams):
         connections = DependencyContext.get()
         unit = CSRUnit(gen_params)
         connections.add_dependency(FetchResumeKey(), unit.fetch_resume)
+        connections.add_dependency(FuncUnitResultKey(), unit.get_result)
         return unit
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/func_blocks/csr/csr.py
+++ b/coreblocks/func_blocks/csr/csr.py
@@ -14,6 +14,7 @@ from coreblocks.params.fu_params import BlockComponentParams
 from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 from coreblocks.interface.layouts import FetchLayouts, FuncUnitLayouts, CSRUnitLayouts
 from coreblocks.interface.keys import (
+    AnnounceKey,
     CSRListKey,
     FetchResumeKey,
     CSRInstancesKey,
@@ -270,6 +271,7 @@ class CSRBlockComponent(BlockComponentParams):
         unit = CSRUnit(gen_params)
         connections.add_dependency(FetchResumeKey(), unit.fetch_resume)
         connections.add_dependency(FuncUnitResultKey(), unit.get_result)
+        connections.add_dependency(AnnounceKey(), unit.update)
         return unit
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/func_blocks/fu/common/rs_func_block.py
+++ b/coreblocks/func_blocks/fu/common/rs_func_block.py
@@ -28,9 +28,6 @@ class RSFuncBlock(FuncBlock, Elaboratable):
         RS select method.
     update: Method
         RS update method.
-    get_result: Method
-        Method used for getting single result out of one of the FUs. It uses
-        layout described by `FuncUnitLayouts`.
     """
 
     def __init__(
@@ -67,7 +64,6 @@ class RSFuncBlock(FuncBlock, Elaboratable):
         self.insert = Method(i=self.rs_layouts.rs.insert_in)
         self.select = Method(o=self.rs_layouts.rs.select_out)
         self.update = Method(i=self.rs_layouts.rs.update_in)
-        self.get_result = Method(o=self.fu_layouts.accept)
 
     def elaborate(self, platform):
         m = TModule()

--- a/coreblocks/func_blocks/fu/common/rs_func_block.py
+++ b/coreblocks/func_blocks/fu/common/rs_func_block.py
@@ -11,7 +11,7 @@ from coreblocks.func_blocks.interface.func_protocols import FuncUnit, FuncBlock
 from transactron.lib import Collector
 from coreblocks.arch import OpType
 from coreblocks.interface.layouts import RSLayouts, FuncUnitLayouts
-from coreblocks.interface.keys import FuncUnitResultKey
+from coreblocks.interface.keys import AnnounceKey, FuncUnitResultKey
 
 __all__ = ["RSFuncBlock", "RSBlockComponent"]
 
@@ -106,9 +106,6 @@ class RSBlockComponent(BlockComponentParams):
 
     def get_module(self, gen_params: GenParams) -> FuncBlock:
         modules = list((u.get_module(gen_params), u.get_optypes()) for u in self.func_units)
-        dependencies = DependencyContext.get()
-        for unit, _ in modules:
-            dependencies.add_dependency(FuncUnitResultKey(), unit.accept)
         rs_unit = RSFuncBlock(
             gen_params=gen_params,
             func_units=modules,
@@ -116,6 +113,10 @@ class RSBlockComponent(BlockComponentParams):
             rs_number=self.rs_number,
             rs_type=self.rs_type,
         )
+        dependencies = DependencyContext.get()
+        dependencies.add_dependency(AnnounceKey(), rs_unit.update)
+        for unit, _ in modules:
+            dependencies.add_dependency(FuncUnitResultKey(), unit.accept)
         return rs_unit
 
     def get_optypes(self) -> set[OpType]:

--- a/coreblocks/func_blocks/fu/common/rs_func_block.py
+++ b/coreblocks/func_blocks/fu/common/rs_func_block.py
@@ -8,7 +8,6 @@ from .rs import RS, RSBase
 from coreblocks.scheduler.wakeup_select import WakeupSelect
 from transactron import Method, TModule
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit, FuncBlock
-from transactron.lib import Collector
 from coreblocks.arch import OpType
 from coreblocks.interface.layouts import RSLayouts, FuncUnitLayouts
 from coreblocks.interface.keys import AnnounceKey, FuncUnitResultKey

--- a/coreblocks/func_blocks/fu/fpu/lza.py
+++ b/coreblocks/func_blocks/fu/fpu/lza.py
@@ -1,0 +1,111 @@
+from amaranth import *
+from amaranth.utils import ceil_log2
+from transactron import TModule, Method, def_method
+from coreblocks.func_blocks.fu.fpu.fpu_common import FPUParams
+from transactron.utils.amaranth_ext import count_leading_zeros
+
+
+class LZAMethodLayout:
+    """LZA module layouts for methods
+
+    Parameters
+    ----------
+    fpu_params: FPUParams
+        FPU parameters
+    """
+
+    def __init__(self, *, fpu_params: FPUParams):
+        """
+        sig_a - significand of a
+        sig_b - significand of b
+        carry - indicates if we want to predict result of a+b or a+b+1
+        shift_amount - position to shift needed to normalize number
+        is_zero - indicates if result is zero
+        """
+        self.predict_in_layout = [
+            ("sig_a", fpu_params.sig_width),
+            ("sig_b", fpu_params.sig_width),
+            ("carry", 1),
+        ]
+        self.predict_out_layout = [
+            ("shift_amount", range(fpu_params.sig_width)),
+            ("is_zero", 1),
+        ]
+
+
+class LZAModule(Elaboratable):
+    """LZA module
+    Based on: https://userpages.cs.umbc.edu/phatak/645/supl/lza/lza-survey-arith01.pdf
+    After performing subtracion, we may have to normalize floating point numbers and
+    For that, we have to know the number of leading zeros.
+    The most basic approach includes using LZC (leading zero counter) after subtracion,
+    a more advanced approach includes using LZA (Leading Zero Anticipator) to predict the number of
+    leading zeroes. It is worth noting that this LZA module works under assumptions that
+    significands are in two's complement and that before complementation sig_a was greater
+    or equal to sig_b. Another thing worth noting is that LZA works with error = 1.
+    That means that if 'n' is the result of the LZA module, in reality, to normalize
+    number we may have to shift left by 'n' or 'n+1'. There are few techniques of
+    dealing with that error like specially designed shifters or predicting the error
+    but the most basic approach is to just use multiplexer after shifter to perform
+    one more shift left if necessary.
+
+    Parameters
+    ----------
+    fpu_params: FPUParams
+        FPU rounding module parameters
+
+    Attributes
+    ----------
+    predict_request: Method
+        Transactional method for initiating leading zeros prediction.
+        Takes 'predict_in_layout' as argument
+        Returns shift amount as 'predict_out_layout'
+    """
+
+    def __init__(self, *, fpu_params: FPUParams):
+
+        self.lza_params = fpu_params
+        self.method_layouts = LZAMethodLayout(fpu_params=self.lza_params)
+        self.predict_request = Method(
+            i=self.method_layouts.predict_in_layout,
+            o=self.method_layouts.predict_out_layout,
+        )
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        @def_method(m, self.predict_request)
+        def _(sig_a, sig_b, carry):
+            f_size = 2 ** ceil_log2(self.lza_params.sig_width)
+            filler_size = f_size - self.lza_params.sig_width
+            lower_ones = Const((2**filler_size) - 1, f_size)
+
+            t = Signal(self.lza_params.sig_width + 1)
+            g = Signal(self.lza_params.sig_width + 1)
+            z = Signal(self.lza_params.sig_width + 1)
+            f = Signal(f_size)
+            shift_amount = Signal(range(self.lza_params.sig_width))
+            is_zero = Signal(1)
+
+            m.d.av_comb += t.eq((sig_a ^ sig_b) << 1)
+            m.d.av_comb += g.eq((sig_a & sig_b) << 1)
+            m.d.av_comb += z.eq(((sig_a | sig_b) << 1))
+            with m.If(carry):
+                m.d.av_comb += g[0].eq(1)
+                m.d.av_comb += z[0].eq(1)
+
+            for i in reversed(range(1, self.lza_params.sig_width + 1)):
+                m.d.av_comb += f[i + filler_size - 1].eq((t[i] ^ z[i - 1]))
+
+            m.d.av_comb += shift_amount.eq(0)
+            m.d.av_comp += f.eq(f | lower_ones)
+            m.d.av_comb += shift_amount.eq(count_leading_zeros(f))
+
+            m.d.av_comb += is_zero.eq((carry & t[1 : self.lza_params.sig_width].all()))
+
+            return {
+                "shift_amount": shift_amount,
+                "is_zero": is_zero,
+            }
+
+        return m

--- a/coreblocks/func_blocks/interface/func_blocks_unifier.py
+++ b/coreblocks/func_blocks/interface/func_blocks_unifier.py
@@ -4,7 +4,7 @@ from amaranth import *
 
 from coreblocks.params import GenParams, BlockComponentParams
 from transactron import TModule
-from transactron.lib import MethodProduct, Collector
+from transactron.lib import MethodProduct
 
 __all__ = ["FuncBlocksUnifier"]
 
@@ -18,9 +18,6 @@ class FuncBlocksUnifier(Elaboratable):
     ):
         self.rs_blocks = [(block.get_module(gen_params), block.get_optypes()) for block in blocks]
 
-        self.result_collector = Collector([block.get_result for block, _ in self.rs_blocks])
-        self.get_result = self.result_collector.method
-
         self.update_combiner = MethodProduct([block.update for block, _ in self.rs_blocks])
         self.update = self.update_combiner.method
 
@@ -30,7 +27,6 @@ class FuncBlocksUnifier(Elaboratable):
         for n, (unit, _) in enumerate(self.rs_blocks):
             m.submodules[f"rs_block_{n}"] = unit
 
-        m.submodules["result_collector"] = self.result_collector
         m.submodules["update_combiner"] = self.update_combiner
 
         return m

--- a/coreblocks/func_blocks/interface/func_blocks_unifier.py
+++ b/coreblocks/func_blocks/interface/func_blocks_unifier.py
@@ -4,7 +4,6 @@ from amaranth import *
 
 from coreblocks.params import GenParams, BlockComponentParams
 from transactron import TModule
-from transactron.lib import MethodProduct
 
 __all__ = ["FuncBlocksUnifier"]
 

--- a/coreblocks/func_blocks/interface/func_blocks_unifier.py
+++ b/coreblocks/func_blocks/interface/func_blocks_unifier.py
@@ -18,15 +18,10 @@ class FuncBlocksUnifier(Elaboratable):
     ):
         self.rs_blocks = [(block.get_module(gen_params), block.get_optypes()) for block in blocks]
 
-        self.update_combiner = MethodProduct([block.update for block, _ in self.rs_blocks])
-        self.update = self.update_combiner.method
-
     def elaborate(self, platform):
         m = TModule()
 
         for n, (unit, _) in enumerate(self.rs_blocks):
             m.submodules[f"rs_block_{n}"] = unit
-
-        m.submodules["update_combiner"] = self.update_combiner
 
         return m

--- a/coreblocks/func_blocks/interface/func_protocols.py
+++ b/coreblocks/func_blocks/interface/func_protocols.py
@@ -15,4 +15,3 @@ class FuncBlock(HasElaborate, Protocol):
     insert: Method
     select: Method
     update: Method
-    get_result: Method

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from transactron.lib.dependencies import SimpleKey, UnifierKey, ListKey
 from transactron import Method
-from transactron.lib import Collector
+from transactron.lib import Collector, MethodProduct
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
 from amaranth import Signal
 
@@ -54,6 +54,11 @@ class FetchResumeKey(UnifierKey, unifier=Collector):
 
 @dataclass(frozen=True)
 class FuncUnitResultKey(UnifierKey, unifier=Collector):
+    pass
+
+
+@dataclass(frozen=True)
+class AnnounceKey(UnifierKey, unifier=MethodProduct):
     pass
 
 

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -53,6 +53,11 @@ class FetchResumeKey(UnifierKey, unifier=Collector):
 
 
 @dataclass(frozen=True)
+class FuncUnitResultKey(UnifierKey, unifier=Collector):
+    pass
+
+
+@dataclass(frozen=True)
 class ExceptionReportKey(SimpleKey[Method]):
     pass
 

--- a/test/func_blocks/fu/fpu/test_lza.py
+++ b/test/func_blocks/fu/fpu/test_lza.py
@@ -1,0 +1,112 @@
+import random
+from coreblocks.func_blocks.fu.fpu.lza import *
+from coreblocks.func_blocks.fu.fpu.fpu_common import FPUParams
+from transactron import TModule
+from transactron.lib import AdapterTrans
+from transactron.testing import *
+from amaranth import *
+
+
+def clz(sig_a, sig_b, carry, sig_width):
+    zeros = 0
+    msb_bit_mask = 1 << (sig_width - 1)
+    sum = sig_a + sig_b + carry
+    while 1:
+        if not (sum & msb_bit_mask):
+            zeros += 1
+            sum = sum << 1
+        else:
+            return zeros
+
+
+class TestLZA(TestCaseWithSimulator):
+    class LZAModuleTest(Elaboratable):
+        def __init__(self, params: FPUParams):
+            self.params = params
+
+        def elaborate(self, platform):
+            m = TModule()
+            m.submodules.lza = lza = self.lza_module = LZAModule(fpu_params=self.params)
+            m.submodules.predict = self.predict_request_adapter = TestbenchIO(AdapterTrans(lza.predict_request))
+            return m
+
+    def test_manual(self):
+        params = FPUParams(sig_width=24, exp_width=8)
+        lza = TestLZA.LZAModuleTest(params)
+
+        async def random_test(sim: TestbenchContext, seed: int, iters: int):
+            xor_mask = (2**params.sig_width) - 1
+            random.seed(seed)
+            for _ in range(iters):
+                sig_a = random.randint(1 << (params.sig_width - 1), (2**params.sig_width) - 1)
+                sig_b = random.randint(1 << (params.sig_width - 1), sig_a)
+                sig_b = (sig_b ^ xor_mask) | (1 << params.sig_width)
+                resp = await lza.predict_request_adapter.call(sim, {"sig_a": sig_a, "sig_b": sig_b, "carry": 0})
+                pred_lz = resp["shift_amount"]
+                true_lz = clz(sig_a, sig_b, 0, params.sig_width)
+                assert pred_lz == true_lz or (pred_lz + 1) == true_lz
+
+        async def lza_test(sim: TestbenchContext):
+            test_cases = [
+                {
+                    "sig_a": 16368512,
+                    "sig_b": 409600,
+                    "carry": 0,
+                },
+                {
+                    "sig_a": 0,
+                    "sig_b": (2**24) - 1,
+                    "carry": 0,
+                },
+                {
+                    "sig_a": (2**24) // 2,
+                    "sig_b": (2**24) // 2,
+                    "carry": 0,
+                },
+                {
+                    "sig_a": 12582912,
+                    "sig_b": 12550144,
+                    "carry": 0,
+                },
+                {
+                    "sig_a": 16744448,
+                    "sig_b": 12615680,
+                    "carry": 0,
+                },
+                {
+                    "sig_a": 8421376,
+                    "sig_b": 8421376,
+                    "carry": 0,
+                },
+            ]
+            expected_results = [
+                {"shift_amount": 13, "is_zero": 0},
+                {"shift_amount": 13, "is_zero": 0},
+                {"shift_amount": 23, "is_zero": 0},
+                {"shift_amount": 0, "is_zero": 1},
+                {"shift_amount": 0, "is_zero": 0},
+                {"shift_amount": 23, "is_zero": 0},
+                {"shift_amount": 0, "is_zero": 0},
+                {"shift_amount": 0, "is_zero": 0},
+                {"shift_amount": 0, "is_zero": 0},
+                {"shift_amount": 0, "is_zero": 0},
+                {"shift_amount": 7, "is_zero": 0},
+                {"shift_amount": 7, "is_zero": 0},
+            ]
+            for i in range(len(test_cases)):
+
+                resp = await lza.predict_request_adapter.call(sim, test_cases[i])
+                assert resp["shift_amount"] == expected_results[2 * i]["shift_amount"]
+                assert resp["is_zero"] == expected_results[2 * i]["is_zero"]
+
+                test_cases[i]["carry"] = 1
+                resp = await lza.predict_request_adapter.call(sim, test_cases[i])
+                assert resp["shift_amount"] == expected_results[2 * i + 1]["shift_amount"]
+                assert resp["is_zero"] == expected_results[2 * i + 1]["is_zero"]
+
+        async def test_process(sim: TestbenchContext):
+            await lza_test(sim)
+            await random_test(sim, 2024, 20)
+
+        with self.run_simulation(lza) as sim:
+            sim.add_testbench(test_process)


### PR DESCRIPTION
This PR simplifies the announcement mechanism using the dependency system. At the same time, two layers of `Collector`s for accepting results were flattened to a single collector. The `func_blocks_unifier` module became trivial, and it might make sense to remove it later.

Benchmark results dropped slightly for some reason, ~but device utilization also seems to be reduced~.