### PR TITLE
Remove transactron from pyrightconfig

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -3,7 +3,6 @@
     "coreblocks",
     "test",
     "constants",
-    "transactron",
     "scripts"
   ],
 


### PR DESCRIPTION
Forgot to do this when separating Transactron.