### PR TITLE
Refector Wishbone to `ComponentInterface`

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -24,7 +24,7 @@ from coreblocks.scheduler.scheduler import Scheduler
 from coreblocks.backend.annoucement import ResultAnnouncement
 from coreblocks.backend.retirement import Retirement
 from coreblocks.peripherals.bus_adapter import WishboneMasterAdapter
-from coreblocks.peripherals.wishbone import WishboneMaster, WishboneInterface, WishboneSignature
+from coreblocks.peripherals.wishbone import WishboneMaster, WishboneInterface
 from transactron.lib.metrics import HwMetricsEnabledKey
 
 __all__ = ["Core"]
@@ -38,8 +38,8 @@ class Core(Component):
     def __init__(self, *, gen_params: GenParams):
         super().__init__(
             {
-                "wb_instr": Out(WishboneSignature(gen_params.wb_params)),
-                "wb_data": Out(WishboneSignature(gen_params.wb_params)),
+                "wb_instr": Out(WishboneInterface(gen_params.wb_params).signature),
+                "wb_data": Out(WishboneInterface(gen_params.wb_params).signature),
                 "interrupts": In(ISA_RESERVED_INTERRUPTS + gen_params.interrupt_custom_count),
             }
         )

--- a/scripts/synthesize.py
+++ b/scripts/synthesize.py
@@ -29,7 +29,7 @@ from coreblocks.func_blocks.fu.zbc import ZbcComponent
 from coreblocks.func_blocks.fu.zbs import ZbsComponent
 from transactron import TransactionModule
 from transactron.lib import Adapter, AdapterTrans
-from coreblocks.peripherals.wishbone import WishboneArbiter, WishboneInterface, WishboneSignature
+from coreblocks.peripherals.wishbone import WishboneArbiter, WishboneInterface
 from constants.ecp5_platforms import (
     ResourceBuilder,
     append_resources,
@@ -81,7 +81,7 @@ class SynthesisCore(Component):
     wb: WishboneInterface
 
     def __init__(self, gen_params: GenParams):
-        super().__init__({"wb": Out(WishboneSignature(gen_params.wb_params))})
+        super().__init__({"wb": Out(WishboneInterface(gen_params.wb_params).signature)})
         self.gen_params = gen_params
 
     def elaborate(self, platform):


### PR DESCRIPTION
https://github.com/kuznia-rdzeni/transactron/pull/42 introduced amaranth extension to avoid boilerplate when typing lib.wiring interfaces.

This PR refactors Wishbone interfaces to use that.