### PR TITLE
Configurable number of PMP entries

### DIFF
--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -108,6 +108,8 @@ class _CoreConfigurationDataClass:
         read-only and directly connected to input signal (implementation must provide clearing method)
     user_mode: bool
         Enable User Mode.
+    pmp_register_count: int
+        Number of Physical Memory Protection CSR entries. Valid values are: 0, 16, and 64.
     allow_partial_extensions: bool
         Allow partial support of extensions.
     extra_verification: bool
@@ -159,6 +161,8 @@ class _CoreConfigurationDataClass:
     interrupt_custom_edge_trig_mask: int = 0
 
     user_mode: bool = True
+
+    pmp_register_count: int = 0
 
     allow_partial_extensions: bool = False
 
@@ -251,6 +255,7 @@ full_core_config = CoreConfiguration(
     compressed=True,
     fetch_block_bytes_log=4,
     instr_buffer_size=16,
+    pmp_register_count=16,
 )
 
 # Core configuration used in internal testbenches

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -91,6 +91,10 @@ class GenParams(DependentCache):
 
         self.user_mode = cfg.user_mode
 
+        self.pmp_register_count = cfg.pmp_register_count
+        if self.pmp_register_count not in [0, 16, 64]:
+            raise ValueError("PMP register count must be 0, 16, or 64")
+
         self._toolchain_isa_str = gen_isa_string(extensions, cfg.xlen, skip_internal=True)
 
         self._generate_test_hardware = cfg._generate_test_hardware


### PR DESCRIPTION
Resolves #817

Adds configuration to PMP entries to `CoreConfiguration`, and slightly refactors `pmpcfg` registers generation (+buggy width on rv64 fixed).
As tilk mentioned, spec allows it to be set to 64, 16 or disabled.

PMP registers take quite a lot of LUT space,  so reduced 16 size options looks very useful if PMP is required. 
It caused  `basic` configuration to no longer fit on an arty board :/ (and breaks the linux tutorial ://)

#816 would need to be adjusted to this change
