### PR TITLE
Simplify JumpBranchFn

### DIFF
--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -74,13 +74,7 @@ class JumpBranch(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        branch_target = Signal(self.gen_params.isa.xlen)
-
-        # Spec: "The 12-bit B-immediate encodes signed offsets in multiples of 2,
-        # and is added to the current pc to give the target address."
-        # Multiplies of 2 are converted to the real offset in the decode stage, so we have 13 bits.
-        m.d.comb += branch_target.eq(self.in_pc + self.in_imm[:13].as_signed())
-
+        m.d.comb += self.jmp_addr.eq(self.in_pc + self.in_imm)
         m.d.comb += self.reg_res.eq(self.in_pc + 4)
 
         if Extension.C in self.gen_params.isa.extensions:
@@ -89,39 +83,25 @@ class JumpBranch(Elaboratable):
 
         with OneHotSwitch(m, self.fn) as OneHotCase:
             with OneHotCase(JumpBranchFn.Fn.JAL):
-                # Spec: "[...] the J-immediate encodes a signed offset in multiples of 2 bytes.
-                # The offset is sign-extended and added to the pc to form the jump target address."
-                # Multiplies of 2 are converted to the real offset in the decode stage, so we have 21 bits.
-                m.d.comb += self.jmp_addr.eq(self.in_pc + self.in_imm[:21].as_signed())
+                m.d.comb += self.jmp_addr.eq(self.in_pc + self.in_imm)
                 m.d.comb += self.taken.eq(1)
             with OneHotCase(JumpBranchFn.Fn.JALR):
-                # Spec: "The target address is obtained by adding the 12-bit signed I-immediate
-                # to the register rs1, then setting the least-significant bit of the result to zero."
-                m.d.comb += self.jmp_addr.eq(self.in1 + self.in_imm[:12].as_signed())
+                m.d.comb += self.jmp_addr.eq(self.in1 + self.in_imm)
                 m.d.comb += self.jmp_addr[0].eq(0)
                 m.d.comb += self.taken.eq(1)
             with OneHotCase(JumpBranchFn.Fn.AUIPC):
-                # Spec: "AUIPC forms a 32-bit offset from the 20-bit U-immediate, filling in the
-                # lowest 12 bits with zeros, adds this offset to the pc"
-                # Order of arguments in Cat is reversed
-                m.d.comb += self.reg_res.eq(self.in_pc + Cat(C(0, 12), self.in_imm[12:]))
+                m.d.comb += self.reg_res.eq(self.in_pc + self.in_imm)
             with OneHotCase(JumpBranchFn.Fn.BEQ):
-                m.d.comb += self.jmp_addr.eq(branch_target)
                 m.d.comb += self.taken.eq(self.in1 == self.in2)
             with OneHotCase(JumpBranchFn.Fn.BNE):
-                m.d.comb += self.jmp_addr.eq(branch_target)
                 m.d.comb += self.taken.eq(self.in1 != self.in2)
             with OneHotCase(JumpBranchFn.Fn.BLT):
-                m.d.comb += self.jmp_addr.eq(branch_target)
                 m.d.comb += self.taken.eq(self.in1.as_signed() < self.in2.as_signed())
             with OneHotCase(JumpBranchFn.Fn.BLTU):
-                m.d.comb += self.jmp_addr.eq(branch_target)
                 m.d.comb += self.taken.eq(self.in1.as_unsigned() < self.in2.as_unsigned())
             with OneHotCase(JumpBranchFn.Fn.BGE):
-                m.d.comb += self.jmp_addr.eq(branch_target)
                 m.d.comb += self.taken.eq(self.in1.as_signed() >= self.in2.as_signed())
             with OneHotCase(JumpBranchFn.Fn.BGEU):
-                m.d.comb += self.jmp_addr.eq(branch_target)
                 m.d.comb += self.taken.eq(self.in1.as_unsigned() >= self.in2.as_unsigned())
 
         return m

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -83,14 +83,13 @@ class JumpBranch(Elaboratable):
 
         with OneHotSwitch(m, self.fn) as OneHotCase:
             with OneHotCase(JumpBranchFn.Fn.JAL):
-                m.d.comb += self.jmp_addr.eq(self.in_pc + self.in_imm)
                 m.d.comb += self.taken.eq(1)
             with OneHotCase(JumpBranchFn.Fn.JALR):
                 m.d.comb += self.jmp_addr.eq(self.in1 + self.in_imm)
                 m.d.comb += self.jmp_addr[0].eq(0)
                 m.d.comb += self.taken.eq(1)
             with OneHotCase(JumpBranchFn.Fn.AUIPC):
-                m.d.comb += self.reg_res.eq(self.in_pc + self.in_imm)
+                m.d.comb += self.reg_res.eq(self.jmp_addr)
             with OneHotCase(JumpBranchFn.Fn.BEQ):
                 m.d.comb += self.taken.eq(self.in1 == self.in2)
             with OneHotCase(JumpBranchFn.Fn.BNE):

--- a/test/func_blocks/fu/test_jb_unit.py
+++ b/test/func_blocks/fu/test_jb_unit.py
@@ -88,16 +88,15 @@ class JumpBranchWrapperComponent(FunctionalComponentParams):
 @staticmethod
 def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn.Fn, xlen: int) -> dict[str, int]:
     max_int = 2**xlen - 1
-    branch_target = pc + signed_to_int(i_imm & 0x1FFF, 13)
+    branch_target = pc + signed_to_int(i_imm, xlen)
     next_pc = 0
     res = pc + 4
 
     match fn:
         case JumpBranchFn.Fn.JAL:
-            next_pc = pc + signed_to_int(i_imm & 0x1FFFFF, 21)  # truncate to first 21 bits
+            next_pc = pc + signed_to_int(i_imm, xlen)
         case JumpBranchFn.Fn.JALR:
-            # truncate to first 12 bits and set 0th bit to 0
-            next_pc = (i1 + signed_to_int(i_imm & 0xFFF, 12)) & ~0x1
+            next_pc = (i1 + signed_to_int(i_imm, xlen)) & ~0x1
         case JumpBranchFn.Fn.BEQ:
             next_pc = branch_target if i1 == i2 else pc + 4
         case JumpBranchFn.Fn.BNE:
@@ -137,7 +136,7 @@ def compute_result_auipc(i1: int, i2: int, i_imm: int, pc: int, fn: JumpBranchFn
     res = pc + 4
 
     if fn == JumpBranchFn.Fn.AUIPC:
-        res = pc + (i_imm & 0xFFFFF000)
+        res = pc + i_imm
 
     res &= max_int
 


### PR DESCRIPTION
The `JumpBranchFn` module unnecessarily repeats the logic already present in the decoder - this can be removed. Intermediate `branch_target` turned out to be unnecessary - `jmp_addr` can be assigned early instead. It's ignored on `auipc`, so there is no need for it being 0 there. The changes might allow the optimizer to reduce the number of adders and multiplexers in the synthesized circuit.

Looks like "LUTs used as carry" decreased slightly.