### PR TITLE
pytest: avoid external dependencies when recursing for test discovery

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 minversion = 7.2.2
 testpaths =
     tests
-norecursedirs = '*.egg', '.*', 'build', 'dist', 'venv', '__traces__', '__pycache__'
+norecursedirs = '*.egg', '.*', 'build', 'dist', 'venv', '__traces__', '__pycache__', 'test/external'
 filterwarnings =
     ignore:cannot collect test class 'TestbenchContext':pytest.PytestCollectionWarning
     ignore:cannot collect test class 'TestbenchIO':pytest.PytestCollectionWarning


### PR DESCRIPTION
Something must have changed recently (last 6 months :sweat_smile:) and pytest now tries to run tests from the test submodules, which fail:
```
______________________________________________________________________________ ERROR collecting test/external/riscof/riscv-arch-test/riscv-isac/tests/test_riscv_isac.py _______________________________________________________________________________
ImportError while importing test module '/home/jurb/dev/repos/coreblocks/test/external/riscof/riscv-arch-test/riscv-isac/tests/test_riscv_isac.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
E   ModuleNotFoundError: No module named 'tests.test_riscv_isac'
```

This PR makes pytest ignore `test/external` directory.