### PR TITLE
Add --reset-pc option to scripts/gen_verilog

### DIFF
--- a/scripts/gen_verilog.py
+++ b/scripts/gen_verilog.py
@@ -66,6 +66,8 @@ def main():
         "-o", "--output", action="store", default="core.v", help="Output file path. Default: %(default)s"
     )
 
+    parser.add_argument("--reset-pc", action="store", default="0x0", help="Set core reset address")
+
     args = parser.parse_args()
 
     os.environ["AMARANTH_verbose"] = "true" if args.verbose else "false"
@@ -76,6 +78,9 @@ def main():
     config = str_to_coreconfig[args.config]
     if args.strip_debug:
         config = config.replace(debug_signals=False)
+
+    assert args.reset_pc[:2] == "0x", "Expected hex number as --reset-pc"
+    config = config.replace(start_pc=int(args.reset_pc[2:], base=16))
 
     gen_verilog(config, args.output)
 


### PR DESCRIPTION
Until we have nicer way of modifying core configuration from CLI (#757),
this is the only option that is really needed to by dynamically set from LiteX for nice integration.