### PR TITLE
Implement initial Fetch Target Queue (FTQ)

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -17,7 +17,7 @@ from transactron.lib.metrics import *
 
 from coreblocks.params.genparams import GenParams
 from coreblocks.arch import ExceptionCause
-from coreblocks.interface.keys import CoreStateKey, CSRInstancesKey, InstructionPrecommitKey
+from coreblocks.interface.keys import CoreStateKey, CSRInstancesKey, InstructionPrecommitKey, FTQCommitEntry
 from coreblocks.priv.csr.csr_instances import CSRAddress, DoubleCounterCSR
 from coreblocks.arch.isa_consts import TrapVectorMode
 
@@ -71,6 +71,8 @@ class Retirement(Elaboratable):
         m_csr = self.dependency_manager.get_dependency(CSRInstancesKey()).m_mode
         m.submodules.instret_csr = self.instret_csr
 
+        ftq_commit = self.dependency_manager.get_dependency(FTQCommitEntry())
+
         side_fx = Signal(init=1)
 
         def free_phys_reg(rp_dst: Value):
@@ -86,6 +88,7 @@ class Retirement(Elaboratable):
 
             # free old rp_dst from overwritten R-RAT mapping
             free_phys_reg(rat_out.old_rp_dst)
+            ftq_commit(m, ftq_ptr=rob_entry.rob_data.ftq_ptr)
 
             self.instret_csr.increment(m)
             self.perf_instr_ret.incr(m)

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -19,7 +19,7 @@ from transactron.lib.metrics import *
 from coreblocks.params.genparams import GenParams
 from coreblocks.arch import ExceptionCause, PrivilegeLevel
 from coreblocks.arch.csr_address import CounterEnableFieldOffsets
-from coreblocks.interface.keys import CoreStateKey, CSRInstancesKey, InstructionPrecommitKey, FTQCommitEntry
+from coreblocks.interface.keys import CoreStateKey, CSRInstancesKey, InstructionPrecommitKey, FTQCommitKey
 from coreblocks.priv.csr.csr_instances import CSRAddress, counteren_access_filter
 from coreblocks.priv.csr.csr_register import CSRRegister
 from coreblocks.priv.csr.double_shadow import DoubleShadowCSR
@@ -107,7 +107,7 @@ class Retirement(Elaboratable):
         m.submodules.instret_csr = self.instret_csr
         m.submodules.instret_shadow = self.instret_shadow
 
-        ftq_commit = self.dependency_manager.get_dependency(FTQCommitEntry())
+        ftq_commit = self.dependency_manager.get_dependency(FTQCommitKey())
 
         def free_phys_reg(i: int, rp_dst: Value):
             # mark reg in Register File as free

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -19,11 +19,7 @@ from transactron.lib.metrics import *
 from coreblocks.params.genparams import GenParams
 from coreblocks.arch import ExceptionCause, PrivilegeLevel
 from coreblocks.arch.csr_address import CounterEnableFieldOffsets
-from coreblocks.interface.keys import (
-    CoreStateKey,
-    CSRInstancesKey,
-    InstructionPrecommitKey,
-)
+from coreblocks.interface.keys import CoreStateKey, CSRInstancesKey, InstructionPrecommitKey, FTQCommitEntry
 from coreblocks.priv.csr.csr_instances import CSRAddress, counteren_access_filter
 from coreblocks.priv.csr.csr_register import CSRRegister
 from coreblocks.priv.csr.double_shadow import DoubleShadowCSR
@@ -110,6 +106,8 @@ class Retirement(Elaboratable):
         s_csr = csr_instances.s_mode if self.gen_params.supervisor_mode else None
         m.submodules.instret_csr = self.instret_csr
         m.submodules.instret_shadow = self.instret_shadow
+
+        ftq_commit = self.dependency_manager.get_dependency(FTQCommitEntry())
 
         def free_phys_reg(i: int, rp_dst: Value):
             # mark reg in Register File as free
@@ -257,11 +255,17 @@ class Retirement(Elaboratable):
                         + Mux(exception, no_trap_count + commit_trapping, retire_count),
                     )
 
+                    last_commit_ftq_ptr = Signal.like(rob_entries.entries[0].rob_data.ftq_ptr)
                     for i in range(self.gen_params.retirement_superscalarity):
                         with m.If(i - commit_trapping < no_trap_count):
                             retire_instr(i, rob_entries.entries[i])
+                            m.d.av_comb += last_commit_ftq_ptr.eq(rob_entries.entries[i].rob_data.ftq_ptr)
                         with m.Elif(i < retire_count):
                             flush_instr(i, rob_entries.entries[i])
+
+                    # Commit the FTQ entry for the last retired instruction this cycle.
+                    with m.If(no_trap_count.bool() | commit_trapping):
+                        ftq_commit(m, ftq_ptr=last_commit_ftq_ptr)
 
             with m.State("TRAP_FLUSH"):
                 with Transaction(name="Retirement_FLUSH").body(m):

--- a/coreblocks/frontend/bpu/bpu.py
+++ b/coreblocks/frontend/bpu/bpu.py
@@ -1,0 +1,50 @@
+from amaranth import *
+
+from transactron.core import *
+from transactron.utils.transactron_helpers import make_layout
+from transactron.lib import logging
+from transactron.lib.connectors import Pipe
+
+from coreblocks.params import *
+from coreblocks.frontend import FrontendParams
+from coreblocks.interface.layouts import CommonLayoutFields
+from coreblocks.interface.layouts import BranchPredictionLayouts
+
+log = logging.HardwareLogger("frontend.bpu")
+
+
+class BranchPredictionUnit(Elaboratable):
+    request: Provided[Method]
+    write_prediction: Required[Method]
+    flush: Provided[Method]
+
+    def __init__(self, gen_params: GenParams) -> None:
+        self.gen_params = gen_params
+        self.layouts = gen_params.get(BranchPredictionLayouts)
+
+        self.request = Method(i=self.layouts.request)
+        self.write_prediction = Method(i=self.layouts.write_prediction)
+        self.flush = Method()
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        fparams = self.gen_params.get(FrontendParams)
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        # TODO: 'clear' method of Pipe creates conflicts with other methods. This blocking behavior is not
+        # needed here and creates a lot of unnecessary logic and delays
+        m.submodules.pipe = pipe = Pipe(layout=make_layout(fields.pc, fields.ftq_ptr))
+
+        @def_method(m, self.request)
+        def _(pc, ftq_ptr):
+            pipe.write(m, pc=fparams.pc_from_fb(fparams.fb_addr(pc) + 1, 0), ftq_ptr=ftq_ptr)
+
+        with Transaction(name="BPU_Stage1").body(m):
+            self.write_prediction(m, pipe.read(m))
+
+        @def_method(m, self.flush, nonexclusive=True)
+        def _():
+            pipe.clear(m)
+
+        return m

--- a/coreblocks/frontend/bpu/bpu.py
+++ b/coreblocks/frontend/bpu/bpu.py
@@ -1,0 +1,50 @@
+from amaranth import *
+
+from transactron.core import *
+from transactron.utils.transactron_helpers import make_layout
+from transactron.utils import logging
+from transactron.lib.connectors import Pipe
+
+from coreblocks.params import *
+from coreblocks.frontend import FrontendParams
+from coreblocks.interface.layouts import CommonLayoutFields
+from coreblocks.interface.layouts import BranchPredictionLayouts
+
+log = logging.HardwareLogger("frontend.bpu")
+
+
+class BranchPredictionUnit(Elaboratable):
+    request: Provided[Method]
+    write_prediction: Required[Method]
+    flush: Provided[Method]
+
+    def __init__(self, gen_params: GenParams) -> None:
+        self.gen_params = gen_params
+        self.layouts = gen_params.get(BranchPredictionLayouts)
+
+        self.request = Method(i=self.layouts.request)
+        self.write_prediction = Method(i=self.layouts.write_prediction)
+        self.flush = Method()
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        fparams = self.gen_params.get(FrontendParams)
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        # TODO: 'clear' method of Pipe creates conflicts with other methods. This blocking behavior is not
+        # needed here and creates a lot of unnecessary logic and delays
+        m.submodules.pipe = pipe = Pipe(layout=make_layout(fields.pc, fields.ftq_ptr))
+
+        @def_method(m, self.request)
+        def _(pc, ftq_ptr):
+            pipe.write(m, pc=fparams.pc_from_fb(fparams.fb_addr(pc) + 1, 0), ftq_ptr=ftq_ptr)
+
+        with Transaction(name="BPU_Stage1").body(m):
+            self.write_prediction(m, pipe.read(m))
+
+        @def_method(m, self.flush, nonexclusive=True)
+        def _():
+            pipe.clear(m)
+
+        return m

--- a/coreblocks/frontend/bpu/bpu.py
+++ b/coreblocks/frontend/bpu/bpu.py
@@ -2,7 +2,8 @@ from amaranth import *
 
 from transactron.core import *
 from transactron.utils.transactron_helpers import make_layout
-from transactron.utils import logging, MethodLayout
+from transactron.utils import logging
+from transactron.lib import Pipe
 
 from coreblocks.params import *
 from coreblocks.frontend import FrontendParams
@@ -10,41 +11,6 @@ from coreblocks.interface.layouts import CommonLayoutFields
 from coreblocks.interface.layouts import BranchPredictionLayouts
 
 log = logging.HardwareLogger("frontend.bpu")
-
-
-class _Pipe(Elaboratable):
-    # TODO: 'clear' method of Pipe creates conflicts with other methods. This blocking behavior is not
-    # needed there and creates a lot of unnecessary logic and delays. Remove this once the clear method
-    # is non-blocking
-
-    def __init__(self, layout: MethodLayout):
-        self.read = Method(o=layout)
-        self.write = Method(i=layout)
-        self.clear = Method()
-
-    def elaborate(self, platform):
-        m = TModule()
-
-        reg = Signal.like(self.read.data_out)
-        reg_valid = Signal()
-
-        self.read.schedule_before(self.write)  # to avoid combinational loops
-
-        @def_method(m, self.read, ready=reg_valid)
-        def _():
-            m.d.sync += reg_valid.eq(0)
-            return reg
-
-        @def_method(m, self.write, ready=~reg_valid | self.read.run)
-        def _(arg):
-            m.d.sync += reg.eq(arg)
-            m.d.sync += reg_valid.eq(1)
-
-        @def_method(m, self.clear)
-        def _():
-            m.d.sync += reg_valid.eq(0)
-
-        return m
 
 
 class BranchPredictionUnit(Elaboratable):
@@ -66,7 +32,7 @@ class BranchPredictionUnit(Elaboratable):
         fparams = self.gen_params.get(FrontendParams)
         fields = self.gen_params.get(CommonLayoutFields)
 
-        m.submodules.pipe = pipe = _Pipe(layout=make_layout(fields.pc, fields.ftq_ptr))
+        m.submodules.pipe = pipe = Pipe(layout=make_layout(fields.pc, fields.ftq_ptr))
 
         @def_method(m, self.request)
         def _(pc, ftq_ptr):

--- a/coreblocks/frontend/bpu/bpu.py
+++ b/coreblocks/frontend/bpu/bpu.py
@@ -2,8 +2,7 @@ from amaranth import *
 
 from transactron.core import *
 from transactron.utils.transactron_helpers import make_layout
-from transactron.utils import logging
-from transactron.lib.connectors import Pipe
+from transactron.utils import logging, MethodLayout
 
 from coreblocks.params import *
 from coreblocks.frontend import FrontendParams
@@ -11,6 +10,41 @@ from coreblocks.interface.layouts import CommonLayoutFields
 from coreblocks.interface.layouts import BranchPredictionLayouts
 
 log = logging.HardwareLogger("frontend.bpu")
+
+
+class _Pipe(Elaboratable):
+    # TODO: 'clear' method of Pipe creates conflicts with other methods. This blocking behavior is not
+    # needed there and creates a lot of unnecessary logic and delays. Remove this once the clear method
+    # is non-blocking
+
+    def __init__(self, layout: MethodLayout):
+        self.read = Method(o=layout)
+        self.write = Method(i=layout)
+        self.clear = Method()
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        reg = Signal.like(self.read.data_out)
+        reg_valid = Signal()
+
+        self.read.schedule_before(self.write)  # to avoid combinational loops
+
+        @def_method(m, self.read, ready=reg_valid)
+        def _():
+            m.d.sync += reg_valid.eq(0)
+            return reg
+
+        @def_method(m, self.write, ready=~reg_valid | self.read.run)
+        def _(arg):
+            m.d.sync += reg.eq(arg)
+            m.d.sync += reg_valid.eq(1)
+
+        @def_method(m, self.clear)
+        def _():
+            m.d.sync += reg_valid.eq(0)
+
+        return m
 
 
 class BranchPredictionUnit(Elaboratable):
@@ -32,9 +66,7 @@ class BranchPredictionUnit(Elaboratable):
         fparams = self.gen_params.get(FrontendParams)
         fields = self.gen_params.get(CommonLayoutFields)
 
-        # TODO: 'clear' method of Pipe creates conflicts with other methods. This blocking behavior is not
-        # needed here and creates a lot of unnecessary logic and delays
-        m.submodules.pipe = pipe = Pipe(layout=make_layout(fields.pc, fields.ftq_ptr))
+        m.submodules.pipe = pipe = _Pipe(layout=make_layout(fields.pc, fields.ftq_ptr))
 
         @def_method(m, self.request)
         def _(pc, ftq_ptr):

--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -108,6 +108,7 @@ class DecodeStage(Elaboratable):
                     ),
                     "csr": instr_decoder.csr,
                     "pc": raw.pc,
+                    "ftq_ptr": raw.ftq_ptr,
                 },
             )
 

--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -31,7 +31,7 @@ class Decode(Elaboratable):
         m = TModule()
 
         @def_method(m, self.decode)
-        def _(instr, pc, rvc, predicted_taken, access_fault, cfi_type):
+        def _(instr, pc, rvc, predicted_taken, access_fault, cfi_type, ftq_ptr):
             m.submodules.instr_decoder = instr_decoder = InstrDecoder(self.gen_params)
             m.d.top_comb += instr_decoder.instr.eq(instr)
 
@@ -93,6 +93,7 @@ class Decode(Elaboratable):
                 ),
                 "csr": instr_decoder.csr,
                 "pc": pc,
+                "ftq_ptr": ftq_ptr,
             }
 
         return m

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -96,7 +96,7 @@ class FetchUnit(Elaboratable):
             log.info(m, True, "Sending an instr to the backend pc=0x{:x} instr=0x{:x}", raw_instr.pc, raw_instr.instr)
             self.cont(m, raw_instr)
 
-        m.submodules.fetch_requests = fetch_requests = BasicFifo(make_layout(fields.pc), depth=2)
+        m.submodules.fetch_requests = fetch_requests = BasicFifo(make_layout(fields.pc, fields.ftq_ptr), depth=2)
 
         # This limits number of fetch blocks the fetch unit can process
         # at a time. We start counting when sending a request to the cache and
@@ -115,11 +115,11 @@ class FetchUnit(Elaboratable):
         # - send a request to the instruction cache
         #
         @def_method(m, self.fetch_request)
-        def _(pc):
+        def _(pc, ftq_ptr):
             log.info(m, True, "[IFU] request pc=0x{:x}", pc)
             req_counter.acquire(m)
             self.icache.issue_req(m, addr=pc)
-            fetch_requests.write(m, pc=pc)
+            fetch_requests.write(m, pc=pc, ftq_ptr=ftq_ptr)
 
         #
         # State passed between stage 1 and stage 2
@@ -127,6 +127,7 @@ class FetchUnit(Elaboratable):
         m.submodules.s1_s2_pipe = s1_s2_pipe = Pipe(
             [
                 fields.fb_addr,
+                fields.ftq_ptr,
                 ("instr_valid", fetch_width),
                 ("access_fault", 1),
                 ("rvc", fetch_width),
@@ -225,6 +226,7 @@ class FetchUnit(Elaboratable):
             s1_s2_pipe.write(
                 m,
                 fb_addr=fetch_block_addr,
+                ftq_ptr=fetch_request.ftq_ptr,
                 instr_valid=valid_instr_mask,
                 access_fault=cache_resp.error,
                 rvc=is_rvc,
@@ -256,6 +258,7 @@ class FetchUnit(Elaboratable):
             req_counter.release(m)
             s1_data = s1_s2_pipe.read(m)
 
+            ftq_ptr = s1_data.ftq_ptr
             instrs = s1_data.instrs
             fetch_block_addr = s1_data.fb_addr
             instr_valid = s1_data.instr_valid
@@ -335,6 +338,7 @@ class FetchUnit(Elaboratable):
                     raw_instrs[i].access_fault.eq(
                         Mux(s1_data.access_fault, FetchLayouts.AccessFaultFlag.ACCESS_FAULT, 0)
                     ),
+                    raw_instrs[i].ftq_ptr.eq(ftq_ptr),
                 ]
 
             if Extension.C in self.gen_params.isa.extensions:
@@ -357,6 +361,7 @@ class FetchUnit(Elaboratable):
                     with m.If(access_fault | unsafe_stall | redirect):
                         self.fetch_writeback(
                             m,
+                            ftq_ptr=ftq_ptr,
                             redirect=redirect,
                             redirect_target=predcheck_res.redirect_target,
                         )

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -7,6 +7,7 @@ from transactron.lib.simultaneous import condition
 from transactron.utils import count_trailing_zeros, popcount, assign, StableSelectingNetwork, logging
 from transactron.utils.transactron_helpers import make_layout
 from transactron.utils.amaranth_ext.coding import PriorityEncoder
+from transactron.lib import Forwarder
 from transactron import *
 
 from coreblocks.cache.iface import CacheInterface
@@ -120,7 +121,7 @@ class FetchUnit(Elaboratable):
             self.cont(m, result)
 
         m.submodules.fetch_requests = fetch_requests = BasicFifo(
-            make_layout(fields.pc, ("access_fault", 1), ("page_fault", 1)),
+            make_layout(fields.pc, ("access_fault", 1), ("page_fault", 1), fields.ftq_ptr),
             depth=2,
         )
 
@@ -147,15 +148,19 @@ class FetchUnit(Elaboratable):
             mode=PMPOperationMode.INSTRUCTION_FETCH,
         )
 
+        m.submodules.ftq_ptr_forwarder = ftq_ptr_forwarder = Forwarder(make_layout(fields.ftq_ptr))
+
         @def_method(m, self.fetch_request)
-        def _(pc):
+        def _(pc, ftq_ptr):
             log.info(m, True, "[IFU] request pc=0x{:x}", pc)
             req_counter.acquire(m)
 
             addr_translator.request(m, addr=pc, is_store=0)
+            ftq_ptr_forwarder.write(m, ftq_ptr=ftq_ptr)
 
         with Transaction().body(m):
             translated = addr_translator.accept(m)
+            ftq_ptr = ftq_ptr_forwarder.read(m).ftq_ptr
             access_fault = Signal()
 
             m.d.av_comb += pmp_checker.paddr.eq(translated.paddr)
@@ -169,6 +174,7 @@ class FetchUnit(Elaboratable):
                 pc=translated.vaddr,
                 access_fault=access_fault,
                 page_fault=translated.page_fault,
+                ftq_ptr=ftq_ptr,
             )
 
         #
@@ -177,6 +183,7 @@ class FetchUnit(Elaboratable):
         m.submodules.s1_s2_pipe = s1_s2_pipe = Pipe(
             [
                 fields.fb_addr,
+                fields.ftq_ptr,
                 ("instr_valid", fetch_width),
                 ("access_fault", FetchLayouts.FaultFlag),
                 ("rvc", fetch_width),
@@ -293,6 +300,7 @@ class FetchUnit(Elaboratable):
                 instr_valid=Mux(access_fault.any(), access_fault_instr_position, instr_position_mask),
                 access_fault=access_fault,
                 rvc=is_rvc,
+                ftq_ptr=fetch_request.ftq_ptr,
                 instrs=expanded_instr,
                 instr_block_cross=instr_block_cross,
             )
@@ -321,6 +329,7 @@ class FetchUnit(Elaboratable):
             req_counter.release(m)
             s1_data = s1_s2_pipe.read(m)
 
+            ftq_ptr = s1_data.ftq_ptr
             instrs = s1_data.instrs
             fetch_block_addr = s1_data.fb_addr
             instr_valid = s1_data.instr_valid
@@ -401,6 +410,7 @@ class FetchUnit(Elaboratable):
                     raw_instrs[i].predicted_taken.eq(redirect & (predcheck_res.fb_instr_idx == i)),
                     raw_instrs[i].access_fault.eq(s1_data.access_fault),
                     raw_instrs[i].cfi_type.eq(predecoded_instr[i].cfi_type),
+                    raw_instrs[i].ftq_ptr.eq(ftq_ptr),
                 ]
 
             if Extension.ZCA in self.gen_params.isa.extensions:
@@ -421,6 +431,7 @@ class FetchUnit(Elaboratable):
                     with m.If(fault_any | unsafe_stall | redirect):
                         self.fetch_writeback(
                             m,
+                            ftq_ptr=ftq_ptr,
                             redirect=redirect,
                             redirect_target=predcheck_res.redirect_target,
                         )

--- a/coreblocks/frontend/fetch_addr_unit.py
+++ b/coreblocks/frontend/fetch_addr_unit.py
@@ -1,0 +1,73 @@
+from amaranth import *
+from transactron import *
+from transactron.utils import make_layout
+
+from coreblocks.params import GenParams
+from coreblocks.arch import *
+from coreblocks.interface.layouts import (
+    CommonLayoutFields,
+    FetchLayouts,
+)
+
+
+class FetchAddressUnit(Elaboratable):
+    """
+    Owns the speculative fetch program counter and arbitrates all frontend redirects.
+    It selects the next fetch PC based on reset, backend redirects, IFU redirects, and branch prediction results.
+    """
+
+    write: Provided[Method]
+    """Supply the next fetch PC (e.g. from a BPU prediction). Requires the current PC to have been consumed."""
+    read: Provided[Method]
+    """Consume the current fetch PC. Blocks until a valid PC is available."""
+    ifu_redirect: Provided[Method]
+    """Redirect the fetch PC after a misprediction detected by the IFU."""
+    backend_redirect: Provided[Method]
+    """Redirect the fetch PC after a misprediction resolved by the backend."""
+
+    def __init__(self, gen_params: GenParams):
+        self.gen_params = gen_params
+
+        layouts = self.gen_params.get(FetchLayouts)
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        self.write = Method(i=make_layout(fields.pc))
+        self.read = Method(o=layouts.fetch_request)
+        self.ifu_redirect = Method(i=layouts.redirect)
+        self.backend_redirect = Method(i=layouts.redirect)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        next_fetch_addr = Signal(self.gen_params.isa.xlen, init=self.gen_params.start_pc)
+        next_fetch_addr_v = Signal(init=1)
+
+        next_fetch_addr_fwd = Signal.like(self.read.data_out)
+
+        self.write.schedule_before(self.read)  # to avoid combinational loops
+
+        @def_method(m, self.write, ready=~next_fetch_addr_v)
+        def _(pc):
+            m.d.av_comb += next_fetch_addr_fwd.eq(pc)
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        with m.If(next_fetch_addr_v):
+            m.d.av_comb += next_fetch_addr_fwd.eq(next_fetch_addr)  # write method is not ready
+
+        @def_method(m, self.read, ready=next_fetch_addr_v | self.write.run)
+        def _():
+            m.d.sync += next_fetch_addr_v.eq(0)
+            return next_fetch_addr_fwd
+
+        @def_method(m, self.ifu_redirect)
+        def _(pc):
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        @def_method(m, self.backend_redirect)
+        def _(pc):
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        return m

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -7,14 +7,15 @@ from transactron.utils.dependencies import DependencyContext
 
 from coreblocks.arch.optypes import OpType
 from coreblocks.params.genparams import GenParams
-from coreblocks.frontend import FrontendParams
+from coreblocks.frontend.ftq import FetchTargetQueue
 from coreblocks.frontend.decoder.decode_stage import DecodeStage
 from coreblocks.frontend.fetch.fetch import FetchUnit
 from coreblocks.frontend.stall_controller import StallController
+from coreblocks.frontend.bpu.bpu import BranchPredictionUnit
 from coreblocks.cache.icache import ICache, ICacheBypass
 from coreblocks.cache.refiller import SimpleCommonBusCacheRefiller
 from coreblocks.interface.layouts import *
-from coreblocks.interface.keys import BranchVerifyKey, FlushICacheKey, PredictedJumpTargetKey, RollbackKey
+from coreblocks.interface.keys import FlushICacheKey, RollbackKey
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
 
 
@@ -73,49 +74,6 @@ class RollbackTagger(Elaboratable):
         return m
 
 
-class FetchAddressUnit(Elaboratable):
-    """
-    This module owns the speculative fetch program counter and arbitrates all frontend redirects.
-    It selects the next fetch PC based on reset, backend redirects, IFU redirects, and branch prediction results.
-    """
-
-    read: Provided[Method]
-    ifu_redirect: Provided[Method]
-    beckend_redirect: Provided[Method]
-
-    def __init__(self, gen_params: GenParams):
-        self.gen_params = gen_params
-
-        layouts = self.gen_params.get(FetchLayouts)
-
-        self.read = Method(o=layouts.fetch_request)
-        self.ifu_redirect = Method(i=layouts.redirect)
-        self.backend_redirect = Method(i=layouts.redirect)
-
-    def elaborate(self, platform):
-        m = TModule()
-
-        front_params = self.gen_params.get(FrontendParams)
-
-        next_fetch_pc = Signal(self.gen_params.isa.xlen, init=self.gen_params.start_pc)
-
-        @def_method(m, self.read)
-        def _():
-            # No branch prediction yet - just fallthrough to the next fetch block.
-            m.d.sync += next_fetch_pc.eq(front_params.pc_from_fb(front_params.fb_addr(next_fetch_pc) + 1, 0))
-            return next_fetch_pc
-
-        @def_method(m, self.ifu_redirect)
-        def _(pc):
-            m.d.sync += next_fetch_pc.eq(pc)
-
-        @def_method(m, self.backend_redirect)
-        def _(pc):
-            m.d.sync += next_fetch_pc.eq(pc)
-
-        return m
-
-
 class CoreFrontend(Elaboratable):
     """Frontend of the core."""
 
@@ -145,9 +103,6 @@ class CoreFrontend(Elaboratable):
 
         self.stall_ctrl = StallController(self.gen_params)
 
-        self.fetch_address_unit = FetchAddressUnit(self.gen_params)
-        self.fetch_writeback = Method(i=gen_params.get(FetchLayouts).fetch_writeback)
-
         self.fetch = FetchUnit(self.gen_params, self.icache)
         self.fetch.cont.provide(self.instr_buffer.write)
         self.fetch.stall_unsafe.provide(self.stall_ctrl.stall_unsafe)
@@ -155,11 +110,8 @@ class CoreFrontend(Elaboratable):
         self.output_pipe = Pipe(self.gen_params.get(SchedulerLayouts).scheduler_in)
         self.decode_buff = Connect(self.gen_params.get(DecodeLayouts).decoded_instr)
 
-        # TODO: move and implement these methods
-        jb_layouts = self.gen_params.get(JumpBranchLayouts)
-        self.target_pred_req = Method(i=jb_layouts.predicted_jump_target_req)
-        self.target_pred_resp = Method(o=jb_layouts.predicted_jump_target_resp)
-        DependencyContext.get().add_dependency(PredictedJumpTargetKey(), (self.target_pred_req, self.target_pred_resp))
+        self.bpu = BranchPredictionUnit(self.gen_params)
+        self.ftq = FetchTargetQueue(self.gen_params)
 
         self.consume_instr = self.output_pipe.read
         self.resume_from_exception = self.stall_ctrl.resume_from_exception
@@ -174,9 +126,20 @@ class CoreFrontend(Elaboratable):
             m.submodules.icache_refiller = self.icache_refiller
         m.submodules.icache = self.icache
 
-        m.submodules.fetch_address_unit = self.fetch_address_unit
         m.submodules.fetch = self.fetch
         m.submodules.instr_buffer = self.instr_buffer
+
+        m.submodules.ftq = self.ftq
+        m.submodules.bpu = self.bpu
+
+        self.ftq.bpu_request.provide(self.bpu.request)
+        self.ftq.bpu_flush.provide(self.bpu.flush)
+        self.ftq.stall_lock.provide(self.stall_ctrl.stall_guard)
+        self.bpu.write_prediction.provide(self.ftq.bpu_response)
+
+        self.ftq.ifu_request.provide(self.fetch.fetch_request)
+        self.fetch.fetch_writeback.provide(self.ftq.ifu_redirect)
+        self.stall_ctrl.redirect_frontend.provide(self.ftq.backend_redirect)
 
         m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)
         decode.get_raw.provide(self.instr_buffer.read)
@@ -191,39 +154,13 @@ class CoreFrontend(Elaboratable):
         m.submodules.output_pipe = self.output_pipe
 
         m.submodules.stall_ctrl = self.stall_ctrl
-        self.stall_ctrl.redirect_frontend.provide(self.fetch_address_unit.backend_redirect)
-        self.fetch.fetch_writeback.provide(self.fetch_writeback)
-
-        # TODO: Remove when Branch Predictor implemented
-        with Transaction(name="DiscardBranchVerify").body(m):
-            read = self.connections.get_dependency(BranchVerifyKey())
-            read(m)  # Consume to not block JB Unit
-
-        @def_method(m, self.target_pred_req)
-        def _():
-            pass
-
-        @def_method(m, self.target_pred_resp)
-        def _(arg):
-            return {"valid": 0, "cfi_target": 0}
-
-        @def_method(m, self.fetch_writeback)
-        def _(redirect, redirect_target):
-            with m.If(redirect):
-                self.fetch_address_unit.ifu_redirect(m, pc=redirect_target)
-
-        with Transaction(name="FetchRequest").body(m):
-            self.stall_ctrl.stall_guard(m)
-            self.fetch.fetch_request(m, self.fetch_address_unit.read(m))
-
-        def flush_frontend():
-            self.fetch.flush(m)
-            self.instr_buffer.clear(m)
-            self.output_pipe.clear(m)
 
         @def_method(m, self.stall)
         def _():
-            flush_frontend()
+            self.fetch.flush(m)
+            self.instr_buffer.clear(m)
+            self.output_pipe.clear(m)
+            self.bpu.flush(m)
             self.stall_ctrl.stall_exception(m)
 
         return m

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -7,14 +7,15 @@ from transactron.utils.dependencies import DependencyContext
 
 from coreblocks.arch.optypes import OpType
 from coreblocks.params.genparams import GenParams
-from coreblocks.frontend import FrontendParams
+from coreblocks.frontend.ftq import FetchTargetQueue
 from coreblocks.frontend.decoder.decode_stage import DecodeStage
 from coreblocks.frontend.fetch.fetch import FetchUnit
 from coreblocks.frontend.stall_controller import StallController
+from coreblocks.frontend.bpu.bpu import BranchPredictionUnit
 from coreblocks.cache.icache import ICache, ICacheBypass
 from coreblocks.cache.refiller import SimpleCommonBusCacheRefiller
 from coreblocks.interface.layouts import *
-from coreblocks.interface.keys import BranchVerifyKey, FlushICacheKey, PredictedJumpTargetKey, RollbackKey
+from coreblocks.interface.keys import FlushICacheKey, RollbackKey
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
 
 
@@ -77,49 +78,6 @@ class RollbackTagger(Elaboratable):
         return m
 
 
-class FetchAddressUnit(Elaboratable):
-    """
-    This module owns the speculative fetch program counter and arbitrates all frontend redirects.
-    It selects the next fetch PC based on reset, backend redirects, IFU redirects, and branch prediction results.
-    """
-
-    read: Provided[Method]
-    ifu_redirect: Provided[Method]
-    beckend_redirect: Provided[Method]
-
-    def __init__(self, gen_params: GenParams):
-        self.gen_params = gen_params
-
-        layouts = self.gen_params.get(FetchLayouts)
-
-        self.read = Method(o=layouts.fetch_request)
-        self.ifu_redirect = Method(i=layouts.redirect)
-        self.backend_redirect = Method(i=layouts.redirect)
-
-    def elaborate(self, platform):
-        m = TModule()
-
-        front_params = self.gen_params.get(FrontendParams)
-
-        next_fetch_pc = Signal(self.gen_params.isa.xlen, init=self.gen_params.start_pc)
-
-        @def_method(m, self.read)
-        def _():
-            # No branch prediction yet - just fallthrough to the next fetch block.
-            m.d.sync += next_fetch_pc.eq(front_params.pc_from_fb(front_params.fb_addr(next_fetch_pc) + 1, 0))
-            return next_fetch_pc
-
-        @def_method(m, self.ifu_redirect)
-        def _(pc):
-            m.d.sync += next_fetch_pc.eq(pc)
-
-        @def_method(m, self.backend_redirect)
-        def _(pc):
-            m.d.sync += next_fetch_pc.eq(pc)
-
-        return m
-
-
 class CoreFrontend(Elaboratable):
     """Frontend of the core."""
 
@@ -149,9 +107,6 @@ class CoreFrontend(Elaboratable):
 
         self.stall_ctrl = StallController(self.gen_params)
 
-        self.fetch_address_unit = FetchAddressUnit(self.gen_params)
-        self.fetch_writeback = Method(i=gen_params.get(FetchLayouts).fetch_writeback)
-
         self.fetch = FetchUnit(self.gen_params, self.icache)
         self.fetch.cont.provide(self.instr_buffer.write)
         self.fetch.stall_unsafe.provide(self.stall_ctrl.stall_unsafe)
@@ -160,11 +115,8 @@ class CoreFrontend(Elaboratable):
         self.output_pipe = Pipe(self.gen_params.get(SchedulerLayouts).scheduler_in)
         self.decode_buff = Connect(self.gen_params.get(DecodeLayouts).decode_result)
 
-        # TODO: move and implement these methods
-        jb_layouts = self.gen_params.get(JumpBranchLayouts)
-        self.target_pred_req = Method(i=jb_layouts.predicted_jump_target_req)
-        self.target_pred_resp = Method(o=jb_layouts.predicted_jump_target_resp)
-        DependencyContext.get().add_dependency(PredictedJumpTargetKey(), (self.target_pred_req, self.target_pred_resp))
+        self.bpu = BranchPredictionUnit(self.gen_params)
+        self.ftq = FetchTargetQueue(self.gen_params)
 
         self.consume_instr = Method(o=self.gen_params.get(SchedulerLayouts).scheduler_in)
         self.resume_from_exception = self.stall_ctrl.resume_from_exception
@@ -179,9 +131,20 @@ class CoreFrontend(Elaboratable):
             m.submodules.icache_refiller = self.icache_refiller
         m.submodules.icache = self.icache
 
-        m.submodules.fetch_address_unit = self.fetch_address_unit
         m.submodules.fetch = self.fetch
         m.submodules.instr_buffer = self.instr_buffer
+
+        m.submodules.ftq = self.ftq
+        m.submodules.bpu = self.bpu
+
+        self.ftq.bpu_request.provide(self.bpu.request)
+        self.ftq.bpu_flush.provide(self.bpu.flush)
+        self.ftq.stall_lock.provide(self.stall_ctrl.stall_guard)
+        self.bpu.write_prediction.provide(self.ftq.bpu_response)
+
+        self.ftq.ifu_request.provide(self.fetch.fetch_request)
+        self.fetch.fetch_writeback.provide(self.ftq.ifu_redirect)
+        self.stall_ctrl.redirect_frontend.provide(self.ftq.backend_redirect)
 
         m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)
         decode.get_raw.provide(self.instr_buffer.read)
@@ -197,39 +160,13 @@ class CoreFrontend(Elaboratable):
         m.submodules.output_pipe = self.output_pipe
 
         m.submodules.stall_ctrl = self.stall_ctrl
-        self.stall_ctrl.redirect_frontend.provide(self.fetch_address_unit.backend_redirect)
-        self.fetch.fetch_writeback.provide(self.fetch_writeback)
-
-        # TODO: Remove when Branch Predictor implemented
-        with Transaction(name="DiscardBranchVerify").body(m):
-            read = self.connections.get_dependency(BranchVerifyKey())
-            read(m)  # Consume to not block JB Unit
-
-        @def_method(m, self.target_pred_req)
-        def _():
-            pass
-
-        @def_method(m, self.target_pred_resp)
-        def _(arg):
-            return {"valid": 0, "cfi_target": 0}
-
-        @def_method(m, self.fetch_writeback)
-        def _(redirect, redirect_target):
-            with m.If(redirect):
-                self.fetch_address_unit.ifu_redirect(m, pc=redirect_target)
-
-        with Transaction(name="FetchRequest").body(m):
-            self.stall_ctrl.stall_guard(m)
-            self.fetch.fetch_request(m, self.fetch_address_unit.read(m))
-
-        def flush_frontend():
-            self.fetch.flush(m)
-            self.instr_buffer.clear(m)
-            self.output_pipe.clear(m)
 
         @def_method(m, self.stall)
         def _():
-            flush_frontend()
+            self.fetch.flush(m)
+            self.instr_buffer.clear(m)
+            self.output_pipe.clear(m)
+            self.bpu.flush(m)
             self.stall_ctrl.stall_exception(m)
 
         return m

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -139,11 +139,11 @@ class CoreFrontend(Elaboratable):
 
         self.ftq.bpu_request.provide(self.bpu.request)
         self.ftq.bpu_flush.provide(self.bpu.flush)
-        self.ftq.stall_lock.provide(self.stall_ctrl.stall_guard)
+        self.ftq.stall_guard.provide(self.stall_ctrl.stall_guard)
         self.bpu.write_prediction.provide(self.ftq.bpu_response)
 
         self.ftq.ifu_request.provide(self.fetch.fetch_request)
-        self.fetch.fetch_writeback.provide(self.ftq.ifu_redirect)
+        self.fetch.fetch_writeback.provide(self.ftq.ifu_writeback)
         self.stall_ctrl.redirect_frontend.provide(self.ftq.backend_redirect)
 
         m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -1,0 +1,255 @@
+from amaranth import *
+from amaranth.lib.data import Layout
+import amaranth.lib.memory as memory
+from transactron import *
+from transactron.utils import make_layout, DependencyContext
+from transactron.lib import logging
+from transactron.lib.metrics import *
+
+from coreblocks.params import GenParams
+from coreblocks.arch import *
+from coreblocks.interface.layouts import (
+    CommonLayoutFields,
+    FetchLayouts,
+    JumpBranchLayouts,
+    BranchPredictionLayouts,
+    FTQPtr,
+    FetchTargetQueueLayouts,
+)
+from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey, FTQCommitEntry
+
+log = logging.HardwareLogger("frontend.ftq")
+
+
+class FetchAddressUnit(Elaboratable):
+    """
+    This module owns the speculative fetch program counter and arbitrates all frontend redirects.
+    It selects the next fetch PC based on reset, backend redirects, IFU redirects, and branch prediction results.
+    """
+
+    read: Provided[Method]
+    ifu_redirect: Provided[Method]
+    beckend_redirect: Provided[Method]
+
+    def __init__(self, gen_params: GenParams):
+        self.gen_params = gen_params
+
+        layouts = self.gen_params.get(FetchLayouts)
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        self.write = Method(i=make_layout(fields.pc))
+        self.read = Method(o=layouts.fetch_request)
+        self.ifu_redirect = Method(i=layouts.redirect)
+        self.backend_redirect = Method(i=layouts.redirect)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        next_fetch_addr = Signal(self.gen_params.isa.xlen, init=self.gen_params.start_pc)
+        next_fetch_addr_v = Signal(init=1)
+
+        next_fetch_addr_fwd = Signal.like(self.read.data_out)
+
+        self.write.schedule_before(self.read)  # to avoid combinational loops
+
+        @def_method(m, self.write, ready=~next_fetch_addr_v)
+        def _(pc):
+            m.d.av_comb += next_fetch_addr_fwd.eq(pc)
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        with m.If(next_fetch_addr_v):
+            m.d.av_comb += next_fetch_addr_fwd.eq(next_fetch_addr)  # write method is not ready
+
+        @def_method(m, self.read, ready=next_fetch_addr_v | self.write.run)
+        def _():
+            m.d.sync += next_fetch_addr_v.eq(0)
+            return next_fetch_addr_fwd
+
+        @def_method(m, self.ifu_redirect)
+        def _(pc):
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        @def_method(m, self.backend_redirect)
+        def _(pc):
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        return m
+
+
+class FTQMemoryWrapper(Elaboratable):
+    def __init__(self, gen_params: GenParams, layout: Layout):
+        self.gen_params = gen_params
+        self.layout = layout
+        self.item_width = self.layout.as_shape().width
+
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        self.write_layout = make_layout(fields.ftq_ptr, ("data", self.layout))
+
+        self.read_ptr_next = FTQPtr(gp=self.gen_params)
+        self.read_data = Signal(self.layout)
+
+        self.write = Method(i=self.write_layout)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.mem = mem = memory.Memory(shape=self.layout.as_shape(), depth=self.gen_params.ftq_size, init=[])
+        wrport = mem.write_port()
+        rdport = mem.read_port(transparent_for=[wrport])
+
+        m.d.comb += rdport.addr.eq(self.read_ptr_next)
+        m.d.comb += self.read_data.eq(rdport.data)
+
+        @def_method(m, self.write)
+        def _(ftq_ptr, data):
+            m.d.comb += wrport.addr.eq(ftq_ptr.ptr)
+            m.d.comb += wrport.data.eq(data)
+            m.d.comb += wrport.en.eq(1)
+
+        return m
+
+
+class FetchTargetQueue(Elaboratable):
+    def __init__(
+        self,
+        gen_params: GenParams,
+    ) -> None:
+        self.gen_params = gen_params
+
+        self.dep_manager = DependencyContext.get()
+
+        self.stall_lock = Method()
+
+        ifu_layouts = self.gen_params.get(FetchLayouts)
+        self.ifu_request = Method(i=ifu_layouts.fetch_request)
+        self.ifu_redirect = Method(i=ifu_layouts.fetch_writeback)
+
+        bpu_layouts = self.gen_params.get(BranchPredictionLayouts)
+        self.bpu_request = Method(i=bpu_layouts.request)
+        self.bpu_response = Method(i=bpu_layouts.write_prediction)
+        self.bpu_flush = Method()
+
+        jb_layouts = self.gen_params.get(JumpBranchLayouts)
+        self.jump_target_req = Method(i=jb_layouts.predicted_jump_target_req)
+        self.jump_target_resp = Method(o=jb_layouts.predicted_jump_target_resp)
+        self.dep_manager.add_dependency(PredictedJumpTargetKey(), (self.jump_target_req, self.jump_target_resp))
+
+        ftq_layouts = self.gen_params.get(FetchTargetQueueLayouts)
+        self.commit = Method(i=ftq_layouts.commit)
+        self.resolve = Method(i=ftq_layouts.branch_resolve)
+        self.backend_redirect = Method(i=ifu_layouts.redirect)
+
+        self.dep_manager.add_dependency(BranchResolveKey(), self.resolve)
+        self.dep_manager.add_dependency(FTQCommitEntry(), self.commit)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        m.submodules.fetch_address_unit = fetch_address_unit = FetchAddressUnit(self.gen_params)
+
+        m.submodules.pc_mem = pc_mem = FTQMemoryWrapper(gen_params=self.gen_params, layout=make_layout(fields.pc))
+
+        alloc_ptr = FTQPtr(gp=self.gen_params)
+        fetch_ptr = FTQPtr(gp=self.gen_params)
+        commit_ptr = FTQPtr(gp=self.gen_params)
+
+        fetch_ptr_next = FTQPtr(gp=self.gen_params)
+        m.d.sync += fetch_ptr.eq(fetch_ptr_next)
+        m.d.comb += fetch_ptr_next.eq(fetch_ptr)
+        m.d.comb += pc_mem.read_ptr_next.eq(fetch_ptr_next)
+
+        alloc_fetch_bypass = Signal(make_layout(fields.pc))
+        with Transaction(name="FTQ_Alloc").body(
+            m, ready=~FTQPtr.queue_full(alloc_ptr, commit_ptr)
+        ) as ftq_alloc_transaction:
+            self.stall_lock(m)
+
+            ret = fetch_address_unit.read(m)
+
+            log.debug(m, True, "[FTQ] Alloc pc={:x}, ftq={}", ret.pc, alloc_ptr.ptr)
+
+            self.bpu_request(m, pc=ret.pc, ftq_ptr=alloc_ptr)
+            pc_mem.write(m, ftq_ptr=alloc_ptr, data=ret.pc)
+
+            m.d.av_comb += alloc_fetch_bypass.eq(ret)
+            m.d.sync += alloc_ptr.eq(alloc_ptr + 1)
+
+        early_fetch = Signal()
+        m.d.comb += early_fetch.eq((fetch_ptr == alloc_ptr) & ftq_alloc_transaction.run)
+        with Transaction(name="FTQ_Send_Fetch_Requests").body(
+            m, ready=early_fetch | (fetch_ptr < alloc_ptr)
+        ) as send_fetch_req_transaction:
+            self.stall_lock(m)
+
+            fetch_pc = Signal(self.gen_params.isa.xlen)
+            m.d.av_comb += fetch_pc.eq(Mux(early_fetch, alloc_fetch_bypass, pc_mem.read_data))
+
+            log.debug(m, True, "[FTQ] IFU request pc={:x}, ftq={} early_fetch={}", fetch_pc, fetch_ptr.ptr, early_fetch)
+            self.ifu_request(m, ftq_ptr=fetch_ptr, pc=fetch_pc)
+            m.d.comb += fetch_ptr_next.eq(fetch_ptr + 1)
+
+        ftq_alloc_transaction.schedule_before(send_fetch_req_transaction)
+
+        @def_method(m, self.bpu_response)
+        def _(pc, ftq_ptr):
+            fetch_address_unit.write(m, pc=pc)
+
+        @def_method(m, self.ifu_redirect)
+        def _(
+            ftq_ptr,
+            redirect,
+            redirect_target,
+        ):
+            ftq_ptr_plus_one = FTQPtr(gp=self.gen_params)
+            m.d.av_comb += ftq_ptr_plus_one.eq(FTQPtr(ftq_ptr, gp=self.gen_params) + 1)
+
+            self.bpu_flush(m)
+
+            with m.If(redirect):
+                fetch_address_unit.ifu_redirect(m, pc=redirect_target)
+                m.d.sync += alloc_ptr.eq(ftq_ptr_plus_one)
+                m.d.comb += fetch_ptr_next.eq(ftq_ptr_plus_one)
+
+        @def_method(m, self.commit)
+        def _(ftq_ptr):
+            # We allow ftq_ptr to be 2 bigger than the commit ptr.
+            # This can happen when we have a FTQ entry with 0 instructions
+            # (an unaligned 4-byte long instruction crossing two fetch blocks).
+            ftq_ptr_casted = FTQPtr(ftq_ptr, gp=self.gen_params)
+            log.assertion(
+                m,
+                (commit_ptr <= ftq_ptr_casted) & (ftq_ptr_casted <= commit_ptr + 2),
+                "FTQ entry was retired out-of-order",
+            )
+
+            log.debug(m, True, "[FTQ] Commit ftq={}", ftq_ptr.ptr)
+            m.d.sync += commit_ptr.eq(ftq_ptr)
+
+        @def_method(m, self.backend_redirect)
+        def _(pc):
+            commit_ptr_plus_one = FTQPtr(gp=self.gen_params)
+            m.d.av_comb += commit_ptr_plus_one.eq(FTQPtr(commit_ptr, gp=self.gen_params) + 1)
+
+            fetch_address_unit.backend_redirect(m, pc=pc)
+            m.d.sync += alloc_ptr.eq(commit_ptr_plus_one)
+            m.d.sync += fetch_ptr.eq(commit_ptr_plus_one)
+
+        @def_method(m, self.jump_target_req)
+        def _():
+            pass
+
+        @def_method(m, self.jump_target_resp)
+        def _(arg):
+            return {"valid": 0, "cfi_target": 0}
+
+        @def_method(m, self.resolve)
+        def _(from_pc, next_pc, misprediction):
+            pass
+
+        return m

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -16,7 +16,7 @@ from coreblocks.interface.layouts import (
     FTQPtr,
     FetchTargetQueueLayouts,
 )
-from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey, FTQCommitEntry
+from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey, FTQCommitKey
 from coreblocks.frontend.fetch_addr_unit import FetchAddressUnit
 
 
@@ -66,7 +66,7 @@ class FetchTargetQueue(Elaboratable):
     """
 
     stall_guard: Required[Method]
-    """Ready only while the pipeline is unlocked; stalls FTQ alloc and fetch when locked (e.g. during a flush)."""
+    """Blocks only while the pipeline is stalled (e.g. during a flush)."""
     ifu_request: Required[Method]
     """Issue a fetch request to the instruction fetch unit for the given PC and FTQ pointer."""
     bpu_request: Required[Method]
@@ -122,7 +122,7 @@ class FetchTargetQueue(Elaboratable):
         self.backend_redirect = Method(i=ifu_layouts.frontend_redirect)
 
         self.dep_manager.add_dependency(BranchResolveKey(), self.resolve)
-        self.dep_manager.add_dependency(FTQCommitEntry(), self.commit)
+        self.dep_manager.add_dependency(FTQCommitKey(), self.commit)
 
     def elaborate(self, platform):
         m = TModule()

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -94,7 +94,7 @@ class FTQMemoryWrapper(Elaboratable):
 
         self.write_layout = make_layout(fields.ftq_ptr, ("data", self.layout))
 
-        self.read_ptr_next = FTQPtr(gp=self.gen_params)
+        self.read_ptr_next = FTQPtr(gen_params=self.gen_params)
         self.read_data = Signal(self.layout)
 
         self.write = Method(i=self.write_layout)
@@ -177,7 +177,7 @@ class FetchTargetQueue(Elaboratable):
         ftq_layouts = self.gen_params.get(FetchTargetQueueLayouts)
         self.commit = Method(i=ftq_layouts.commit)
         self.resolve = Method(i=ftq_layouts.branch_resolve)
-        self.backend_redirect = Method(i=ifu_layouts.redirect)
+        self.backend_redirect = Method(i=ifu_layouts.frontend_redirect)
 
         self.dep_manager.add_dependency(BranchResolveKey(), self.resolve)
         self.dep_manager.add_dependency(FTQCommitEntry(), self.commit)
@@ -192,11 +192,11 @@ class FetchTargetQueue(Elaboratable):
         m.submodules.pc_mem = pc_mem = FTQMemoryWrapper(gen_params=self.gen_params, layout=make_layout(fields.pc))
 
         # Three pointers in the queue.
-        alloc_ptr = FTQPtr(gp=self.gen_params)
-        fetch_ptr = FTQPtr(gp=self.gen_params)
-        commit_ptr = FTQPtr(gp=self.gen_params)
+        alloc_ptr = FTQPtr(gen_params=self.gen_params)
+        fetch_ptr = FTQPtr(gen_params=self.gen_params)
+        commit_ptr = FTQPtr(gen_params=self.gen_params)
 
-        fetch_ptr_next = FTQPtr(gp=self.gen_params)
+        fetch_ptr_next = FTQPtr(gen_params=self.gen_params)
         m.d.sync += fetch_ptr.eq(fetch_ptr_next)
         m.d.comb += fetch_ptr_next.eq(fetch_ptr)
         m.d.comb += pc_mem.read_ptr_next.eq(fetch_ptr_next)
@@ -244,19 +244,20 @@ class FetchTargetQueue(Elaboratable):
             redirect,
             redirect_target,
         ):
-            ftq_ptr_plus_one = FTQPtr(gp=self.gen_params)
-            m.d.av_comb += ftq_ptr_plus_one.eq(FTQPtr(ftq_ptr, gp=self.gen_params) + 1)
+            ftq_ptr_plus_one = FTQPtr(gen_params=self.gen_params)
+            m.d.av_comb += ftq_ptr_plus_one.eq(FTQPtr(ftq_ptr, gen_params=self.gen_params) + 1)
 
             self.bpu_flush(m)
 
+            m.d.sync += alloc_ptr.eq(ftq_ptr_plus_one)
+            m.d.comb += fetch_ptr_next.eq(ftq_ptr_plus_one)
+
             with m.If(redirect):
                 fetch_address_unit.ifu_redirect(m, pc=redirect_target)
-                m.d.sync += alloc_ptr.eq(ftq_ptr_plus_one)
-                m.d.comb += fetch_ptr_next.eq(ftq_ptr_plus_one)
 
         @def_method(m, self.commit)
         def _(ftq_ptr):
-            ftq_ptr_casted = FTQPtr(ftq_ptr, gp=self.gen_params)
+            ftq_ptr_casted = FTQPtr(ftq_ptr, gen_params=self.gen_params)
             # With superscalar retirement, multiple FTQ entries can be committed per cycle,
             # so only check that commit advances monotonically
             log.assertion(
@@ -268,13 +269,21 @@ class FetchTargetQueue(Elaboratable):
             m.d.sync += commit_ptr.eq(ftq_ptr)
 
         @def_method(m, self.backend_redirect)
-        def _(pc):
-            commit_ptr_plus_one = FTQPtr(gp=self.gen_params)
-            m.d.av_comb += commit_ptr_plus_one.eq(FTQPtr(commit_ptr, gp=self.gen_params) + 1)
+        def _(pc, from_unsafe):
+            commit_ptr_plus_one = FTQPtr(gen_params=self.gen_params)
+            m.d.av_comb += commit_ptr_plus_one.eq(FTQPtr(commit_ptr, gen_params=self.gen_params) + 1)
 
             fetch_address_unit.backend_redirect(m, pc=pc)
-            m.d.sync += alloc_ptr.eq(commit_ptr_plus_one)
-            m.d.sync += fetch_ptr.eq(commit_ptr_plus_one)
+
+            # An unsafe instruction (e.g. a CSR access) is not squashed - it keeps its FTQ entry
+            # and is committed normally. Its resume is signalled before it retires, so `commit_ptr`
+            # is stale here and must not be used. The alloc/fetch pointers were already rewound to
+            # just past the unsafe instruction when the fetch unit wrote it back (`ifu_redirect`).
+            # For an exception/backend redirect the whole pipeline is squashed, so we restart
+            # allocation right after the last committed entry.
+            with m.If(~from_unsafe):
+                m.d.sync += alloc_ptr.eq(commit_ptr_plus_one)
+                m.d.sync += fetch_ptr.eq(commit_ptr_plus_one)
 
         @def_method(m, self.jump_target_req)
         def _():

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -1,0 +1,291 @@
+from amaranth import *
+from amaranth.lib.data import Layout
+import amaranth.lib.memory as memory
+from transactron import *
+from transactron.utils import make_layout, DependencyContext
+from transactron.utils import logging
+from transactron.lib.metrics import *
+
+from coreblocks.params import GenParams
+from coreblocks.arch import *
+from coreblocks.interface.layouts import (
+    CommonLayoutFields,
+    FetchLayouts,
+    JumpBranchLayouts,
+    BranchPredictionLayouts,
+    FTQPtr,
+    FetchTargetQueueLayouts,
+)
+from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey, FTQCommitEntry
+
+log = logging.HardwareLogger("frontend.ftq")
+
+
+class FetchAddressUnit(Elaboratable):
+    """
+    Owns the speculative fetch program counter and arbitrates all frontend redirects.
+    It selects the next fetch PC based on reset, backend redirects, IFU redirects, and branch prediction results.
+    """
+
+    write: Provided[Method]
+    """Supply the next fetch PC (e.g. from a BPU prediction). Requires the current PC to have been consumed."""
+    read: Provided[Method]
+    """Consume the current fetch PC. Blocks until a valid PC is available."""
+    ifu_redirect: Provided[Method]
+    """Redirect the fetch PC after a misprediction detected by the IFU."""
+    backend_redirect: Provided[Method]
+    """Redirect the fetch PC after a misprediction resolved by the backend."""
+
+    def __init__(self, gen_params: GenParams):
+        self.gen_params = gen_params
+
+        layouts = self.gen_params.get(FetchLayouts)
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        self.write = Method(i=make_layout(fields.pc))
+        self.read = Method(o=layouts.fetch_request)
+        self.ifu_redirect = Method(i=layouts.redirect)
+        self.backend_redirect = Method(i=layouts.redirect)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        next_fetch_addr = Signal(self.gen_params.isa.xlen, init=self.gen_params.start_pc)
+        next_fetch_addr_v = Signal(init=1)
+
+        next_fetch_addr_fwd = Signal.like(self.read.data_out)
+
+        self.write.schedule_before(self.read)  # to avoid combinational loops
+
+        @def_method(m, self.write, ready=~next_fetch_addr_v)
+        def _(pc):
+            m.d.av_comb += next_fetch_addr_fwd.eq(pc)
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        with m.If(next_fetch_addr_v):
+            m.d.av_comb += next_fetch_addr_fwd.eq(next_fetch_addr)  # write method is not ready
+
+        @def_method(m, self.read, ready=next_fetch_addr_v | self.write.run)
+        def _():
+            m.d.sync += next_fetch_addr_v.eq(0)
+            return next_fetch_addr_fwd
+
+        @def_method(m, self.ifu_redirect)
+        def _(pc):
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        @def_method(m, self.backend_redirect)
+        def _(pc):
+            m.d.sync += next_fetch_addr.eq(pc)
+            m.d.sync += next_fetch_addr_v.eq(1)
+
+        return m
+
+
+class FTQMemoryWrapper(Elaboratable):
+    def __init__(self, gen_params: GenParams, layout: Layout):
+        self.gen_params = gen_params
+        self.layout = layout
+        self.item_width = self.layout.as_shape().width
+
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        self.write_layout = make_layout(fields.ftq_ptr, ("data", self.layout))
+
+        self.read_ptr_next = FTQPtr(gp=self.gen_params)
+        self.read_data = Signal(self.layout)
+
+        self.write = Method(i=self.write_layout)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.mem = mem = memory.Memory(shape=self.layout.as_shape(), depth=self.gen_params.ftq_size, init=[])
+        wrport = mem.write_port()
+        rdport = mem.read_port(transparent_for=[wrport])
+
+        m.d.comb += rdport.addr.eq(self.read_ptr_next)
+        m.d.comb += self.read_data.eq(rdport.data)
+
+        @def_method(m, self.write)
+        def _(ftq_ptr, data):
+            m.d.comb += wrport.addr.eq(ftq_ptr.ptr)
+            m.d.comb += wrport.data.eq(data)
+            m.d.comb += wrport.en.eq(1)
+
+        return m
+
+
+class FetchTargetQueue(Elaboratable):
+    """
+    Tracks speculative fetch targets in a circular buffer indexed by FTQ pointer.
+    Each entry represents one fetch block: the FTQ allocates an entry per fetch, sends the PC to
+    both the IFU and BPU, and advances the fetch pointer. Entries are freed at retirement via
+    ``commit`` and the buffer stalls allocation when full.
+    """
+
+    stall_lock: Required[Method]
+    """Stalls the FTQ alloc and fetch when the pipeline is locked (e.g. during a flush)."""
+    ifu_request: Required[Method]
+    """Issue a fetch request to the instruction fetch unit for the given PC and FTQ pointer."""
+    bpu_request: Required[Method]
+    """Request a branch prediction for the given PC and FTQ pointer."""
+    bpu_flush: Required[Method]
+    """Flush pending branch prediction requests (called on any redirect)."""
+
+    ifu_redirect: Provided[Method]
+    """Handle an IFU-detected misprediction: flush the BPU and optionally redirect fetch to a new PC."""
+    bpu_response: Provided[Method]
+    """Accept a branch prediction result and supply the predicted next PC to the FAU."""
+    jump_target_req: Provided[Method]
+    """Request the predicted jump target for a given FTQ entry (stub)."""
+    jump_target_resp: Provided[Method]
+    """Return the predicted jump target for a given FTQ entry (stub)."""
+    commit: Provided[Method]
+    """Retire an FTQ entry, advancing the commit pointer and freeing the slot."""
+    resolve: Provided[Method]
+    """Record branch resolution information for a committed FTQ entry (stub)."""
+    backend_redirect: Provided[Method]
+    """Handle a backend misprediction: reset alloc/fetch pointers to commit+1 and redirect the FAU."""
+
+    def __init__(
+        self,
+        gen_params: GenParams,
+    ) -> None:
+        self.gen_params = gen_params
+
+        self.dep_manager = DependencyContext.get()
+
+        self.stall_lock = Method()
+
+        ifu_layouts = self.gen_params.get(FetchLayouts)
+        self.ifu_request = Method(i=ifu_layouts.fetch_request)
+        self.ifu_redirect = Method(i=ifu_layouts.fetch_writeback)
+
+        bpu_layouts = self.gen_params.get(BranchPredictionLayouts)
+        self.bpu_request = Method(i=bpu_layouts.request)
+        self.bpu_response = Method(i=bpu_layouts.write_prediction)
+        self.bpu_flush = Method()
+
+        jb_layouts = self.gen_params.get(JumpBranchLayouts)
+        self.jump_target_req = Method(i=jb_layouts.predicted_jump_target_req)
+        self.jump_target_resp = Method(o=jb_layouts.predicted_jump_target_resp)
+        self.dep_manager.add_dependency(PredictedJumpTargetKey(), (self.jump_target_req, self.jump_target_resp))
+
+        ftq_layouts = self.gen_params.get(FetchTargetQueueLayouts)
+        self.commit = Method(i=ftq_layouts.commit)
+        self.resolve = Method(i=ftq_layouts.branch_resolve)
+        self.backend_redirect = Method(i=ifu_layouts.redirect)
+
+        self.dep_manager.add_dependency(BranchResolveKey(), self.resolve)
+        self.dep_manager.add_dependency(FTQCommitEntry(), self.commit)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        fields = self.gen_params.get(CommonLayoutFields)
+
+        m.submodules.fetch_address_unit = fetch_address_unit = FetchAddressUnit(self.gen_params)
+
+        m.submodules.pc_mem = pc_mem = FTQMemoryWrapper(gen_params=self.gen_params, layout=make_layout(fields.pc))
+
+        # Three pointers in the queue.
+        alloc_ptr = FTQPtr(gp=self.gen_params)
+        fetch_ptr = FTQPtr(gp=self.gen_params)
+        commit_ptr = FTQPtr(gp=self.gen_params)
+
+        fetch_ptr_next = FTQPtr(gp=self.gen_params)
+        m.d.sync += fetch_ptr.eq(fetch_ptr_next)
+        m.d.comb += fetch_ptr_next.eq(fetch_ptr)
+        m.d.comb += pc_mem.read_ptr_next.eq(fetch_ptr_next)
+
+        # FTQ_Alloc takes the next speculative PC, allocates an FTQ entry, and sends
+        # a request back to BPU
+        alloc_fetch_bypass = Signal(make_layout(fields.pc))
+        with Transaction(name="FTQ_Alloc").body(
+            m, ready=~FTQPtr.queue_full(alloc_ptr, commit_ptr)
+        ) as ftq_alloc_transaction:
+            self.stall_lock(m)
+
+            ret = fetch_address_unit.read(m)
+
+            self.bpu_request(m, pc=ret.pc, ftq_ptr=alloc_ptr)
+            pc_mem.write(m, ftq_ptr=alloc_ptr, data=ret.pc)
+
+            m.d.av_comb += alloc_fetch_bypass.eq(ret)
+            m.d.sync += alloc_ptr.eq(alloc_ptr + 1)
+
+        # FTQ_Send_Fetch_Requests follows fetch_ptr and sends requests to IFU. It has its data
+        # bypassed from FTQ_Alloc.
+        early_fetch = Signal()
+        m.d.comb += early_fetch.eq((fetch_ptr == alloc_ptr) & ftq_alloc_transaction.run)
+        with Transaction(name="FTQ_Send_Fetch_Requests").body(
+            m, ready=early_fetch | (fetch_ptr < alloc_ptr)
+        ) as send_fetch_req_transaction:
+            self.stall_lock(m)
+
+            fetch_pc = Signal(self.gen_params.isa.xlen)
+            m.d.av_comb += fetch_pc.eq(Mux(early_fetch, alloc_fetch_bypass, pc_mem.read_data))
+
+            self.ifu_request(m, ftq_ptr=fetch_ptr, pc=fetch_pc)
+            m.d.comb += fetch_ptr_next.eq(fetch_ptr + 1)
+
+        ftq_alloc_transaction.schedule_before(send_fetch_req_transaction)
+
+        @def_method(m, self.bpu_response)
+        def _(pc, ftq_ptr):
+            fetch_address_unit.write(m, pc=pc)
+
+        @def_method(m, self.ifu_redirect)
+        def _(
+            ftq_ptr,
+            redirect,
+            redirect_target,
+        ):
+            ftq_ptr_plus_one = FTQPtr(gp=self.gen_params)
+            m.d.av_comb += ftq_ptr_plus_one.eq(FTQPtr(ftq_ptr, gp=self.gen_params) + 1)
+
+            self.bpu_flush(m)
+
+            with m.If(redirect):
+                fetch_address_unit.ifu_redirect(m, pc=redirect_target)
+                m.d.sync += alloc_ptr.eq(ftq_ptr_plus_one)
+                m.d.comb += fetch_ptr_next.eq(ftq_ptr_plus_one)
+
+        @def_method(m, self.commit)
+        def _(ftq_ptr):
+            ftq_ptr_casted = FTQPtr(ftq_ptr, gp=self.gen_params)
+            # With superscalar retirement, multiple FTQ entries can be committed per cycle,
+            # so only check that commit advances monotonically
+            log.assertion(
+                m,
+                commit_ptr <= ftq_ptr_casted,
+                "FTQ entry was retired out-of-order",
+            )
+
+            m.d.sync += commit_ptr.eq(ftq_ptr)
+
+        @def_method(m, self.backend_redirect)
+        def _(pc):
+            commit_ptr_plus_one = FTQPtr(gp=self.gen_params)
+            m.d.av_comb += commit_ptr_plus_one.eq(FTQPtr(commit_ptr, gp=self.gen_params) + 1)
+
+            fetch_address_unit.backend_redirect(m, pc=pc)
+            m.d.sync += alloc_ptr.eq(commit_ptr_plus_one)
+            m.d.sync += fetch_ptr.eq(commit_ptr_plus_one)
+
+        @def_method(m, self.jump_target_req)
+        def _():
+            pass
+
+        @def_method(m, self.jump_target_resp)
+        def _(arg):
+            return {"valid": 0, "cfi_target": 0}
+
+        @def_method(m, self.resolve)
+        def _(from_pc, next_pc, misprediction):
+            pass
+
+        return m

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -17,71 +17,10 @@ from coreblocks.interface.layouts import (
     FetchTargetQueueLayouts,
 )
 from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey, FTQCommitEntry
+from coreblocks.frontend.fetch_addr_unit import FetchAddressUnit
+
 
 log = logging.HardwareLogger("frontend.ftq")
-
-
-class FetchAddressUnit(Elaboratable):
-    """
-    Owns the speculative fetch program counter and arbitrates all frontend redirects.
-    It selects the next fetch PC based on reset, backend redirects, IFU redirects, and branch prediction results.
-    """
-
-    write: Provided[Method]
-    """Supply the next fetch PC (e.g. from a BPU prediction). Requires the current PC to have been consumed."""
-    read: Provided[Method]
-    """Consume the current fetch PC. Blocks until a valid PC is available."""
-    ifu_redirect: Provided[Method]
-    """Redirect the fetch PC after a misprediction detected by the IFU."""
-    backend_redirect: Provided[Method]
-    """Redirect the fetch PC after a misprediction resolved by the backend."""
-
-    def __init__(self, gen_params: GenParams):
-        self.gen_params = gen_params
-
-        layouts = self.gen_params.get(FetchLayouts)
-        fields = self.gen_params.get(CommonLayoutFields)
-
-        self.write = Method(i=make_layout(fields.pc))
-        self.read = Method(o=layouts.fetch_request)
-        self.ifu_redirect = Method(i=layouts.redirect)
-        self.backend_redirect = Method(i=layouts.redirect)
-
-    def elaborate(self, platform):
-        m = TModule()
-
-        next_fetch_addr = Signal(self.gen_params.isa.xlen, init=self.gen_params.start_pc)
-        next_fetch_addr_v = Signal(init=1)
-
-        next_fetch_addr_fwd = Signal.like(self.read.data_out)
-
-        self.write.schedule_before(self.read)  # to avoid combinational loops
-
-        @def_method(m, self.write, ready=~next_fetch_addr_v)
-        def _(pc):
-            m.d.av_comb += next_fetch_addr_fwd.eq(pc)
-            m.d.sync += next_fetch_addr.eq(pc)
-            m.d.sync += next_fetch_addr_v.eq(1)
-
-        with m.If(next_fetch_addr_v):
-            m.d.av_comb += next_fetch_addr_fwd.eq(next_fetch_addr)  # write method is not ready
-
-        @def_method(m, self.read, ready=next_fetch_addr_v | self.write.run)
-        def _():
-            m.d.sync += next_fetch_addr_v.eq(0)
-            return next_fetch_addr_fwd
-
-        @def_method(m, self.ifu_redirect)
-        def _(pc):
-            m.d.sync += next_fetch_addr.eq(pc)
-            m.d.sync += next_fetch_addr_v.eq(1)
-
-        @def_method(m, self.backend_redirect)
-        def _(pc):
-            m.d.sync += next_fetch_addr.eq(pc)
-            m.d.sync += next_fetch_addr_v.eq(1)
-
-        return m
 
 
 class FTQMemoryWrapper(Elaboratable):
@@ -126,8 +65,8 @@ class FetchTargetQueue(Elaboratable):
     ``commit`` and the buffer stalls allocation when full.
     """
 
-    stall_lock: Required[Method]
-    """Stalls the FTQ alloc and fetch when the pipeline is locked (e.g. during a flush)."""
+    stall_guard: Required[Method]
+    """Ready only while the pipeline is unlocked; stalls FTQ alloc and fetch when locked (e.g. during a flush)."""
     ifu_request: Required[Method]
     """Issue a fetch request to the instruction fetch unit for the given PC and FTQ pointer."""
     bpu_request: Required[Method]
@@ -135,8 +74,11 @@ class FetchTargetQueue(Elaboratable):
     bpu_flush: Required[Method]
     """Flush pending branch prediction requests (called on any redirect)."""
 
-    ifu_redirect: Provided[Method]
-    """Handle an IFU-detected misprediction: flush the BPU and optionally redirect fetch to a new PC."""
+    ifu_writeback: Provided[Method]
+    """
+    Handle an IFU-detected misprediction/unsafe instruction: flush the BPU and optionally
+    redirect fetch to a new PC.
+    """
     bpu_response: Provided[Method]
     """Accept a branch prediction result and supply the predicted next PC to the FAU."""
     jump_target_req: Provided[Method]
@@ -158,11 +100,11 @@ class FetchTargetQueue(Elaboratable):
 
         self.dep_manager = DependencyContext.get()
 
-        self.stall_lock = Method()
+        self.stall_guard = Method()
 
         ifu_layouts = self.gen_params.get(FetchLayouts)
         self.ifu_request = Method(i=ifu_layouts.fetch_request)
-        self.ifu_redirect = Method(i=ifu_layouts.fetch_writeback)
+        self.ifu_writeback = Method(i=ifu_layouts.fetch_writeback)
 
         bpu_layouts = self.gen_params.get(BranchPredictionLayouts)
         self.bpu_request = Method(i=bpu_layouts.request)
@@ -207,7 +149,7 @@ class FetchTargetQueue(Elaboratable):
         with Transaction(name="FTQ_Alloc").body(
             m, ready=~FTQPtr.queue_full(alloc_ptr, commit_ptr)
         ) as ftq_alloc_transaction:
-            self.stall_lock(m)
+            self.stall_guard(m)
 
             ret = fetch_address_unit.read(m)
 
@@ -224,7 +166,7 @@ class FetchTargetQueue(Elaboratable):
         with Transaction(name="FTQ_Send_Fetch_Requests").body(
             m, ready=early_fetch | (fetch_ptr < alloc_ptr)
         ) as send_fetch_req_transaction:
-            self.stall_lock(m)
+            self.stall_guard(m)
 
             fetch_pc = Signal(self.gen_params.isa.xlen)
             m.d.av_comb += fetch_pc.eq(Mux(early_fetch, alloc_fetch_bypass, pc_mem.read_data))
@@ -238,7 +180,7 @@ class FetchTargetQueue(Elaboratable):
         def _(pc, ftq_ptr):
             fetch_address_unit.write(m, pc=pc)
 
-        @def_method(m, self.ifu_redirect)
+        @def_method(m, self.ifu_writeback)
         def _(
             ftq_ptr,
             redirect,
@@ -278,7 +220,7 @@ class FetchTargetQueue(Elaboratable):
             # An unsafe instruction (e.g. a CSR access) is not squashed - it keeps its FTQ entry
             # and is committed normally. Its resume is signalled before it retires, so `commit_ptr`
             # is stale here and must not be used. The alloc/fetch pointers were already rewound to
-            # just past the unsafe instruction when the fetch unit wrote it back (`ifu_redirect`).
+            # just past the unsafe instruction when the fetch unit wrote it back (`ifu_writeback`).
             # For an exception/backend redirect the whole pipeline is squashed, so we restart
             # allocation right after the last committed entry.
             with m.If(~from_unsafe):

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -66,7 +66,7 @@ class FetchTargetQueue(Elaboratable):
     """
 
     stall_guard: Required[Method]
-    """Ready only while the pipeline is unlocked; stalls FTQ alloc and fetch when locked (e.g. during a flush)."""
+    """Blocks only while the pipeline is stalled (e.g. during a flush)."""
     ifu_request: Required[Method]
     """Issue a fetch request to the instruction fetch unit for the given PC and FTQ pointer."""
     bpu_request: Required[Method]

--- a/coreblocks/frontend/stall_controller.py
+++ b/coreblocks/frontend/stall_controller.py
@@ -55,7 +55,7 @@ class StallController(Elaboratable):
         self.resume_from_exception = Method(i=layouts.resume)
         self._resume_from_unsafe = Method(i=layouts.resume)
 
-        self.redirect_frontend = Method(i=layouts.redirect)
+        self.redirect_frontend = Method(i=layouts.frontend_redirect)
 
         DependencyContext.get().add_dependency(UnsafeInstructionResolvedKey(), self._resume_from_unsafe)
 
@@ -87,7 +87,7 @@ class StallController(Elaboratable):
             with condition(m, nonblocking=True) as branch:
                 with branch(~stalled_exception):
                     log.info(m, True, "Resuming from unsafe instruction new_pc=0x{:x}", pc)
-                    self.redirect_frontend(m, pc=pc)
+                    self.redirect_frontend(m, pc=pc, from_unsafe=1)
 
         @def_method(m, self.resume_from_exception)
         def _(pc):
@@ -95,7 +95,7 @@ class StallController(Elaboratable):
             m.d.sync += stalled_exception.eq(0)
 
             log.info(m, True, "Resuming from exception new_pc=0x{:x}", pc)
-            self.redirect_frontend(m, pc=pc)
+            self.redirect_frontend(m, pc=pc, from_unsafe=0)
 
         @def_method(m, self.stall_unsafe)
         def _():

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -15,7 +15,7 @@ from coreblocks.arch import Funct3, OpType, ExceptionCause, Extension
 from coreblocks.interface.layouts import FuncUnitLayouts, JumpBranchLayouts, CommonLayoutFields
 from coreblocks.interface.keys import (
     AsyncInterruptInsertSignalKey,
-    BranchVerifyKey,
+    BranchResolveKey,
     ExceptionReportKey,
     PredictedJumpTargetKey,
 )
@@ -115,12 +115,9 @@ class JumpBranchFuncUnit(FuncUnit, Elaboratable):
         self.issue = Method(i=layouts.issue)
         self.push_result = Method(i=layouts.push_result)
 
-        self.fifo_branch_resolved = FIFO(self.gen_params.get(JumpBranchLayouts).verify_branch, 2)
-
         self.jb_fn = jb_fn
 
         self.dm = DependencyContext.get()
-        self.dm.add_dependency(BranchVerifyKey(), self.fifo_branch_resolved.read)
 
         self.perf_instr = TaggedCounter(
             "backend.fu.jumpbranch.instr",
@@ -144,10 +141,10 @@ class JumpBranchFuncUnit(FuncUnit, Elaboratable):
         ]
 
         jump_target_req, jump_target_resp = self.dm.get_dependency(PredictedJumpTargetKey())
+        resolve_branch = self.dm.get_dependency(BranchResolveKey())
 
         m.submodules.jb = jb = JumpBranch(self.gen_params, fn=self.jb_fn)
         m.submodules.decoder = decoder = self.jb_fn.get_decoder(self.gen_params)
-        m.submodules.fifo_branch_resolved = self.fifo_branch_resolved
 
         fields = self.gen_params.get(CommonLayoutFields)
         instr_fifo_layout = make_layout(
@@ -220,7 +217,7 @@ class JumpBranchFuncUnit(FuncUnit, Elaboratable):
                 )
 
             with m.If(~is_auipc):
-                self.fifo_branch_resolved.write(m, from_pc=instr.pc, next_pc=jump_result, misprediction=misprediction)
+                resolve_branch(m, from_pc=instr.pc, next_pc=jump_result, misprediction=misprediction)
                 log.debug(
                     m,
                     True,

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -15,7 +15,7 @@ from coreblocks.arch import Funct3, OpType, ExceptionCause, Extension
 from coreblocks.interface.layouts import JumpBranchLayouts, CommonLayoutFields
 from coreblocks.interface.keys import (
     AsyncInterruptInsertSignalKey,
-    BranchVerifyKey,
+    BranchResolveKey,
     ExceptionReportKey,
     PredictedJumpTargetKey,
 )
@@ -110,10 +110,7 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
     def __init__(self, gen_params: GenParams, fn=JumpBranchFn()):
         super().__init__(gen_params, fn)
 
-        self.fifo_branch_resolved = FIFO(self.gen_params.get(JumpBranchLayouts).verify_branch, 2)
-
         self.dm = DependencyContext.get()
-        self.dm.add_dependency(BranchVerifyKey(), self.fifo_branch_resolved.read)
 
         self.perf_misaligned = HwCounter(
             "backend.fu.jumpbranch.misaligned", "Number of instructions with misaligned target address"
@@ -131,9 +128,9 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
         ]
 
         jump_target_req, jump_target_resp = self.dm.get_dependency(PredictedJumpTargetKey())
+        resolve_branch = self.dm.get_dependency(BranchResolveKey())
 
         m.submodules.jb = jb = JumpBranch(self.gen_params, fn=self.fn)
-        m.submodules.fifo_branch_resolved = self.fifo_branch_resolved
 
         fields = self.gen_params.get(CommonLayoutFields)
         instr_fifo_layout = make_layout(
@@ -206,7 +203,7 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
                 )
 
             with m.If(~is_auipc):
-                self.fifo_branch_resolved.write(m, from_pc=instr.pc, next_pc=jump_result, misprediction=misprediction)
+                resolve_branch(m, from_pc=instr.pc, next_pc=jump_result, misprediction=misprediction)
                 log.debug(
                     m,
                     True,

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 __all__ = [
     "CommonBusDataKey",
     "InstructionPrecommitKey",
-    "BranchVerifyKey",
+    "BranchResolveKey",
     "PredictedJumpTargetKey",
     "UnsafeInstructionResolvedKey",
     "ExceptionReportKey",
@@ -40,7 +40,7 @@ class InstructionPrecommitKey(SimpleKey[Method]):
 
 
 @dataclass(frozen=True)
-class BranchVerifyKey(SimpleKey[Method]):
+class BranchResolveKey(SimpleKey[Method]):
     pass
 
 
@@ -105,6 +105,11 @@ class CSRListKey(ListKey["CSRRegister"]):
 
 @dataclass(frozen=True)
 class FlushICacheKey(SimpleKey[Method]):
+    pass
+
+
+@dataclass(frozen=True)
+class FTQCommitEntry(SimpleKey[Method]):
     pass
 
 

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -30,7 +30,7 @@ __all__ = [
     "FlushICacheKey",
     "SFenceVMAKey",
     "L1TLBBackingDeviceKey",
-    "FTQCommitEntry",
+    "FTQCommitKey",
     "RollbackKey",
     "InstructionTaggedCounterKey",
 ]
@@ -135,8 +135,8 @@ class L1TLBBackingDeviceKey(SimpleKey["TLBBackingDevice"]):
 
 
 @dataclass(frozen=True)
-class FTQCommitEntry(SimpleKey[Method]):
-    pass
+class FTQCommitKey(SimpleKey[Method]):
+    """Method called when the retirement unit commits an instruction."""
 
 
 @dataclass(frozen=True)

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -30,6 +30,7 @@ __all__ = [
     "FlushICacheKey",
     "SFenceVMAKey",
     "L1TLBBackingDeviceKey",
+    "FTQCommitEntry",
     "RollbackKey",
     "InstructionTaggedCounterKey",
 ]

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = [
     "CommonBusDataKey",
     "InstructionPrecommitKey",
-    "BranchVerifyKey",
+    "BranchResolveKey",
     "PredictedJumpTargetKey",
     "UnsafeInstructionResolvedKey",
     "ExceptionReportKey",
@@ -46,7 +46,7 @@ class InstructionPrecommitKey(SimpleKey[Method]):
 
 
 @dataclass(frozen=True)
-class BranchVerifyKey(SimpleKey[Method]):
+class BranchResolveKey(SimpleKey[Method]):
     pass
 
 
@@ -132,6 +132,9 @@ class SFenceVMAKey(UnifierKey, unifier=MethodProduct.create):
 class L1TLBBackingDeviceKey(SimpleKey["TLBBackingDevice"]):
     """Used to provide a component that can be used as a backing device for the L1 TLB."""
 
+
+@dataclass(frozen=True)
+class FTQCommitEntry(SimpleKey[Method]):
     pass
 
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -4,6 +4,7 @@ from amaranth.lib.data import ArrayLayout
 from amaranth.lib.enum import IntFlag, auto
 from coreblocks.params import GenParams
 from coreblocks.arch import *
+from coreblocks.interface.views import CircularBufferPointer
 from transactron.utils import LayoutList, LayoutListField, layout_subset
 from transactron.utils.transactron_helpers import make_layout, extend_layout
 
@@ -25,7 +26,19 @@ __all__ = [
     "CSRUnitLayouts",
     "ICacheLayouts",
     "JumpBranchLayouts",
+    "FetchTargetQueueLayouts",
+    "BranchPredictionLayouts",
 ]
+
+
+class FTQPtrLayout(CircularBufferPointer.Layout):
+    def __init__(self, gp: GenParams):
+        super().__init__(size_log=gp.ftq_size_log)
+
+
+class FTQPtr(CircularBufferPointer):
+    def __init__(self, target=None, *, gp: GenParams, **kwargs):
+        super().__init__(layout=FTQPtrLayout(gp), target=target, **kwargs)
 
 
 class CommonLayoutFields:
@@ -70,6 +83,9 @@ class CommonLayoutFields:
 
         self.rob_id: LayoutListField = ("rob_id", gen_params.rob_entries_bits)
         """Reorder buffer entry identifier."""
+
+        self.ftq_ptr: LayoutListField = ("ftq_ptr", FTQPtrLayout(gen_params))
+        """A pointer into the Fetch Target Queue"""
 
         self.fb_addr: LayoutListField = ("fb_addr", gen_params.isa.xlen - gen_params.fetch_block_bytes_log)
         """Address of a fetch block"""
@@ -192,6 +208,7 @@ class SchedulerLayouts:
             fields.rollback_tag,
             fields.rollback_tag_v,
             fields.commit_checkpoint,
+            fields.ftq_ptr,
         )
 
         self.instr_tag_in = self.reg_alloc_out = make_layout(
@@ -204,6 +221,7 @@ class SchedulerLayouts:
             fields.rollback_tag,
             fields.rollback_tag_v,
             fields.commit_checkpoint,
+            fields.ftq_ptr,
         )
 
         self.renaming_in = self.instr_tag_out = make_layout(
@@ -216,6 +234,7 @@ class SchedulerLayouts:
             fields.tag,
             fields.tag_increment,
             fields.commit_checkpoint,
+            fields.ftq_ptr,
         )
 
         self.renaming_out = make_layout(
@@ -227,6 +246,7 @@ class SchedulerLayouts:
             fields.pc,
             fields.tag,
             fields.tag_increment,
+            fields.ftq_ptr,
         )
 
         self.rob_allocate_in = self.renaming_out
@@ -324,6 +344,7 @@ class ROBLayouts:
             fields.rl_dst,
             fields.rp_dst,
             fields.tag_increment,
+            fields.ftq_ptr,
         )
 
         self.rob_data: LayoutListField = ("rob_data", self.data_layout)
@@ -515,6 +536,25 @@ class ICacheLayouts:
         )
 
 
+class BranchPredictionLayouts:
+    def __init__(self, gen_params: GenParams):
+        fields = gen_params.get(CommonLayoutFields)
+
+        self.request = make_layout(fields.pc, fields.ftq_ptr)
+        self.write_prediction = make_layout(fields.pc, fields.ftq_ptr)
+
+
+class FetchTargetQueueLayouts:
+    def __init__(self, gen_params: GenParams):
+        fields = gen_params.get(CommonLayoutFields)
+
+        self.branch_resolve = make_layout(
+            ("from_pc", gen_params.isa.xlen), ("next_pc", gen_params.isa.xlen), ("misprediction", 1)
+        )
+
+        self.commit = make_layout(fields.ftq_ptr)
+
+
 class FetchLayouts:
     """Layouts used in the fetcher."""
 
@@ -539,10 +579,11 @@ class FetchLayouts:
             self.access_fault,
             fields.rvc,
             fields.predicted_taken,
+            fields.ftq_ptr,
         )
 
-        self.fetch_request = make_layout(fields.pc)
-        self.fetch_writeback = make_layout(("redirect", 1), ("redirect_target", gen_params.isa.xlen))
+        self.fetch_request = make_layout(fields.pc, fields.ftq_ptr)
+        self.fetch_writeback = make_layout(fields.ftq_ptr, ("redirect", 1), ("redirect_target", gen_params.isa.xlen))
         self.redirect = make_layout(fields.pc)
         self.resume = make_layout(fields.pc)
 
@@ -580,6 +621,7 @@ class DecodeLayouts:
             fields.imm,
             fields.csr,
             fields.pc,
+            fields.ftq_ptr,
         )
 
 
@@ -642,11 +684,6 @@ class JumpBranchLayouts:
 
         self.predicted_jump_target_req = make_layout()
         self.predicted_jump_target_resp = make_layout(fields.cfi_target, ("valid", 1))
-
-        self.verify_branch = make_layout(
-            ("from_pc", gen_params.isa.xlen), ("next_pc", gen_params.isa.xlen), ("misprediction", 1)
-        )
-        """ Hint for Branch Predictor about branch result """
 
         self.funct7_info = make_layout(
             fields.rvc,

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -3,6 +3,7 @@ from amaranth.lib.data import ArrayLayout
 from amaranth.lib.enum import IntFlag, IntEnum, auto
 from coreblocks.params import GenParams
 from coreblocks.arch import *
+from coreblocks.interface.views import CircularBufferPointer
 from transactron.utils import LayoutList, LayoutListField, layout_subset
 from transactron.utils.transactron_helpers import make_layout, extend_layout
 
@@ -26,7 +27,19 @@ __all__ = [
     "ICacheLayouts",
     "JumpBranchLayouts",
     "PrivUnitLayouts",
+    "FetchTargetQueueLayouts",
+    "BranchPredictionLayouts",
 ]
+
+
+class FTQPtrLayout(CircularBufferPointer.Layout):
+    def __init__(self, gp: GenParams):
+        super().__init__(size_log=gp.ftq_size_log)
+
+
+class FTQPtr(CircularBufferPointer):
+    def __init__(self, target=None, *, gp: GenParams, **kwargs):
+        super().__init__(layout=FTQPtrLayout(gp), target=target, **kwargs)
 
 
 class CommonLayoutFields:
@@ -71,6 +84,9 @@ class CommonLayoutFields:
 
         self.rob_id: LayoutListField = ("rob_id", gen_params.rob_entries_bits)
         """Reorder buffer entry identifier."""
+
+        self.ftq_ptr: LayoutListField = ("ftq_ptr", FTQPtrLayout(gen_params))
+        """A pointer into the Fetch Target Queue"""
 
         self.fb_addr: LayoutListField = ("fb_addr", gen_params.isa.xlen - gen_params.fetch_block_bytes_log)
         """Address of a fetch block"""
@@ -250,6 +266,7 @@ class SchedulerLayouts:
             fields.rollback_tag,
             fields.rollback_tag_v,
             fields.commit_checkpoint,
+            fields.ftq_ptr,
         )
 
         self.reg_alloc_in = self.scheduler_in = make_layout(
@@ -267,6 +284,7 @@ class SchedulerLayouts:
             fields.rollback_tag,
             fields.rollback_tag_v,
             fields.commit_checkpoint,
+            fields.ftq_ptr,
         )
 
         self.reg_alloc_out = self.instr_tag_in = make_layout(
@@ -284,6 +302,7 @@ class SchedulerLayouts:
             fields.tag,
             fields.tag_increment,
             fields.commit_checkpoint,
+            fields.ftq_ptr,
         )
 
         self.renaming_in = self.instr_tag_out = make_layout(
@@ -300,6 +319,7 @@ class SchedulerLayouts:
             fields.pc,
             fields.tag,
             fields.tag_increment,
+            fields.ftq_ptr,
         )
 
         self.renaming_out = self.rob_allocate_in = make_layout(
@@ -410,6 +430,7 @@ class ROBLayouts:
             fields.rl_dst,
             fields.rp_dst,
             fields.tag_increment,
+            fields.ftq_ptr,
         )
 
         self.rob_data: LayoutListField = ("rob_data", self.data_layout)
@@ -613,6 +634,25 @@ class ICacheLayouts:
         )
 
 
+class BranchPredictionLayouts:
+    def __init__(self, gen_params: GenParams):
+        fields = gen_params.get(CommonLayoutFields)
+
+        self.request = make_layout(fields.pc, fields.ftq_ptr)
+        self.write_prediction = make_layout(fields.pc, fields.ftq_ptr)
+
+
+class FetchTargetQueueLayouts:
+    def __init__(self, gen_params: GenParams):
+        fields = gen_params.get(CommonLayoutFields)
+
+        self.branch_resolve = make_layout(
+            ("from_pc", gen_params.isa.xlen), ("next_pc", gen_params.isa.xlen), ("misprediction", 1)
+        )
+
+        self.commit = make_layout(fields.ftq_ptr)
+
+
 class FetchLayouts:
     """Layouts used in the fetcher."""
 
@@ -641,6 +681,7 @@ class FetchLayouts:
             fields.rvc,
             fields.predicted_taken,
             fields.cfi_type,
+            fields.ftq_ptr,
         )
 
         self.fetch_result = make_layout(
@@ -648,8 +689,8 @@ class FetchLayouts:
             ("data", ArrayLayout(self.raw_instr, gen_params.frontend_superscalarity)),
         )
 
-        self.fetch_request = make_layout(fields.pc)
-        self.fetch_writeback = make_layout(("redirect", 1), ("redirect_target", gen_params.isa.xlen))
+        self.fetch_request = make_layout(fields.pc, fields.ftq_ptr)
+        self.fetch_writeback = make_layout(fields.ftq_ptr, ("redirect", 1), ("redirect_target", gen_params.isa.xlen))
         self.redirect = make_layout(fields.pc)
         self.resume = make_layout(fields.pc)
 
@@ -687,6 +728,7 @@ class DecodeLayouts:
             fields.imm,
             fields.csr,
             fields.pc,
+            fields.ftq_ptr,
         )
 
         self.decode_result = make_layout(
@@ -704,6 +746,7 @@ class DecodeLayouts:
             fields.rollback_tag,
             fields.rollback_tag_v,
             fields.commit_checkpoint,
+            fields.ftq_ptr,
         )
 
         self.tagged_decode_result = make_layout(
@@ -771,11 +814,6 @@ class JumpBranchLayouts:
 
         self.predicted_jump_target_req = make_layout()
         self.predicted_jump_target_resp = make_layout(fields.cfi_target, ("valid", 1))
-
-        self.verify_branch = make_layout(
-            ("from_pc", gen_params.isa.xlen), ("next_pc", gen_params.isa.xlen), ("misprediction", 1)
-        )
-        """ Hint for Branch Predictor about branch result """
 
         self.funct7_info = make_layout(
             fields.rvc,

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -33,13 +33,13 @@ __all__ = [
 
 
 class FTQPtrLayout(CircularBufferPointer.Layout):
-    def __init__(self, gp: GenParams):
-        super().__init__(size_log=gp.ftq_size_log)
+    def __init__(self, gen_params: GenParams):
+        super().__init__(size_log=gen_params.ftq_size_log)
 
 
 class FTQPtr(CircularBufferPointer):
-    def __init__(self, target=None, *, gp: GenParams, **kwargs):
-        super().__init__(layout=FTQPtrLayout(gp), target=target, **kwargs)
+    def __init__(self, target=None, *, gen_params: GenParams, **kwargs):
+        super().__init__(layout=FTQPtrLayout(gen_params), target=target, **kwargs)
 
 
 class CommonLayoutFields:
@@ -692,6 +692,7 @@ class FetchLayouts:
         self.fetch_request = make_layout(fields.pc, fields.ftq_ptr)
         self.fetch_writeback = make_layout(fields.ftq_ptr, ("redirect", 1), ("redirect_target", gen_params.isa.xlen))
         self.redirect = make_layout(fields.pc)
+        self.frontend_redirect = make_layout(fields.pc, ("from_unsafe", 1))
         self.resume = make_layout(fields.pc)
 
         self.predecoded_instr = make_layout(fields.cfi_type, ("cfi_offset", signed(21)), ("unsafe", 1))

--- a/coreblocks/interface/views.py
+++ b/coreblocks/interface/views.py
@@ -1,0 +1,57 @@
+from amaranth.lib import data
+from typing import Optional
+from amaranth_types import ValueLike
+from amaranth import *
+
+
+class CircularBufferPointer(data.View):
+    class Layout(data.StructLayout):
+        def __init__(self, size_log: int):
+            super().__init__(
+                {
+                    "ptr": size_log,
+                    "parity": 1,
+                }
+            )
+
+            self.ptr_width = size_log
+
+    def __init__(self, layout: Layout, target: Optional[ValueLike] = None, **kwargs):
+        super().__init__(layout=layout, target=target if target is not None else Signal(layout), **kwargs)
+
+        self.layout = layout
+
+    def __add__(self, val: int) -> "CircularBufferPointer":
+        return CircularBufferPointer(self.layout, (Cat(self.ptr, self.parity) + val)[: self.layout.ptr_width + 1])
+
+    def __sub__(self, val: int) -> "CircularBufferPointer":
+        return CircularBufferPointer(self.layout, (Cat(self.ptr, self.parity) - val)[: self.layout.ptr_width + 1])
+
+    def __lt__(self, other: "CircularBufferPointer") -> Value:
+        parity_different = self.parity ^ other.parity
+        ptr_smaller = self.ptr < other.ptr
+        return parity_different ^ ptr_smaller
+
+    def __le__(self, other: "CircularBufferPointer") -> Value:
+        parity_different = self.parity ^ other.parity
+        ptr_smaller_equal = self.ptr <= other.ptr
+        return parity_different ^ ptr_smaller_equal
+
+    def __ge__(self, other: "CircularBufferPointer") -> Value:
+        parity_different = self.parity ^ other.parity
+        ptr_smaller_equal = self.ptr >= other.ptr
+        return parity_different ^ ptr_smaller_equal
+
+    @staticmethod
+    def queue_full(enqueue_ptr: "CircularBufferPointer", dequeue_ptr: "CircularBufferPointer") -> Value:
+        return (enqueue_ptr.parity != dequeue_ptr.parity) & (enqueue_ptr.ptr == dequeue_ptr.ptr)
+
+    @staticmethod
+    def queue_empty(enqueue_ptr: "CircularBufferPointer", dequeue_ptr: "CircularBufferPointer") -> Value:
+        return enqueue_ptr.as_value() == dequeue_ptr.as_value()
+
+    @staticmethod
+    def queue_size(enqueue_ptr: "CircularBufferPointer", dequeue_ptr: "CircularBufferPointer") -> Value:
+        return (enqueue_ptr.ptr - dequeue_ptr.ptr).as_unsigned()[: enqueue_ptr.layout.ptr_width] + (
+            enqueue_ptr.parity ^ dequeue_ptr.parity
+        )

--- a/coreblocks/interface/views.py
+++ b/coreblocks/interface/views.py
@@ -5,7 +5,15 @@ from amaranth import *
 
 
 class CircularBufferPointer(data.View):
+    """A pointer into a power-of-two-sized circular buffer, with an extra parity (wrap) bit.
+
+    The ``parity`` bit toggles on every wrap-around, distinguishing a full buffer from an
+    empty one and making ordering comparisons well-defined across the wrap point.
+    """
+
     class Layout(data.StructLayout):
+        """Layout of a circular buffer pointer: a ``size_log``-bit index plus a 1-bit parity."""
+
         def __init__(self, size_log: int):
             super().__init__(
                 {

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -98,6 +98,8 @@ class _CoreConfigurationDataClass:
         Log of the cache line size (in bytes).
     fetch_block_bytes_log: int
         Log of the size of the fetch block (in bytes).
+    ftq_size_log: int
+        Log of the number of entries in the Fetch Target Queue
     instr_buffer_size: int
         Size of the instruction buffer.
     interrupt_custom_count: int
@@ -158,6 +160,8 @@ class _CoreConfigurationDataClass:
     icache_line_bytes_log: int = 5
 
     fetch_block_bytes_log: int = 2
+
+    ftq_size_log: int = 4
 
     instr_buffer_size: int = 4
 

--- a/coreblocks/params/core_configuration.py
+++ b/coreblocks/params/core_configuration.py
@@ -99,6 +99,8 @@ class _CoreConfigurationDataClass:
         Log of the cache line size (in bytes).
     fetch_block_bytes_log: int
         Log of the size of the fetch block (in bytes).
+    ftq_size_log: int
+        Log of the number of entries in the Fetch Target Queue
     instr_buffer_size: int
         Size of the instruction buffer.
     interrupt_custom_count: int
@@ -180,6 +182,7 @@ class _CoreConfigurationDataClass:
     icache_line_bytes_log: int = 5
 
     fetch_block_bytes_log: int = 2
+    ftq_size_log: int = 4
 
     instr_buffer_size: int = 4
 

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -69,6 +69,9 @@ class GenParams(DependentCache):
         self.max_rs_entries_bits = ceil_log2(self.max_rs_entries)
         self.start_pc = cfg.start_pc
 
+        self.ftq_size_log = cfg.ftq_size_log
+        self.ftq_size = 2**cfg.ftq_size_log
+
         self.frontend_superscalarity = cfg.frontend_superscalarity
         self.announcement_superscalarity = cfg.announcement_superscalarity
         self.retirement_superscalarity = cfg.retirement_superscalarity

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -94,6 +94,9 @@ class GenParams(DependentCache):
         self.max_rs_entries_bits = ceil_log2(self.max_rs_entries)
         self.start_pc = cfg.start_pc
 
+        self.ftq_size_log = cfg.ftq_size_log
+        self.ftq_size = 2**cfg.ftq_size_log
+
         self.frontend_superscalarity = cfg.frontend_superscalarity
         self.announcement_superscalarity = cfg.announcement_superscalarity
         self.retirement_superscalarity = cfg.retirement_superscalarity

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -143,7 +143,9 @@ class Renaming(Elaboratable):
                 commit_checkpoint=instr.commit_checkpoint,
             )
 
-            m.d.comb += assign(data_out, instr, fields={"exec_fn", "imm", "csr", "pc", "tag", "tag_increment"})
+            m.d.comb += assign(
+                data_out, instr, fields={"exec_fn", "imm", "csr", "pc", "tag", "tag_increment", "ftq_ptr"}
+            )
             m.d.comb += assign(data_out.regs_l, instr.regs_l, fields=AssignType.COMMON)
             m.d.comb += data_out.regs_p.rp_dst.eq(instr.regs_p.rp_dst)
             m.d.comb += data_out.regs_p.rp_s1.eq(renamed_regs.rp_s1)
@@ -192,6 +194,7 @@ class ROBAllocation(Elaboratable):
                         "rl_dst": instr.regs_l.rl_dst,
                         "rp_dst": instr.regs_p.rp_dst,
                         "tag_increment": instr.tag_increment,
+                        "ftq_ptr": instr.ftq_ptr,
                     }
                 ],
             )

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -172,7 +172,9 @@ class Renaming(Elaboratable):
                         rp_dst=instr.regs_p.rp_dst,
                     )
 
-                m.d.av_comb += assign(instr_out, instr, fields={"exec_fn", "imm", "csr", "pc", "tag", "tag_increment"})
+                m.d.av_comb += assign(
+                    instr_out, instr, fields={"exec_fn", "imm", "csr", "pc", "tag", "tag_increment", "ftq_ptr"}
+                )
                 m.d.av_comb += assign(instr_out.regs_l, instr.regs_l, fields=AssignType.COMMON)
                 m.d.av_comb += instr_out.regs_p.rp_dst.eq(instr.regs_p.rp_dst)
                 m.d.av_comb += instr_out.regs_p.rp_s1.eq(renamed_regs.rp_s1)
@@ -223,6 +225,7 @@ class ROBAllocation(Elaboratable):
                             "rl_dst": instr.regs_l.rl_dst,
                             "rp_dst": instr.regs_p.rp_dst,
                             "tag_increment": instr.tag_increment,
+                            "ftq_ptr": instr.ftq_ptr,
                         },
                         "pure": ~Cat(instr.exec_fn.op_type == op_type for op_type in impure_optypes).any(),
                     }

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -5,6 +5,8 @@ from transactron.lib import FIFO, Adapter
 from coreblocks.core_structs.rat import RRAT
 from coreblocks.params import GenParams
 from coreblocks.params.configurations import test_core_config
+from coreblocks.interface.layouts import *
+from coreblocks.interface.keys import FTQCommitEntry
 from transactron.lib.adapters import AdapterTrans
 
 from transactron.testing import *
@@ -26,6 +28,11 @@ class RetirementTestCircuit(Elaboratable):
 
         m.submodules.csr_instances = self.csr_instances = CSRInstances(self.gen_params)
         DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
+
+        m.submodules.ftq_commit = self.ftq_commit = TestbenchIO(
+            Adapter(i=self.gen_params.get(FetchTargetQueueLayouts).commit)
+        )
+        DependencyContext.get().add_dependency(FTQCommitEntry(), self.ftq_commit.adapter.iface)
 
         m.submodules.retirement = self.retirement = Retirement(self.gen_params)
 
@@ -178,6 +185,10 @@ class TestRetirement(TestCaseWithSimulator):
 
     @def_method_mock(lambda self: self.retc.mock_checkpoint_tag_free)
     def mock_checkpoint_tag_free(self):
+        pass
+
+    @def_method_mock(lambda self: self.retc.ftq_commit)
+    def ftq_commit(self, ftq_ptr):
         pass
 
     def test_rand(self):

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -9,7 +9,8 @@ from transactron.utils import DependencyContext
 from coreblocks.core_structs.rat import RRAT
 from coreblocks.params import GenParams
 from coreblocks.params import configurations
-from coreblocks.interface.keys import CSRInstancesKey, InstructionPrecommitKey
+from coreblocks.interface.layouts import FetchTargetQueueLayouts
+from coreblocks.interface.keys import CSRInstancesKey, InstructionPrecommitKey, FTQCommitEntry
 from transactron.lib.adapters import AdapterTrans
 
 from transactron.testing import *
@@ -31,6 +32,11 @@ class RetirementTestCircuit(Elaboratable):
 
         m.submodules.csr_instances = self.csr_instances = CSRInstances(self.gen_params)
         DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
+
+        m.submodules.ftq_commit = self.ftq_commit = TestbenchIO(
+            Adapter(i=self.gen_params.get(FetchTargetQueueLayouts).commit)
+        )
+        DependencyContext.get().add_dependency(FTQCommitEntry(), self.ftq_commit.adapter.iface)
 
         m.submodules.retirement = self.retirement = Retirement(self.gen_params)
 
@@ -189,6 +195,10 @@ class TestRetirement(TestCaseWithSimulator):
 
     @def_method_mock(lambda self: self.retc.mock_checkpoint_tag_free)
     def mock_checkpoint_tag_free(self):
+        pass
+
+    @def_method_mock(lambda self: self.retc.ftq_commit)
+    def ftq_commit(self, ftq_ptr):
         pass
 
     def test_rand(self):

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -10,7 +10,7 @@ from coreblocks.core_structs.rat import RRAT
 from coreblocks.params import GenParams
 from coreblocks.params import configurations
 from coreblocks.interface.layouts import FetchTargetQueueLayouts
-from coreblocks.interface.keys import CSRInstancesKey, InstructionPrecommitKey, FTQCommitEntry
+from coreblocks.interface.keys import CSRInstancesKey, InstructionPrecommitKey, FTQCommitKey
 from transactron.lib.adapters import AdapterTrans
 
 from transactron.testing import *
@@ -36,7 +36,7 @@ class RetirementTestCircuit(Elaboratable):
         m.submodules.ftq_commit = self.ftq_commit = TestbenchIO(
             Adapter(i=self.gen_params.get(FetchTargetQueueLayouts).commit)
         )
-        DependencyContext.get().add_dependency(FTQCommitEntry(), self.ftq_commit.adapter.iface)
+        DependencyContext.get().add_dependency(FTQCommitKey(), self.ftq_commit.adapter.iface)
 
         m.submodules.retirement = self.retirement = Retirement(self.gen_params)
 

--- a/test/core_structs/test_reorder_buffer.py
+++ b/test/core_structs/test_reorder_buffer.py
@@ -67,7 +67,9 @@ class TestReorderBuffer(TestCaseWithSimulator):
                     assert phys_reg in self.executed_set
                     self.executed_set.remove(phys_reg)
 
-                    assert data_const_to_dict(results.entries[k].rob_data) == regs[k]
+                    rob_data = data_const_to_dict(results.entries[k].rob_data)
+                    for reg_key in regs[k].keys():
+                        assert rob_data[reg_key] == regs[k][reg_key]
                     self.regs_left_queue.append(phys_reg)
 
     def test_single(self, mark_done_ports: int, frontend_superscalarity: int, retirement_superscalarity: int):

--- a/test/core_structs/test_reorder_buffer.py
+++ b/test/core_structs/test_reorder_buffer.py
@@ -25,7 +25,17 @@ class TestReorderBuffer(TestCaseWithSimulator):
             for k in range(count):
                 log_reg = self.rand.randint(0, self.log_regs - 1)
                 phys_reg = self.regs_left_queue.popleft()
-                entries.append({"rob_data": {"rl_dst": log_reg, "rp_dst": phys_reg, "tag_increment": 0}, "pure": 0})
+                entries.append(
+                    {
+                        "rob_data": {
+                            "rl_dst": log_reg,
+                            "rp_dst": phys_reg,
+                            "tag_increment": 0,
+                            "ftq_ptr": {"ptr": 0, "parity": 0},
+                        },
+                        "pure": 0,
+                    }
+                )
             rob_ids = (await self.m.put.call(sim, count=count, entries=entries)).entries
             for k in range(count):
                 self.to_execute_list.append((rob_ids[k].rob_id, entries[k]["rob_data"]["rp_dst"]))

--- a/test/frontend/test_decode_stage.py
+++ b/test/frontend/test_decode_stage.py
@@ -77,7 +77,9 @@ class TestDecode(TestCaseWithSimulator):
                 data["csr"] = decoded.csr
             if data["imm"] is None:
                 data["imm"] = decoded.imm
-            assert data_const_to_dict(decoded) == data
+            decoded_data = data_const_to_dict(decoded)
+            for key in data.keys():
+                assert decoded_data[key] == data[key]
 
     def test(self):
         with self.run_simulation(self.m) as sim:

--- a/test/frontend/test_decode_stage.py
+++ b/test/frontend/test_decode_stage.py
@@ -61,7 +61,9 @@ class TestDecode(TestCaseWithSimulator):
                 data["csr"] = decoded.csr
             if data["imm"] is None:
                 data["imm"] = decoded.imm
-            assert data_const_to_dict(decoded) == data
+            decoded_data = data_const_to_dict(decoded)
+            for key in data.keys():
+                assert decoded_data[key] == data[key]
 
     def test(self):
         with self.run_simulation(self.m) as sim:

--- a/test/frontend/test_decode_stage.py
+++ b/test/frontend/test_decode_stage.py
@@ -29,6 +29,7 @@ def mk_test(
         "imm": imm,
         "pc": 0,
         "csr": csr,
+        "ftq_ptr": {"ptr": 0, "parity": 0},
     }
 
 

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -192,7 +192,7 @@ class TestFetchUnit(TestCaseWithSimulator):
         pass
 
     @def_method_mock(lambda self: self.fetch.fetch_writeback)
-    def fetch_writeback_mock(self, redirect, redirect_target):
+    def fetch_writeback_mock(self, ftq_ptr, redirect, redirect_target):
         @MethodMock.effect
         def eff():
             if redirect:

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -190,7 +190,7 @@ class TestFetchUnit(TestCaseWithSimulator):
             return self.output_q[0]
 
     @def_method_mock(lambda self: self.fetch.stall_unsafe)
-    def stall_lock_unsafe(self):
+    def stall_guard_unsafe(self):
         pass
 
     @def_method_mock(lambda self: self.fetch.fetch_writeback)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -194,7 +194,7 @@ class TestFetchUnit(TestCaseWithSimulator):
         pass
 
     @def_method_mock(lambda self: self.fetch.fetch_writeback)
-    def fetch_writeback_mock(self, redirect, redirect_target):
+    def fetch_writeback_mock(self, ftq_ptr, redirect, redirect_target):
         @MethodMock.effect
         def eff():
             if redirect:

--- a/test/frontend/test_ftq.py
+++ b/test/frontend/test_ftq.py
@@ -26,8 +26,8 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
 
         self.ftq = SimpleTestCircuit(FetchTargetQueue(self.gen_params))
 
-    @def_method_mock(lambda self: self.ftq.stall_lock)
-    def stall_lock_mock(self):
+    @def_method_mock(lambda self: self.ftq.stall_guard)
+    def stall_guard_mock(self):
         pass
 
     @def_method_mock(lambda self: self.ftq.bpu_flush)
@@ -84,25 +84,25 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
-    def test_ifu_redirect_triggers_bpu_flush(self):
+    def test_ifu_writeback_triggers_bpu_flush(self):
         async def proc(sim: TestbenchContext):
             for _ in range(5):
                 await sim.tick()
             flush_count_before = self.bpu_flush_count
-            await self.ftq.ifu_redirect.call(sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, redirect_target=0x200)
+            await self.ftq.ifu_writeback.call(sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, redirect_target=0x200)
             assert self.bpu_flush_count > flush_count_before
 
         with self.run_simulation(self.ftq) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
-    def test_ifu_redirect_restarts_fetch_from_new_pc(self):
-        # ifu_redirect calls FAU.ifu_redirect which sets the new PC directly,
+    def test_ifu_writeback_restarts_fetch_from_new_pc(self):
+        # ifu_writeback calls FAU.ifu_redirect which sets the new PC directly,
         # so the next alloc uses redirect_pc without needing a BPU response.
         redirect_pc = 0x200
 
         async def proc(sim: TestbenchContext):
-            await self.ftq.ifu_redirect.call(
+            await self.ftq.ifu_writeback.call(
                 sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, redirect_target=redirect_pc
             )
             for _ in range(5):
@@ -137,8 +137,8 @@ class TestFetchTargetQueueFull(TestCaseWithSimulator):
 
         self.ftq = SimpleTestCircuit(FetchTargetQueue(self.gen_params))
 
-    @def_method_mock(lambda self: self.ftq.stall_lock)
-    def stall_lock_mock(self):
+    @def_method_mock(lambda self: self.ftq.stall_guard)
+    def stall_guard_mock(self):
         pass
 
     @def_method_mock(lambda self: self.ftq.bpu_flush)

--- a/test/frontend/test_ftq.py
+++ b/test/frontend/test_ftq.py
@@ -1,0 +1,193 @@
+import pytest
+from collections import deque
+
+from transactron.testing import (
+    TestCaseWithSimulator,
+    def_method_mock,
+    SimpleTestCircuit,
+    TestbenchContext,
+    ProcessContext,
+)
+from transactron.testing.method_mock import MethodMock
+
+from coreblocks.frontend.ftq import FetchTargetQueue
+from coreblocks.params import GenParams
+from coreblocks.params import configurations
+
+
+class TestFetchTargetQueue(TestCaseWithSimulator):
+    @pytest.fixture(autouse=True)
+    def setup(self, fixture_initialize_testing_env):
+        self.start_pc = 0x100
+        self.gen_params = GenParams(configurations.test.replace(start_pc=self.start_pc))
+        self.ifu_requests: deque = deque()
+        self.bpu_requests: deque = deque()
+        self.bpu_flush_count: int = 0
+
+        self.ftq = SimpleTestCircuit(FetchTargetQueue(self.gen_params))
+
+    @def_method_mock(lambda self: self.ftq.stall_lock)
+    def stall_lock_mock(self):
+        pass
+
+    @def_method_mock(lambda self: self.ftq.bpu_flush)
+    def bpu_flush_mock(self):
+        @MethodMock.effect
+        def eff():
+            self.bpu_flush_count += 1
+
+    @def_method_mock(lambda self: self.ftq.bpu_request)
+    def bpu_request_mock(self, pc, ftq_ptr):
+        @MethodMock.effect
+        def eff():
+            self.bpu_requests.append(pc)
+
+    @def_method_mock(lambda self: self.ftq.ifu_request)
+    def ifu_request_mock(self, pc, ftq_ptr):
+        @MethodMock.effect
+        def eff():
+            self.ifu_requests.append({"pc": pc, "ftq_ptr": ftq_ptr["ptr"]})
+
+    async def auto_bpu_process(self, sim: ProcessContext):
+        """Responds to each BPU request by predicting PC+4 as the next PC."""
+        while True:
+            if self.bpu_requests:
+                pc = self.bpu_requests.popleft()
+                await self.ftq.bpu_response.call(sim, pc=pc + 4, ftq_ptr={"ptr": 0, "parity": 0})
+            else:
+                await sim.tick()
+
+    def test_alloc_sends_ifu_request_with_start_pc(self):
+        async def proc(sim: TestbenchContext):
+            for _ in range(5):
+                await sim.tick()
+            assert len(self.ifu_requests) >= 1
+            assert self.ifu_requests[0]["pc"] == self.start_pc
+            assert self.ifu_requests[0]["ftq_ptr"] == 0
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
+            sim.add_testbench(proc)
+
+    def test_sequential_allocs_advance_ftq_ptr(self):
+        n_allocs = 4
+
+        async def proc(sim: TestbenchContext):
+            for _ in range(20):
+                await sim.tick()
+            assert len(self.ifu_requests) >= n_allocs
+            for i in range(n_allocs):
+                assert self.ifu_requests[i]["pc"] == self.start_pc + 4 * i
+                assert self.ifu_requests[i]["ftq_ptr"] == i
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
+            sim.add_testbench(proc)
+
+    def test_ifu_redirect_triggers_bpu_flush(self):
+        async def proc(sim: TestbenchContext):
+            for _ in range(5):
+                await sim.tick()
+            flush_count_before = self.bpu_flush_count
+            await self.ftq.ifu_redirect.call(sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, redirect_target=0x200)
+            assert self.bpu_flush_count > flush_count_before
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
+            sim.add_testbench(proc)
+
+    def test_ifu_redirect_restarts_fetch_from_new_pc(self):
+        # ifu_redirect calls FAU.ifu_redirect which sets the new PC directly,
+        # so the next alloc uses redirect_pc without needing a BPU response.
+        redirect_pc = 0x200
+
+        async def proc(sim: TestbenchContext):
+            await self.ftq.ifu_redirect.call(
+                sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, redirect_target=redirect_pc
+            )
+            for _ in range(5):
+                await sim.tick()
+            assert redirect_pc in [req["pc"] for req in self.ifu_requests]
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_testbench(proc)
+
+    def test_backend_redirect_restarts_fetch_from_new_pc(self):
+        # backend_redirect calls FAU.backend_redirect which sets the new PC directly.
+        redirect_pc = 0x400
+
+        async def proc(sim: TestbenchContext):
+            await self.ftq.backend_redirect.call(sim, pc=redirect_pc)
+            for _ in range(5):
+                await sim.tick()
+            assert redirect_pc in [req["pc"] for req in self.ifu_requests]
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_testbench(proc)
+
+
+class TestFetchTargetQueueFull(TestCaseWithSimulator):
+    @pytest.fixture(autouse=True)
+    def setup(self, fixture_initialize_testing_env):
+        self.start_pc = 0x100
+        # small FTQ (4 entries) to exercise the full condition quickly
+        self.gen_params = GenParams(configurations.test.replace(start_pc=self.start_pc, ftq_size_log=2))
+        self.ifu_requests: deque = deque()
+        self.bpu_requests: deque = deque()
+
+        self.ftq = SimpleTestCircuit(FetchTargetQueue(self.gen_params))
+
+    @def_method_mock(lambda self: self.ftq.stall_lock)
+    def stall_lock_mock(self):
+        pass
+
+    @def_method_mock(lambda self: self.ftq.bpu_flush)
+    def bpu_flush_mock(self):
+        pass
+
+    @def_method_mock(lambda self: self.ftq.bpu_request)
+    def bpu_request_mock(self, pc, ftq_ptr):
+        @MethodMock.effect
+        def eff():
+            self.bpu_requests.append(pc)
+
+    @def_method_mock(lambda self: self.ftq.ifu_request)
+    def ifu_request_mock(self, pc, ftq_ptr):
+        @MethodMock.effect
+        def eff():
+            self.ifu_requests.append(pc)
+
+    async def auto_bpu_process(self, sim: ProcessContext):
+        while True:
+            if self.bpu_requests:
+                pc = self.bpu_requests.popleft()
+                await self.ftq.bpu_response.call(sim, pc=pc + 4, ftq_ptr={"ptr": 0, "parity": 0})
+            else:
+                await sim.tick()
+
+    def test_ftq_full_stalls_then_commit_unblocks(self):
+        ftq_size = self.gen_params.ftq_size  # 4
+
+        async def proc(sim: TestbenchContext):
+            # Let the FTQ fill up
+            for _ in range(20):
+                await sim.tick()
+            count_when_full = len(self.ifu_requests)
+            assert count_when_full == ftq_size
+
+            # Wait a few more cycles to confirm no new requests come in
+            for _ in range(5):
+                await sim.tick()
+            assert len(self.ifu_requests) == count_when_full
+
+            # Commit entry 1, freeing one slot
+            await self.ftq.commit.call(sim, ftq_ptr={"ptr": 1, "parity": 0})
+
+            # Wait for one more alloc
+            for _ in range(5):
+                await sim.tick()
+            assert len(self.ifu_requests) == ftq_size + 1
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
+            sim.add_testbench(proc)

--- a/test/func_blocks/fu/test_jb_unit.py
+++ b/test/func_blocks/fu/test_jb_unit.py
@@ -6,10 +6,10 @@ from coreblocks.params import *
 from coreblocks.func_blocks.fu.jumpbranch import JumpBranchFuncUnit, JumpBranchFn
 from transactron import Method, def_method, TModule, Transaction
 
-from coreblocks.interface.layouts import FuncUnitLayouts, JumpBranchLayouts
+from coreblocks.interface.layouts import FuncUnitLayouts, JumpBranchLayouts, FetchTargetQueueLayouts
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 from coreblocks.arch import Funct3, OpType, ExceptionCause
-from coreblocks.interface.keys import PredictedJumpTargetKey
+from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey
 
 from transactron.utils import signed_to_int, DependencyContext
 from transactron.lib import BasicFifo
@@ -23,17 +23,22 @@ class JumpBranchWrapper(FuncUnit, Elaboratable):
         self.auipc_test = auipc_test
         layouts = gen_params.get(JumpBranchLayouts)
 
+        branch_resolve_layout = gen_params.get(FetchTargetQueueLayouts).branch_resolve
+
         self.target_pred_req = Method(i=layouts.predicted_jump_target_req)
         self.target_pred_resp = Method(o=layouts.predicted_jump_target_resp)
 
+        self.fifo_branch_resolved = BasicFifo(branch_resolve_layout, 2)
+
         DependencyContext.get().add_dependency(PredictedJumpTargetKey(), (self.target_pred_req, self.target_pred_resp))
+        DependencyContext.get().add_dependency(BranchResolveKey(), self.fifo_branch_resolved.write)
 
         self.jb = JumpBranchFuncUnit(gen_params)
         self.issue = self.jb.issue
         self.push_result = Method(
             i=StructLayout(
                 gen_params.get(FuncUnitLayouts).push_result.members
-                | (gen_params.get(JumpBranchLayouts).verify_branch.members if not auipc_test else {})
+                | (branch_resolve_layout.members if not auipc_test else {})
             )
         )
 
@@ -42,6 +47,7 @@ class JumpBranchWrapper(FuncUnit, Elaboratable):
 
         m.submodules.jb_unit = self.jb
         m.submodules.res_fifo = res_fifo = BasicFifo(self.gp.get(FuncUnitLayouts).push_result, 2)
+        m.submodules.fifo_branch_resolved = self.fifo_branch_resolved
 
         self.jb.push_result.provide(res_fifo.write)
 
@@ -62,7 +68,7 @@ class JumpBranchWrapper(FuncUnit, Elaboratable):
                 "exception": res.exception,
             }
             if not self.auipc_test:
-                verify = self.jb.fifo_branch_resolved.read(m)
+                verify = self.fifo_branch_resolved.read(m)
                 ret = ret | {
                     "next_pc": verify.next_pc,
                     "from_pc": verify.from_pc,

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -143,7 +143,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
 @parameterized_class(
     ("name", "source_file", "cycle_count", "expected_regvals", "configuration"),
     [
-        ("fibonacci", "fibonacci.asm", 500, {2: 2971215073}, basic_core_config),
+        ("fibonacci", "fibonacci.asm", 550, {2: 2971215073}, basic_core_config),
         ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, basic_core_config),
         ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, tiny_core_config),
         ("csr", "csr.asm", 200, {1: 1, 2: 4}, full_core_config),

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -180,7 +180,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
 @parameterized_class(
     ("name", "source_file", "cycle_count", "expected_regvals", "exit_csr", "configuration"),
     [
-        ("fibonacci", "fibonacci.asm", 550, {2: 2971215073}, True, configurations.basic),
+        ("fibonacci", "fibonacci.asm", 500, {2: 2971215073}, True, configurations.basic),
         ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, False, configurations.basic),
         ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, False, configurations.tiny),
         ("csr", "csr.asm", 200, {1: 1, 2: 4}, True, configurations.full),

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -180,7 +180,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
 @parameterized_class(
     ("name", "source_file", "cycle_count", "expected_regvals", "exit_csr", "configuration"),
     [
-        ("fibonacci", "fibonacci.asm", 500, {2: 2971215073}, True, configurations.basic),
+        ("fibonacci", "fibonacci.asm", 550, {2: 2971215073}, True, configurations.basic),
         ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, False, configurations.basic),
         ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, False, configurations.tiny),
         ("csr", "csr.asm", 200, {1: 1, 2: 4}, True, configurations.full),


### PR DESCRIPTION
The Fetch Target Queue (FTQ) is a buffer that decouples branch prediction from instruction fetch. The branch predictor writes predicted fetch addresses (along with some prediction metadata) into the FTQ ahead of time, while the fetch unit consumes entries from the queue to retrieve the corresponding instruction blocks. FTQ stores prediction information so it can be later sent back to the BPU for predictor training after instruction commit. FTQ maintains the complete lifecycle of instructions from prediction to commit.

In this PR I'm adding an initial implementation of FTQ. It doesn't do anything meaningful at this point: it simply stores basic predictions from the branch prediction unit and then sends them to the fetch unit.

TODO in this PR:
- [x] some FTQ unit tests
- [x] documentation