### PR TITLE
Implement Zaamo - atomic memory operations extension

### DIFF
--- a/coreblocks/arch/isa.py
+++ b/coreblocks/arch/isa.py
@@ -59,6 +59,8 @@ class Extension(enum.IntFlag):
     ZIHPM = auto()
     #: Integer conditional operations
     ZICOND = auto()
+    #: Atomic memory operations
+    ZAAMO = auto()
     #: Misaligned atomic operations
     ZAM = auto()
     #: Half precision floating-point operations (16-bit)
@@ -107,6 +109,7 @@ _extension_requirements = {
 extension_implications = {
     Extension.F: Extension.ZICSR,
     Extension.M: Extension.ZMMUL,
+    Extension.A: Extension.ZAAMO,
     Extension.B: Extension.ZBA | Extension.ZBB | Extension.ZBC | Extension.ZBS,
 }
 

--- a/coreblocks/arch/isa_consts.py
+++ b/coreblocks/arch/isa_consts.py
@@ -36,6 +36,7 @@ class Opcode(IntEnum, shape=5):
     OP_IMM_32 = 0b00110
     STORE = 0b01000
     STORE_FP = 0b01001
+    AMO = 0b01011
     OP = 0b01100
     LUI = 0b01101
     OP32 = 0b01110
@@ -59,18 +60,22 @@ class Funct3(IntEnum, shape=3):
 
 
 class Funct7(IntEnum, shape=7):
-    SL = SLT = ADD = XOR = OR = AND = 0b0000000
-    SA = SUB = ANDN = ORN = XNOR = 0b0100000
+    SL = SLT = ADD = XOR = OR = AND = AMOADD = 0b0000000
     MULDIV = 0b0000001
-    SH1ADD = SH2ADD = SH3ADD = 0b0010000
-    BCLR = BEXT = 0b0100100
-    BINV = REV8 = 0b0110100
-    BSET = ORCB = 0b0010100
+    ZEXTH = AMOSWAP = 0b0000100
     MAX = MIN = CLMUL = 0b0000101
     CZERO = 0b0000111
-    ROL = ROR = SEXTB = SEXTH = CPOP = CLZ = CTZ = 0b0110000
-    ZEXTH = 0b0000100
     SFENCEVMA = 0b0001001
+    SH1ADD = SH2ADD = SH3ADD = AMOXOR = 0b0010000
+    BSET = ORCB = 0b0010100
+    SA = SUB = ANDN = ORN = XNOR = AMOOR = 0b0100000
+    BCLR = BEXT = 0b0100100
+    ROL = ROR = SEXTB = SEXTH = CPOP = CLZ = CTZ = AMOAND = 0b0110000
+    BINV = REV8 = 0b0110100
+    AMOMIN = 0b1000000
+    AMOMAX = 0b1010000
+    AMOMINU = 0b1100000
+    AMOMAXU = 0b1110000
 
 
 class Funct12(IntEnum, shape=12):

--- a/coreblocks/arch/optypes.py
+++ b/coreblocks/arch/optypes.py
@@ -51,6 +51,7 @@ class OpType(IntEnum):
     SRET = auto()
     SFENCEVMA = auto()
     CZERO = auto()
+    ATOMIC_MEMORY_OP = auto()
     #: Internal Coreblocks OpType, specifing that instruction caused Exception before FU execution
     EXCEPTION = auto()
 
@@ -129,6 +130,9 @@ optypes_by_extensions = {
     Extension.M: [
         OpType.DIV_REM,
     ],
+    Extension.ZAAMO: [
+        OpType.ATOMIC_MEMORY_OP,
+    ],
     Extension.ZBS: [
         OpType.SINGLE_BIT_MANIPULATION,
     ],
@@ -147,6 +151,9 @@ optypes_by_extensions = {
     Extension.ZBC: [
         OpType.CLMUL,
     ],
+    Extension.ZICOND: [
+        OpType.CZERO,
+    ],
     Extension.XINTMACHINEMODE: [
         OpType.MRET,
         OpType.WFI,
@@ -154,9 +161,6 @@ optypes_by_extensions = {
     Extension.XINTSUPERVISOR: [
         OpType.SRET,
         OpType.SFENCEVMA,
-    ],
-    Extension.ZICOND: [
-        OpType.CZERO,
     ],
 }
 

--- a/coreblocks/frontend/decoder/instr_decoder.py
+++ b/coreblocks/frontend/decoder/instr_decoder.py
@@ -225,10 +225,13 @@ class InstrDecoder(Elaboratable):
         m.d.comb += self.optype.eq(OpType.UNKNOWN)
 
         for enc in supported_encodings:
+            funct7 = self.funct7 & ~(
+                0b11 if enc.opcode == Opcode.AMO else 0
+            )  # HACK: AMO stores aq/rl fields in LSB of Funct7, match Funct5 as Funct7
             with m.If(
                 (opcode == enc.opcode if enc.opcode is not None else 1)
                 & (self.funct3 == enc.funct3 if enc.funct3 is not None else 1)
-                & (self.funct7 == enc.funct7 if enc.funct7 is not None else 1)
+                & (funct7 == enc.funct7 if enc.funct7 is not None else 1)
                 & (self.funct12 == enc.funct12 if enc.funct12 is not None else 1)
                 & (self.rd == 0 if enc.rd_zero else 1)
                 & (self.rs1 == 0 if enc.rs1_zero else 1)

--- a/coreblocks/frontend/decoder/instr_description.py
+++ b/coreblocks/frontend/decoder/instr_description.py
@@ -208,4 +208,15 @@ instructions_by_optype = {
         Encoding(Opcode.OP, Funct3.CZEROEQZ, Funct7.CZERO),
         Encoding(Opcode.OP, Funct3.CZERONEZ, Funct7.CZERO),
     ],
+    OpType.ATOMIC_MEMORY_OP: [
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOSWAP),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOADD),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOAND),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOOR),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOXOR),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOMAXU),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOMINU),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOMAX),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.AMOMIN),
+    ],
 }

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -73,7 +73,7 @@ class LSUDummy(FuncUnit, Elaboratable):
         m.submodules.issued = issued = FIFO(self.fu_layouts.issue, 2)
         m.submodules.issued_noop = issued_noop = FIFO(self.fu_layouts.issue, 2)
 
-        @def_method(m, self.issue, single_caller=True)
+        @def_method(m, self.issue)
         def _(arg):
             self.log.debug(
                 m, 1, "issue rob_id={} funct3={} op_type={}", arg.rob_id, arg.exec_fn.funct3, arg.exec_fn.op_type

--- a/coreblocks/func_blocks/fu/lsu/lsu_atomic_wrapper.py
+++ b/coreblocks/func_blocks/fu/lsu/lsu_atomic_wrapper.py
@@ -2,8 +2,7 @@ from amaranth import *
 
 from dataclasses import dataclass
 
-from transactron.core import Priority, TModule, Method, Transaction, def_method
-from transactron.lib import BasicFifo
+from transactron.core import TModule, Method, Transaction, def_method
 from transactron.lib.connectors import Forwarder
 from transactron.lib.simultaneous import condition
 from transactron.utils import assign, layout_subset, AssignType
@@ -95,46 +94,36 @@ class LSUAtomicWrapper(FuncUnit, Elaboratable):
         atomic_second_reqest = Signal()
         atomic_fin = Signal()
 
-        # NOTE: Accepting result from LSU is split to two transactions, to avoid combinational loop on rob_id condition.
-        # Standard LSU path writes directly to forwarder with no delay, while atomic path is decoulpled from FU accept
-        # readiness by FIFO.
-
-        with Transaction().body(m, request=~atomic_in_progress) as lsu_forward_transaction:
-            res = self.lsu.accept(m)
-            accept_forwarder.write(m, res)
-
-        atomic_res_fifo = BasicFifo(self.fu_layouts.accept, 2)
-
-        with Transaction().body(m, request=atomic_in_progress):
+        with Transaction().body(m):
             res = self.lsu.accept(m)
 
             with condition(m) as cond:
-                # Remaining non-atomic results
-                with cond(res.rob_id != atomic_op.rob_id):
-                    atomic_res_fifo.write(m, res)
+                # Non-atomic results
+                with cond(~atomic_in_progress | (res.rob_id != atomic_op.rob_id)):
+                    accept_forwarder.write(m, res)
 
                 # 1st atomic result
-                with cond((res.rob_id == atomic_op.rob_id) & ~atomic_second_reqest & res.exception):
-                    atomic_res_fifo.write(m, res)
+                with cond(
+                    (res.rob_id == atomic_op.rob_id) & atomic_in_progress & ~atomic_second_reqest & res.exception
+                ):
+                    accept_forwarder.write(m, res)
                     m.d.sync += atomic_in_progress.eq(0)
-                with cond((res.rob_id == atomic_op.rob_id) & ~atomic_second_reqest & ~res.exception):
+                with cond(
+                    (res.rob_id == atomic_op.rob_id) & atomic_in_progress & ~atomic_second_reqest & ~res.exception
+                ):
                     m.d.sync += load_val.eq(res.result)
                     m.d.sync += atomic_second_reqest.eq(1)
 
                 # 2nd atomic result
-                with cond(atomic_fin):
+                with cond(atomic_in_progress & atomic_fin):
                     atomic_res = Signal(self.fu_layouts.accept)
                     m.d.av_comb += assign(atomic_res, res)
                     m.d.av_comb += atomic_res.result.eq(Mux(res.exception, 0, load_val))
-                    atomic_res_fifo.write(m, atomic_res)
+                    accept_forwarder.write(m, atomic_res)
 
                     m.d.sync += atomic_in_progress.eq(0)
                     m.d.sync += atomic_second_reqest.eq(0)
                     m.d.sync += atomic_fin.eq(0)
-
-        with Transaction().body(m) as accept_atomic_transaction:
-            accept_forwarder.write(m, atomic_res_fifo.read(m))
-        accept_atomic_transaction.add_conflict(lsu_forward_transaction, priority=Priority.LEFT)
 
         with Transaction().body(m, request=atomic_in_progress & atomic_second_reqest & ~atomic_fin):
             atomic_store_op = Signal(self.fu_layouts.issue)
@@ -148,7 +137,6 @@ class LSUAtomicWrapper(FuncUnit, Elaboratable):
             m.d.sync += atomic_fin.eq(1)
 
         m.submodules.accept_forwarder = accept_forwarder
-        m.submodules.atomic_res_fifo = atomic_res_fifo
         m.submodules.lsu = self.lsu
 
         return m

--- a/coreblocks/func_blocks/fu/lsu/lsu_atomic_wrapper.py
+++ b/coreblocks/func_blocks/fu/lsu/lsu_atomic_wrapper.py
@@ -102,7 +102,7 @@ class LSUAtomicWrapper(FuncUnit, Elaboratable):
                 # accept.ready, but it causes combinational loop because of `rob_id` data dependency.
                 m.d.sync += load_val.eq(res.result)
                 m.d.sync += atomic_second_reqest.eq(1)
-            with m.If((res.rob_id == atomic_op.rob_id) & atomic_in_progress & ~atomic_second_reqest & res.exception):
+            with m.Elif((res.rob_id == atomic_op.rob_id) & atomic_in_progress & ~atomic_second_reqest & res.exception):
                 accept_forwarder.write(m, res)
                 m.d.sync += atomic_in_progress.eq(0)
 

--- a/coreblocks/func_blocks/fu/lsu/lsu_atomic_wrapper.py
+++ b/coreblocks/func_blocks/fu/lsu/lsu_atomic_wrapper.py
@@ -14,6 +14,20 @@ from coreblocks.params import GenParams, FunctionalComponentParams
 
 
 class LSUAtomicWrapper(FuncUnit, Elaboratable):
+    """
+    Wrapper for LSU that adds support for atomic operations.
+
+    It provides simplified implementation of atomic operations under assumptions that:
+        * LSU doesn't reorder memory accesses, like in `LSUDummy`
+        * There is only one hart
+
+    AMO operations issue two independent accesses (unless there is an exception) to LSU and execute operations
+    in the internal ALU.
+    SC are only matched to LR, reservation set size is infinite.
+
+    Behaviour of atomic insturctions on Memory Mapped I/O space is currently undefined.
+    """
+
     def __init__(self, gen_params: GenParams, lsu: FuncUnit):
         self.gen_params = gen_params
         self.lsu = lsu

--- a/coreblocks/func_blocks/fu/lsu/lsu_atomic_wrapper.py
+++ b/coreblocks/func_blocks/fu/lsu/lsu_atomic_wrapper.py
@@ -1,0 +1,153 @@
+from amaranth import *
+
+from dataclasses import dataclass
+
+from transactron.core import TModule, Method, Transaction, def_method
+from transactron.lib.connectors import Forwarder
+from transactron.lib.simultaneous import condition
+from transactron.utils import assign, layout_subset, AssignType
+
+from coreblocks.arch import Funct3, Funct7, OpType
+from coreblocks.func_blocks.fu.lsu.dummyLsu import LSUComponent
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.interface.layouts import FuncUnitLayouts
+from coreblocks.params import GenParams, FunctionalComponentParams
+
+
+class LSUAtomicWrapper(FuncUnit, Elaboratable):
+    def __init__(self, gen_params: GenParams, lsu: FuncUnit):
+        self.gen_params = gen_params
+        self.lsu = lsu
+
+        self.fu_layouts = fu_layouts = gen_params.get(FuncUnitLayouts)
+        self.issue = Method(i=fu_layouts.issue)
+        self.accept = Method(o=fu_layouts.accept)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        atomic_in_progress = Signal()
+        atomic_op = Signal(
+            layout_subset(self.fu_layouts.issue, fields=set(["rob_id", "s1_val", "s2_val", "rp_dst", "exec_fn"]))
+        )
+
+        def atomic_op_res(v1: Value, v2: Value):
+            ret = Signal(self.gen_params.isa.xlen)
+
+            cmp = Signal()
+            ucmp = Signal()
+            m.d.av_comb += cmp.eq(v1.as_signed() < v2.as_signed())
+            m.d.av_comb += ucmp.eq(v1.as_unsigned() < v2.as_unsigned())
+
+            funct7 = atomic_op.exec_fn.funct7
+            rl = funct7[0]  # noqa: F841
+            aq = funct7[1]  # noqa: F841
+
+            with m.Switch(funct7 & ~0b11):
+                with m.Case(Funct7.AMOSWAP):
+                    m.d.av_comb += ret.eq(v2)
+                with m.Case(Funct7.AMOADD):
+                    m.d.av_comb += ret.eq(v1 + v2)
+                with m.Case(Funct7.AMOXOR):
+                    m.d.av_comb += ret.eq(v1 ^ v2)
+                with m.Case(Funct7.AMOAND):
+                    m.d.av_comb += ret.eq(v1 & v2)
+                with m.Case(Funct7.AMOOR):
+                    m.d.av_comb += ret.eq(v1 | v2)
+                with m.Case(Funct7.AMOMIN):
+                    m.d.av_comb += ret.eq(Mux(cmp, v1, v2))
+                with m.Case(Funct7.AMOMAX):
+                    m.d.av_comb += ret.eq(Mux(cmp, v2, v1))
+                with m.Case(Funct7.AMOMINU):
+                    m.d.av_comb += ret.eq(Mux(ucmp, v1, v2))
+                with m.Case(Funct7.AMOMAXU):
+                    m.d.av_comb += ret.eq(Mux(ucmp, v2, v1))
+
+            return ret
+
+        load_val = Signal(self.gen_params.isa.xlen)
+
+        accept_forwarder = Forwarder(self.fu_layouts.accept)
+
+        @def_method(m, self.issue, ready=~atomic_in_progress)
+        def _(arg):
+            is_atomic = arg.exec_fn.op_type == OpType.ATOMIC_MEMORY_OP
+
+            atomic_load_op = Signal(self.fu_layouts.issue)
+            m.d.av_comb += assign(atomic_load_op, arg)
+            m.d.av_comb += assign(atomic_load_op.exec_fn, {"op_type": OpType.LOAD, "funct3": Funct3.W})
+            m.d.av_comb += atomic_load_op.imm.eq(0)
+
+            with m.If(is_atomic):
+                self.lsu.issue(m, atomic_load_op)
+            with m.Else():
+                self.lsu.issue(m, arg)
+
+            with m.If(is_atomic):
+                m.d.sync += atomic_in_progress.eq(1)
+                m.d.sync += assign(atomic_op, arg, fields=AssignType.LHS)
+
+        @def_method(m, self.accept)
+        def _():
+            return accept_forwarder.read(m)
+
+        atomic_second_reqest = Signal()
+        atomic_fin = Signal()
+
+        with Transaction().body(m):
+            res = self.lsu.accept(m)
+
+            with condition(m) as cond:
+                # Non-atomic results
+                with cond(~atomic_in_progress | (res.rob_id != atomic_op.rob_id)):
+                    accept_forwarder.write(m, res)
+
+                # 1st atomic result
+                with cond(
+                    (res.rob_id == atomic_op.rob_id) & atomic_in_progress & ~atomic_second_reqest & res.exception
+                ):
+                    accept_forwarder.write(m, res)
+                    m.d.sync += atomic_in_progress.eq(0)
+                with cond(
+                    (res.rob_id == atomic_op.rob_id) & atomic_in_progress & ~atomic_second_reqest & ~res.exception
+                ):
+                    m.d.sync += load_val.eq(res.result)
+                    m.d.sync += atomic_second_reqest.eq(1)
+
+                # 2nd atomic result
+                with cond(atomic_in_progress & atomic_fin):
+                    atomic_res = Signal(self.fu_layouts.accept)
+                    m.d.av_comb += assign(atomic_res, res)
+                    m.d.av_comb += atomic_res.result.eq(Mux(res.exception, 0, load_val))
+                    accept_forwarder.write(m, atomic_res)
+
+                    m.d.sync += atomic_in_progress.eq(0)
+                    m.d.sync += atomic_second_reqest.eq(0)
+                    m.d.sync += atomic_fin.eq(0)
+
+        with Transaction().body(m, request=atomic_in_progress & atomic_second_reqest & ~atomic_fin):
+            atomic_store_op = Signal(self.fu_layouts.issue)
+            m.d.av_comb += assign(atomic_store_op, atomic_op)
+            m.d.av_comb += assign(atomic_store_op.exec_fn, {"op_type": OpType.STORE, "funct3": Funct3.W})
+            m.d.av_comb += atomic_store_op.imm.eq(0)
+            m.d.av_comb += atomic_store_op.s2_val.eq(atomic_op_res(load_val, atomic_op.s2_val))
+
+            self.lsu.issue(m, atomic_store_op)
+
+            m.d.sync += atomic_fin.eq(1)
+
+        m.submodules.accept_forwarder = accept_forwarder
+        m.submodules.lsu = self.lsu
+
+        return m
+
+
+@dataclass(frozen=True)
+class LSUAtomicWrapperComponent(FunctionalComponentParams):
+    lsu: LSUComponent
+
+    def get_module(self, gen_params: GenParams) -> FuncUnit:
+        return LSUAtomicWrapper(gen_params, self.lsu.get_module(gen_params))
+
+    def get_optypes(self) -> set[OpType]:
+        return {OpType.ATOMIC_MEMORY_OP} | self.lsu.get_optypes()

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -22,6 +22,7 @@ from coreblocks.func_blocks.fu.exception import ExceptionUnitComponent
 from coreblocks.func_blocks.fu.priv import PrivilegedUnitComponent
 from coreblocks.func_blocks.fu.lsu.dummyLsu import LSUComponent
 from coreblocks.func_blocks.fu.lsu.pma import PMARegion
+from coreblocks.func_blocks.fu.lsu.lsu_atomic_wrapper import LSUAtomicWrapperComponent
 from coreblocks.func_blocks.csr.csr import CSRBlockComponent
 
 
@@ -197,7 +198,7 @@ full_core_config = CoreConfiguration(
             ],
             rs_entries=2,
         ),
-        RSBlockComponent([LSUComponent()], rs_entries=4, rs_type=FifoRS),
+        RSBlockComponent([LSUAtomicWrapperComponent(LSUComponent())], rs_entries=4, rs_type=FifoRS),
         CSRBlockComponent(),
     ),
     compressed=True,

--- a/test/common/test_isa.py
+++ b/test/common/test_isa.py
@@ -16,7 +16,9 @@ class TestISA(unittest.TestCase):
     ISA_TESTS = [
         ISATestEntry("rv32i", True, 32, 32, Extension.I),
         ISATestEntry("RV32I", True, 32, 32, Extension.I),
-        ISATestEntry("rv32ima", True, 32, 32, Extension.I | Extension.M | Extension.ZMMUL | Extension.A),
+        ISATestEntry(
+            "rv32ima", True, 32, 32, Extension.I | Extension.M | Extension.ZMMUL | Extension.A | Extension.ZAAMO
+        ),
         ISATestEntry(
             "rv32imafdc_zicsr",
             True,
@@ -25,6 +27,7 @@ class TestISA(unittest.TestCase):
             Extension.I
             | Extension.M
             | Extension.A
+            | Extension.ZAAMO
             | Extension.F
             | Extension.D
             | Extension.C
@@ -68,6 +71,7 @@ class TestISA(unittest.TestCase):
             | Extension.M
             | Extension.ZMMUL
             | Extension.A
+            | Extension.ZAAMO
             | Extension.F
             | Extension.D
             | Extension.C
@@ -83,6 +87,7 @@ class TestISA(unittest.TestCase):
             | Extension.M
             | Extension.ZMMUL
             | Extension.A
+            | Extension.ZAAMO
             | Extension.F
             | Extension.D
             | Extension.C
@@ -98,6 +103,7 @@ class TestISA(unittest.TestCase):
             | Extension.M
             | Extension.ZMMUL
             | Extension.A
+            | Extension.ZAAMO
             | Extension.F
             | Extension.D
             | Extension.C
@@ -115,6 +121,7 @@ class TestISA(unittest.TestCase):
             | Extension.M
             | Extension.ZMMUL
             | Extension.A
+            | Extension.ZAAMO
             | Extension.F
             | Extension.D
             | Extension.ZIFENCEI

--- a/test/frontend/test_instr_decoder.py
+++ b/test/frontend/test_instr_decoder.py
@@ -181,7 +181,10 @@ class TestDecoder(TestCaseWithSimulator):
     ]
 
     DECODER_TESTS_A = [
-        InstrTest(0x0821A22F, Opcode.AMO, Funct3.W, Funct7.AMOSWAP, rd=4, rs2=2, rs1=3, op=OpType.ATOMIC_MEMORY_OP)
+        InstrTest(0x0821A22F, Opcode.AMO, Funct3.W, Funct7.AMOSWAP, rd=4, rs2=2, rs1=3, op=OpType.ATOMIC_MEMORY_OP),
+        InstrTest(
+            0x0C21A22F, Opcode.AMO, Funct3.W, Funct7.AMOSWAP | 0x2, rd=4, rs2=2, rs1=3, op=OpType.ATOMIC_MEMORY_OP
+        ),
     ]
 
     def setup_method(self):

--- a/test/frontend/test_instr_decoder.py
+++ b/test/frontend/test_instr_decoder.py
@@ -180,6 +180,10 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x0E005033, Opcode.OP, Funct3.CZEROEQZ, Funct7.CZERO, rd=0, rs1=0, rs2=0, op=OpType.CZERO),
     ]
 
+    DECODER_TESTS_A = [
+        InstrTest(0x0821A22F, Opcode.AMO, Funct3.W, Funct7.AMOSWAP, rd=4, rs2=2, rs1=3, op=OpType.ATOMIC_MEMORY_OP)
+    ]
+
     def setup_method(self):
         self.gen_params = GenParams(
             test_core_config.replace(
@@ -278,6 +282,9 @@ class TestDecoder(TestCaseWithSimulator):
 
     def test_zicond(self):
         self.do_test(self.DECODER_TESTS_ZICOND)
+
+    def test_a(self):
+        self.do_test(self.DECODER_TESTS_A)
 
 
 class TestDecoderEExtLegal(TestCaseWithSimulator):

--- a/test/func_blocks/lsu/test_lsu_atomic_wrapper.py
+++ b/test/func_blocks/lsu/test_lsu_atomic_wrapper.py
@@ -18,8 +18,8 @@ class FuncUnitMock(FuncUnit, Elaboratable):
     def __init__(self, gen_params):
         layouts = gen_params.get(FuncUnitLayouts)
 
-        self.issue_tb = TestbenchIO(Adapter.create(i=layouts.issue))
-        self.accept_tb = TestbenchIO(Adapter.create(o=layouts.accept))
+        self.issue_tb = TestbenchIO(Adapter(i=layouts.issue))
+        self.accept_tb = TestbenchIO(Adapter(o=layouts.accept))
 
         self.issue = self.issue_tb.adapter.iface
         self.accept = self.accept_tb.adapter.iface

--- a/test/func_blocks/lsu/test_lsu_atomic_wrapper.py
+++ b/test/func_blocks/lsu/test_lsu_atomic_wrapper.py
@@ -1,0 +1,198 @@
+from collections import deque
+import random
+from amaranth import *
+from transactron import TModule
+from transactron.lib import Adapter
+from transactron.testing import MethodMock, SimpleTestCircuit, TestCaseWithSimulator, TestbenchIO, def_method_mock
+
+from coreblocks.arch.isa_consts import Funct3, Funct7
+from coreblocks.arch.optypes import OpType
+from coreblocks.func_blocks.fu.lsu.lsu_atomic_wrapper import LSUAtomicWrapper
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.interface.layouts import FuncUnitLayouts
+from coreblocks.params.configurations import test_core_config
+from coreblocks.params.genparams import GenParams
+
+
+class FuncUnitMock(FuncUnit, Elaboratable):
+    def __init__(self, gen_params):
+        layouts = gen_params.get(FuncUnitLayouts)
+
+        self.issue_tb = TestbenchIO(Adapter(i=layouts.issue))
+        self.accept_tb = TestbenchIO(Adapter(o=layouts.accept))
+
+        self.issue = self.issue_tb.adapter.iface
+        self.accept = self.accept_tb.adapter.iface
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.issue_tb = self.issue_tb
+        m.submodules.accept_tb = self.accept_tb
+
+        return m
+
+
+class TestLSUAtomicWrapper(TestCaseWithSimulator):
+    def setup_method(self):
+        random.seed(1258)
+        self.gen_params = GenParams(test_core_config)
+        self.lsu = FuncUnitMock(self.gen_params)
+        self.dut = SimpleTestCircuit(LSUAtomicWrapper(self.gen_params, self.lsu))
+
+        self.mem_cell = 0
+        self.instr_q = deque()
+        self.result_q = deque()
+        self.lsu_res_q = deque()
+        self.lsu_except_q = deque()
+
+        self.inst_cnt = 200
+        self.generate_instrs(self.inst_cnt)
+
+    @def_method_mock(lambda self: self.lsu.issue_tb, enable=lambda _: random.random() < 0.9)
+    def lsu_issue_mock(self, arg):
+        @MethodMock.effect
+        def _():
+            res = 0
+            addr = arg["s1_val"] + arg["imm"]
+
+            exc = self.lsu_except_q[0]
+            self.lsu_except_q.popleft()
+            assert addr == exc["addr"]
+
+            if not exc["exception"]:
+                match arg["exec_fn"]["op_type"]:
+                    case OpType.STORE:
+                        self.mem_cell = arg["s2_val"]
+                    case OpType.LOAD:
+                        res = self.mem_cell
+                    case _:
+                        assert False
+
+            self.lsu_res_q.append(
+                {"rob_id": arg["rob_id"], "result": res, "rp_dst": arg["rp_dst"], "exception": exc["exception"]}
+            )
+
+    @def_method_mock(
+        lambda self: self.lsu.accept_tb, enable=lambda self: random.random() < 0.9 and len(self.lsu_res_q) > 0
+    )
+    def lsu_accept_mock(self, arg):
+        res = self.lsu_res_q[0]
+
+        @MethodMock.effect
+        def _():
+            self.lsu_res_q.popleft()
+
+        return res
+
+    def generate_instrs(self, cnt):
+        generation_mem_cell = 0
+        for i in range(cnt):
+            optype = random.choice([OpType.LOAD, OpType.STORE, OpType.ATOMIC_MEMORY_OP])
+            funct7 = 0
+
+            imm = random.randint(0, 1)
+            s1_val = random.randrange(0, 2**self.gen_params.isa.xlen - 1)
+            s2_val = random.randrange(0, 2**self.gen_params.isa.xlen)
+            rp_dst = random.randrange(0, 2**self.gen_params.phys_regs_bits)
+
+            exception = 0
+            result = 0
+
+            if optype == OpType.ATOMIC_MEMORY_OP:
+                funct7 = random.choice(
+                    [
+                        Funct7.AMOSWAP,
+                        Funct7.AMOADD,
+                        Funct7.AMOMAXU,
+                        Funct7.AMOMIN,
+                        Funct7.AMOXOR,
+                        Funct7.AMOOR,
+                        Funct7.AMOAND,
+                        Funct7.AMOMAX,
+                        Funct7.AMOMINU,
+                    ]
+                )
+
+                exception = random.random() < 0.3
+                exception_on_load = exception and random.random() < 0.5
+                self.lsu_except_q.append({"addr": s1_val, "exception": exception_on_load})
+
+                if not exception:
+                    result = generation_mem_cell
+
+                    def twos(x):
+                        if x & (1 << (self.gen_params.isa.xlen - 1)):
+                            x ^= (1 << self.gen_params.isa.xlen) - 1
+                            x += 1
+                            x *= -1
+                        return x
+
+                    match funct7:
+                        case Funct7.AMOSWAP:
+                            generation_mem_cell = s2_val
+                        case Funct7.AMOADD:
+                            generation_mem_cell += s2_val
+                            generation_mem_cell %= 2**self.gen_params.isa.xlen
+                        case Funct7.AMOAND:
+                            generation_mem_cell &= s2_val
+                        case Funct7.AMOOR:
+                            generation_mem_cell |= s2_val
+                        case Funct7.AMOXOR:
+                            generation_mem_cell ^= s2_val
+                        case Funct7.AMOMIN:
+                            generation_mem_cell = (
+                                generation_mem_cell if twos(generation_mem_cell) < twos(s2_val) else s2_val
+                            )
+                        case Funct7.AMOMAX:
+                            generation_mem_cell = (
+                                generation_mem_cell if twos(generation_mem_cell) > twos(s2_val) else s2_val
+                            )
+                        case Funct7.AMOMINU:
+                            generation_mem_cell = min(generation_mem_cell, s2_val)
+                        case Funct7.AMOMAXU:
+                            generation_mem_cell = max(generation_mem_cell, s2_val)
+
+                if not exception_on_load:
+                    self.lsu_except_q.append({"addr": s1_val, "exception": exception})
+
+            elif optype == OpType.LOAD:
+                result = generation_mem_cell
+                self.lsu_except_q.append({"addr": s1_val + imm, "exception": 0})
+            elif optype == OpType.STORE:
+                generation_mem_cell = s2_val
+                result = 0
+                self.lsu_except_q.append({"addr": s1_val + imm, "exception": 0})
+
+            exec_fn = {"op_type": optype, "funct3": Funct3.W, "funct7": funct7}
+            instr = {
+                "rp_dst": rp_dst,
+                "rob_id": i,
+                "exec_fn": exec_fn,
+                "s1_val": s1_val,
+                "s2_val": s2_val,
+                "imm": imm,
+                "pc": 0,
+            }
+            self.instr_q.append(instr)
+            self.result_q.append({"rob_id": 0, "rp_dst": rp_dst, "result": result, "exception": exception})
+
+    async def issue_process(self, sim):
+        while self.instr_q:
+            await self.dut.issue.call(sim, self.instr_q[0])
+            self.instr_q.popleft()
+            await self.random_wait_geom(sim, 0.9)
+
+    async def accept_process(self, sim):
+        for _ in range(self.inst_cnt):
+            res = await self.dut.accept.call(sim)
+            assert res["exception"] == self.result_q[0]["exception"]
+            assert res["result"] == self.result_q[0]["result"]
+            assert res["rp_dst"] == self.result_q[0]["rp_dst"]
+            self.result_q.popleft()
+            await self.random_wait_geom(sim, 0.9)
+
+    def test_randomized(self):
+        with self.run_simulation(self.dut, max_cycles=600) as sim:
+            sim.add_testbench(self.issue_process)
+            sim.add_testbench(self.accept_process)

--- a/test/func_blocks/lsu/test_lsu_atomic_wrapper.py
+++ b/test/func_blocks/lsu/test_lsu_atomic_wrapper.py
@@ -18,8 +18,8 @@ class FuncUnitMock(FuncUnit, Elaboratable):
     def __init__(self, gen_params):
         layouts = gen_params.get(FuncUnitLayouts)
 
-        self.issue_tb = TestbenchIO(Adapter(i=layouts.issue))
-        self.accept_tb = TestbenchIO(Adapter(o=layouts.accept))
+        self.issue_tb = TestbenchIO(Adapter.create(i=layouts.issue))
+        self.accept_tb = TestbenchIO(Adapter.create(o=layouts.accept))
 
         self.issue = self.issue_tb.adapter.iface
         self.accept = self.accept_tb.adapter.iface

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -24,9 +24,9 @@ class TestConfigurationsISAString(TestCase):
         ),
         ISAStrTest(
             full_core_config,
-            "rv32imcbzicsr_zifencei_zicond_xintmachinemode",
-            "rv32imcbzicsr_zifencei_zicond_xintmachinemode",
-            "rv32imcbzicsr_zifencei_zicond_xintmachinemode",
+            "rv32imcbzicsr_zifencei_zicond_zaamo_xintmachinemode",
+            "rv32imcbzicsr_zifencei_zicond_zaamo_xintmachinemode",
+            "rv32imcbzicsr_zifencei_zicond_zaamo_xintmachinemode",
         ),
         ISAStrTest(tiny_core_config, "rv32e", "rv32e", "rv32e"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),


### PR DESCRIPTION
Implements Atomic Memory Operations (part of A extension), that do read/modify/write operations on memory.

It is implemented as DummyLSU wrapper, that itself is another `FuncUnit` that forwards LOAD/STORE instructions, but switches to atomic mode on AMO instructions and internally issues LOAD to LSU, then does arithmetic operation (via own ALU), issue STORE and produces final result.

Atomic requirements are more relaxed in our case because (a) there is only one core, (b) LSU doesn't reoder accesses. Only problem to solve was executing multiple operations one one instruction. I selected this approach instead of expanding to multiple instructions, because that would require additional temporary registers.
Both requirements can be approached (with wrapper solution) in future - (a) with informing LSU that it should lock target on bus (and add bus that supports that like AXI4) and (b) with the same mechanism as FENCE.

TODO: docstring