### PR TITLE
Superscalar register allocation

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -42,7 +42,7 @@ class Retirement(Elaboratable):
         self.fetch_continue = Method(i=self.gen_params.get(FetchLayouts).resume)
         self.instr_decrement = Method(
             i=gen_params.get(CoreInstructionCounterLayouts).decrement_in,
-            o=gen_params.get(CoreInstructionCounterLayouts).decrement,
+            o=gen_params.get(CoreInstructionCounterLayouts).decrement_out,
         )
         self.trap_entry = Method()
         self.async_interrupt_cause = Method(o=gen_params.get(InternalInterruptControllerLayouts).interrupt_cause)

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -40,7 +40,10 @@ class Retirement(Elaboratable):
         self.exception_cause_clear = Method()
         self.c_rat_restore = Method(i=gen_params.get(RATLayouts).crat_flush_restore)
         self.fetch_continue = Method(i=self.gen_params.get(FetchLayouts).resume)
-        self.instr_decrement = Method(o=gen_params.get(CoreInstructionCounterLayouts).decrement)
+        self.instr_decrement = Method(
+            i=gen_params.get(CoreInstructionCounterLayouts).decrement_in,
+            o=gen_params.get(CoreInstructionCounterLayouts).decrement,
+        )
         self.trap_entry = Method()
         self.async_interrupt_cause = Method(o=gen_params.get(InternalInterruptControllerLayouts).interrupt_cause)
         self.checkpoint_tag_free = Method()
@@ -124,7 +127,7 @@ class Retirement(Elaboratable):
                     with m.If(rob_entry.rob_data.tag_increment):
                         self.checkpoint_tag_free(m)
 
-                    core_empty = self.instr_decrement(m)
+                    core_empty = self.instr_decrement(m, count=1)
 
                     commit = Signal()
 
@@ -203,7 +206,7 @@ class Retirement(Elaboratable):
                     with m.If(rob_entry.rob_data.tag_increment):
                         self.checkpoint_tag_free(m)
 
-                    core_empty = self.instr_decrement(m)
+                    core_empty = self.instr_decrement(m, count=1)
 
                     flush_instr(rob_entry)
 

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -60,7 +60,9 @@ class Core(Component):
 
         self.frontend = CoreFrontend(gen_params=self.gen_params, instr_bus=self.bus_master_instr_adapter)
 
-        self.rf_allocator = PriorityEncoderAllocator(gen_params.phys_regs, init=2**gen_params.phys_regs - 2)
+        self.rf_allocator = PriorityEncoderAllocator(
+            gen_params.phys_regs, gen_params.frontend_superscalarity, init=2**gen_params.phys_regs - 2
+        )
 
         self.CRAT = CheckpointRAT(gen_params=self.gen_params)
         self.RRAT = RRAT(gen_params=self.gen_params)
@@ -126,7 +128,7 @@ class Core(Component):
 
         m.submodules.scheduler = scheduler = Scheduler(gen_params=self.gen_params)
         scheduler.get_instr.provide(get_instr.method)
-        scheduler.get_free_reg.provide(rf_allocator.alloc[0])
+        scheduler.get_free_reg.provide(rf_allocator.alloc)
         scheduler.crat_rename.provide(crat.rename)
         scheduler.crat_tag.provide(crat.tag)
         scheduler.crat_active_tags.provide(crat.get_active_tags)

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -6,8 +6,8 @@ from transactron.utils.dependencies import DependencyContext
 from coreblocks.priv.traps.instr_counter import CoreInstructionCounter
 from coreblocks.func_blocks.interface.func_blocks_unifier import FuncBlocksUnifier
 from coreblocks.priv.traps.interrupt_controller import ISA_RESERVED_INTERRUPTS, InternalInterruptController
-from transactron.core import TModule, Method
-from transactron.lib import CrossbarConnectTrans, MethodProduct
+from transactron.core import TModule, Method, def_method
+from transactron.lib import CrossbarConnectTrans
 from coreblocks.interface.layouts import *
 from coreblocks.interface.keys import (
     CSRInstancesKey,
@@ -121,13 +121,16 @@ class Core(Component):
 
         m.submodules.core_counter = core_counter = CoreInstructionCounter(self.gen_params)
 
-        drop_second_ret_value = (self.gen_params.get(SchedulerLayouts).scheduler_in, lambda _, rets: rets[0])
-        m.submodules.get_instr = get_instr = MethodProduct.create(
-            [self.frontend.consume_instr, core_counter.increment], combiner=drop_second_ret_value
-        )
+        get_instr = Method.like(self.frontend.consume_instr)
+
+        @def_method(m, get_instr)
+        def _():
+            ret = self.frontend.consume_instr(m)
+            core_counter.increment(m, ret.count)
+            return ret
 
         m.submodules.scheduler = scheduler = Scheduler(gen_params=self.gen_params)
-        scheduler.get_instr.provide(get_instr.method)
+        scheduler.get_instr.provide(get_instr)
         scheduler.get_free_reg.provide(rf_allocator.alloc)
         scheduler.crat_rename.provide(crat.rename)
         scheduler.crat_tag.provide(crat.tag)

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -1,7 +1,7 @@
 from amaranth import *
 
 from transactron.core import *
-from transactron.lib import BasicFifo, Connect, WideFifo
+from transactron.lib import BasicFifo, Connect, Pipe
 from transactron.utils import assign
 from transactron.utils.dependencies import DependencyContext
 
@@ -155,12 +155,7 @@ class CoreFrontend(Elaboratable):
         self.fetch.stall_unsafe.provide(self.stall_ctrl.stall_unsafe)
 
         # TODO: change back to Pipe after Scheduler made superscalar
-        self.output_pipe = WideFifo(
-            self.gen_params.get(SchedulerLayouts).scheduler_in,
-            2 * gen_params.frontend_superscalarity,
-            read_width=1,
-            write_width=gen_params.frontend_superscalarity,
-        )
+        self.output_pipe = Pipe(self.gen_params.get(SchedulerLayouts).scheduler_in)
         self.decode_buff = Connect(self.gen_params.get(DecodeLayouts).decode_result)
 
         # TODO: move and implement these methods
@@ -195,6 +190,7 @@ class CoreFrontend(Elaboratable):
         m.submodules.rollback_tagger = rollback_tagger = self.rollback_tagger
         rollback_tagger.get_instr.provide(self.decode_buff.read)
         rollback_tagger.push_instr.provide(self.output_pipe.write)
+        self.consume_instr.provide(self.output_pipe.read)
 
         m.submodules.output_pipe = self.output_pipe
 
@@ -206,10 +202,6 @@ class CoreFrontend(Elaboratable):
         with Transaction(name="DiscardBranchVerify").body(m):
             read = self.connections.get_dependency(BranchVerifyKey())
             read(m)  # Consume to not block JB Unit
-
-        @def_method(m, self.consume_instr)
-        def _():
-            return self.output_pipe.read(m, count=1).data[0]
 
         @def_method(m, self.target_pred_req)
         def _():

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -787,4 +787,4 @@ class CoreInstructionCounterLayouts:
     def __init__(self, gen_params: GenParams):
         self.increment_in = [("count", range(gen_params.frontend_superscalarity + 1))]
         self.decrement_in = [("count", range(gen_params.retirement_superscalarity + 1))]
-        self.decrement = [("empty", 1)]
+        self.decrement_out = [("empty", 1)]

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -785,4 +785,6 @@ class InternalInterruptControllerLayouts:
 
 class CoreInstructionCounterLayouts:
     def __init__(self, gen_params: GenParams):
+        self.increment_in = [("count", range(gen_params.frontend_superscalarity + 1))]
+        self.decrement_in = [("count", range(gen_params.retirement_superscalarity + 1))]
         self.decrement = [("empty", 1)]

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -183,7 +183,7 @@ class SchedulerLayouts:
         )
         """Logical register number for the destination operand, before ROB allocation."""
 
-        self.reg_alloc_in = self.scheduler_in = make_layout(
+        self.reg_alloc_in_data = make_layout(
             fields.exec_fn,
             fields.regs_l,
             fields.imm,
@@ -194,7 +194,12 @@ class SchedulerLayouts:
             fields.commit_checkpoint,
         )
 
-        self.instr_tag_in = self.reg_alloc_out = make_layout(
+        self.reg_alloc_in = self.scheduler_in = make_layout(
+            ("count", range(gen_params.frontend_superscalarity + 1)),
+            ("data", ArrayLayout(self.reg_alloc_in_data, gen_params.frontend_superscalarity)),
+        )
+
+        self.instr_tag_in_data = make_layout(
             fields.exec_fn,
             fields.regs_l,
             self.regs_p_alloc_out,
@@ -205,6 +210,13 @@ class SchedulerLayouts:
             fields.rollback_tag_v,
             fields.commit_checkpoint,
         )
+
+        self.reg_alloc_out = make_layout(
+            ("count", range(gen_params.frontend_superscalarity + 1)),
+            ("data", ArrayLayout(self.instr_tag_in_data, gen_params.frontend_superscalarity)),
+        )
+
+        self.instr_tag_in = self.instr_tag_in_data
 
         self.renaming_in = self.instr_tag_out = make_layout(
             fields.exec_fn,

--- a/coreblocks/priv/traps/instr_counter.py
+++ b/coreblocks/priv/traps/instr_counter.py
@@ -1,46 +1,51 @@
 from amaranth import *
 from coreblocks.params.genparams import GenParams
 from coreblocks.interface.layouts import CoreInstructionCounterLayouts
-from transactron.core import Method, TModule, def_method
+from transactron.core import Method, Provided, TModule, def_method
 
 
 class CoreInstructionCounter(Elaboratable):
     """
     Counts instructions currently processed in core.
     Used in exception handling, to wait for core flush to finish.
+    """
 
-    Attributes
-    ----------
-    increment : Method
-        Increments the counter. Should be called when new instruction leaves fetch stage.
-    decrement : Method
-        Decrements the counter, and returns if the counter will be equal to zero after that cycle (it was the
-        last instruction in core and no new instruction is fetched). Should be called when instruction is retired.
+    increment: Provided[Method]
+    """Increments the counter. Should be called when new instruction leaves fetch stage."""
+
+    decrement: Provided[Method]
+    """Decrements the counter. Should be called when instruction is retired.
+    Returns a boolean saying if the counter will be equal to zero after that cycle (it was the
+    last instruction in core and no new instruction is fetched).
     """
 
     def __init__(self, gen_params: GenParams):
         self.gen_params = gen_params
 
-        self.increment = Method()
-        self.decrement = Method(o=gen_params.get(CoreInstructionCounterLayouts).decrement)
+        layouts = gen_params.get(CoreInstructionCounterLayouts)
+        self.increment = Method(i=layouts.increment_in)
+        self.decrement = Method(i=layouts.decrement_in, o=layouts.decrement)
 
     def elaborate(self, platform) -> TModule:
         m = TModule()
 
-        count = Signal(self.gen_params.rob_entries_bits + 1)
+        counter = Signal(self.gen_params.rob_entries_bits + 1)
+        counter_next = Signal.like(counter)
+        incr_value = Signal(self.increment.layout_in.members["count"])
+        decr_value = Signal(self.decrement.layout_in.members["count"])
 
-        with m.If(self.increment.run & ~self.decrement.run):
-            m.d.sync += count.eq(count + 1)
+        m.d.comb += counter_next.eq(counter + incr_value - decr_value)
+        m.d.sync += counter.eq(counter_next)
 
-        with m.If(self.decrement.run & ~self.increment.run):
-            m.d.sync += count.eq(count - 1)
+        limit = (2 ** counter.shape().width) - self.gen_params.frontend_superscalarity
 
-        @def_method(m, self.increment, ready=(count != (2 ** count.shape().width) - 1))
-        def _():
-            pass
+        @def_method(m, self.increment, ready=counter < limit)
+        def _(count):
+            m.d.comb += incr_value.eq(count)
 
         @def_method(m, self.decrement)
-        def _():
-            return (count == 1) & ~self.increment.run
+        def _(count):
+            m.d.comb += decr_value.eq(count)
+            return counter_next == 0
 
         return m

--- a/coreblocks/priv/traps/instr_counter.py
+++ b/coreblocks/priv/traps/instr_counter.py
@@ -24,7 +24,7 @@ class CoreInstructionCounter(Elaboratable):
 
         layouts = gen_params.get(CoreInstructionCounterLayouts)
         self.increment = Method(i=layouts.increment_in)
-        self.decrement = Method(i=layouts.decrement_in, o=layouts.decrement)
+        self.decrement = Method(i=layouts.decrement_in, o=layouts.decrement_out)
 
     def elaborate(self, platform) -> TModule:
         m = TModule()

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -22,8 +22,8 @@ class RegAllocation(Elaboratable):
     the instruction result). A part of the scheduling process.
     """
 
-    get_instr: Required[Method]
-    push_instr: Required[Method]
+    get_instrs: Required[Method]
+    push_instrs: Required[Method]
     get_free_reg: Required[Methods]
 
     def __init__(self, *, gen_params: GenParams):
@@ -36,24 +36,24 @@ class RegAllocation(Elaboratable):
         self.gen_params = gen_params
         layouts = gen_params.get(SchedulerLayouts)
 
-        self.get_instr = Method(o=layouts.reg_alloc_in)
-        self.push_instr = Method(i=layouts.reg_alloc_out)
+        self.get_instrs = Method(o=layouts.reg_alloc_in)
+        self.push_instrs = Method(i=layouts.reg_alloc_out)
         self.get_free_reg = Methods(gen_params.frontend_superscalarity, o=layouts.free_rf_layout)
 
     def elaborate(self, platform):
         m = TModule()
 
-        data_out = Signal(self.push_instr.layout_in)
+        data_out = Signal(self.push_instrs.layout_in)
 
         with Transaction().body(m):
-            instrs = self.get_instr(m)
+            instrs = self.get_instrs(m)
             m.d.av_comb += assign(data_out, instrs)
 
             for i in range(self.gen_params.frontend_superscalarity):
                 with m.If((i < instrs.count) & (instrs.data[i].regs_l.rl_dst != 0)):
                     m.d.av_comb += data_out.data[i].regs_p.rp_dst.eq(self.get_free_reg[i](m).ident)
 
-            self.push_instr(m, data_out)
+            self.push_instrs(m, data_out)
 
         return m
 
@@ -447,8 +447,8 @@ class Scheduler(Elaboratable):
             self.gen_params.frontend_superscalarity,
         )
         m.submodules.reg_alloc = reg_alloc = RegAllocation(gen_params=self.gen_params)
-        reg_alloc.get_instr.provide(self.get_instr)
-        reg_alloc.push_instr.provide(alloc_rename_buf.write)
+        reg_alloc.get_instrs.provide(self.get_instr)
+        reg_alloc.push_instrs.provide(alloc_rename_buf.write)
         reg_alloc.get_free_reg.provide(self.get_free_reg)
 
         m.submodules.instr_tag_buf = instr_tag_buf = FIFO(self.layouts.instr_tag_out, 2)

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -2,8 +2,8 @@ from collections.abc import Sequence
 
 from amaranth import *
 
-from transactron import Method, Required, Transaction, TModule
-from transactron.lib import FIFO
+from transactron import Method, Methods, Required, Transaction, TModule, def_method
+from transactron.lib import FIFO, WideFifo
 from transactron.lib.connectors import Connect
 from transactron.utils import assign, AssignType
 from transactron.utils.dependencies import DependencyContext
@@ -24,7 +24,7 @@ class RegAllocation(Elaboratable):
 
     get_instr: Required[Method]
     push_instr: Required[Method]
-    get_free_reg: Required[Method]
+    get_free_reg: Required[Methods]
 
     def __init__(self, *, gen_params: GenParams):
         """
@@ -38,22 +38,21 @@ class RegAllocation(Elaboratable):
 
         self.get_instr = Method(o=layouts.reg_alloc_in)
         self.push_instr = Method(i=layouts.reg_alloc_out)
-        self.get_free_reg = Method(o=layouts.free_rf_layout)
+        self.get_free_reg = Methods(gen_params.frontend_superscalarity, o=layouts.free_rf_layout)
 
     def elaborate(self, platform):
         m = TModule()
 
-        free_reg = Signal(self.gen_params.phys_regs_bits)
         data_out = Signal(self.push_instr.layout_in)
 
         with Transaction().body(m):
-            instr = self.get_instr(m)
-            with m.If(instr.regs_l.rl_dst != 0):
-                reg_id = self.get_free_reg(m)
-                m.d.comb += free_reg.eq(reg_id)
+            instrs = self.get_instr(m)
+            m.d.av_comb += assign(data_out, instrs)
 
-            m.d.comb += assign(data_out, instr)
-            m.d.comb += data_out.regs_p.rp_dst.eq(free_reg)
+            for i in range(self.gen_params.frontend_superscalarity):
+                with m.If((i < instrs.count) & (instrs.data[i].regs_l.rl_dst != 0)):
+                    m.d.av_comb += data_out.data[i].regs_p.rp_dst.eq(self.get_free_reg[i](m).ident)
+
             self.push_instr(m, data_out)
 
         return m
@@ -379,7 +378,7 @@ class Scheduler(Elaboratable):
     by `SchedulerLayouts.scheduler_in`.
     """
 
-    get_free_reg: Required[Method]
+    get_free_reg: Required[Methods]
     """Provides the ID of a currently free physical register."""
 
     crat_rename: Required[Method]
@@ -422,7 +421,7 @@ class Scheduler(Elaboratable):
         self.gen_params = gen_params
         self.layouts = self.gen_params.get(SchedulerLayouts)
         self.get_instr = Method(o=self.layouts.scheduler_in)
-        self.get_free_reg = Method(o=self.layouts.free_rf_layout)
+        self.get_free_reg = Methods(gen_params.frontend_superscalarity, o=self.layouts.free_rf_layout)
         self.crat_rename = Method(
             i=gen_params.get(RATLayouts).crat_rename_in, o=gen_params.get(RATLayouts).crat_rename_out
         )
@@ -440,7 +439,13 @@ class Scheduler(Elaboratable):
         m = TModule()
 
         # This could be ideally changed to Connect, but unfortunately causes comb loop
-        m.submodules.alloc_rename_buf = alloc_rename_buf = FIFO(self.layouts.reg_alloc_out, 2)
+        # TODO: convert back to normal FIFO
+        m.submodules.alloc_rename_buf = alloc_rename_buf = WideFifo(
+            self.layouts.instr_tag_in_data,
+            2 * self.gen_params.frontend_superscalarity,
+            1,
+            self.gen_params.frontend_superscalarity,
+        )
         m.submodules.reg_alloc = reg_alloc = RegAllocation(gen_params=self.gen_params)
         reg_alloc.get_instr.provide(self.get_instr)
         reg_alloc.push_instr.provide(alloc_rename_buf.write)
@@ -448,7 +453,12 @@ class Scheduler(Elaboratable):
 
         m.submodules.instr_tag_buf = instr_tag_buf = FIFO(self.layouts.instr_tag_out, 2)
         m.submodules.instr_tag = instr_tag = InstructionTagger(gen_params=self.gen_params)
-        instr_tag.get_instr.provide(alloc_rename_buf.read)
+
+        # instr_tag.get_instr.provide(alloc_rename_buf.read)
+        @def_method(m, instr_tag.get_instr)
+        def _():
+            return alloc_rename_buf.read(m, count=1).data[0]
+
         instr_tag.push_instr.provide(instr_tag_buf.write)
         instr_tag.crat_tag.provide(self.crat_tag)
 

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -157,7 +157,7 @@ class TestRetirement(TestCaseWithSimulator):
         pass
 
     @def_method_mock(lambda self: self.retc.mock_instr_decrement)
-    def instr_decrement_process(self):
+    def instr_decrement_process(self, count):
         return {"empty": 0}
 
     @def_method_mock(lambda self: self.retc.mock_trap_entry)

--- a/test/scheduler/test_checkpointing.py
+++ b/test/scheduler/test_checkpointing.py
@@ -115,7 +115,7 @@ class TestSchedulerCheckpointing(TestCaseWithSimulator):
             nonlocal end
             for _ in range(instr_cnt):
                 data = get_instr()
-                await dut.instr_inp.call(sim, data)
+                await dut.instr_inp.call(sim, count=1, data=[data])
                 await self.random_wait_geom(sim, 0.5)
             end = True
 

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -97,7 +97,7 @@ class SchedulerTestCircuit(Elaboratable):
         # main scheduler
         m.submodules.scheduler = self.scheduler = Scheduler(gen_params=self.gen_params)
         self.scheduler.get_instr.provide(instr_fifo.read)
-        self.scheduler.get_free_reg.provide(free_rf_fifo.read)
+        self.scheduler.get_free_reg[0].provide(free_rf_fifo.read)
         self.scheduler.crat_rename.provide(crat.rename)
         self.scheduler.crat_tag.provide(crat.tag)
         self.scheduler.crat_active_tags.provide(crat.get_active_tags)

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -346,19 +346,22 @@ class TestScheduler(TestCaseWithSimulator):
 
                 await self.m.instr_inp.call(
                     sim,
-                    {
-                        "exec_fn": {
-                            "op_type": op_type,
-                            "funct3": funct3,
-                            "funct7": funct7,
-                        },
-                        "regs_l": {
-                            "rl_s1": rl_s1,
-                            "rl_s2": rl_s2,
-                            "rl_dst": rl_dst,
-                        },
-                        "imm": immediate,
-                    },
+                    count=1,
+                    data=[
+                        {
+                            "exec_fn": {
+                                "op_type": op_type,
+                                "funct3": funct3,
+                                "funct7": funct7,
+                            },
+                            "regs_l": {
+                                "rl_s1": rl_s1,
+                                "rl_s2": rl_s2,
+                                "rl_dst": rl_dst,
+                            },
+                            "imm": immediate,
+                        }
+                    ],
                 )
             # Terminate other processes
             self.expected_rename_queue.append(None)


### PR DESCRIPTION
This PR implements superscalar register allocation. Groups of instructions are now passed from the frontend to the scheduler, which are then serialized after register allocation. In-flight instruction counter is modified to allow changing its value by more than 1 each cycle.

Originally I wanted to superscalarize the entire scheduler in one PR, but I think I'll do it piecewise instead.

TODO:
- [x] Superscalar reg allocation
- [x] Fix tests