### PR TITLE
Superscalar decode

### DIFF
--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -2,13 +2,98 @@ from amaranth import *
 
 from coreblocks.arch import *
 from transactron.lib.metrics import *
-from transactron import Method, Transaction, TModule
-from transactron.utils import MethodStruct
+from transactron import Method, Provided, Required, Transaction, TModule, def_method
 from coreblocks.interface.layouts import DecodeLayouts, FetchLayouts, JumpBranchLayouts
 from transactron.utils.transactron_helpers import from_method_layout
 from coreblocks.params import GenParams
 from .instr_decoder import InstrDecoder
 from coreblocks.params import *
+
+
+class Decode(Elaboratable):
+    """
+    Simple decode unit. This is a transactional interface which instantiates a
+    submodule `InstrDecoder`. This `InstrDecoder` makes actual decoding in
+    a combinatorial manner.
+    """
+
+    decode: Provided[Method]
+    """Receives a raw instruction and returns a decoded one."""
+
+    illegal: Required[Method]
+    """Called when received instruction is illegal."""
+
+    def __init__(self, gen_params: GenParams) -> None:
+        self.gen_params = gen_params
+        self.decode = Method(i=gen_params.get(FetchLayouts).raw_instr, o=gen_params.get(DecodeLayouts).decoded_instr)
+        self.illegal = Method()
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        @def_method(m, self.decode)
+        def _(instr, pc, rvc, predicted_taken, access_fault, cfi_type):
+            m.submodules.instr_decoder = instr_decoder = InstrDecoder(self.gen_params)
+            m.d.top_comb += instr_decoder.instr.eq(instr)
+
+            # Jump-branch unit requires some information from the fetch unit (for example
+            # if the instruction was decoded from a compressed instruction). To avoid adding
+            # a new signal to the pipeline, we pack it in funct7 - it is not used in jb
+            # unit anyway. This is a temporary hack will be removed soon (TODO(jurb)).
+            is_jb_unit_instr = (
+                (instr_decoder.optype == OpType.JAL)
+                | (instr_decoder.optype == OpType.JALR)
+                | (instr_decoder.optype == OpType.BRANCH)
+            )
+            jb_funct7 = Signal(from_method_layout(self.gen_params.get(JumpBranchLayouts).funct7_info))
+            m.d.av_comb += [
+                jb_funct7.rvc.eq(rvc),
+                jb_funct7.predicted_taken.eq(predicted_taken),
+            ]
+
+            exception_override = Signal()
+            m.d.comb += exception_override.eq(instr_decoder.illegal | access_fault.any())
+            exception_funct = Signal(Funct3)
+            with m.If(access_fault.any()):
+                m.d.comb += exception_funct.eq(Funct3._EINSTRACCESSFAULT)
+            with m.Elif(instr_decoder.illegal):
+                self.illegal(m)
+                m.d.comb += exception_funct.eq(Funct3._EILLEGALINSTR)
+
+            return {
+                "exec_fn": {
+                    "op_type": Mux(~exception_override, instr_decoder.optype, OpType.EXCEPTION),
+                    # imm muxing in FUs depend on unused functs set to 0
+                    # todo: this is a bit awkward and needs a refactor in the future
+                    "funct3": Mux(
+                        ~exception_override, Mux(instr_decoder.funct3_v, instr_decoder.funct3, 0), exception_funct
+                    ),
+                    "funct7": Mux(
+                        ~exception_override,
+                        Mux(instr_decoder.funct7_v, instr_decoder.funct7, Mux(is_jb_unit_instr, jb_funct7, 0)),
+                        0,
+                    ),
+                },
+                "regs_l": {
+                    # read/writes to phys reg 0 make no effect
+                    "rl_dst": Mux(instr_decoder.rd_v & (~exception_override), instr_decoder.rd, 0),
+                    "rl_s1": Mux(instr_decoder.rs1_v & (~exception_override), instr_decoder.rs1, 0),
+                    "rl_s2": Mux(instr_decoder.rs2_v & (~exception_override), instr_decoder.rs2, 0),
+                },
+                "imm": Mux(
+                    ~exception_override,
+                    instr_decoder.imm,
+                    Mux(
+                        access_fault.any(),
+                        access_fault,  # pass access fault details to FU
+                        instr,  # illegal instruction -  pass raw instruction bits for `mtval`
+                    ),
+                ),
+                "csr": instr_decoder.csr,
+                "pc": pc,
+            }
+
+        return m
 
 
 class DecodeStage(Elaboratable):
@@ -46,66 +131,10 @@ class DecodeStage(Elaboratable):
 
         m.submodules.perf_illegal_instr = self.perf_illegal_instr
 
-        def perform_decode(i: int, raw: MethodStruct):
-            m.submodules[f"instr_decoder{i}"] = instr_decoder = InstrDecoder(self.gen_params)
-            m.d.top_comb += instr_decoder.instr.eq(raw.instr)
-
-            # Jump-branch unit requires some information from the fetch unit (for example
-            # if the instruction was decoded from a compressed instruction). To avoid adding
-            # a new signal to the pipeline, we pack it in funct7 - it is not used in jb
-            # unit anyway. This is a temporary hack will be removed soon (TODO(jurb)).
-            is_jb_unit_instr = (
-                (instr_decoder.optype == OpType.JAL)
-                | (instr_decoder.optype == OpType.JALR)
-                | (instr_decoder.optype == OpType.BRANCH)
-            )
-            jb_funct7 = Signal(from_method_layout(self.gen_params.get(JumpBranchLayouts).funct7_info))
-            m.d.av_comb += [
-                jb_funct7.rvc.eq(raw.rvc),
-                jb_funct7.predicted_taken.eq(raw.predicted_taken),
-            ]
-
-            exception_override = Signal()
-            m.d.comb += exception_override.eq(instr_decoder.illegal | raw.access_fault.any())
-            exception_funct = Signal(Funct3)
-            with m.If(raw.access_fault.any()):
-                m.d.comb += exception_funct.eq(Funct3._EINSTRACCESSFAULT)
-            with m.Elif(instr_decoder.illegal):
-                self.perf_illegal_instr.incr[i](m)
-                m.d.comb += exception_funct.eq(Funct3._EILLEGALINSTR)
-
-            return {
-                "exec_fn": {
-                    "op_type": Mux(~exception_override, instr_decoder.optype, OpType.EXCEPTION),
-                    # imm muxing in FUs depend on unused functs set to 0
-                    # todo: this is a bit awkward and needs a refactor in the future
-                    "funct3": Mux(
-                        ~exception_override, Mux(instr_decoder.funct3_v, instr_decoder.funct3, 0), exception_funct
-                    ),
-                    "funct7": Mux(
-                        ~exception_override,
-                        Mux(instr_decoder.funct7_v, instr_decoder.funct7, Mux(is_jb_unit_instr, jb_funct7, 0)),
-                        0,
-                    ),
-                },
-                "regs_l": {
-                    # read/writes to phys reg 0 make no effect
-                    "rl_dst": Mux(instr_decoder.rd_v & (~exception_override), instr_decoder.rd, 0),
-                    "rl_s1": Mux(instr_decoder.rs1_v & (~exception_override), instr_decoder.rs1, 0),
-                    "rl_s2": Mux(instr_decoder.rs2_v & (~exception_override), instr_decoder.rs2, 0),
-                },
-                "imm": Mux(
-                    ~exception_override,
-                    instr_decoder.imm,
-                    Mux(
-                        raw.access_fault.any(),
-                        raw.access_fault,  # pass access fault details to FU
-                        raw.instr,  # illegal instruction -  pass raw instruction bits for `mtval`
-                    ),
-                ),
-                "csr": instr_decoder.csr,
-                "pc": raw.pc,
-            }
+        decoders = [Decode(self.gen_params) for _ in range(self.gen_params.frontend_superscalarity)]
+        for i, decoder in enumerate(decoders):
+            m.submodules[f"decoder{i}"] = decoder
+            decoder.illegal.provide(self.perf_illegal_instr.incr[i])
 
         with Transaction().body(m):
             instrs = self.get_raw(m)
@@ -113,7 +142,7 @@ class DecodeStage(Elaboratable):
                 m,
                 {
                     "count": instrs.count,
-                    "data": [perform_decode(i, instrs.data[i]) for i in range(self.gen_params.frontend_superscalarity)],
+                    "data": [decoder.decode(m, instrs.data[i]) for i, decoder in enumerate(decoders)],
                 },
             )
 

--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -45,9 +45,9 @@ class DecodeStage(Elaboratable):
         m = TModule()
 
         m.submodules.perf_illegal_instr = self.perf_illegal_instr
-        m.submodules.instr_decoder = instr_decoder = InstrDecoder(self.gen_params)
 
         def perform_decode(i: int, raw: MethodStruct):
+            m.submodules[f"instr_decoder{i}"] = instr_decoder = InstrDecoder(self.gen_params)
             m.d.top_comb += instr_decoder.instr.eq(raw.instr)
 
             # Jump-branch unit requires some information from the fetch unit (for example

--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -3,6 +3,7 @@ from amaranth import *
 from coreblocks.arch import *
 from transactron.lib.metrics import *
 from transactron import Method, Transaction, TModule
+from transactron.utils import MethodStruct
 from coreblocks.interface.layouts import DecodeLayouts, FetchLayouts, JumpBranchLayouts
 from transactron.utils.transactron_helpers import from_method_layout
 from coreblocks.params import GenParams
@@ -35,10 +36,10 @@ class DecodeStage(Elaboratable):
             fetch unit.
         """
         self.gen_params = gen_params
-        self.get_raw = Method(o=gen_params.get(FetchLayouts).raw_instr)
-        self.push_decoded = Method(i=gen_params.get(DecodeLayouts).decoded_instr)
+        self.get_raw = Method(o=gen_params.get(FetchLayouts).fetch_result)
+        self.push_decoded = Method(i=gen_params.get(DecodeLayouts).decode_result)
 
-        self.perf_illegal_instr = HwCounter("frontend.decode.illegal_instr")
+        self.perf_illegal_instr = HwCounter("frontend.decode.illegal_instr", ways=gen_params.frontend_superscalarity)
 
     def elaborate(self, platform):
         m = TModule()
@@ -46,9 +47,7 @@ class DecodeStage(Elaboratable):
         m.submodules.perf_illegal_instr = self.perf_illegal_instr
         m.submodules.instr_decoder = instr_decoder = InstrDecoder(self.gen_params)
 
-        with Transaction().body(m):
-            raw = self.get_raw(m)
-
+        def perform_decode(i: int, raw: MethodStruct):
             m.d.top_comb += instr_decoder.instr.eq(raw.instr)
 
             # Jump-branch unit requires some information from the fetch unit (for example
@@ -72,42 +71,49 @@ class DecodeStage(Elaboratable):
             with m.If(raw.access_fault.any()):
                 m.d.comb += exception_funct.eq(Funct3._EINSTRACCESSFAULT)
             with m.Elif(instr_decoder.illegal):
-                self.perf_illegal_instr.incr(m)
+                self.perf_illegal_instr.incr[i](m)
                 m.d.comb += exception_funct.eq(Funct3._EILLEGALINSTR)
 
+            return {
+                "exec_fn": {
+                    "op_type": Mux(~exception_override, instr_decoder.optype, OpType.EXCEPTION),
+                    # imm muxing in FUs depend on unused functs set to 0
+                    # todo: this is a bit awkward and needs a refactor in the future
+                    "funct3": Mux(
+                        ~exception_override, Mux(instr_decoder.funct3_v, instr_decoder.funct3, 0), exception_funct
+                    ),
+                    "funct7": Mux(
+                        ~exception_override,
+                        Mux(instr_decoder.funct7_v, instr_decoder.funct7, Mux(is_jb_unit_instr, jb_funct7, 0)),
+                        0,
+                    ),
+                },
+                "regs_l": {
+                    # read/writes to phys reg 0 make no effect
+                    "rl_dst": Mux(instr_decoder.rd_v & (~exception_override), instr_decoder.rd, 0),
+                    "rl_s1": Mux(instr_decoder.rs1_v & (~exception_override), instr_decoder.rs1, 0),
+                    "rl_s2": Mux(instr_decoder.rs2_v & (~exception_override), instr_decoder.rs2, 0),
+                },
+                "imm": Mux(
+                    ~exception_override,
+                    instr_decoder.imm,
+                    Mux(
+                        raw.access_fault.any(),
+                        raw.access_fault,  # pass access fault details to FU
+                        raw.instr,  # illegal instruction -  pass raw instruction bits for `mtval`
+                    ),
+                ),
+                "csr": instr_decoder.csr,
+                "pc": raw.pc,
+            }
+
+        with Transaction().body(m):
+            instrs = self.get_raw(m)
             self.push_decoded(
                 m,
                 {
-                    "exec_fn": {
-                        "op_type": Mux(~exception_override, instr_decoder.optype, OpType.EXCEPTION),
-                        # imm muxing in FUs depend on unused functs set to 0
-                        # todo: this is a bit awkward and needs a refactor in the future
-                        "funct3": Mux(
-                            ~exception_override, Mux(instr_decoder.funct3_v, instr_decoder.funct3, 0), exception_funct
-                        ),
-                        "funct7": Mux(
-                            ~exception_override,
-                            Mux(instr_decoder.funct7_v, instr_decoder.funct7, Mux(is_jb_unit_instr, jb_funct7, 0)),
-                            0,
-                        ),
-                    },
-                    "regs_l": {
-                        # read/writes to phys reg 0 make no effect
-                        "rl_dst": Mux(instr_decoder.rd_v & (~exception_override), instr_decoder.rd, 0),
-                        "rl_s1": Mux(instr_decoder.rs1_v & (~exception_override), instr_decoder.rs1, 0),
-                        "rl_s2": Mux(instr_decoder.rs2_v & (~exception_override), instr_decoder.rs2, 0),
-                    },
-                    "imm": Mux(
-                        ~exception_override,
-                        instr_decoder.imm,
-                        Mux(
-                            raw.access_fault.any(),
-                            raw.access_fault,  # pass access fault details to FU
-                            raw.instr,  # illegal instruction -  pass raw instruction bits for `mtval`
-                        ),
-                    ),
-                    "csr": instr_decoder.csr,
-                    "pc": raw.pc,
+                    "count": instrs.count,
+                    "data": [perform_decode(i, instrs.data[i]) for i in range(self.gen_params.frontend_superscalarity)],
                 },
             )
 

--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -1,8 +1,10 @@
+from collections.abc import Callable
+from typing import Any
 from amaranth import *
 
 from coreblocks.arch import *
 from transactron.lib.metrics import *
-from transactron import Method, Provided, Required, Transaction, TModule, def_method
+from transactron import Method, Provided, Transaction, TModule, def_method
 from coreblocks.interface.layouts import DecodeLayouts, FetchLayouts, JumpBranchLayouts
 from transactron.utils.transactron_helpers import from_method_layout
 from coreblocks.params import GenParams
@@ -20,13 +22,10 @@ class Decode(Elaboratable):
     decode: Provided[Method]
     """Receives a raw instruction and returns a decoded one."""
 
-    illegal: Required[Method]
-    """Called when received instruction is illegal."""
-
-    def __init__(self, gen_params: GenParams) -> None:
+    def __init__(self, gen_params: GenParams, illegal: Callable[[TModule], Any]) -> None:
         self.gen_params = gen_params
         self.decode = Method(i=gen_params.get(FetchLayouts).raw_instr, o=gen_params.get(DecodeLayouts).decoded_instr)
-        self.illegal = Method()
+        self.illegal = illegal
 
     def elaborate(self, platform):
         m = TModule()
@@ -131,10 +130,12 @@ class DecodeStage(Elaboratable):
 
         m.submodules.perf_illegal_instr = self.perf_illegal_instr
 
-        decoders = [Decode(self.gen_params) for _ in range(self.gen_params.frontend_superscalarity)]
+        decoders = [
+            Decode(self.gen_params, self.perf_illegal_instr.incr[i])
+            for i in range(self.gen_params.frontend_superscalarity)
+        ]
         for i, decoder in enumerate(decoders):
             m.submodules[f"decoder{i}"] = decoder
-            decoder.illegal.provide(self.perf_illegal_instr.incr[i])
 
         with Transaction().body(m):
             instrs = self.get_raw(m)

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -4,7 +4,7 @@ from amaranth.lib.data import ArrayLayout
 from transactron.lib import BasicFifo, WideFifo, Semaphore, logging, Pipe
 from transactron.lib.metrics import *
 from transactron.lib.simultaneous import condition
-from transactron.utils import popcount, assign, StableSelectingNetwork
+from transactron.utils import count_trailing_zeros, popcount, assign, StableSelectingNetwork
 from transactron.utils.transactron_helpers import make_layout
 from transactron.utils.amaranth_ext.coding import PriorityEncoder
 from transactron import *
@@ -97,7 +97,12 @@ class FetchUnit(Elaboratable):
         )
 
         with Transaction(name="cont").body(m):
-            result = serializer.read(m, count=self.gen_params.frontend_superscalarity)
+            count = Signal(range(self.gen_params.frontend_superscalarity + 1))
+            result = serializer.read(m, count=count)
+            # we want only one branch insn in scheduling group, and only at the beginning (for simplicity)
+            # some insts in result.data might not be valid, but this is still correct
+            which_is_branch = [0] + [instr.cfi_type == CfiType.BRANCH for instr in result.data][1:]
+            m.d.comb += count.eq(count_trailing_zeros(Cat(which_is_branch)))
             for i in range(self.gen_params.frontend_superscalarity):
                 log.info(
                     m,
@@ -347,6 +352,7 @@ class FetchUnit(Elaboratable):
                     raw_instrs[i].access_fault.eq(
                         Mux(s1_data.access_fault, FetchLayouts.AccessFaultFlag.ACCESS_FAULT, 0)
                     ),
+                    raw_instrs[i].cfi_type.eq(predecoded_instr[i].cfi_type),
                 ]
 
             if Extension.C in self.gen_params.isa.extensions:

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -1,3 +1,4 @@
+from math import lcm
 from amaranth import *
 from amaranth.lib.data import ArrayLayout
 from transactron.lib import BasicFifo, WideFifo, Semaphore, logging, Pipe
@@ -59,11 +60,11 @@ class FetchUnit(Elaboratable):
         """
         self.gen_params = gen_params
         self.icache = icache
-        self.cont = Method(i=gen_params.get(FetchLayouts).raw_instr)
         self.stall_unsafe = Method()
 
         self.layouts = self.gen_params.get(FetchLayouts)
 
+        self.cont = Method(i=self.layouts.fetch_result)
         self.fetch_request = Method(i=self.layouts.fetch_request)
         self.fetch_writeback = Method(i=self.layouts.fetch_writeback)
 
@@ -87,14 +88,25 @@ class FetchUnit(Elaboratable):
         # Serializer creates a continuous instruction stream from fetch
         # blocks, which can have holes in them.
         m.submodules.aligner = aligner = StableSelectingNetwork(fetch_width, self.layouts.raw_instr)
+        serializer_depth = 2 * lcm(self.gen_params.frontend_superscalarity, fetch_width)
         m.submodules.serializer = serializer = WideFifo(
-            self.layouts.raw_instr, depth=2 * fetch_width, read_width=1, write_width=fetch_width
+            self.layouts.raw_instr,
+            depth=serializer_depth,
+            read_width=self.gen_params.frontend_superscalarity,
+            write_width=fetch_width,
         )
 
         with Transaction(name="cont").body(m):
-            raw_instr = serializer.read(m, count=1).data[0]
-            log.info(m, True, "Sending an instr to the backend pc=0x{:x} instr=0x{:x}", raw_instr.pc, raw_instr.instr)
-            self.cont(m, raw_instr)
+            result = serializer.read(m, count=self.gen_params.frontend_superscalarity)
+            for i in range(self.gen_params.frontend_superscalarity):
+                log.info(
+                    m,
+                    i < result.count,
+                    "Sending an instr to the backend pc=0x{:x} instr=0x{:x}",
+                    result.data[i].pc,
+                    result.data[i].instr,
+                )
+            self.cont(m, result)
 
         m.submodules.fetch_requests = fetch_requests = BasicFifo(make_layout(fields.pc), depth=2)
 

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -97,12 +97,13 @@ class FetchUnit(Elaboratable):
         )
 
         with Transaction(name="cont").body(m):
+            peek_result = serializer.peek(m)
             count = Signal(range(self.gen_params.frontend_superscalarity + 1))
-            result = serializer.read(m, count=count)
             # we want only one branch insn in scheduling group, and only at the beginning (for simplicity)
-            # some insts in result.data might not be valid, but this is still correct
-            which_is_branch = [0] + [instr.cfi_type == CfiType.BRANCH for instr in result.data][1:]
+            # some insts in peek_result.data might not be valid, but this is still correct
+            which_is_branch = [0] + [instr.cfi_type == CfiType.BRANCH for instr in peek_result.data][1:]
             m.d.comb += count.eq(count_trailing_zeros(Cat(which_is_branch)))
+            result = serializer.read(m, count=count)
             for i in range(self.gen_params.frontend_superscalarity):
                 log.info(
                     m,

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -1,7 +1,7 @@
 from amaranth import *
 
 from transactron.core import *
-from transactron.lib import BasicFifo, Connect, Pipe
+from transactron.lib import BasicFifo, Connect, Pipe, WideFifo
 from transactron.utils import assign
 from transactron.utils.dependencies import DependencyContext
 
@@ -132,7 +132,7 @@ class CoreFrontend(Elaboratable):
         self.gen_params = gen_params
         self.connections = DependencyContext.get()
 
-        self.instr_buffer = BasicFifo(self.gen_params.get(FetchLayouts).raw_instr, self.gen_params.instr_buffer_size)
+        self.instr_buffer = BasicFifo(self.gen_params.get(FetchLayouts).fetch_result, self.gen_params.instr_buffer_size)
 
         cache_layouts = self.gen_params.get(ICacheLayouts)
         if gen_params.icache_params.enable:
@@ -179,10 +179,20 @@ class CoreFrontend(Elaboratable):
         m.submodules.instr_buffer = self.instr_buffer
 
         m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)
+        m.submodules.temporary_serializer = temporary_serializer = WideFifo(
+            self.gen_params.get(DecodeLayouts).decoded_instr,
+            2 * self.gen_params.frontend_superscalarity,
+            read_width=self.gen_params.frontend_superscalarity,
+            write_width=1,
+        )
         decode.get_raw.provide(self.instr_buffer.read)
-        decode.push_decoded.provide(self.decode_buff.write)
+        decode.push_decoded.provide(temporary_serializer.write)
 
         m.submodules.decode_buff = self.decode_buff
+
+        with Transaction(name="TemporarySerializerOut").body(m):
+            res = temporary_serializer.read(m, count=1)
+            self.decode_buff.write(m, res.data[0])
 
         m.submodules.rollback_tagger = rollback_tagger = self.rollback_tagger
         rollback_tagger.get_instr.provide(self.decode_buff.read)

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -178,13 +178,15 @@ class CoreFrontend(Elaboratable):
         m.submodules.fetch = self.fetch
         m.submodules.instr_buffer = self.instr_buffer
 
-        m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)
+        # TODO: remove after more scheduler superscalarity
         m.submodules.temporary_serializer = temporary_serializer = WideFifo(
             self.gen_params.get(DecodeLayouts).decoded_instr,
             2 * self.gen_params.frontend_superscalarity,
-            read_width=self.gen_params.frontend_superscalarity,
-            write_width=1,
+            read_width=1,
+            write_width=self.gen_params.frontend_superscalarity,
         )
+
+        m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)
         decode.get_raw.provide(self.instr_buffer.read)
         decode.push_decoded.provide(temporary_serializer.write)
 

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -1,7 +1,7 @@
 from amaranth import *
 
 from transactron.core import *
-from transactron.lib import BasicFifo, Connect, Pipe, WideFifo
+from transactron.lib import BasicFifo, Connect, WideFifo
 from transactron.utils import assign
 from transactron.utils.dependencies import DependencyContext
 
@@ -37,8 +37,8 @@ class RollbackTagger(Elaboratable):
     def __init__(self, gen_params: GenParams) -> None:
         self.gen_params = gen_params
 
-        self.get_instr = Method(o=gen_params.get(DecodeLayouts).decoded_instr)
-        self.push_instr = Method(i=gen_params.get(SchedulerLayouts).scheduler_in)
+        self.get_instr = Method(o=gen_params.get(DecodeLayouts).decode_result)
+        self.push_instr = Method(i=gen_params.get(DecodeLayouts).tagged_decode_result)
 
         self.rollback = Method(i=gen_params.get(RATLayouts).rollback_in)
         DependencyContext.get().add_dependency(RollbackKey(), self.rollback)
@@ -50,16 +50,18 @@ class RollbackTagger(Elaboratable):
         rollback_tag_v = Signal()
 
         with Transaction().body(m):
-            instr = self.get_instr(m)
+            instrs = self.get_instr(m)
 
-            is_branch = instr.exec_fn.op_type == OpType.BRANCH
+            is_branch = instrs.data[0].exec_fn.op_type == OpType.BRANCH
             # no need to make checkpoint at JALR, we currently stall the fetch on it
 
-            out = Signal(self.gen_params.get(SchedulerLayouts).scheduler_in)
-            m.d.av_comb += assign(out, instr)
-            m.d.av_comb += out.rollback_tag.eq(rollback_tag)
-            m.d.av_comb += out.rollback_tag_v.eq(rollback_tag_v)
-            m.d.av_comb += out.commit_checkpoint.eq(is_branch)
+            out = Signal(self.gen_params.get(DecodeLayouts).tagged_decode_result)
+            m.d.av_comb += assign(out, instrs)
+            # TODO: as branch is always the first insn, these should be per group
+            for i in range(self.gen_params.frontend_superscalarity):
+                m.d.av_comb += out.data[i].rollback_tag.eq(rollback_tag)
+                m.d.av_comb += out.data[i].rollback_tag_v.eq(rollback_tag_v)
+            m.d.av_comb += out.data[0].commit_checkpoint.eq(is_branch)
 
             m.d.sync += rollback_tag_v.eq(0)
 
@@ -152,8 +154,14 @@ class CoreFrontend(Elaboratable):
         self.fetch.cont.provide(self.instr_buffer.write)
         self.fetch.stall_unsafe.provide(self.stall_ctrl.stall_unsafe)
 
-        self.output_pipe = Pipe(self.gen_params.get(SchedulerLayouts).scheduler_in)
-        self.decode_buff = Connect(self.gen_params.get(DecodeLayouts).decoded_instr)
+        # TODO: change back to Pipe after Scheduler made superscalar
+        self.output_pipe = WideFifo(
+            self.gen_params.get(SchedulerLayouts).scheduler_in,
+            2 * gen_params.frontend_superscalarity,
+            read_width=1,
+            write_width=gen_params.frontend_superscalarity,
+        )
+        self.decode_buff = Connect(self.gen_params.get(DecodeLayouts).decode_result)
 
         # TODO: move and implement these methods
         jb_layouts = self.gen_params.get(JumpBranchLayouts)
@@ -161,7 +169,7 @@ class CoreFrontend(Elaboratable):
         self.target_pred_resp = Method(o=jb_layouts.predicted_jump_target_resp)
         DependencyContext.get().add_dependency(PredictedJumpTargetKey(), (self.target_pred_req, self.target_pred_resp))
 
-        self.consume_instr = self.output_pipe.read
+        self.consume_instr = Method(o=self.gen_params.get(SchedulerLayouts).scheduler_in)
         self.resume_from_exception = self.stall_ctrl.resume_from_exception
         self.stall = Method()
 
@@ -178,23 +186,11 @@ class CoreFrontend(Elaboratable):
         m.submodules.fetch = self.fetch
         m.submodules.instr_buffer = self.instr_buffer
 
-        # TODO: remove after more scheduler superscalarity
-        m.submodules.temporary_serializer = temporary_serializer = WideFifo(
-            self.gen_params.get(DecodeLayouts).decoded_instr,
-            2 * self.gen_params.frontend_superscalarity,
-            read_width=1,
-            write_width=self.gen_params.frontend_superscalarity,
-        )
-
         m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)
         decode.get_raw.provide(self.instr_buffer.read)
-        decode.push_decoded.provide(temporary_serializer.write)
+        decode.push_decoded.provide(self.decode_buff.write)
 
         m.submodules.decode_buff = self.decode_buff
-
-        with Transaction(name="TemporarySerializerOut").body(m):
-            res = temporary_serializer.read(m, count=1)
-            self.decode_buff.write(m, res.data[0])
 
         m.submodules.rollback_tagger = rollback_tagger = self.rollback_tagger
         rollback_tagger.get_instr.provide(self.decode_buff.read)
@@ -210,6 +206,10 @@ class CoreFrontend(Elaboratable):
         with Transaction(name="DiscardBranchVerify").body(m):
             read = self.connections.get_dependency(BranchVerifyKey())
             read(m)  # Consume to not block JB Unit
+
+        @def_method(m, self.consume_instr)
+        def _():
+            return self.output_pipe.read(m, count=1).data[0]
 
         @def_method(m, self.target_pred_req)
         def _():

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -541,6 +541,11 @@ class FetchLayouts:
             fields.predicted_taken,
         )
 
+        self.fetch_result = make_layout(
+            ("count", range(gen_params.frontend_superscalarity + 1)),
+            ("data", ArrayLayout(self.raw_instr, gen_params.frontend_superscalarity)),
+        )
+
         self.fetch_request = make_layout(fields.pc)
         self.fetch_writeback = make_layout(("redirect", 1), ("redirect_target", gen_params.isa.xlen))
         self.redirect = make_layout(fields.pc)
@@ -580,6 +585,11 @@ class DecodeLayouts:
             fields.imm,
             fields.csr,
             fields.pc,
+        )
+
+        self.decode_result = make_layout(
+            ("count", range(gen_params.frontend_superscalarity + 1)),
+            ("data", ArrayLayout(self.decoded_instr, gen_params.frontend_superscalarity)),
         )
 
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -593,6 +593,23 @@ class DecodeLayouts:
             ("data", ArrayLayout(self.decoded_instr, gen_params.frontend_superscalarity)),
         )
 
+        # TODO: move tag fields to tagged_decode_result
+        self.tagged_decoded_instr = make_layout(
+            fields.exec_fn,
+            fields.regs_l,
+            fields.imm,
+            fields.csr,
+            fields.pc,
+            fields.rollback_tag,
+            fields.rollback_tag_v,
+            fields.commit_checkpoint,
+        )
+
+        self.tagged_decode_result = make_layout(
+            ("count", range(gen_params.frontend_superscalarity + 1)),
+            ("data", ArrayLayout(self.tagged_decoded_instr, gen_params.frontend_superscalarity)),
+        )
+
 
 class FuncUnitLayouts:
     """Layouts used in functional units."""

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -539,6 +539,7 @@ class FetchLayouts:
             self.access_fault,
             fields.rvc,
             fields.predicted_taken,
+            fields.cfi_type,
         )
 
         self.fetch_result = make_layout(

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -260,6 +260,7 @@ full_core_config = CoreConfiguration(
     fetch_block_bytes_log=4,
     instr_buffer_size=16,
     pmp_register_count=16,
+    frontend_superscalarity=2,
     announcement_superscalarity=2,
 )
 

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -193,7 +193,8 @@ class ROBAllocation(Elaboratable):
                         "rp_dst": instr.regs_p.rp_dst,
                         "tag_increment": instr.tag_increment,
                     }
-                ],
+                ]
+                * self.gen_params.frontend_superscalarity,  # TODO: actual superscalarity
             )
 
             m.d.comb += assign(data_out, instr, fields=AssignType.COMMON)

--- a/test/frontend/test_decode_stage.py
+++ b/test/frontend/test_decode_stage.py
@@ -5,7 +5,6 @@ from transactron.testing import (
     SimpleTestCircuit,
     TestbenchContext,
     data_const_to_dict,
-    def_method_mock,
 )
 
 from coreblocks.frontend.decoder.decode_stage import Decode

--- a/test/frontend/test_decode_stage.py
+++ b/test/frontend/test_decode_stage.py
@@ -50,7 +50,7 @@ class TestDecode(TestCaseWithSimulator):
     def setup(self, fixture_initialize_testing_env):
         self.gen_params = GenParams(test_core_config.replace(start_pc=24))
 
-        self.decode = Decode(self.gen_params)
+        self.decode = Decode(self.gen_params, lambda m: ())
 
         self.m = SimpleTestCircuit(self.decode)
 
@@ -63,10 +63,6 @@ class TestDecode(TestCaseWithSimulator):
             if data["imm"] is None:
                 data["imm"] = decoded.imm
             assert data_const_to_dict(decoded) == data
-
-    @def_method_mock(lambda self: self.m.illegal)
-    def illegal_mock(self):
-        pass  # TODO: implement
 
     def test(self):
         with self.run_simulation(self.m) as sim:

--- a/test/frontend/test_decode_stage.py
+++ b/test/frontend/test_decode_stage.py
@@ -1,16 +1,14 @@
 from typing import Optional
 import pytest
-from transactron.lib import Adapter
-from transactron.utils.amaranth_ext.elaboratables import ModuleConnector
 from transactron.testing import (
     TestCaseWithSimulator,
-    TestbenchIO,
     SimpleTestCircuit,
     TestbenchContext,
     data_const_to_dict,
+    def_method_mock,
 )
 
-from coreblocks.frontend.decoder.decode_stage import DecodeStage
+from coreblocks.frontend.decoder.decode_stage import Decode
 from coreblocks.params import GenParams
 from coreblocks.arch import OpType, Funct3, Funct7
 from coreblocks.params.configurations import test_core_config
@@ -52,26 +50,13 @@ class TestDecode(TestCaseWithSimulator):
     def setup(self, fixture_initialize_testing_env):
         self.gen_params = GenParams(test_core_config.replace(start_pc=24))
 
-        self.decode = DecodeStage(self.gen_params)
+        self.decode = Decode(self.gen_params)
 
-        self.push_raw = TestbenchIO(Adapter.create(self.decode.get_raw))
-        self.get_decoded = TestbenchIO(Adapter.create(self.decode.push_decoded))
+        self.m = SimpleTestCircuit(self.decode)
 
-        self.m = SimpleTestCircuit(
-            ModuleConnector(
-                decode=self.decode,
-                push_raw=self.push_raw,
-                get_decoded=self.get_decoded,
-            )
-        )
-
-    async def decode_input_proc(self, sim: TestbenchContext):
-        for instr, access_fault, _ in tests:
-            await self.push_raw.call(sim, instr=instr, access_fault=access_fault)
-
-    async def decode_output_proc(self, sim: TestbenchContext):
-        for _, _, data in tests:
-            decoded = await self.get_decoded.call(sim)
+    async def decode_proc(self, sim: TestbenchContext):
+        for instr, access_fault, data in tests:
+            decoded = await self.m.decode.call(sim, instr=instr, access_fault=access_fault)
             data = dict(data)
             if data["csr"] is None:
                 data["csr"] = decoded.csr
@@ -79,7 +64,10 @@ class TestDecode(TestCaseWithSimulator):
                 data["imm"] = decoded.imm
             assert data_const_to_dict(decoded) == data
 
+    @def_method_mock(lambda self: self.m.illegal)
+    def illegal_mock(self):
+        pass  # TODO: implement
+
     def test(self):
         with self.run_simulation(self.m) as sim:
-            sim.add_testbench(self.decode_input_proc)
-            sim.add_testbench(self.decode_output_proc)
+            sim.add_testbench(self.decode_proc)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -48,32 +48,25 @@ class MockedICache(Elaboratable, CacheInterface):
         return m
 
 
-@parameterized_class(
-    ("name", "fetch_block_log", "with_rvc"),
-    [
-        ("block4B", 2, False),
-        ("block4B_rvc", 2, True),
-        ("block8B", 3, False),
-        ("block8B_rvc", 3, True),
-        ("block16B", 4, False),
-        ("block16B_rvc", 4, True),
-    ],
-)
+@pytest.mark.parametrize("fetch_block_log", [2, 3, 4])
+@pytest.mark.parametrize("with_rvc", [False, True])
+@pytest.mark.parametrize("superscalarity", [1, 2])
 class TestFetchUnit(TestCaseWithSimulator):
-    fetch_block_log: int
-    with_rvc: bool
-
     @pytest.fixture(autouse=True)
-    def setup(self, fixture_initialize_testing_env):
+    def setup(self, fixture_initialize_testing_env, fetch_block_log: int, with_rvc: bool, superscalarity: int):
+        self.with_rvc = with_rvc
         self.pc = 0
         self.gen_params = GenParams(
             test_core_config.replace(
-                start_pc=self.pc, compressed=self.with_rvc, fetch_block_bytes_log=self.fetch_block_log
+                start_pc=self.pc,
+                compressed=with_rvc,
+                fetch_block_bytes_log=fetch_block_log,
+                frontend_superscalarity=superscalarity,
             )
         )
 
         self.icache = MockedICache(self.gen_params)
-        fifo = BasicFifo(self.gen_params.get(FetchLayouts).raw_instr, depth=2)
+        fifo = BasicFifo(self.gen_params.get(FetchLayouts).fetch_result, depth=2)
         self.fifo = SimpleTestCircuit(fifo, exclude={"write"})
         self.fetch_resume_mock = TestbenchIO(Adapter())
 
@@ -201,14 +194,10 @@ class TestFetchUnit(TestCaseWithSimulator):
                 self.stalled = True
 
     async def fetch_out_check(self, sim: TestbenchContext):
-        while self.instr_queue:
-            instr = self.instr_queue.popleft()
-
+        async def check_instr(instr, v):
             access_fault = instr["pc"] in self.memerr
             if not instr["rvc"]:
                 access_fault |= instr["pc"] + 2 in self.memerr
-
-            v = await self.fifo.read.call(sim)
 
             assert v["pc"] == instr["pc"]
             assert v["access_fault"] == access_fault
@@ -234,6 +223,20 @@ class TestFetchUnit(TestCaseWithSimulator):
                         instr["pc"] & ~(self.gen_params.fetch_block_bytes - 1)
                     ) + self.gen_params.fetch_block_bytes
                 self.backend_redirect.append(resume_pc)
+
+                return True
+
+        while self.instr_queue:
+            v = await self.fifo.read.call(sim)
+
+            for k in range(v.count):
+                instr = self.instr_queue.popleft()
+                # if fault happened, throw away rest of insns
+                if await check_instr(instr, v.data[k]):
+                    break
+                # test ended, garbage insns ahead
+                if not self.instr_queue:
+                    break
 
     async def requester(self, sim: ProcessContext):
         while True:


### PR DESCRIPTION
This PR adds superscalar decoding. Serialization of the instruction stream is moved, for now, before the rollback tagger.

An architectural decision needs to be made later about how checkpointing works together with superscalarity. I believe that there is no need for multiple checkpoints per cycle. (Idea for later: for now, require that the jump must be the first instruction in loaded groups.)

TODO:
* [x] fix tests.