### PR TITLE
ISA string generation fixes

### DIFF
--- a/coreblocks/arch/isa.py
+++ b/coreblocks/arch/isa.py
@@ -13,6 +13,8 @@ __all__ = [
 class Extension(enum.IntFlag):
     """
     Enum of available RISC-V extensions.
+
+    Extensions are ordered by ISA naming convention: IMAFDQLCBKJTPVH, Z[category letter order]*, S[vshm]*, X*
     """
 
     #: Reduced integer operations
@@ -45,20 +47,22 @@ class Extension(enum.IntFlag):
     V = auto()
     #: User-level interruptions
     N = auto()
+    #: Enables base counters and timers
+    ZICNTR = auto()
+    #: Integer conditional operations
+    ZICOND = auto()
     #: Control and Status Register access
     ZICSR = auto()
     #: Instruction-Fetch fence operations
     ZIFENCEI = auto()
-    #: Enables sending pause hint for energy saving
-    ZIHINTPAUSE = auto()
     #: Enables non-temporal locality hints
     ZIHINTNTL = auto()
-    #: Enables base counters and timers
-    ZICNTR = auto()
+    #: Enables sending pause hint for energy saving
+    ZIHINTPAUSE = auto()
     #: Enables hardware performance counters
     ZIHPM = auto()
-    #: Integer conditional operations
-    ZICOND = auto()
+    #: Integer multiplication operations
+    ZMMUL = auto()
     #: Atomic memory operations
     ZAAMO = auto()
     #: Load-Reserved/Store-Conditional Instructions
@@ -75,8 +79,6 @@ class Extension(enum.IntFlag):
     ZDINX = auto()
     #: Support for half precision floating-point operations in integer registers
     ZHINX = auto()
-    #: Integer multiplication operations
-    ZMMUL = auto()
     #: Extended shift operations
     ZBA = auto()
     #: Basic bit manipulation operations

--- a/coreblocks/arch/isa.py
+++ b/coreblocks/arch/isa.py
@@ -112,7 +112,7 @@ extension_implications = {
     Extension.F: Extension.ZICSR,
     Extension.M: Extension.ZMMUL,
     Extension.A: Extension.ZAAMO | Extension.ZALRSC,
-    Extension.B: Extension.ZBA | Extension.ZBB | Extension.ZBC | Extension.ZBS,
+    Extension.B: Extension.ZBA | Extension.ZBB | Extension.ZBS,
 }
 
 # Extensions (not aliases) that only imply other sub-extensions, but don't add any new OpTypes.

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -24,9 +24,9 @@ class TestConfigurationsISAString(TestCase):
         ),
         ISAStrTest(
             full_core_config,
-            "rv32imacbzicsr_zifencei_zicond_zbc_xintmachinemode",
-            "rv32imacbzicsr_zifencei_zicond_zbc_xintmachinemode",
-            "rv32imacbzicsr_zifencei_zicond_zbc_xintmachinemode",
+            "rv32imacbzicond_zicsr_zifencei_zbc_xintmachinemode",
+            "rv32imacbzicond_zicsr_zifencei_zbc_xintmachinemode",
+            "rv32imacbzicond_zicsr_zifencei_zbc_xintmachinemode",
         ),
         ISAStrTest(tiny_core_config, "rv32e", "rv32e", "rv32e"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -24,9 +24,9 @@ class TestConfigurationsISAString(TestCase):
         ),
         ISAStrTest(
             full_core_config,
-            "rv32imacbzicsr_zifencei_zicond_xintmachinemode",
-            "rv32imacbzicsr_zifencei_zicond_xintmachinemode",
-            "rv32imacbzicsr_zifencei_zicond_xintmachinemode",
+            "rv32imacbzicsr_zifencei_zicond_zbc_xintmachinemode",
+            "rv32imacbzicsr_zifencei_zicond_zbc_xintmachinemode",
+            "rv32imacbzicsr_zifencei_zicond_zbc_xintmachinemode",
         ),
         ISAStrTest(tiny_core_config, "rv32e", "rv32e", "rv32e"),
         ISAStrTest(test_core_config, "rv32", "rv32", "rv32i"),


### PR DESCRIPTION
Two ISA string generation fixes:
* Zbc is not in B as reported in #825 
* Fix ordering of Z* extensions to rules defined in spec `37.5. Additional Standard Unprivileged Extension Names` (first by category letter order, then alphabetically).
