### PR TITLE
Add `small_linux` core configuration

### DIFF
--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -32,6 +32,7 @@ __all__ = [
     "CoreConfiguration",
     "basic_core_config",
     "tiny_core_config",
+    "small_linux_config",
     "full_core_config",
     "test_core_config",
 ]
@@ -195,6 +196,31 @@ tiny_core_config = CoreConfiguration(
     rob_entries_bits=basic_core_config.rob_entries_bits - 1,
     icache_enable=False,
     user_mode=False,
+)
+
+# Basic core config with minimal additions required for Linux
+small_linux_config = CoreConfiguration(
+    func_units_config=(
+        RSBlockComponent(
+            [
+                ALUComponent(),
+                ShiftUnitComponent(),
+                JumpComponent(),
+                ExceptionUnitComponent(),
+                PrivilegedUnitComponent(),
+            ],
+            rs_entries=4,
+        ),
+        RSBlockComponent(
+            [
+                MulComponent(mul_unit_type=MulType.SEQUENCE_MUL),
+                DivComponent(),
+            ],
+            rs_entries=2,
+        ),
+        RSBlockComponent([LSUAtomicWrapperComponent(LSUComponent())], rs_entries=2, rs_type=FifoRS),
+        CSRBlockComponent(),
+    )
 )
 
 # Core configuration with all supported components

--- a/scripts/gen_verilog.py
+++ b/scripts/gen_verilog.py
@@ -22,6 +22,7 @@ from coreblocks.params.configurations import *
 str_to_coreconfig: dict[str, CoreConfiguration] = {
     "basic": basic_core_config,
     "tiny": tiny_core_config,
+    "small_linux": small_linux_config,
     "full": full_core_config,
 }
 

--- a/test/params/test_configurations.py
+++ b/test/params/test_configurations.py
@@ -23,6 +23,12 @@ class TestConfigurationsISAString(TestCase):
             "rv32imzicsr_zifencei_xintmachinemode",
         ),
         ISAStrTest(
+            small_linux_config,
+            "rv32imazicsr_zifencei_xintmachinemode",
+            "rv32imazicsr_zifencei_xintmachinemode",
+            "rv32imazicsr_zifencei_xintmachinemode",
+        ),
+        ISAStrTest(
             full_core_config,
             "rv32imacbzicond_zicsr_zifencei_zbc_xintmachinemode",
             "rv32imacbzicond_zicsr_zifencei_zbc_xintmachinemode",


### PR DESCRIPTION
New `small_linux` core configuration, currently the same as `basic` configuration, but with atomic extension (required for Linux).

Aims to provide configuration similar to `basic`, but with minimal additions needed for rich OS use case.
Synthesis of `full` config takes a longer time and adds many features that are not used at all anyway.

Will be added to LiteX port (+ automatically select CoreSoCks).
