### PR TITLE
Superscalar rename prep

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -99,9 +99,9 @@ class FetchUnit(Elaboratable):
         with Transaction(name="cont").body(m):
             peek_result = serializer.peek(m)
             count = Signal(range(self.gen_params.frontend_superscalarity + 1))
-            # we want only one branch insn in scheduling group, and only at the beginning (for simplicity)
+            # we want at most one branch insn in scheduling group, and only at the end (for simplicity)
             # some insts in peek_result.data might not be valid, but this is still correct
-            which_is_branch = [0] + [instr.cfi_type == CfiType.BRANCH for instr in peek_result.data][1:]
+            which_is_branch = [0] + [instr.cfi_type == CfiType.BRANCH for instr in peek_result.data][:-1]
             m.d.comb += count.eq(count_trailing_zeros(Cat(which_is_branch)))
             result = serializer.read(m, count=count)
             for i in range(self.gen_params.frontend_superscalarity):

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -52,17 +52,18 @@ class RollbackTagger(Elaboratable):
         with Transaction().body(m):
             instrs = self.get_instr(m)
 
-            # fetcher guarantees that if branch is present, it's the last insn
-            is_branch = instrs.data[(instrs.count - 1).as_unsigned()].exec_fn.op_type == OpType.BRANCH
-            # no need to make checkpoint at JALR, we currently stall the fetch on it
-
             out = Signal(self.gen_params.get(DecodeLayouts).tagged_decode_result)
             m.d.av_comb += assign(out, instrs)
             # TODO: as branch is always the first insn, these should be per group
             for i in range(self.gen_params.frontend_superscalarity):
+                # fetcher guarantees that if branch is present, it's the last insn
+                # but computing this for each insn is simpler
+                is_branch = instrs.data[i].exec_fn.op_type == OpType.BRANCH
+                # no need to make checkpoint at JALR, we currently stall the fetch on it
+
                 m.d.av_comb += out.data[i].rollback_tag.eq(rollback_tag)
                 m.d.av_comb += out.data[i].rollback_tag_v.eq(rollback_tag_v)
-            m.d.av_comb += out.data[(instrs.count - 1).as_unsigned()].commit_checkpoint.eq(is_branch)
+                m.d.av_comb += out.data[i].commit_checkpoint.eq(is_branch)
 
             m.d.sync += rollback_tag_v.eq(0)
 

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -52,7 +52,8 @@ class RollbackTagger(Elaboratable):
         with Transaction().body(m):
             instrs = self.get_instr(m)
 
-            is_branch = instrs.data[0].exec_fn.op_type == OpType.BRANCH
+            # fetcher guarantees that if branch is present, it's the last insn
+            is_branch = instrs.data[(instrs.count - 1).as_unsigned()].exec_fn.op_type == OpType.BRANCH
             # no need to make checkpoint at JALR, we currently stall the fetch on it
 
             out = Signal(self.gen_params.get(DecodeLayouts).tagged_decode_result)
@@ -61,7 +62,7 @@ class RollbackTagger(Elaboratable):
             for i in range(self.gen_params.frontend_superscalarity):
                 m.d.av_comb += out.data[i].rollback_tag.eq(rollback_tag)
                 m.d.av_comb += out.data[i].rollback_tag_v.eq(rollback_tag_v)
-            m.d.av_comb += out.data[0].commit_checkpoint.eq(is_branch)
+            m.d.av_comb += out.data[(instrs.count - 1).as_unsigned()].commit_checkpoint.eq(is_branch)
 
             m.d.sync += rollback_tag_v.eq(0)
 


### PR DESCRIPTION
Implementing superscalar rename with CRAT will be simpler if the jump instruction will be the last one.