### PR TITLE
Refactor Scheduler to use provide

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -124,20 +124,20 @@ class Core(Component):
             [self.frontend.consume_instr, core_counter.increment], combiner=drop_second_ret_value
         )
 
-        m.submodules.scheduler = Scheduler(
-            get_instr=get_instr.method,
-            get_free_reg=rf_allocator.alloc[0],
-            crat_rename=crat.rename,
-            crat_tag=crat.tag,
-            crat_active_tags=crat.get_active_tags,
-            rob_put=rob.put,
-            rf_read_req1=rf.read_req[0],
-            rf_read_req2=rf.read_req[1],
-            rf_read_resp1=rf.read_resp[0],
-            rf_read_resp2=rf.read_resp[1],
-            reservation_stations=self.func_blocks_unifier.rs_blocks,
+        m.submodules.scheduler = scheduler = Scheduler(
             gen_params=self.gen_params,
+            reservation_stations=self.func_blocks_unifier.rs_blocks,
         )
+        scheduler.get_instr.provide(get_instr.method)
+        scheduler.get_free_reg.provide(rf_allocator.alloc[0])
+        scheduler.crat_rename.provide(crat.rename)
+        scheduler.crat_tag.provide(crat.tag)
+        scheduler.crat_active_tags.provide(crat.get_active_tags)
+        scheduler.rob_put.provide(rob.put)
+        scheduler.rf_read_req1.provide(rf.read_req[0])
+        scheduler.rf_read_req2.provide(rf.read_req[1])
+        scheduler.rf_read_resp1.provide(rf.read_resp[0])
+        scheduler.rf_read_resp2.provide(rf.read_resp[1])
 
         m.submodules.exception_information_register = self.exception_information_register
 

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -124,10 +124,7 @@ class Core(Component):
             [self.frontend.consume_instr, core_counter.increment], combiner=drop_second_ret_value
         )
 
-        m.submodules.scheduler = scheduler = Scheduler(
-            gen_params=self.gen_params,
-            reservation_stations=self.func_blocks_unifier.rs_blocks,
-        )
+        m.submodules.scheduler = scheduler = Scheduler(gen_params=self.gen_params)
         scheduler.get_instr.provide(get_instr.method)
         scheduler.get_free_reg.provide(rf_allocator.alloc[0])
         scheduler.crat_rename.provide(crat.rename)
@@ -138,6 +135,9 @@ class Core(Component):
         scheduler.rf_read_req2.provide(rf.read_req[1])
         scheduler.rf_read_resp1.provide(rf.read_resp[0])
         scheduler.rf_read_resp2.provide(rf.read_resp[1])
+        for i, block in enumerate(self.func_blocks_unifier.rs_blocks):
+            scheduler.rs_select[i].provide(block.select)
+            scheduler.rs_insert[i].provide(block.insert)
 
         m.submodules.exception_information_register = self.exception_information_register
 

--- a/coreblocks/func_blocks/csr/csr.py
+++ b/coreblocks/func_blocks/csr/csr.py
@@ -12,7 +12,7 @@ from coreblocks.arch.isa_consts import Opcode
 from coreblocks.params import GenParams
 from coreblocks.params.fu_params import BlockComponentParams
 from coreblocks.func_blocks.interface.func_protocols import FuncBlock
-from coreblocks.interface.layouts import FuncUnitLayouts, CSRUnitLayouts
+from coreblocks.interface.layouts import FuncUnitLayouts, CSRUnitLayouts, RSInterfaceLayouts
 from coreblocks.interface.keys import (
     CSRListKey,
     UnsafeInstructionResolvedKey,
@@ -263,6 +263,9 @@ class CSRBlockComponent(BlockComponentParams):
 
     def get_optypes(self) -> set[OpType]:
         return {OpType.CSR_REG, OpType.CSR_IMM}
+
+    def get_layouts(self, gen_params: GenParams) -> RSInterfaceLayouts:
+        return gen_params.get(CSRUnitLayouts).rs
 
     def get_rs_entry_count(self) -> int:
         return 1

--- a/coreblocks/func_blocks/fu/common/rs_func_block.py
+++ b/coreblocks/func_blocks/fu/common/rs_func_block.py
@@ -8,7 +8,7 @@ from transactron import Method, Methods, TModule
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit, FuncBlock
 from transactron.lib import FIFO, Collector, Connect
 from coreblocks.arch import OpType
-from coreblocks.interface.layouts import RSLayouts, FuncUnitLayouts
+from coreblocks.interface.layouts import RSInterfaceLayouts, RSLayouts, FuncUnitLayouts
 
 __all__ = ["RSFuncBlock", "RSBlockComponent"]
 
@@ -127,6 +127,9 @@ class RSBlockComponent(BlockComponentParams):
 
     def get_optypes(self) -> set[OpType]:
         return optypes_supported(self.func_units)
+
+    def get_layouts(self, gen_params: GenParams) -> RSInterfaceLayouts:
+        return gen_params.get(RSLayouts, rs_entries=self.rs_entries).rs
 
     def get_rs_entry_count(self) -> int:
         return self.rs_entries

--- a/coreblocks/func_blocks/interface/func_blocks_unifier.py
+++ b/coreblocks/func_blocks/interface/func_blocks_unifier.py
@@ -16,19 +16,19 @@ class FuncBlocksUnifier(Elaboratable):
         gen_params: GenParams,
         blocks: Iterable[BlockComponentParams],
     ):
-        self.rs_blocks = [(block.get_module(gen_params), block.get_optypes()) for block in blocks]
+        self.rs_blocks = [block.get_module(gen_params) for block in blocks]
 
-        self.get_result = [block.get_result for block, _ in self.rs_blocks]
+        self.get_result = [block.get_result for block in self.rs_blocks]
 
-        self.update = Methods(gen_params.announcement_superscalarity, i=self.rs_blocks[0][0].update.layout_in)
+        self.update = Methods(gen_params.announcement_superscalarity, i=self.rs_blocks[0].update.layout_in)
 
     def elaborate(self, platform):
         m = TModule()
 
-        for n, (unit, _) in enumerate(self.rs_blocks):
+        for n, unit in enumerate(self.rs_blocks):
             m.submodules[f"rs_block_{n}"] = unit
 
         for n in range(len(self.update)):
-            self.update[n].provide(MethodProduct.create([block.update[n] for block, _ in self.rs_blocks]).use(m))
+            self.update[n].provide(MethodProduct.create([block.update[n] for block in self.rs_blocks]).use(m))
 
         return m

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -257,7 +257,7 @@ class SchedulerLayouts:
 
         self.rs_insert_in = self.rs_select_out
 
-        self.free_rf_layout = make_layout(fields.reg_id)
+        self.free_rf_layout = make_layout(("ident", gen_params.phys_regs_bits))
 
 
 class RFLayouts:

--- a/coreblocks/params/fu_params.py
+++ b/coreblocks/params/fu_params.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from coreblocks.params.genparams import GenParams
     from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+    from coreblocks.interface.layouts import RSInterfaceLayouts
 
 
 __all__ = [
@@ -29,6 +30,10 @@ class BlockComponentParams(ABC):
 
     @abstractmethod
     def get_optypes(self) -> set["OpType"]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_layouts(self, gen_params: "GenParams") -> "RSInterfaceLayouts":
         raise NotImplementedError()
 
     @abstractmethod

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -2,13 +2,13 @@ from collections.abc import Sequence
 
 from amaranth import *
 
-from transactron import Method, Transaction, TModule
+from transactron import Method, Required, Transaction, TModule
 from transactron.lib import FIFO
 from transactron.lib.connectors import Connect
 from transactron.utils import assign, AssignType
 from transactron.utils.dependencies import DependencyContext
 
-from coreblocks.interface.layouts import SchedulerLayouts
+from coreblocks.interface.layouts import DecodeLayouts, RATLayouts, RFLayouts, ROBLayouts, SchedulerLayouts
 from coreblocks.params import GenParams
 from coreblocks.arch.optypes import OpType
 from coreblocks.interface.keys import CoreStateKey
@@ -23,34 +23,29 @@ class RegAllocation(Elaboratable):
     the instruction result). A part of the scheduling process.
     """
 
-    def __init__(self, *, get_instr: Method, push_instr: Method, get_free_reg: Method, gen_params: GenParams):
+    get_instr: Required[Method]
+    push_instr: Required[Method]
+    get_free_reg: Required[Method]
+
+    def __init__(self, *, gen_params: GenParams):
         """
         Parameters
         ----------
-        get_instr: Method
-            Method providing decoded instructions to be scheduled for execution. Uses
-            `SchedulerLayouts.reg_alloc_in`.
-        push_instr: Method
-            Method used for pushing the serviced instruction to the next step. Uses `SchedulerLayouts.reg_alloc_out`.
-        get_free_reg: Method
-             Method providing the ID of a currently free physical register.
         gen_params: GenParams
             Core generation parameters.
         """
         self.gen_params = gen_params
         layouts = gen_params.get(SchedulerLayouts)
-        self.input_layout = layouts.reg_alloc_in
-        self.output_layout = layouts.reg_alloc_out
 
-        self.get_instr = get_instr
-        self.push_instr = push_instr
-        self.get_free_reg = get_free_reg
+        self.get_instr = Method(o=layouts.reg_alloc_in)
+        self.push_instr = Method(i=layouts.reg_alloc_out)
+        self.get_free_reg = Method(o=[("ident", gen_params.phys_regs_bits)])
 
     def elaborate(self, platform):
         m = TModule()
 
         free_reg = Signal(self.gen_params.phys_regs_bits)
-        data_out = Signal(self.output_layout)
+        data_out = Signal(self.push_instr.layout_in)
 
         with Transaction().body(m):
             instr = self.get_instr(m)
@@ -70,20 +65,22 @@ class InstructionTagger(Elaboratable):
     `Scheduler` driver of `CheckpointRAT` `tag` stage. See `CheckpointRAT.tag` for description.
     """
 
-    def __init__(self, *, get_instr: Method, push_instr: Method, crat_tag: Method, gen_params: GenParams):
+    get_free_reg: Required[Method]
+    get_instr: Required[Method]
+    push_instr: Required[Method]
+
+    def __init__(self, *, gen_params: GenParams):
         self.gen_params = gen_params
         layouts = gen_params.get(SchedulerLayouts)
-        self.input_layout = layouts.instr_tag_in
-        self.output_layout = layouts.instr_tag_out
 
-        self.get_instr = get_instr
-        self.push_instr = push_instr
-        self.crat_tag = crat_tag
+        self.get_instr = Method(o=layouts.instr_tag_in)
+        self.push_instr = Method(i=layouts.instr_tag_out)
+        self.crat_tag = Method(i=gen_params.get(RATLayouts).crat_tag_in, o=gen_params.get(RATLayouts).crat_tag_out)
 
     def elaborate(self, platform):
         m = TModule()
 
-        data_out = Signal(self.output_layout)
+        data_out = Signal(self.push_instr.layout_in)
 
         with Transaction().body(m):
             instr = self.get_instr(m)
@@ -421,68 +418,65 @@ class Scheduler(Elaboratable):
     Instruction without any supporting RS will get stuck and block the scheduler pipeline.
     """
 
+    get_instr: Required[Method]
+    """
+    Method providing decoded instructions to be scheduled for execution. It has layout as described
+    by `SchedulerLayouts.scheduler_in`. 
+    """
+
+    get_free_reg: Required[Method]
+    """Provides the ID of a currently free physical register."""
+
+    crat_rename: Required[Method]
+    """Renames the source register in C-RAT."""
+
+    crat_tag: Required[Method]
+    """Tags instructions to checkpoints in C-RAT."""
+
+    crat_active_tags: Required[Method]
+    """Gets information about tags that are on current speculation path from C-RAT."""
+
+    rob_put: Required[Method]
+    """Gets a free entry in ROB."""
+
+    rf_read_req1: Required[Method]
+    """Requests value of first source register."""
+
+    rf_read_req2: Required[Method]
+    """Requests value of second source register."""
+
+    rf_read_resp1: Required[Method]
+    """Gets requested value of first source register and information if it is valid."""
+
+    rf_read_resp2: Required[Method]
+    """Gets requested value of second source register and information if it is valid."""
+
     def __init__(
         self,
         *,
-        get_instr: Method,
-        get_free_reg: Method,
-        crat_rename: Method,
-        crat_tag: Method,
-        crat_active_tags: Method,
-        rob_put: Method,
-        rf_read_req1: Method,
-        rf_read_req2: Method,
-        rf_read_resp1: Method,
-        rf_read_resp2: Method,
-        reservation_stations: Sequence[tuple[FuncBlock, set[OpType]]],
-        gen_params: GenParams
+        gen_params: GenParams,
+        reservation_stations: Sequence[tuple[FuncBlock, set[OpType]]]
     ):
         """
         Parameters
         ----------
-        get_instr: Method
-            Method providing decoded instructions to be scheduled for execution. It has
-            layout as described by `DecodeLayouts.decoded_instr`.
-        get_free_reg: Method
-            Method providing the ID of a currently free physical register.
-        crat_rename: Method
-            Method used for renaming the source register in C-RAT. Uses `RATLayouts.crat_rename_in`
-            and `RATLayouts.crat_rename_out`.
-        crat_tag: Method
-            Method used for tagging instruction to checkpoints in C-RAT.
-        crat_active_tags: Method
-            Method used to get information about tags that are on current speculation path from C-RAT.
-        rob_put: Method
-            Method used for getting a free entry in ROB. Uses `ROBLayouts.data_layout`.
-        rf_read_req1: Method
-            Method used for requesting value of first source register and information if it is valid.
-            Uses `RFLayouts.rf_read_out`.
-        rf_read_req2: Method
-            Method used for requesting value of second source register and information if it is valid.
-            Uses `RFLayouts.rf_read_out`.
-        rf_read_resp1: Method
-            Method used for getting value of first source register and information if it is valid.
-            Uses `RFLayouts.rf_read_out` and `RFLayouts.rf_read_in`.
-        rf_read_resp2: Method
-            Method used for getting value of second source register and information if it is valid.
-            Uses `RFLayouts.rf_read_out` and `RFLayouts.rf_read_in`.
-        reservation_stations: Sequence[FuncBlock]
-            Sequence of units with RS interfaces to which instructions should be inserted.
         gen_params: GenParams
             Core generation parameters.
+        reservation_stations: Sequence[FuncBlock]
+            Sequence of units with RS interfaces to which instructions should be inserted.
         """
         self.gen_params = gen_params
         self.layouts = self.gen_params.get(SchedulerLayouts)
-        self.get_instr = get_instr
-        self.get_free_reg = get_free_reg
-        self.crat_rename = crat_rename
-        self.crat_active_tags = crat_active_tags
-        self.crat_tag = crat_tag
-        self.rob_put = rob_put
-        self.rf_read_req1 = rf_read_req1
-        self.rf_read_req2 = rf_read_req2
-        self.rf_read_resp1 = rf_read_resp1
-        self.rf_read_resp2 = rf_read_resp2
+        self.get_instr = Method(o=self.layouts.scheduler_in)
+        self.get_free_reg = Method(o=[("ident", gen_params.phys_regs_bits)])
+        self.crat_rename = Method(i=gen_params.get(RATLayouts).crat_rename_in, o=gen_params.get(RATLayouts).crat_rename_out)
+        self.crat_active_tags = Method(o=gen_params.get(RATLayouts).get_active_tags_out)
+        self.crat_tag = Method(i=gen_params.get(RATLayouts).crat_tag_in, o=gen_params.get(RATLayouts).crat_tag_out)
+        self.rob_put = Method(i=gen_params.get(ROBLayouts).put_layout, o=gen_params.get(ROBLayouts).put_out_layout)
+        self.rf_read_req1 = Method(i=gen_params.get(RFLayouts).rf_read_in)
+        self.rf_read_req2 = Method(i=gen_params.get(RFLayouts).rf_read_in)
+        self.rf_read_resp1 = Method(i=gen_params.get(RFLayouts).rf_read_in, o=gen_params.get(RFLayouts).rf_read_out)
+        self.rf_read_resp2 = Method(i=gen_params.get(RFLayouts).rf_read_in, o=gen_params.get(RFLayouts).rf_read_out)
         self.rs = reservation_stations
 
     def elaborate(self, platform):
@@ -490,20 +484,16 @@ class Scheduler(Elaboratable):
 
         # This could be ideally changed to Connect, but unfortunately causes comb loop
         m.submodules.alloc_rename_buf = alloc_rename_buf = FIFO(self.layouts.reg_alloc_out, 2)
-        m.submodules.reg_alloc = RegAllocation(
-            get_instr=self.get_instr,
-            push_instr=alloc_rename_buf.write,
-            get_free_reg=self.get_free_reg,
-            gen_params=self.gen_params,
-        )
+        m.submodules.reg_alloc = reg_alloc = RegAllocation(gen_params=self.gen_params)
+        reg_alloc.get_instr.provide(self.get_instr)
+        reg_alloc.push_instr.provide(alloc_rename_buf.write)
+        reg_alloc.get_free_reg.provide(self.get_free_reg)
 
         m.submodules.instr_tag_buf = instr_tag_buf = FIFO(self.layouts.instr_tag_out, 2)
-        m.submodules.instr_tag = InstructionTagger(
-            get_instr=alloc_rename_buf.read,
-            push_instr=instr_tag_buf.write,
-            crat_tag=self.crat_tag,
-            gen_params=self.gen_params,
-        )
+        m.submodules.instr_tag = instr_tag = InstructionTagger(gen_params=self.gen_params)
+        instr_tag.get_instr.provide(alloc_rename_buf.read)
+        instr_tag.push_instr.provide(instr_tag_buf.write)
+        instr_tag.crat_tag.provide(self.crat_tag)
 
         m.submodules.rename_out_buf = rename_out_buf = Connect(self.layouts.renaming_out)
         m.submodules.renaming = Renaming(

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -12,7 +12,6 @@ from coreblocks.interface.layouts import RATLayouts, RFLayouts, ROBLayouts, Sche
 from coreblocks.params import GenParams
 from coreblocks.arch.optypes import OpType
 from coreblocks.interface.keys import CoreStateKey
-from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 
 __all__ = ["Scheduler"]
 
@@ -218,16 +217,12 @@ class RSSelection(Elaboratable):
     push_instr: Required[Method]
     rf_read_req1: Required[Method]
     rf_read_req2: Required[Method]
+    rs_select: Required[Sequence[Method]]
 
-    def __init__(self, *, rs_select: Sequence[tuple[Method, set[OpType]]], gen_params: GenParams):
+    def __init__(self, *, gen_params: GenParams):
         """
         Parameters
         ----------
-        rs_select: Sequence[tuple[Method, set[OpType]]]
-            Sequence of pairs, each representing a single RS. The components are:
-
-            - A method used for allocating an entry in the RS. Uses `RSLayouts.select_out`.
-            - A set of `OpType`\\s that can be handled by this RS.
         gen_params: GenParams
             Core generation parameters.
         """
@@ -239,7 +234,7 @@ class RSSelection(Elaboratable):
         self.push_instr = Method(i=layouts.rs_select_out)
         self.rf_read_req1 = Method(i=gen_params.get(RFLayouts).rf_read_in)
         self.rf_read_req2 = Method(i=gen_params.get(RFLayouts).rf_read_in)
-        self.rs_select = rs_select
+        self.rs_select = [Method(o=conf.get_layouts(gen_params).select_out) for conf in gen_params.func_units_config]
 
     def decode_optype_set(self, optypes: set[OpType]) -> int:
         res = 0x0
@@ -255,9 +250,9 @@ class RSSelection(Elaboratable):
 
         data_out = Signal(self.push_instr.layout_in)
 
-        for i, (alloc, optypes) in enumerate(self.rs_select):
+        for i, (alloc, block_params) in enumerate(zip(self.rs_select, self.gen_params.func_units_config)):
             # checks if RS can perform this kind of operation
-            optype_matches = Cat(lookup == op for op in optypes).any()
+            optype_matches = Cat(lookup == op for op in block_params.get_optypes()).any()
             with Transaction().body(m, ready=optype_matches):
                 instr = self.get_instr(m)
                 allocated_field = alloc(m)
@@ -286,14 +281,12 @@ class RSInsertion(Elaboratable):
     rf_read_resp1: Required[Method]
     rf_read_resp2: Required[Method]
     crat_active_tags: Required[Method]
+    rs_insert: Required[Sequence[Method]]
 
-    def __init__(self, *, rs_insert: Sequence[Method], gen_params: GenParams):
+    def __init__(self, *, gen_params: GenParams):
         """
         Parameters
         ----------
-        rs_insert: Sequence[Method]
-            Sequence of methods used for pushing an instruction into the RS. Ordering of this list
-            determines the ID of a specific RS. They use `RSLayouts.insert_in`
         gen_params: GenParams
             Core generation parameters.
         """
@@ -305,7 +298,7 @@ class RSInsertion(Elaboratable):
         self.rf_read_resp1 = Method(i=gen_params.get(RFLayouts).rf_read_in, o=gen_params.get(RFLayouts).rf_read_out)
         self.rf_read_resp2 = Method(i=gen_params.get(RFLayouts).rf_read_in, o=gen_params.get(RFLayouts).rf_read_out)
         self.crat_active_tags = Method(o=gen_params.get(RATLayouts).get_active_tags_out)
-        self.rs_insert = rs_insert
+        self.rs_insert = [Method(i=conf.get_layouts(gen_params).insert_in) for conf in gen_params.func_units_config]
 
     def elaborate(self, platform):
         m = TModule()
@@ -412,14 +405,18 @@ class Scheduler(Elaboratable):
     rf_read_resp2: Required[Method]
     """Gets requested value of second source register and information if it is valid."""
 
-    def __init__(self, *, gen_params: GenParams, reservation_stations: Sequence[tuple[FuncBlock, set[OpType]]]):
+    rs_select: Required[Sequence[Method]]
+    """Selects RS slot."""
+
+    rs_insert: Required[Sequence[Method]]
+    """Inserts instruction into RS slot."""
+
+    def __init__(self, *, gen_params: GenParams):
         """
         Parameters
         ----------
         gen_params: GenParams
             Core generation parameters.
-        reservation_stations: Sequence[FuncBlock]
-            Sequence of units with RS interfaces to which instructions should be inserted.
         """
         self.gen_params = gen_params
         self.layouts = self.gen_params.get(SchedulerLayouts)
@@ -435,7 +432,8 @@ class Scheduler(Elaboratable):
         self.rf_read_req2 = Method(i=gen_params.get(RFLayouts).rf_read_in)
         self.rf_read_resp1 = Method(i=gen_params.get(RFLayouts).rf_read_in, o=gen_params.get(RFLayouts).rf_read_out)
         self.rf_read_resp2 = Method(i=gen_params.get(RFLayouts).rf_read_in, o=gen_params.get(RFLayouts).rf_read_out)
-        self.rs = reservation_stations
+        self.rs_select = [Method(o=conf.get_layouts(gen_params).select_out) for conf in gen_params.func_units_config]
+        self.rs_insert = [Method(i=conf.get_layouts(gen_params).insert_in) for conf in gen_params.func_units_config]
 
     def elaborate(self, platform):
         m = TModule()
@@ -466,22 +464,20 @@ class Scheduler(Elaboratable):
         rob_alloc.rob_put.provide(self.rob_put)
 
         m.submodules.rs_select_out_buf = rs_select_out_buf = FIFO(self.layouts.rs_select_out, 2)
-        m.submodules.rs_selector = rs_selector = RSSelection(
-            gen_params=self.gen_params,
-            rs_select=[(rs.select, optypes) for rs, optypes in self.rs],
-        )
+        m.submodules.rs_selector = rs_selector = RSSelection(gen_params=self.gen_params)
         rs_selector.get_instr.provide(rob_alloc_out_buf.read)
         rs_selector.push_instr.provide(rs_select_out_buf.write)
         rs_selector.rf_read_req1.provide(self.rf_read_req1)
         rs_selector.rf_read_req2.provide(self.rf_read_req2)
+        for rs_select, rs_select_impl in zip(rs_selector.rs_select, self.rs_select):
+            rs_select.provide(rs_select_impl)
 
-        m.submodules.rs_insertion = rs_insertion = RSInsertion(
-            rs_insert=[rs.insert for rs, _ in self.rs],
-            gen_params=self.gen_params,
-        )
+        m.submodules.rs_insertion = rs_insertion = RSInsertion(gen_params=self.gen_params)
         rs_insertion.get_instr.provide(rs_select_out_buf.read)
         rs_insertion.rf_read_resp1.provide(self.rf_read_resp1)
         rs_insertion.rf_read_resp2.provide(self.rf_read_resp2)
         rs_insertion.crat_active_tags.provide(self.crat_active_tags)
+        for rs_insert, rs_insert_impl in zip(rs_insertion.rs_insert, self.rs_insert):
+            rs_insert.provide(rs_insert_impl)
 
         return m

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -65,9 +65,9 @@ class InstructionTagger(Elaboratable):
     `Scheduler` driver of `CheckpointRAT` `tag` stage. See `CheckpointRAT.tag` for description.
     """
 
-    get_free_reg: Required[Method]
     get_instr: Required[Method]
     push_instr: Required[Method]
+    crat_tag: Required[Method]
 
     def __init__(self, *, gen_params: GenParams):
         self.gen_params = gen_params
@@ -109,33 +109,28 @@ class Renaming(Elaboratable):
     the F-RAT with the translation from the logical destination register ID to the physical ID.
     """
 
-    def __init__(self, *, get_instr: Method, push_instr: Method, rename: Method, gen_params: GenParams):
+    get_instr: Required[Method]
+    push_instr: Required[Method]
+    rename: Required[Method]
+
+    def __init__(self, *, gen_params: GenParams):
         """
         Parameters
         ----------
-        get_instr: Method
-            Method providing instructions with an allocated physical register. Uses `SchedulerLayouts.renaming_in`.
-        push_instr: Method
-            Method used for pushing the serviced instruction to the next step. Uses `SchedulerLayouts.renaming_out`.
-        rename: Method
-            Method used for renaming the source register in F-RAT. Uses
-            `RATLayouts.rename_input_layout` and `RATLayouts.rename_output_layout`.
         gen_params: GenParams
             Core generation parameters.
         """
         self.gen_params = gen_params
         layouts = gen_params.get(SchedulerLayouts)
-        self.input_layout = layouts.renaming_in
-        self.output_layout = layouts.renaming_out
 
-        self.get_instr = get_instr
-        self.push_instr = push_instr
-        self.rename = rename
+        self.get_instr = Method(o=layouts.renaming_in)
+        self.push_instr = Method(i=layouts.renaming_out)
+        self.rename = Method(i=gen_params.get(RATLayouts).crat_rename_in, o=gen_params.get(RATLayouts).crat_rename_out)
 
     def elaborate(self, platform):
         m = TModule()
 
-        data_out = Signal(self.output_layout)
+        data_out = Signal(self.push_instr.layout_in)
 
         with Transaction().body(m):
             instr = self.get_instr(m)
@@ -164,35 +159,28 @@ class ROBAllocation(Elaboratable):
     Module performing "ReOrder Buffer entry allocation" step of scheduling process.
     """
 
-    def __init__(self, *, get_instr: Method, push_instr: Method, rob_put: Method, gen_params: GenParams):
+    get_instr: Required[Method]
+    push_instr: Required[Method]
+    rob_put: Required[Method]
+
+    def __init__(self, *, gen_params: GenParams):
         """
         Parameters
         ----------
-        get_instr: Method
-            Method providing instructions with physical register IDs present for all used registers.
-            Uses `SchedulerLayouts.rob_allocate_in`.
-        push_instr: Method
-            Method used for pushing the serviced instruction to the next step.
-            Uses `SchedulerLayouts.rob_allocate_out`.
-        rob_put: Method
-            Method used for getting a free entry in the ROB. Uses `ROBLayouts.data_layout`
-            and `ROBLayouts.id_layout`.
         gen_params: GenParams
             Core generation parameters.
         """
         self.gen_params = gen_params
         layouts = gen_params.get(SchedulerLayouts)
-        self.input_layout = layouts.rob_allocate_in
-        self.output_layout = layouts.rob_allocate_out
 
-        self.get_instr = get_instr
-        self.push_instr = push_instr
-        self.rob_put = rob_put
+        self.get_instr = Method(o=layouts.rob_allocate_in)
+        self.push_instr = Method(i=layouts.rob_allocate_out)
+        self.rob_put = Method(i=gen_params.get(ROBLayouts).put_layout, o=gen_params.get(ROBLayouts).put_out_layout)
 
     def elaborate(self, platform):
         m = TModule()
 
-        data_out = Signal(self.output_layout)
+        data_out = Signal(self.push_instr.layout_in)
 
         with Transaction().body(m):
             instr = self.get_instr(m)
@@ -493,20 +481,16 @@ class Scheduler(Elaboratable):
         instr_tag.crat_tag.provide(self.crat_tag)
 
         m.submodules.rename_out_buf = rename_out_buf = Connect(self.layouts.renaming_out)
-        m.submodules.renaming = Renaming(
-            get_instr=instr_tag_buf.read,
-            push_instr=rename_out_buf.write,
-            rename=self.crat_rename,
-            gen_params=self.gen_params,
-        )
+        m.submodules.renaming = renaming = Renaming(gen_params=self.gen_params)
+        renaming.get_instr.provide(instr_tag_buf.read)
+        renaming.push_instr.provide(rename_out_buf.write)
+        renaming.rename.provide(self.crat_rename)
 
         m.submodules.rob_alloc_out_buf = rob_alloc_out_buf = FIFO(self.layouts.rob_allocate_out, 2)
-        m.submodules.rob_alloc = ROBAllocation(
-            get_instr=rename_out_buf.read,
-            push_instr=rob_alloc_out_buf.write,
-            rob_put=self.rob_put,
-            gen_params=self.gen_params,
-        )
+        m.submodules.rob_alloc = rob_alloc = ROBAllocation(gen_params=self.gen_params)
+        rob_alloc.get_instr.provide(rename_out_buf.read)
+        rob_alloc.push_instr.provide(rob_alloc_out_buf.write)
+        rob_alloc.rob_put.provide(self.rob_put)
 
         m.submodules.rs_select_out_buf = rs_select_out_buf = FIFO(self.layouts.rs_select_out, 2)
         m.submodules.rs_selector = RSSelection(

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -214,49 +214,32 @@ class RSSelection(Elaboratable):
     methods to be available at the same time.
     """
 
-    def __init__(
-        self,
-        *,
-        get_instr: Method,
-        push_instr: Method,
-        rs_select: Sequence[tuple[Method, set[OpType]]],
-        rf_read_req1: Method,
-        rf_read_req2: Method,
-        gen_params: GenParams
-    ):
+    get_instr: Required[Method]
+    push_instr: Required[Method]
+    rf_read_req1: Required[Method]
+    rf_read_req2: Required[Method]
+
+    def __init__(self, *, rs_select: Sequence[tuple[Method, set[OpType]]], gen_params: GenParams):
         """
         Parameters
         ----------
-        get_instr: Method
-            Method providing instructions with entry in ROB. Uses `SchedulerLayouts.rs_select_in`.
-        push_instr: Method
-            Method used for pushing instruction with selected RS to next step.
-            Uses `SchedulerLayouts.rs_select_out`.
         rs_select: Sequence[tuple[Method, set[OpType]]]
             Sequence of pairs, each representing a single RS. The components are:
 
             - A method used for allocating an entry in the RS. Uses `RSLayouts.select_out`.
             - A set of `OpType`\\s that can be handled by this RS.
-        rf_read_req1: Method
-            Method used for requesting value of first source register and information if it is valid.
-            Uses `RFLayouts.rf_read_out`.
-        rf_read_req2: Method
-            Method used for requesting value of second source register and information if it is valid.
-            Uses `RFLayouts.rf_read_out`.
         gen_params: GenParams
             Core generation parameters.
         """
         self.gen_params = gen_params
 
         layouts = gen_params.get(SchedulerLayouts)
-        self.input_layout = layouts.rs_select_in
-        self.output_layout = layouts.rs_select_out
 
-        self.get_instr = get_instr
+        self.get_instr = Method(o=layouts.rs_select_in)
+        self.push_instr = Method(i=layouts.rs_select_out)
+        self.rf_read_req1 = Method(i=gen_params.get(RFLayouts).rf_read_in)
+        self.rf_read_req2 = Method(i=gen_params.get(RFLayouts).rf_read_in)
         self.rs_select = rs_select
-        self.push_instr = push_instr
-        self.rf_read_req1 = rf_read_req1
-        self.rf_read_req2 = rf_read_req2
 
     def decode_optype_set(self, optypes: set[OpType]) -> int:
         res = 0x0
@@ -270,7 +253,7 @@ class RSSelection(Elaboratable):
         lookup = Signal(OpType)  # lookup of currently processed optype
         m.d.comb += lookup.eq(self.get_instr.data_out.exec_fn.op_type)
 
-        data_out = Signal(self.output_layout)
+        data_out = Signal(self.push_instr.layout_in)
 
         for i, (alloc, optypes) in enumerate(self.rs_select):
             # checks if RS can perform this kind of operation
@@ -299,40 +282,30 @@ class RSInsertion(Elaboratable):
     a single instruction to the RS.
     """
 
-    def __init__(
-        self,
-        *,
-        get_instr: Method,
-        rs_insert: Sequence[Method],
-        rf_read_resp1: Method,
-        rf_read_resp2: Method,
-        crat_active_tags: Method,
-        gen_params: GenParams
-    ):
+    get_instr: Required[Method]
+    rf_read_resp1: Required[Method]
+    rf_read_resp2: Required[Method]
+    crat_active_tags: Required[Method]
+
+    def __init__(self, *, rs_insert: Sequence[Method], gen_params: GenParams):
         """
         Parameters
         ----------
-        get_instr: Method
-            Method providing instructions with reserved entry in ROB. Uses `SchedulerLayouts.rs_insert_in`.
         rs_insert: Sequence[Method]
             Sequence of methods used for pushing an instruction into the RS. Ordering of this list
             determines the ID of a specific RS. They use `RSLayouts.insert_in`
-        rf_read_resp1: Method
-            Method used for getting value of first source register and information if it is valid.
-            Uses `RFLayouts.rf_read_out` and `RFLayouts.rf_read_in`.
-        rf_read_resp2: Method
-            Method used for getting value of second source register and information if it is valid.
-            Uses `RFLayouts.rf_read_out` and `RFLayouts.rf_read_in`.
         gen_params: GenParams
             Core generation parameters.
         """
         self.gen_params = gen_params
 
-        self.get_instr = get_instr
+        layouts = gen_params.get(SchedulerLayouts)
+
+        self.get_instr = Method(o=layouts.rs_insert_in)
+        self.rf_read_resp1 = Method(i=gen_params.get(RFLayouts).rf_read_in, o=gen_params.get(RFLayouts).rf_read_out)
+        self.rf_read_resp2 = Method(i=gen_params.get(RFLayouts).rf_read_in, o=gen_params.get(RFLayouts).rf_read_out)
+        self.crat_active_tags = Method(o=gen_params.get(RATLayouts).get_active_tags_out)
         self.rs_insert = rs_insert
-        self.rf_read_resp1 = rf_read_resp1
-        self.rf_read_resp2 = rf_read_resp2
-        self.crat_active_tags = crat_active_tags
 
     def elaborate(self, platform):
         m = TModule()
@@ -493,22 +466,22 @@ class Scheduler(Elaboratable):
         rob_alloc.rob_put.provide(self.rob_put)
 
         m.submodules.rs_select_out_buf = rs_select_out_buf = FIFO(self.layouts.rs_select_out, 2)
-        m.submodules.rs_selector = RSSelection(
+        m.submodules.rs_selector = rs_selector = RSSelection(
             gen_params=self.gen_params,
-            get_instr=rob_alloc_out_buf.read,
             rs_select=[(rs.select, optypes) for rs, optypes in self.rs],
-            push_instr=rs_select_out_buf.write,
-            rf_read_req1=self.rf_read_req1,
-            rf_read_req2=self.rf_read_req2,
         )
+        rs_selector.get_instr.provide(rob_alloc_out_buf.read)
+        rs_selector.push_instr.provide(rs_select_out_buf.write)
+        rs_selector.rf_read_req1.provide(self.rf_read_req1)
+        rs_selector.rf_read_req2.provide(self.rf_read_req2)
 
-        m.submodules.rs_insertion = RSInsertion(
-            get_instr=rs_select_out_buf.read,
+        m.submodules.rs_insertion = rs_insertion = RSInsertion(
             rs_insert=[rs.insert for rs, _ in self.rs],
-            rf_read_resp1=self.rf_read_resp1,
-            rf_read_resp2=self.rf_read_resp2,
-            crat_active_tags=self.crat_active_tags,
             gen_params=self.gen_params,
         )
+        rs_insertion.get_instr.provide(rs_select_out_buf.read)
+        rs_insertion.rf_read_resp1.provide(self.rf_read_resp1)
+        rs_insertion.rf_read_resp2.provide(self.rf_read_resp2)
+        rs_insertion.crat_active_tags.provide(self.crat_active_tags)
 
         return m

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -8,7 +8,7 @@ from transactron.lib.connectors import Connect
 from transactron.utils import assign, AssignType
 from transactron.utils.dependencies import DependencyContext
 
-from coreblocks.interface.layouts import DecodeLayouts, RATLayouts, RFLayouts, ROBLayouts, SchedulerLayouts
+from coreblocks.interface.layouts import RATLayouts, RFLayouts, ROBLayouts, SchedulerLayouts
 from coreblocks.params import GenParams
 from coreblocks.arch.optypes import OpType
 from coreblocks.interface.keys import CoreStateKey
@@ -39,7 +39,7 @@ class RegAllocation(Elaboratable):
 
         self.get_instr = Method(o=layouts.reg_alloc_in)
         self.push_instr = Method(i=layouts.reg_alloc_out)
-        self.get_free_reg = Method(o=[("ident", gen_params.phys_regs_bits)])
+        self.get_free_reg = Method(o=layouts.free_rf_layout)
 
     def elaborate(self, platform):
         m = TModule()
@@ -421,7 +421,7 @@ class Scheduler(Elaboratable):
     get_instr: Required[Method]
     """
     Method providing decoded instructions to be scheduled for execution. It has layout as described
-    by `SchedulerLayouts.scheduler_in`. 
+    by `SchedulerLayouts.scheduler_in`.
     """
 
     get_free_reg: Required[Method]
@@ -451,12 +451,7 @@ class Scheduler(Elaboratable):
     rf_read_resp2: Required[Method]
     """Gets requested value of second source register and information if it is valid."""
 
-    def __init__(
-        self,
-        *,
-        gen_params: GenParams,
-        reservation_stations: Sequence[tuple[FuncBlock, set[OpType]]]
-    ):
+    def __init__(self, *, gen_params: GenParams, reservation_stations: Sequence[tuple[FuncBlock, set[OpType]]]):
         """
         Parameters
         ----------
@@ -468,8 +463,10 @@ class Scheduler(Elaboratable):
         self.gen_params = gen_params
         self.layouts = self.gen_params.get(SchedulerLayouts)
         self.get_instr = Method(o=self.layouts.scheduler_in)
-        self.get_free_reg = Method(o=[("ident", gen_params.phys_regs_bits)])
-        self.crat_rename = Method(i=gen_params.get(RATLayouts).crat_rename_in, o=gen_params.get(RATLayouts).crat_rename_out)
+        self.get_free_reg = Method(o=self.layouts.free_rf_layout)
+        self.crat_rename = Method(
+            i=gen_params.get(RATLayouts).crat_rename_in, o=gen_params.get(RATLayouts).crat_rename_out
+        )
         self.crat_active_tags = Method(o=gen_params.get(RATLayouts).get_active_tags_out)
         self.crat_tag = Method(i=gen_params.get(RATLayouts).crat_tag_in, o=gen_params.get(RATLayouts).crat_tag_out)
         self.rob_put = Method(i=gen_params.get(ROBLayouts).put_layout, o=gen_params.get(ROBLayouts).put_out_layout)

--- a/test/scheduler/test_checkpointing.py
+++ b/test/scheduler/test_checkpointing.py
@@ -5,12 +5,11 @@ from collections import deque
 from enum import Enum
 
 from coreblocks.arch import OpType
-from coreblocks.func_blocks.fu.common.rs_func_block import RSBlockComponent
 from coreblocks.params import GenParams
 from coreblocks.params.configurations import test_core_config
 from transactron.testing import CallTrigger, MethodMock, TestCaseWithSimulator, def_method_mock
 
-from test.scheduler.test_scheduler import SchedulerTestCircuit
+from test.scheduler.test_scheduler import SchedulerTestCircuit, MockedBlockComponent
 
 
 class TestSchedulerCheckpointing(TestCaseWithSimulator):
@@ -19,16 +18,16 @@ class TestSchedulerCheckpointing(TestCaseWithSimulator):
         gen_params = GenParams(
             test_core_config.replace(
                 func_units_config=(
-                    RSBlockComponent([], rs_entries=4, rs_number=0),
-                    RSBlockComponent([], rs_entries=4, rs_number=1),
+                    MockedBlockComponent({OpType.ARITHMETIC}, rs_entries=4),
+                    MockedBlockComponent({OpType.BRANCH}, rs_entries=4),
                 ),
                 tag_bits=tag_bits,
                 checkpoint_count=checkpoint_count,
+                allow_partial_extensions=True,
             )
         )
 
-        rs = [{OpType.ARITHMETIC}, {OpType.BRANCH}]
-        dut = SchedulerTestCircuit(gen_params, rs)
+        dut = SchedulerTestCircuit(gen_params)
 
         branch_in_flight = set()
 

--- a/test/scheduler/test_checkpointing.py
+++ b/test/scheduler/test_checkpointing.py
@@ -125,7 +125,7 @@ class TestSchedulerCheckpointing(TestCaseWithSimulator):
         async def free_rf_process(sim):
             free_rp_inp = 1
             while True:
-                await dut.free_rf_inp.call(sim, {"reg_id": free_rp_inp})
+                await dut.free_rf_inp.call(sim, {"ident": free_rp_inp})
                 free_rp_inp += 1
                 if free_rp_inp == gen_params.phys_regs:
                     free_rp_inp = 1

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -1,57 +1,18 @@
 from collections import deque
 import random
 
-from amaranth import *
-
 from coreblocks.params import GenParams
-from coreblocks.interface.layouts import RFLayouts, RSLayouts, SchedulerLayouts
 from coreblocks.arch import Funct3, Funct7
 from coreblocks.arch import OpType
 from coreblocks.params.configurations import test_core_config
 from coreblocks.scheduler.scheduler import RSSelection
-from transactron.lib import FIFO, Adapter, AdapterTrans
-from transactron.testing import TestCaseWithSimulator, TestbenchIO, TestbenchContext
+from transactron.testing import SimpleTestCircuit, TestCaseWithSimulator, TestbenchIO, TestbenchContext
 from transactron.testing.functions import data_const_to_dict
 from transactron.testing.method_mock import MethodMock, def_method_mock
 from .test_scheduler import MockedBlockComponent
 
 _rs1_optypes = {OpType.ARITHMETIC, OpType.COMPARE}
 _rs2_optypes = {OpType.LOGIC, OpType.COMPARE}
-
-
-class RSSelector(Elaboratable):
-    def __init__(self, gen_params: GenParams):
-        self.gen_params = gen_params
-
-    def elaborate(self, platform):
-        m = Module()
-
-        rs_layouts = self.gen_params.get(RSLayouts, rs_entries=self.gen_params.max_rs_entries)
-        rf_layouts = self.gen_params.get(RFLayouts)
-        scheduler_layouts = self.gen_params.get(SchedulerLayouts)
-
-        # data structures
-        m.submodules.instr_fifo = instr_fifo = FIFO(scheduler_layouts.rs_select_in, 2)
-        m.submodules.out_fifo = out_fifo = FIFO(scheduler_layouts.rs_select_out, 2)
-
-        # mocked input and output
-        m.submodules.instr_in = self.instr_in = TestbenchIO(AdapterTrans.create(instr_fifo.write))
-        m.submodules.instr_out = self.instr_out = TestbenchIO(AdapterTrans.create(out_fifo.read))
-        m.submodules.rs1_alloc = self.rs1_alloc = TestbenchIO(Adapter(o=rs_layouts.rs.select_out))
-        m.submodules.rs2_alloc = self.rs2_alloc = TestbenchIO(Adapter(o=rs_layouts.rs.select_out))
-        m.submodules.rf_read_req1 = self.rf_read_req1 = TestbenchIO(Adapter(i=rf_layouts.rf_read_in))
-        m.submodules.rf_read_req2 = self.rf_read_req2 = TestbenchIO(Adapter(i=rf_layouts.rf_read_in))
-
-        # rs selector
-        m.submodules.selector = self.selector = RSSelection(gen_params=self.gen_params)
-        self.selector.get_instr.provide(instr_fifo.read)
-        self.selector.push_instr.provide(out_fifo.write)
-        self.selector.rf_read_req1.provide(self.rf_read_req1.adapter.iface)
-        self.selector.rf_read_req2.provide(self.rf_read_req2.adapter.iface)
-        self.selector.rs_select[0].provide(self.rs1_alloc.adapter.iface)
-        self.selector.rs_select[1].provide(self.rs2_alloc.adapter.iface)
-
-        return m
 
 
 class TestRSSelect(TestCaseWithSimulator):
@@ -62,7 +23,7 @@ class TestRSSelect(TestCaseWithSimulator):
                 allow_partial_extensions=True,
             )
         )
-        self.m = RSSelector(self.gen_params)
+        self.m = SimpleTestCircuit(RSSelection(gen_params=self.gen_params))
         self.expected_out: deque[dict] = deque()
         self.instr_in: deque[dict] = deque()
         random.seed(1789)
@@ -103,7 +64,7 @@ class TestRSSelect(TestCaseWithSimulator):
                 }
 
                 self.instr_in.append(instr)
-                await self.m.instr_in.call(sim, instr)
+                await self.m.get_instr.call(sim, instr)
                 await self.random_wait(sim, random_wait)
 
         return process
@@ -136,7 +97,7 @@ class TestRSSelect(TestCaseWithSimulator):
     def create_output_process(self, instr_count: int, random_wait: int = 0):
         async def process(sim: TestbenchContext):
             for _ in range(instr_count):
-                result = await self.m.instr_out.call(sim)
+                result = await self.m.push_instr.call(sim)
                 outputs = self.expected_out.popleft()
 
                 await self.random_wait(sim, random_wait)
@@ -151,8 +112,8 @@ class TestRSSelect(TestCaseWithSimulator):
 
         with self.run_simulation(self.m, max_cycles=1500) as sim:
             sim.add_testbench(self.create_instr_input_process(100, _rs1_optypes.union(_rs2_optypes)))
-            self.add_mock(sim, self.create_rs_alloc_process(self.m.rs1_alloc, rs_id=0, rs_optypes=_rs1_optypes))
-            self.add_mock(sim, self.create_rs_alloc_process(self.m.rs2_alloc, rs_id=1, rs_optypes=_rs2_optypes))
+            self.add_mock(sim, self.create_rs_alloc_process(self.m.rs_select[0], rs_id=0, rs_optypes=_rs1_optypes))
+            self.add_mock(sim, self.create_rs_alloc_process(self.m.rs_select[1], rs_id=1, rs_optypes=_rs2_optypes))
             sim.add_testbench(self.create_output_process(100))
 
     def test_only_rs1(self):
@@ -163,7 +124,7 @@ class TestRSSelect(TestCaseWithSimulator):
 
         with self.run_simulation(self.m, max_cycles=1500) as sim:
             sim.add_testbench(self.create_instr_input_process(100, _rs1_optypes.intersection(_rs2_optypes)))
-            self.add_mock(sim, self.create_rs_alloc_process(self.m.rs1_alloc, rs_id=0, rs_optypes=_rs1_optypes))
+            self.add_mock(sim, self.create_rs_alloc_process(self.m.rs_select[0], rs_id=0, rs_optypes=_rs1_optypes))
             sim.add_testbench(self.create_output_process(100))
 
     def test_only_rs2(self):
@@ -174,7 +135,7 @@ class TestRSSelect(TestCaseWithSimulator):
 
         with self.run_simulation(self.m, max_cycles=1500) as sim:
             sim.add_testbench(self.create_instr_input_process(100, _rs1_optypes.intersection(_rs2_optypes)))
-            self.add_mock(sim, self.create_rs_alloc_process(self.m.rs2_alloc, rs_id=1, rs_optypes=_rs2_optypes))
+            self.add_mock(sim, self.create_rs_alloc_process(self.m.rs_select[1], rs_id=1, rs_optypes=_rs2_optypes))
             sim.add_testbench(self.create_output_process(100))
 
     def test_delays(self):
@@ -186,9 +147,11 @@ class TestRSSelect(TestCaseWithSimulator):
         with self.run_simulation(self.m, max_cycles=5000) as sim:
             sim.add_testbench(self.create_instr_input_process(300, _rs1_optypes.union(_rs2_optypes), random_wait=4))
             self.add_mock(
-                sim, self.create_rs_alloc_process(self.m.rs1_alloc, rs_id=0, rs_optypes=_rs1_optypes, enable_prob=0.1)
+                sim,
+                self.create_rs_alloc_process(self.m.rs_select[0], rs_id=0, rs_optypes=_rs1_optypes, enable_prob=0.1),
             )
             self.add_mock(
-                sim, self.create_rs_alloc_process(self.m.rs2_alloc, rs_id=1, rs_optypes=_rs2_optypes, enable_prob=0.1)
+                sim,
+                self.create_rs_alloc_process(self.m.rs_select[1], rs_id=1, rs_optypes=_rs2_optypes, enable_prob=0.1),
             )
             sim.add_testbench(self.create_output_process(300, random_wait=12))

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -13,6 +13,7 @@ from transactron.lib import FIFO, Adapter, AdapterTrans
 from transactron.testing import TestCaseWithSimulator, TestbenchIO, TestbenchContext
 from transactron.testing.functions import data_const_to_dict
 from transactron.testing.method_mock import MethodMock, def_method_mock
+from .test_scheduler import MockedBlockComponent
 
 _rs1_optypes = {OpType.ARITHMETIC, OpType.COMPARE}
 _rs2_optypes = {OpType.LOGIC, OpType.COMPARE}
@@ -42,21 +43,25 @@ class RSSelector(Elaboratable):
         m.submodules.rf_read_req2 = self.rf_read_req2 = TestbenchIO(Adapter(i=rf_layouts.rf_read_in))
 
         # rs selector
-        m.submodules.selector = self.selector = RSSelection(
-            gen_params=self.gen_params,
-            get_instr=instr_fifo.read,
-            rs_select=[(self.rs1_alloc.adapter.iface, _rs1_optypes), (self.rs2_alloc.adapter.iface, _rs2_optypes)],
-            push_instr=out_fifo.write,
-            rf_read_req1=self.rf_read_req1.adapter.iface,
-            rf_read_req2=self.rf_read_req2.adapter.iface,
-        )
+        m.submodules.selector = self.selector = RSSelection(gen_params=self.gen_params)
+        self.selector.get_instr.provide(instr_fifo.read)
+        self.selector.push_instr.provide(out_fifo.write)
+        self.selector.rf_read_req1.provide(self.rf_read_req1.adapter.iface)
+        self.selector.rf_read_req2.provide(self.rf_read_req2.adapter.iface)
+        self.selector.rs_select[0].provide(self.rs1_alloc.adapter.iface)
+        self.selector.rs_select[1].provide(self.rs2_alloc.adapter.iface)
 
         return m
 
 
 class TestRSSelect(TestCaseWithSimulator):
     def setup_method(self):
-        self.gen_params = GenParams(test_core_config)
+        self.gen_params = GenParams(
+            test_core_config.replace(
+                func_units_config=(MockedBlockComponent(_rs1_optypes, 4), MockedBlockComponent(_rs2_optypes, 4)),
+                allow_partial_extensions=True,
+            )
+        )
         self.m = RSSelector(self.gen_params)
         self.expected_out: deque[dict] = deque()
         self.instr_in: deque[dict] = deque()

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -99,20 +99,17 @@ class SchedulerTestCircuit(Elaboratable):
         dm.add_dependency(CoreStateKey(), self.core_state.adapter.iface)
 
         # main scheduler
-        m.submodules.scheduler = self.scheduler = Scheduler(
-            get_instr=instr_fifo.read,
-            get_free_reg=free_rf_fifo.read,
-            crat_rename=crat.rename,
-            crat_tag=crat.tag,
-            crat_active_tags=crat.get_active_tags,
-            rob_put=self.rob.put,
-            rf_read_req1=self.rf.read_req[0],
-            rf_read_req2=self.rf.read_req[1],
-            rf_read_resp1=self.rf.read_resp[0],
-            rf_read_resp2=self.rf.read_resp[1],
-            reservation_stations=rs_blocks,
-            gen_params=self.gen_params,
-        )
+        m.submodules.scheduler = self.scheduler = Scheduler(gen_params=self.gen_params, reservation_stations=rs_blocks)
+        self.scheduler.get_instr.provide(instr_fifo.read)
+        self.scheduler.get_free_reg.provide(free_rf_fifo.read)
+        self.scheduler.crat_rename.provide(crat.rename)
+        self.scheduler.crat_tag.provide(crat.tag)
+        self.scheduler.crat_active_tags.provide(crat.get_active_tags)
+        self.scheduler.rob_put.provide(self.rob.put)
+        self.scheduler.rf_read_req1.provide(self.rf.read_req[0])
+        self.scheduler.rf_read_req2.provide(self.rf.read_req[1])
+        self.scheduler.rf_read_resp1.provide(self.rf.read_resp[0])
+        self.scheduler.rf_read_resp2.provide(self.rf.read_resp[1])
 
         rollback, rollback_unifiers = dm.get_dependency(RollbackKey())
         m.submodules.rollback_unifiers = ModuleConnector(**rollback_unifiers)
@@ -167,7 +164,7 @@ class TestScheduler(TestCaseWithSimulator):
             self.free_phys_reg(i)
 
     def free_phys_reg(self, reg_id):
-        self.free_regs_queue.append({"reg_id": reg_id})
+        self.free_regs_queue.append({"ident": reg_id})
         self.expected_phys_reg_queue.append(reg_id)
 
     async def queue_gather(self, sim: TestbenchContext, queues: Iterable[deque]):

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -1,19 +1,20 @@
+from dataclasses import dataclass
 import random
 from amaranth import *
 
 from collections import namedtuple, deque
 from typing import Callable, Optional, Iterable
 from parameterized import parameterized_class
+from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 from coreblocks.interface.keys import CoreStateKey, RollbackKey
-from coreblocks.interface.layouts import RetirementLayouts
-from coreblocks.func_blocks.fu.common.rs_func_block import RSBlockComponent
+from coreblocks.interface.layouts import RSInterfaceLayouts, RetirementLayouts
 
-from transactron.core import Method, Methods
 from transactron.lib import FIFO, AdapterTrans, Adapter
 from transactron.testing.functions import MethodData, data_const_to_dict
 from transactron.testing.method_mock import MethodMock
 from transactron.utils.amaranth_ext.elaboratables import ModuleConnector
 from transactron.utils.dependencies import DependencyContext
+from coreblocks.params.fu_params import BlockComponentParams
 from coreblocks.scheduler.scheduler import Scheduler
 from coreblocks.core_structs.rf import RegisterFile
 from coreblocks.core_structs.crat import CheckpointRAT
@@ -22,8 +23,25 @@ from coreblocks.interface.layouts import RSLayouts, SchedulerLayouts
 from coreblocks.arch import OpType, Funct3, Funct7
 from coreblocks.params.configurations import test_core_config
 from coreblocks.core_structs.rob import ReorderBuffer
-from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 from transactron.testing import TestCaseWithSimulator, TestbenchIO, def_method_mock, TestbenchContext
+
+
+@dataclass(frozen=True)
+class MockedBlockComponent(BlockComponentParams):
+    op_types: set[OpType]
+    rs_entries: int
+
+    def get_module(self, gen_params: GenParams) -> FuncBlock:
+        raise NotImplementedError()
+
+    def get_optypes(self) -> set[OpType]:
+        return self.op_types
+
+    def get_layouts(self, gen_params: GenParams) -> RSInterfaceLayouts:
+        return gen_params.get(RSLayouts, rs_entries=self.rs_entries).rs
+
+    def get_rs_entry_count(self) -> int:
+        return self.rs_entries
 
 
 class SchedulerTestCircuit(Elaboratable):
@@ -46,37 +64,16 @@ class SchedulerTestCircuit(Elaboratable):
         m.submodules.rob = self.rob = ReorderBuffer(self.gen_params, 1)
         m.submodules.rf = self.rf = RegisterFile(gen_params=self.gen_params, read_ports=2, write_ports=1, free_ports=1)
 
-        # mocked RSFuncBlock
-        class MockedRSFuncBlock(FuncBlock):
-            def __init__(self, select, insert):
-                self.select = select
-                self.insert = insert
-
-            update: Methods
-            get_result: Method
-
-            def elaborate(self, platform):
-                raise NotImplementedError
-
-        method_rs_alloc = []
-        method_rs_insert = []
-        rs_blocks: list[tuple[FuncBlock, set[OpType]]] = []
-        self.rs_alloc = []
-        self.rs_insert = []
+        self.rs_alloc: list[TestbenchIO] = []
+        self.rs_insert: list[TestbenchIO] = []
 
         # mocked RS
         for i, rs in enumerate(self.rs):
-            alloc_adapter = Adapter(o=rs_layouts.rs.select_out)
-            insert_adapter = Adapter(i=rs_layouts.rs.insert_in)
+            select_test = TestbenchIO(Adapter(o=rs_layouts.rs.select_out))
+            insert_test = TestbenchIO(Adapter(i=rs_layouts.rs.insert_in))
 
-            select_test = TestbenchIO(alloc_adapter)
-            insert_test = TestbenchIO(insert_adapter)
-
-            method_rs_alloc.append(alloc_adapter)
-            method_rs_insert.append(insert_adapter)
             self.rs_alloc.append(select_test)
             self.rs_insert.append(insert_test)
-            rs_blocks.append((MockedRSFuncBlock(alloc_adapter.iface, insert_adapter.iface), rs))
 
             m.submodules[f"rs_alloc_{i}"] = self.rs_alloc[i]
             m.submodules[f"rs_insert_{i}"] = self.rs_insert[i]
@@ -99,7 +96,7 @@ class SchedulerTestCircuit(Elaboratable):
         dm.add_dependency(CoreStateKey(), self.core_state.adapter.iface)
 
         # main scheduler
-        m.submodules.scheduler = self.scheduler = Scheduler(gen_params=self.gen_params, reservation_stations=rs_blocks)
+        m.submodules.scheduler = self.scheduler = Scheduler(gen_params=self.gen_params)
         self.scheduler.get_instr.provide(instr_fifo.read)
         self.scheduler.get_free_reg.provide(free_rf_fifo.read)
         self.scheduler.crat_rename.provide(crat.rename)
@@ -110,6 +107,9 @@ class SchedulerTestCircuit(Elaboratable):
         self.scheduler.rf_read_req2.provide(self.rf.read_req[1])
         self.scheduler.rf_read_resp1.provide(self.rf.read_resp[0])
         self.scheduler.rf_read_resp2.provide(self.rf.read_resp[1])
+        for i, (rs_select, rs_insert) in enumerate(zip(self.rs_alloc, self.rs_insert)):
+            self.scheduler.rs_select[i].provide(rs_select.adapter.iface)
+            self.scheduler.rs_insert[i].provide(rs_insert.adapter.iface)
 
         rollback, rollback_unifiers = dm.get_dependency(RollbackKey())
         m.submodules.rollback_unifiers = ModuleConnector(**rollback_unifiers)
@@ -138,7 +138,8 @@ class TestScheduler(TestCaseWithSimulator):
         self.rs_count = len(self.optype_sets)
         self.gen_params = GenParams(
             test_core_config.replace(
-                func_units_config=tuple(RSBlockComponent([], rs_entries=4, rs_number=k) for k in range(self.rs_count))
+                func_units_config=tuple(MockedBlockComponent(optypes, rs_entries=4) for optypes in self.optype_sets),
+                allow_partial_extensions=True,
             )
         )
         self.expected_rename_queue = deque()

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -45,9 +45,8 @@ class MockedBlockComponent(BlockComponentParams):
 
 
 class SchedulerTestCircuit(Elaboratable):
-    def __init__(self, gen_params: GenParams, rs: list[set[OpType]]):
+    def __init__(self, gen_params: GenParams):
         self.gen_params = gen_params
-        self.rs = rs
 
     def elaborate(self, platform):
         m = Module()
@@ -68,7 +67,7 @@ class SchedulerTestCircuit(Elaboratable):
         self.rs_insert: list[TestbenchIO] = []
 
         # mocked RS
-        for i, rs in enumerate(self.rs):
+        for i in range(len(self.gen_params.func_units_config)):
             select_test = TestbenchIO(Adapter(o=rs_layouts.rs.select_out))
             insert_test = TestbenchIO(Adapter(i=rs_layouts.rs.insert_in))
 
@@ -149,7 +148,7 @@ class TestScheduler(TestCaseWithSimulator):
         self.expected_rs_entry_queue = [deque() for _ in self.optype_sets]
         self.current_RAT = [0] * self.gen_params.isa.reg_cnt
         self.allocated_instr_count = 0
-        self.m = SchedulerTestCircuit(self.gen_params, self.optype_sets)
+        self.m = SchedulerTestCircuit(self.gen_params)
 
         random.seed(42)
 


### PR DESCRIPTION
This PR refactors the `Scheduler` to use modern method passing style. The cleanup may simplify adding superscalarity to the scheduler.