### PR TITLE
Prepare for MMU implementation

### DIFF
--- a/coreblocks/arch/isa_consts.py
+++ b/coreblocks/arch/isa_consts.py
@@ -16,6 +16,8 @@ __all__ = [
     "PrivilegeLevel",
     "InterruptCauseNumber",
     "XlenEncoding",
+    "PAGE_SIZE",
+    "PAGE_SIZE_LOG",
 ]
 
 
@@ -264,3 +266,7 @@ class SatpLayout(StructLayout):
                 )
             case _:
                 raise ValueError(f"Unsupported XLEN for SATP layout: {xlen}")
+
+
+PAGE_SIZE_LOG = 12
+PAGE_SIZE = 1 << PAGE_SIZE_LOG

--- a/coreblocks/arch/isa_consts.py
+++ b/coreblocks/arch/isa_consts.py
@@ -240,6 +240,18 @@ class SatpMode(IntEnum, shape=4):
             case _:
                 raise ValueError(f"Unsupported XLEN for SATP mode encoding: {xlen}")
 
+    @classmethod
+    def mode_dependencies(cls, mode: "SatpMode") -> Set["SatpMode"]:
+        match mode:
+            case cls.BARE | cls.SV32 | cls.SV39:
+                return frozenset()
+            case cls.SV48:
+                return frozenset({cls.SV39})
+            case cls.SV57:
+                return frozenset({cls.SV48})
+            case _:
+                raise ValueError(f"Unsupported SATP mode: {mode}")
+
 
 class SatpLayout(StructLayout):
     ppn: Value

--- a/coreblocks/cache/icache.py
+++ b/coreblocks/cache/icache.py
@@ -44,11 +44,11 @@ class ICacheBypass(Elaboratable, CacheInterface):
         req_addr = Signal(self.params.addr_width)
 
         @def_method(m, self.issue_req)
-        def _(addr: Value) -> None:
-            m.d.sync += req_addr.eq(addr)
+        def _(paddr: Value) -> None:
+            m.d.sync += req_addr.eq(paddr)
             self.bus_master.request_read(
                 m,
-                addr=addr >> exact_log2(self.params.word_width_bytes),
+                addr=paddr >> exact_log2(self.params.word_width_bytes),
                 sel=C(1).replicate(self.bus_master.params.data_width // self.bus_master.params.granularity),
             )
 
@@ -212,7 +212,7 @@ class ICache(Elaboratable, CacheInterface):
                 # Align to the beginning of the cache line
                 aligned_addr = self.serialize_addr(req_addr) & ~((1 << self.params.offset_bits) - 1)
                 log.debug(m, True, "Refilling line 0x{:x}", aligned_addr)
-                self.refiller.start_refill(m, addr=aligned_addr)
+                self.refiller.start_refill(m, paddr=aligned_addr)
 
         @def_method(m, self.accept_res)
         def _():
@@ -222,11 +222,11 @@ class ICache(Elaboratable, CacheInterface):
             return output.results
 
         @def_method(m, self.issue_req, ready=accepting_requests)
-        def _(addr: Value) -> None:
+        def _(paddr: Value) -> None:
             self.perf_loads.incr(m)
             self.req_latency.start(m)
 
-            deserialized = self.deserialize_addr(addr)
+            deserialized = self.deserialize_addr(paddr)
             m.d.comb += assign(mem_read_addr, deserialized)
             m.d.sync += assign(prev_mem_read_addr, deserialized)
             req_zipper.write_args(m, deserialized)
@@ -255,7 +255,7 @@ class ICache(Elaboratable, CacheInterface):
         # Slow path - data refilling
         with Transaction().body(m):
             ret = self.refiller.accept_refill(m)
-            deserialized = self.deserialize_addr(ret.addr)
+            deserialized = self.deserialize_addr(ret.paddr)
 
             self.perf_errors.incr(m, enable_call=ret.error)
 

--- a/coreblocks/cache/refiller.py
+++ b/coreblocks/cache/refiller.py
@@ -26,7 +26,7 @@ class SimpleCommonBusCacheRefiller(Elaboratable, CacheRefillerInterface):
 
         m.submodules.resp_fwd = resp_fwd = Forwarder(self.layouts.accept_refill)
 
-        cache_line_address = Signal(self.params.word_width - self.params.offset_bits)
+        cache_line_address = Signal(self.params.addr_width - self.params.offset_bits)
 
         refill_active = Signal()
         flushing = Signal()

--- a/coreblocks/cache/refiller.py
+++ b/coreblocks/cache/refiller.py
@@ -72,7 +72,7 @@ class SimpleCommonBusCacheRefiller(Elaboratable, CacheRefillerInterface):
 
                     resp_fwd.write(
                         m,
-                        addr=fetch_block_addr,
+                        paddr=fetch_block_addr,
                         fetch_block=block,
                         error=bus_response.err,
                         last=(resp_word_counter == self.params.words_in_line - 1) | bus_response.err,
@@ -91,8 +91,8 @@ class SimpleCommonBusCacheRefiller(Elaboratable, CacheRefillerInterface):
             m.d.sync += flushing.eq(0)
 
         @def_method(m, self.start_refill, ready=~refill_active)
-        def _(addr) -> None:
-            m.d.sync += cache_line_address.eq(addr[self.params.offset_bits :])
+        def _(paddr) -> None:
+            m.d.sync += cache_line_address.eq(paddr[self.params.offset_bits :])
             m.d.sync += req_word_counter.eq(0)
             m.d.sync += sending_requests.eq(1)
 

--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -54,7 +54,10 @@ class Decode(Elaboratable):
             m.d.comb += exception_override.eq(instr_decoder.illegal | access_fault.any())
             exception_funct = Signal(Funct3)
             with m.If(access_fault.any()):
-                m.d.comb += exception_funct.eq(Funct3._EINSTRACCESSFAULT)
+                with m.If(access_fault & FetchLayouts.FaultFlag.PAGE_FAULT):
+                    m.d.comb += exception_funct.eq(Funct3._EINSTRPAGEFAULT)
+                with m.Else():
+                    m.d.comb += exception_funct.eq(Funct3._EINSTRACCESSFAULT)
             with m.Elif(instr_decoder.illegal):
                 self.illegal(m)
                 m.d.comb += exception_funct.eq(Funct3._EILLEGALINSTR)

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -16,6 +16,7 @@ from coreblocks.arch import *
 from coreblocks.params import *
 from coreblocks.interface.layouts import *
 from coreblocks.frontend import FrontendParams
+from coreblocks.priv.vmem.translation import AddressTranslator, AddressTranslatorMode
 
 log = logging.HardwareLogger("frontend.fetch")
 
@@ -79,6 +80,9 @@ class FetchUnit(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
+        m.submodules.addr_translator = addr_translator = AddressTranslator(
+            self.gen_params, mode=AddressTranslatorMode.INSTRUCTION
+        )
         m.submodules += [self.perf_fetch_utilization]
 
         fetch_width = self.gen_params.fetch_width
@@ -114,7 +118,10 @@ class FetchUnit(Elaboratable):
                 )
             self.cont(m, result)
 
-        m.submodules.fetch_requests = fetch_requests = BasicFifo(make_layout(fields.pc), depth=2)
+        m.submodules.fetch_requests = fetch_requests = BasicFifo(
+            make_layout(fields.pc, ("access_fault", 1), ("page_fault", 1)),
+            depth=2,
+        )
 
         # This limits number of fetch blocks the fetch unit can process
         # at a time. We start counting when sending a request to the cache and
@@ -136,8 +143,20 @@ class FetchUnit(Elaboratable):
         def _(pc):
             log.info(m, True, "[IFU] request pc=0x{:x}", pc)
             req_counter.acquire(m)
-            self.icache.issue_req(m, addr=pc)
-            fetch_requests.write(m, pc=pc)
+
+            addr_translator.request(m, addr=pc)
+
+        with Transaction().body(m):
+            translated = addr_translator.accept(m)
+            with m.If(~translated.page_fault & ~translated.access_fault):
+                self.icache.issue_req(m, addr=translated.paddr)
+
+            fetch_requests.write(
+                m,
+                pc=translated.addr,
+                access_fault=translated.access_fault,
+                page_fault=translated.page_fault,
+            )
 
         #
         # State passed between stage 1 and stage 2
@@ -146,7 +165,7 @@ class FetchUnit(Elaboratable):
             [
                 fields.fb_addr,
                 ("instr_valid", fetch_width),
-                ("access_fault", 1),
+                ("access_fault", FetchLayouts.FaultFlag),
                 ("rvc", fetch_width),
                 ("instrs", ArrayLayout(self.gen_params.isa.ilen, fetch_width)),
                 ("instr_block_cross", 1),
@@ -173,7 +192,20 @@ class FetchUnit(Elaboratable):
         prev_half_v = Signal()
         with Transaction(name="Fetch_Stage1").body(m):
             fetch_request = fetch_requests.read(m)
-            cache_resp = self.icache.accept_res(m)
+            cache_resp = Signal(self.gen_params.get(ICacheLayouts).accept_res)
+            access_fault = Signal(FetchLayouts.FaultFlag)
+
+            with condition(m) as branch:
+                with branch(fetch_request.page_fault | fetch_request.access_fault):
+                    with m.If(fetch_request.page_fault):
+                        m.d.av_comb += access_fault.eq(FetchLayouts.FaultFlag.PAGE_FAULT)
+                    with m.Else():
+                        m.d.av_comb += access_fault.eq(FetchLayouts.FaultFlag.ACCESS_FAULT)
+                    m.d.av_comb += cache_resp.fetch_block.eq(0)
+                    m.d.av_comb += cache_resp.error.eq(0)
+                with branch():
+                    m.d.av_comb += cache_resp.eq(self.icache.accept_res(m))
+                    m.d.av_comb += access_fault.eq(Mux(cache_resp.error, FetchLayouts.FaultFlag.ACCESS_FAULT, 0))
 
             # The address of the fetch block.
             fetch_block_addr = params.fb_addr(fetch_request.pc)
@@ -233,7 +265,7 @@ class FetchUnit(Elaboratable):
                 instr_position_mask = Cat(instr_start[:-1], instr_start[-1] & is_rvc[-1])
 
                 m.d.sync += prev_half_v.eq(
-                    (flushing_counter <= 1) & (cache_resp.error == 0) & ~is_rvc[-1] & instr_start[-1]
+                    (flushing_counter <= 1) & ~access_fault.any() & ~is_rvc[-1] & instr_start[-1]
                 )
                 m.d.sync += prev_half.eq(cache_resp.fetch_block[-16:])
                 m.d.sync += prev_half_addr.eq(fetch_block_addr)
@@ -246,8 +278,8 @@ class FetchUnit(Elaboratable):
             s1_s2_pipe.write(
                 m,
                 fb_addr=fetch_block_addr,
-                instr_valid=Mux(cache_resp.error, access_fault_instr_position, instr_position_mask),
-                access_fault=cache_resp.error,
+                instr_valid=Mux(access_fault.any(), access_fault_instr_position, instr_position_mask),
+                access_fault=access_fault,
                 rvc=is_rvc,
                 instrs=expanded_instr,
                 instr_block_cross=instr_block_cross,
@@ -281,6 +313,8 @@ class FetchUnit(Elaboratable):
             fetch_block_addr = s1_data.fb_addr
             instr_valid = s1_data.instr_valid
             access_fault = s1_data.access_fault
+            fault_any = Signal()
+            m.d.av_comb += fault_any.eq(access_fault.any())
 
             # Predecode instructions
             predecoded_instr = [predecoders[i].predecode(m, instrs[i]) for i in range(fetch_width)]
@@ -304,7 +338,7 @@ class FetchUnit(Elaboratable):
             instr_unsafe = Signal(fetch_width)
             for i in range(fetch_width):
                 # If there was an access fault, mark every instruction as unsafe
-                m.d.av_comb += instr_unsafe[i].eq((predecoded_instr[i].unsafe | access_fault) & instr_valid[i])
+                m.d.av_comb += instr_unsafe[i].eq((predecoded_instr[i].unsafe | fault_any) & instr_valid[i])
 
             m.submodules.unsafe_prio_encoder = unsafe_prio_encoder = PriorityEncoder(fetch_width)
             m.d.av_comb += unsafe_prio_encoder.i.eq(instr_unsafe)
@@ -353,9 +387,7 @@ class FetchUnit(Elaboratable):
                     raw_instrs[i].pc.eq(params.pc_from_fb(fetch_block_addr, i)),
                     raw_instrs[i].rvc.eq(s1_data.rvc[i]),
                     raw_instrs[i].predicted_taken.eq(redirect & (predcheck_res.fb_instr_idx == i)),
-                    raw_instrs[i].access_fault.eq(
-                        Mux(s1_data.access_fault, FetchLayouts.AccessFaultFlag.ACCESS_FAULT, 0)
-                    ),
+                    raw_instrs[i].access_fault.eq(s1_data.access_fault),
                     raw_instrs[i].cfi_type.eq(predecoded_instr[i].cfi_type),
                 ]
 
@@ -363,20 +395,18 @@ class FetchUnit(Elaboratable):
                 with m.If(s1_data.instr_block_cross):
                     m.d.av_comb += raw_instrs[0].pc.eq(params.pc_from_fb(fetch_block_addr, 0) - 2)
                     with m.If(s1_data.access_fault):
-                        # Mark that access fault happened only at second (current) half.
+                        # Mark that access/page fault happened only at second (current) half.
                         # If fault happened on the first half `instr_block_cross` would be false
                         m.d.av_comb += raw_instrs[0].access_fault.eq(
-                            FetchLayouts.AccessFaultFlag.ACCESS_FAULT_ON_SECOND_HALF
+                            s1_data.access_fault | FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF
                         )
 
             with condition(m) as branch:
                 with branch(flushing_counter == 0):
-                    with m.If(access_fault | unsafe_stall):
-                        # TODO: Raise different code for page fault when supported
-                        # could be passed in 3rd bit of access_fault
+                    with m.If(fault_any | unsafe_stall):
                         self.stall_unsafe(m)
 
-                    with m.If(access_fault | unsafe_stall | redirect):
+                    with m.If(fault_any | unsafe_stall | redirect):
                         self.fetch_writeback(
                             m,
                             redirect=redirect,

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -149,7 +149,7 @@ class FetchUnit(Elaboratable):
         with Transaction().body(m):
             translated = addr_translator.accept(m)
             with m.If(~translated.page_fault & ~translated.access_fault):
-                self.icache.issue_req(m, addr=translated.paddr)
+                self.icache.issue_req(m, paddr=translated.paddr)
 
             fetch_requests.write(
                 m,

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -153,7 +153,7 @@ class FetchUnit(Elaboratable):
 
             fetch_requests.write(
                 m,
-                pc=translated.addr,
+                pc=translated.vaddr,
                 access_fault=translated.access_fault,
                 page_fault=translated.page_fault,
             )

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -141,10 +141,8 @@ class FetchUnit(Elaboratable):
         # - send a request to the instruction cache
         # - check PMP execute permission (if PMP is enabled)
         #
-        pmp_addr = Signal(self.gen_params.isa.xlen)
 
         m.submodules.pmp_checker = pmp_checker = PMPChecker(self.gen_params)
-        m.d.comb += pmp_checker.paddr.eq(pmp_addr)
 
         @def_method(m, self.fetch_request)
         def _(pc):
@@ -155,9 +153,9 @@ class FetchUnit(Elaboratable):
 
         with Transaction().body(m):
             translated = addr_translator.accept(m)
-            m.d.av_comb += pmp_addr.eq(translated.paddr)
-
             access_fault = Signal()
+
+            m.d.av_comb += pmp_checker.paddr.eq(translated.paddr)
             m.d.av_comb += access_fault.eq(translated.access_fault | ~pmp_checker.result.x)
 
             with m.If(~translated.page_fault & ~access_fault):

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -76,7 +76,9 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
                     m.d.av_comb += cause.eq(ExceptionCause.INSTRUCTION_ACCESS_FAULT)
                     # With C extension access fault can be only on the second half of instruction, and mepc != mtval.
                     # This information is passed in imm field
-                    m.d.av_comb += mtval.eq(arg.pc + (instr_exc_on_second_half << 1))
+                    m.d.av_comb += mtval.eq(
+                        arg.pc + ((arg.imm & FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF).any() << 1)
+                    )
                 with OneHotCase(ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION):
                     m.d.av_comb += cause.eq(ExceptionCause.ILLEGAL_INSTRUCTION)
                     m.d.av_comb += mtval.eq(arg.imm)  # passed instruction bytes
@@ -85,7 +87,9 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
                     m.d.av_comb += mtval.eq(arg.pc)
                 with OneHotCase(ExceptionUnitFn.Fn.INSTR_PAGE_FAULT):
                     m.d.av_comb += cause.eq(ExceptionCause.INSTRUCTION_PAGE_FAULT)
-                    m.d.av_comb += mtval.eq(arg.pc + (instr_exc_on_second_half << 1))
+                    m.d.av_comb += mtval.eq(
+                        arg.pc + ((arg.imm & FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF).any() << 1)
+                    )
 
             self.report(m, rob_id=arg.rob_id, cause=cause, pc=arg.pc, mtval=mtval)
 

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -59,7 +59,9 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
             priv_level = self.dm.get_dependency(CSRInstancesKey()).m_mode.priv_mode.read(m).data
 
             instr_exc_on_second_half = Signal()
-            m.d.av_comb += instr_exc_on_second_half.eq((arg.imm & FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF).any())
+            m.d.av_comb += instr_exc_on_second_half.eq(
+                (arg.imm & FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF).any()
+            )
 
             with OneHotSwitch(m, arg.decode_fn) as OneHotCase:
                 with OneHotCase(ExceptionUnitFn.Fn.EBREAK):

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -78,9 +78,7 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
                     m.d.av_comb += cause.eq(ExceptionCause.INSTRUCTION_ACCESS_FAULT)
                     # With C extension access fault can be only on the second half of instruction, and mepc != mtval.
                     # This information is passed in imm field
-                    m.d.av_comb += mtval.eq(
-                        arg.pc + ((arg.imm & FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF).any() << 1)
-                    )
+                    m.d.av_comb += mtval.eq(arg.pc + (instr_exc_on_second_half << 1))
                 with OneHotCase(ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION):
                     m.d.av_comb += cause.eq(ExceptionCause.ILLEGAL_INSTRUCTION)
                     m.d.av_comb += mtval.eq(arg.imm)  # passed instruction bytes
@@ -89,9 +87,7 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
                     m.d.av_comb += mtval.eq(arg.pc)
                 with OneHotCase(ExceptionUnitFn.Fn.INSTR_PAGE_FAULT):
                     m.d.av_comb += cause.eq(ExceptionCause.INSTRUCTION_PAGE_FAULT)
-                    m.d.av_comb += mtval.eq(
-                        arg.pc + ((arg.imm & FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF).any() << 1)
-                    )
+                    m.d.av_comb += mtval.eq(arg.pc + (instr_exc_on_second_half << 1))
 
             self.report(m, rob_id=arg.rob_id, cause=cause, pc=arg.pc, mtval=mtval)
 

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -58,6 +58,9 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
 
             priv_level = self.dm.get_dependency(CSRInstancesKey()).m_mode.priv_mode.read(m).data
 
+            instr_exc_on_second_half = Signal()
+            m.d.av_comb += instr_exc_on_second_half.eq((arg.imm & FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF).any())
+
             with OneHotSwitch(m, arg.decode_fn) as OneHotCase:
                 with OneHotCase(ExceptionUnitFn.Fn.EBREAK):
                     m.d.av_comb += cause.eq(ExceptionCause.BREAKPOINT)
@@ -73,9 +76,7 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
                     m.d.av_comb += cause.eq(ExceptionCause.INSTRUCTION_ACCESS_FAULT)
                     # With C extension access fault can be only on the second half of instruction, and mepc != mtval.
                     # This information is passed in imm field
-                    m.d.av_comb += mtval.eq(
-                        arg.pc + ((arg.imm & FetchLayouts.AccessFaultFlag.ACCESS_FAULT_ON_SECOND_HALF).any() << 1)
-                    )
+                    m.d.av_comb += mtval.eq(arg.pc + (instr_exc_on_second_half << 1))
                 with OneHotCase(ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION):
                     m.d.av_comb += cause.eq(ExceptionCause.ILLEGAL_INSTRUCTION)
                     m.d.av_comb += mtval.eq(arg.imm)  # passed instruction bytes
@@ -84,7 +85,7 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
                     m.d.av_comb += mtval.eq(arg.pc)
                 with OneHotCase(ExceptionUnitFn.Fn.INSTR_PAGE_FAULT):
                     m.d.av_comb += cause.eq(ExceptionCause.INSTRUCTION_PAGE_FAULT)
-                    m.d.av_comb += mtval.eq(arg.pc + (arg.imm[1] << 1))
+                    m.d.av_comb += mtval.eq(arg.pc + (instr_exc_on_second_half << 1))
 
             self.report(m, rob_id=arg.rob_id, cause=cause, pc=arg.pc, mtval=mtval)
 

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -118,7 +118,7 @@ class LSUDummy(FuncUnit, Elaboratable):
             arg = requests.read(m)
             translated_req = translated.read(m)
             paddr = translated_req.paddr
-            addr = translated_req.addr
+            addr = translated_req.vaddr
 
             m.d.av_comb += pma_checker.paddr.eq(paddr)
             m.d.av_comb += pmp_checker.paddr.eq(paddr)

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -2,11 +2,10 @@ from dataclasses import dataclass
 
 from amaranth import *
 from transactron import Method, TModule, Transaction, def_method
-from transactron.lib.connectors import FIFO
+from transactron.lib.connectors import FIFO, ConnectTrans
 from transactron.lib.logging import HardwareLogger
 from transactron.lib.simultaneous import condition
 from transactron.utils import DependencyContext
-from transactron.utils.transactron_helpers import make_layout
 
 from coreblocks.arch import OpType
 from coreblocks.arch.isa_consts import ExceptionCause
@@ -22,9 +21,10 @@ from coreblocks.interface.keys import (
     ExceptionReportKey,
     InstructionPrecommitKey,
 )
-from coreblocks.interface.layouts import FuncUnitLayouts, LSULayouts
+from coreblocks.interface.layouts import FuncUnitLayouts, LSULayouts, AddressTranslationLayouts
 from coreblocks.params import *
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
+from coreblocks.priv.vmem.translation import AddressTranslator, AddressTranslatorMode
 
 __all__ = ["LSUDummy", "LSUComponent"]
 
@@ -49,6 +49,7 @@ class LSUDummy(FuncUnit, Elaboratable):
         self.gen_params = gen_params
         self.fu_layouts = gen_params.get(FuncUnitLayouts)
         self.lsu_layouts = gen_params.get(LSULayouts)
+        self.translator_layouts = gen_params.get(AddressTranslationLayouts)
 
         self.dependency_manager = DependencyContext.get()
         self.report = self.dependency_manager.get_dependency(ExceptionReportKey())()
@@ -75,15 +76,15 @@ class LSUDummy(FuncUnit, Elaboratable):
         is_load = Signal()
 
         csr = self.dependency_manager.get_dependency(CSRInstancesKey())
+        m.submodules.addr_translator = addr_translator = AddressTranslator(
+            self.gen_params, mode=AddressTranslatorMode.LSU
+        )
         m.submodules.pma_checker = pma_checker = PMAChecker(self.gen_params)
         m.submodules.pmp_checker = pmp_checker = PMPChecker(self.gen_params, csr.m_mode)
         m.submodules.requester = requester = LSURequester(self.gen_params, self.bus)
 
-        request_layout = make_layout(
-            ("data", self.fu_layouts.issue),
-            ("addr", self.gen_params.isa.xlen),
-        )
-        m.submodules.requests = requests = FIFO(request_layout, 2)
+        m.submodules.requests = requests = FIFO(self.fu_layouts.issue, 2)
+        m.submodules.translated = translated = FIFO(self.translator_layouts.accept, 2)
         m.submodules.results_noop = results_noop = FIFO(self.lsu_layouts.accept, 2)
         m.submodules.issued = issued = FIFO(self.fu_layouts.issue, 2)
         m.submodules.issued_noop = issued_noop = FIFO(self.fu_layouts.issue, 2)
@@ -97,10 +98,14 @@ class LSUDummy(FuncUnit, Elaboratable):
             with m.If(~is_fence):
                 addr = Signal(self.gen_params.isa.xlen)
                 m.d.av_comb += addr.eq(arg.s1_val + arg.imm)
-                requests.write(m, data=arg, addr=addr)
+
+                addr_translator.request(m, addr=addr)
+                requests.write(m, arg)
             with m.Else():
                 results_noop.write(m, data=0, exception=0, cause=0, addr=0)
                 issued_noop.write(m, arg)
+
+        m.submodules += ConnectTrans.create(addr_translator.accept, translated.write)
 
         # Issues load/store requests when the instruction is known, is a LOAD/STORE, and just before commit.
         # Memory loads can be issued speculatively.
@@ -110,28 +115,38 @@ class LSUDummy(FuncUnit, Elaboratable):
 
         do_issue = ~flush & want_issue
         with Transaction().body(m, ready=do_issue):
-            req = requests.read(m)
-            arg = req.data
-            addr = req.addr
+            arg = requests.read(m)
+            translated_req = translated.read(m)
+            paddr = translated_req.paddr
+            addr = translated_req.addr
 
-            m.d.av_comb += pma_checker.addr.eq(addr)
-            m.d.av_comb += pmp_checker.addr.eq(addr)
+            m.d.av_comb += pma_checker.addr.eq(paddr)
+            m.d.av_comb += pmp_checker.addr.eq(paddr)
             m.d.av_comb += is_load.eq(arg.exec_fn.op_type == OpType.LOAD)
             m.d.av_comb += request_rob_id.eq(arg.rob_id)
 
-            pmp_exception = Signal()
-            pmp_cause = Signal(ExceptionCause)
+            exception = Signal()
+            cause = Signal(ExceptionCause)
 
-            with m.If(is_load & ~pmp_checker.result.r):
-                m.d.av_comb += pmp_exception.eq(1)
-                m.d.av_comb += pmp_cause.eq(ExceptionCause.LOAD_ACCESS_FAULT)
+            with m.If(translated_req.page_fault):
+                m.d.av_comb += exception.eq(1)
+                m.d.av_comb += cause.eq(Mux(is_load, ExceptionCause.LOAD_PAGE_FAULT, ExceptionCause.STORE_PAGE_FAULT))
+            with m.Elif(translated_req.access_fault):
+                m.d.av_comb += exception.eq(1)
+                m.d.av_comb += cause.eq(
+                    Mux(is_load, ExceptionCause.LOAD_ACCESS_FAULT, ExceptionCause.STORE_ACCESS_FAULT)
+                )
+            with m.Elif(is_load & ~pmp_checker.result.r):
+                m.d.av_comb += exception.eq(1)
+                m.d.av_comb += cause.eq(ExceptionCause.LOAD_ACCESS_FAULT)
             with m.Elif(~is_load & ~pmp_checker.result.w):
-                m.d.av_comb += pmp_exception.eq(1)
-                m.d.av_comb += pmp_cause.eq(ExceptionCause.STORE_ACCESS_FAULT)
+                m.d.av_comb += exception.eq(1)
+                m.d.av_comb += cause.eq(ExceptionCause.STORE_ACCESS_FAULT)
 
-            with m.If(~pmp_exception):
+            with m.If(~exception):
                 res = requester.issue(
                     m,
+                    paddr=paddr,
                     addr=addr,
                     data=arg.s2_val,
                     funct3=arg.exec_fn.funct3,
@@ -144,13 +159,14 @@ class LSUDummy(FuncUnit, Elaboratable):
                     issued.write(m, arg)
             with m.Else():
                 issued_noop.write(m, arg)
-                results_noop.write(m, data=0, exception=1, cause=pmp_cause, addr=addr)
+                results_noop.write(m, data=0, exception=1, cause=cause, addr=addr)
 
         # Handles flushed instructions as a no-op.
         with Transaction().body(m, ready=flush):
-            req = requests.read(m)
+            arg = requests.read(m)
+            translated.read(m)
             results_noop.write(m, data=0, exception=0, cause=0, addr=0)
-            issued_noop.write(m, req.data)
+            issued_noop.write(m, arg)
 
         with Transaction().body(m):
             arg = Signal(self.fu_layouts.issue)

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -120,8 +120,8 @@ class LSUDummy(FuncUnit, Elaboratable):
             paddr = translated_req.paddr
             addr = translated_req.addr
 
-            m.d.av_comb += pma_checker.addr.eq(paddr)
-            m.d.av_comb += pmp_checker.addr.eq(paddr)
+            m.d.av_comb += pma_checker.paddr.eq(paddr)
+            m.d.av_comb += pmp_checker.paddr.eq(paddr)
             m.d.av_comb += is_load.eq(arg.exec_fn.op_type == OpType.LOAD)
             m.d.av_comb += request_rob_id.eq(arg.rob_id)
 

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -147,7 +147,7 @@ class LSUDummy(FuncUnit, Elaboratable):
                 res = requester.issue(
                     m,
                     paddr=paddr,
-                    addr=addr,
+                    vaddr=addr,
                     data=arg.s2_val,
                     funct3=arg.exec_fn.funct3,
                     store=~is_load,

--- a/coreblocks/func_blocks/fu/lsu/lsu_requester.py
+++ b/coreblocks/func_blocks/fu/lsu/lsu_requester.py
@@ -106,17 +106,23 @@ class LSURequester(Elaboratable):
         m = TModule()
 
         m.submodules.args_fifo = args_fifo = BasicFifo(
-            [("addr", self.gen_params.isa.xlen), ("funct3", Funct3), ("store", 1)], self.depth
+            [
+                ("paddr", self.gen_params.phys_addr_bits),
+                ("addr", self.gen_params.isa.xlen),
+                ("funct3", Funct3),
+                ("store", 1),
+            ],
+            self.depth,
         )
 
         @def_method(m, self.issue)
-        def _(addr: Value, data: Value, funct3: Value, store: Value):
+        def _(paddr: Value, addr: Value, data: Value, funct3: Value, store: Value):
             exception = Signal()
             cause = Signal(ExceptionCause)
 
-            aligned = self.check_align(m, funct3, addr)
-            bytes_mask = self.prepare_bytes_mask(m, funct3, addr)
-            bus_data = self.prepare_data_to_save(m, funct3, data, addr)
+            aligned = self.check_align(m, funct3, paddr)
+            bytes_mask = self.prepare_bytes_mask(m, funct3, paddr)
+            bus_data = self.prepare_data_to_save(m, funct3, data, paddr)
 
             self.log.debug(
                 m,
@@ -131,12 +137,12 @@ class LSURequester(Elaboratable):
 
             with condition(m, nonblocking=True) as branch:
                 with branch(aligned & store):
-                    self.bus.request_write(m, addr=addr >> 2, data=bus_data, sel=bytes_mask)
+                    self.bus.request_write(m, addr=paddr >> 2, data=bus_data, sel=bytes_mask)
                 with branch(aligned & ~store):
-                    self.bus.request_read(m, addr=addr >> 2, sel=bytes_mask)
+                    self.bus.request_read(m, addr=paddr >> 2, sel=bytes_mask)
 
             with m.If(aligned):
-                args_fifo.write(m, addr=addr, funct3=funct3, store=store)
+                args_fifo.write(m, paddr=paddr, addr=addr, funct3=funct3, store=store)
             with m.Else():
                 m.d.av_comb += exception.eq(1)
                 m.d.av_comb += cause.eq(
@@ -163,7 +169,7 @@ class LSURequester(Elaboratable):
                     fetched = self.bus.get_read_response(m)
                     m.d.comb += err.eq(fetched.err)
                     m.d.top_comb += data.eq(
-                        self.postprocess_load_data(m, request_args.funct3, fetched.data, request_args.addr)
+                        self.postprocess_load_data(m, request_args.funct3, fetched.data, request_args.paddr)
                     )
 
             with m.If(err):

--- a/coreblocks/func_blocks/fu/lsu/lsu_requester.py
+++ b/coreblocks/func_blocks/fu/lsu/lsu_requester.py
@@ -8,7 +8,7 @@ from transactron.lib import BasicFifo
 from coreblocks.params import *
 from coreblocks.arch import Funct3, ExceptionCause
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
-from coreblocks.interface.layouts import LSULayouts
+from coreblocks.interface.layouts import CommonLayoutFields, LSULayouts
 
 
 class LSURequester(Elaboratable):
@@ -105,10 +105,11 @@ class LSURequester(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
+        layouts = self.gen_params.get(CommonLayoutFields)
         m.submodules.args_fifo = args_fifo = BasicFifo(
             [
-                ("paddr", self.gen_params.phys_addr_bits),
-                ("addr", self.gen_params.isa.xlen),
+                layouts.vaddr,
+                layouts.paddr,
                 ("funct3", Funct3),
                 ("store", 1),
             ],
@@ -116,7 +117,7 @@ class LSURequester(Elaboratable):
         )
 
         @def_method(m, self.issue)
-        def _(paddr: Value, addr: Value, data: Value, funct3: Value, store: Value):
+        def _(paddr: Value, vaddr: Value, data: Value, funct3: Value, store: Value):
             exception = Signal()
             cause = Signal(ExceptionCause)
 
@@ -128,7 +129,7 @@ class LSURequester(Elaboratable):
                 m,
                 1,
                 "issue addr=0x{:08x} data=0x{:08x} funct3={} store={} aligned={}",
-                addr,
+                vaddr,
                 data,
                 funct3,
                 store,
@@ -142,7 +143,7 @@ class LSURequester(Elaboratable):
                     self.bus.request_read(m, addr=paddr >> 2, sel=bytes_mask)
 
             with m.If(aligned):
-                args_fifo.write(m, paddr=paddr, addr=addr, funct3=funct3, store=store)
+                args_fifo.write(m, paddr=paddr, vaddr=vaddr, funct3=funct3, store=store)
             with m.Else():
                 m.d.av_comb += exception.eq(1)
                 m.d.av_comb += cause.eq(
@@ -178,6 +179,6 @@ class LSURequester(Elaboratable):
                     Mux(request_args.store, ExceptionCause.STORE_ACCESS_FAULT, ExceptionCause.LOAD_ACCESS_FAULT)
                 )
 
-            return {"data": data, "exception": exception, "cause": cause, "addr": request_args.addr}
+            return {"data": data, "exception": exception, "cause": cause, "addr": request_args.vaddr}
 
         return m

--- a/coreblocks/func_blocks/fu/lsu/pma.py
+++ b/coreblocks/func_blocks/fu/lsu/pma.py
@@ -42,7 +42,7 @@ class PMAChecker(Elaboratable):
 
     Attributes
     ----------
-    addr : Signal
+    paddr : Signal
         Memory address, for which PMAs are requested.
     result : View
         PMAs for given address.
@@ -52,20 +52,20 @@ class PMAChecker(Elaboratable):
         # poor man's interval list
         self.segments = gen_params.pma
         self.result = Signal(PMALayout())
-        self.addr = Signal(gen_params.phys_addr_bits)
+        self.paddr = Signal(gen_params.phys_addr_bits)
 
     def elaborate(self, platform) -> HasElaborate:
         m = TModule()
 
         outputs = [Signal(PMALayout()) for _ in self.segments]
 
-        # zero output if addr not in region, propagate value if addr in region
+        # zero output if paddr not in region, propagate value if paddr in region
         for i, segment in enumerate(self.segments):
             start = segment.start
             end = segment.end
 
-            # check if addr in region
-            with m.If((self.addr >= start) & (self.addr <= end)):
+            # check if paddr in region
+            with m.If((self.paddr >= start) & (self.paddr <= end)):
                 m.d.comb += outputs[i].eq(segment.mmio)
 
         # OR all outputs

--- a/coreblocks/func_blocks/fu/lsu/pma.py
+++ b/coreblocks/func_blocks/fu/lsu/pma.py
@@ -52,7 +52,7 @@ class PMAChecker(Elaboratable):
         # poor man's interval list
         self.segments = gen_params.pma
         self.result = Signal(PMALayout())
-        self.addr = Signal(gen_params.isa.xlen)
+        self.addr = Signal(gen_params.phys_addr_bits)
 
     def elaborate(self, platform) -> HasElaborate:
         m = TModule()

--- a/coreblocks/func_blocks/fu/lsu/pmp.py
+++ b/coreblocks/func_blocks/fu/lsu/pmp.py
@@ -29,7 +29,7 @@ class PMPChecker(Elaboratable):
 
     Attributes
     ----------
-    addr : Signal
+    paddr : Signal
         Memory address, for which PMP checks are requested.
     result : PMPLayout
         RWX permission bits for the given address based on current PMP configuration
@@ -39,7 +39,7 @@ class PMPChecker(Elaboratable):
     def __init__(self, gen_params: GenParams, csr: MachineModeCSRRegisters) -> None:
         self.gen_params = gen_params
         self.csr = csr
-        self.addr = Signal(gen_params.phys_addr_bits)
+        self.paddr = Signal(gen_params.phys_addr_bits)
 
         self.result = Signal(PMPLayout())
 
@@ -73,12 +73,12 @@ class PMPChecker(Elaboratable):
                     m.d.comb += entry_match.eq(0)
                 with m.Case(PMPAFlagEncoding.TOR):
                     lower = addr_vals[i - 1] if i > 0 else 0
-                    m.d.comb += entry_match.eq((self.addr[2:] >= lower) & (self.addr[2:] < addr_val))
+                    m.d.comb += entry_match.eq((self.paddr[2:] >= lower) & (self.paddr[2:] < addr_val))
                 with m.Case(PMPAFlagEncoding.NA4):
-                    m.d.comb += entry_match.eq(self.addr[2:] == addr_val)
+                    m.d.comb += entry_match.eq(self.paddr[2:] == addr_val)
                 with m.Case(PMPAFlagEncoding.NAPOT):
                     napot_mask = addr_val ^ (addr_val + 1)
-                    m.d.comb += entry_match.eq((self.addr[2:] & ~napot_mask) == (addr_val & ~napot_mask))
+                    m.d.comb += entry_match.eq((self.paddr[2:] & ~napot_mask) == (addr_val & ~napot_mask))
 
             entry_matches.append(entry_match)
 

--- a/coreblocks/func_blocks/fu/lsu/pmp.py
+++ b/coreblocks/func_blocks/fu/lsu/pmp.py
@@ -39,7 +39,7 @@ class PMPChecker(Elaboratable):
     def __init__(self, gen_params: GenParams, csr: MachineModeCSRRegisters) -> None:
         self.gen_params = gen_params
         self.csr = csr
-        self.addr = Signal(gen_params.isa.xlen)
+        self.addr = Signal(gen_params.phys_addr_bits)
 
         self.result = Signal(PMPLayout())
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -89,6 +89,9 @@ class CommonLayoutFields:
         self.addr: LayoutListField = ("addr", gen_params.isa.xlen)
         """Memory address."""
 
+        self.vaddr: LayoutListField = ("vaddr", gen_params.isa.xlen)
+        """Memory address - used when both virtual and physical addresses are present."""
+
         self.paddr: LayoutListField = ("paddr", gen_params.phys_addr_bits)
         """Physical memory address."""
 
@@ -171,7 +174,7 @@ class AddressTranslationLayouts:
         self.request = make_layout(fields.addr)
 
         self.accept = make_layout(
-            fields.addr,
+            fields.vaddr,
             fields.paddr,
             ("page_fault", 1),
             ("access_fault", 1),
@@ -740,7 +743,7 @@ class LSULayouts:
 
         self.store: LayoutListField = ("store", 1)
 
-        self.issue = make_layout(fields.paddr, fields.addr, fields.data, fields.funct3, self.store)
+        self.issue = make_layout(fields.paddr, fields.vaddr, fields.data, fields.funct3, self.store)
 
         self.issue_out = make_layout(fields.exception, fields.cause)
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -8,6 +8,7 @@ from transactron.utils.transactron_helpers import make_layout, extend_layout
 
 __all__ = [
     "CommonLayoutFields",
+    "AddressTranslationLayouts",
     "SchedulerLayouts",
     "ROBLayouts",
     "FetchLayouts",
@@ -88,6 +89,9 @@ class CommonLayoutFields:
         self.addr: LayoutListField = ("addr", gen_params.isa.xlen)
         """Memory address."""
 
+        self.paddr: LayoutListField = ("paddr", gen_params.phys_addr_bits)
+        """Physical memory address."""
+
         self.data: LayoutListField = ("data", gen_params.isa.xlen)
         """Piece of data."""
 
@@ -156,6 +160,22 @@ class CommonLayoutFields:
 
         self.commit_checkpoint: LayoutListField = ("commit_checkpoint", 1)
         """New checkpoint should be made for this instruction"""
+
+
+class AddressTranslationLayouts:
+    """Layouts used by virtual-to-physical address translation methods."""
+
+    def __init__(self, gen_params: GenParams):
+        fields = gen_params.get(CommonLayoutFields)
+
+        self.request = make_layout(fields.addr)
+
+        self.accept = make_layout(
+            fields.addr,
+            fields.paddr,
+            ("page_fault", 1),
+            ("access_fault", 1),
+        )
 
 
 class SchedulerLayouts:
@@ -522,7 +542,7 @@ class ICacheLayouts:
         self.fetch_block: LayoutListField = ("fetch_block", gen_params.fetch_block_bytes * 8)
         """The block of data the fetch unit operates on."""
 
-        self.issue_req = make_layout(fields.addr)
+        self.issue_req = make_layout(("addr", gen_params.phys_addr_bits))
 
         self.accept_res = make_layout(
             self.fetch_block,
@@ -530,11 +550,11 @@ class ICacheLayouts:
         )
 
         self.start_refill = make_layout(
-            fields.addr,
+            ("addr", gen_params.phys_addr_bits),
         )
 
         self.accept_refill = make_layout(
-            fields.addr,
+            ("addr", gen_params.phys_addr_bits),
             self.fetch_block,
             fields.error,
             self.last,
@@ -544,20 +564,23 @@ class ICacheLayouts:
 class FetchLayouts:
     """Layouts used in the fetcher."""
 
-    class AccessFaultFlag(IntFlag):
+    class FaultFlag(IntFlag):
         # standard access fault when accessing instruction
         # from beginning (exception pc = instruction pc) (fault on full instruction or first half)
         ACCESS_FAULT = auto()
+        # standard page fault when accessing instruction
+        # from beginning (exception pc = instruction pc) (fault on full instruction or first half)
+        PAGE_FAULT = auto()
         # with C extension (2-byte alignment enabled) fault condition
         # could only affect second half of 4-byte instruction.
         # Bit set if this is the case
-        ACCESS_FAULT_ON_SECOND_HALF = auto()
+        EXCEPTION_ON_SECOND_HALF = auto()
 
     def __init__(self, gen_params: GenParams):
         fields = gen_params.get(CommonLayoutFields)
 
-        self.access_fault: LayoutListField = ("access_fault", FetchLayouts.AccessFaultFlag)
-        """Instruction fetch errors. See `FetchLayouts.AccessFaultFlag` fields documentation"""
+        self.access_fault: LayoutListField = ("access_fault", FetchLayouts.FaultFlag)
+        """Instruction fetch errors. See `FetchLayouts.FaultFlag` fields documentation"""
 
         self.raw_instr = make_layout(
             fields.instr,
@@ -717,7 +740,7 @@ class LSULayouts:
 
         self.store: LayoutListField = ("store", 1)
 
-        self.issue = make_layout(fields.addr, fields.data, fields.funct3, self.store)
+        self.issue = make_layout(fields.paddr, fields.addr, fields.data, fields.funct3, self.store)
 
         self.issue_out = make_layout(fields.exception, fields.cause)
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -542,7 +542,7 @@ class ICacheLayouts:
         self.fetch_block: LayoutListField = ("fetch_block", gen_params.fetch_block_bytes * 8)
         """The block of data the fetch unit operates on."""
 
-        self.issue_req = make_layout(("addr", gen_params.phys_addr_bits))
+        self.issue_req = make_layout(fields.paddr)
 
         self.accept_res = make_layout(
             self.fetch_block,
@@ -550,11 +550,11 @@ class ICacheLayouts:
         )
 
         self.start_refill = make_layout(
-            ("addr", gen_params.phys_addr_bits),
+            fields.paddr,
         )
 
         self.accept_refill = make_layout(
-            ("addr", gen_params.phys_addr_bits),
+            fields.paddr,
             self.fetch_block,
             fields.error,
             self.last,

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -118,7 +118,8 @@ class _CoreConfigurationDataClass:
     supported_vm_schemes: Collection[SatpMode]
         SATP MODE values accepted by this core.
     phys_addr_bits: int | None
-        Width of physical addresses in bits. If not set, defaults to 34 for RV32 and 56 for RV64.
+        Width of physical addresses in bits. If not set, defaults to 34 for RV32 if supported_vm_schemes has
+        SV32 enabled, 32 for RV32 with only BARE mode and 56 for RV64.
     hpm_counters_count: int
         Number of implemented HPM counters (mhpmcounter3..mhpmcounter31).
     pmp_register_count: int

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -117,6 +117,8 @@ class _CoreConfigurationDataClass:
         Number of writable ASID bits in SATP.
     supported_vm_schemes: Collection[SatpMode]
         SATP MODE values accepted by this core.
+    phys_addr_bits: int | None
+        Width of physical addresses in bits. If not set, defaults to 34 for RV32 and 56 for RV64.
     hpm_counters_count: int
         Number of implemented HPM counters (mhpmcounter3..mhpmcounter31).
     pmp_register_count: int
@@ -181,6 +183,7 @@ class _CoreConfigurationDataClass:
 
     asidlen: int = 0
     supported_vm_schemes: Collection[SatpMode] = (SatpMode.BARE,)
+    phys_addr_bits: int | None = None
     hpm_counters_count: int = 0
 
     pmp_register_count: int = 0

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -37,7 +37,24 @@ class GenParams(DependentCache):
 
         bytes_in_word = self.isa.xlen // 8
         bytes_in_word_log = exact_log2(bytes_in_word)
-        self.wb_params = WishboneParameters(data_width=self.isa.xlen, addr_width=self.isa.xlen - bytes_in_word_log)
+
+        max_phys_addr_bits = VirtualMemoryParams.max_physical_address_bits(cfg.xlen)
+        self.phys_addr_bits = cfg.phys_addr_bits if cfg.phys_addr_bits is not None else max_phys_addr_bits
+        if self.phys_addr_bits < bytes_in_word_log:
+            raise ValueError(
+                f"Physical address width ({self.phys_addr_bits}) " f"must be at least {bytes_in_word_log} bits"
+            )
+        if self.phys_addr_bits > max_phys_addr_bits:
+            raise ValueError(
+                "Physical address width "
+                f"({self.phys_addr_bits}) exceeds maximum {max_phys_addr_bits} "
+                f"bits for XLEN={cfg.xlen}"
+            )
+
+        self.wb_params = WishboneParameters(
+            data_width=self.isa.xlen,
+            addr_width=self.phys_addr_bits - bytes_in_word_log,
+        )
 
         self.vmem_params = VirtualMemoryParameters(
             xlen=cfg.xlen,
@@ -47,7 +64,7 @@ class GenParams(DependentCache):
         )
 
         self.icache_params = ICacheParameters(
-            addr_width=self.isa.xlen,
+            addr_width=self.phys_addr_bits,
             word_width=self.isa.xlen,
             fetch_block_bytes_log=cfg.fetch_block_bytes_log,
             num_of_ways=cfg.icache_ways,

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -38,7 +38,7 @@ class GenParams(DependentCache):
         bytes_in_word = self.isa.xlen // 8
         bytes_in_word_log = exact_log2(bytes_in_word)
 
-        max_phys_addr_bits = VirtualMemoryParams.max_physical_address_bits(cfg.xlen)
+        max_phys_addr_bits = VirtualMemoryParameters.max_physical_address_bits(cfg.xlen)
         self.phys_addr_bits = cfg.phys_addr_bits if cfg.phys_addr_bits is not None else max_phys_addr_bits
         if self.phys_addr_bits < bytes_in_word_log:
             raise ValueError(

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -38,7 +38,7 @@ class GenParams(DependentCache):
         bytes_in_word = self.isa.xlen // 8
         bytes_in_word_log = exact_log2(bytes_in_word)
 
-        max_phys_addr_bits = VirtualMemoryParameters.max_physical_address_bits(cfg.xlen)
+        max_phys_addr_bits = VirtualMemoryParameters.max_physical_address_bits(cfg.xlen, cfg.supported_vm_schemes)
         self.phys_addr_bits = cfg.phys_addr_bits if cfg.phys_addr_bits is not None else max_phys_addr_bits
         if self.phys_addr_bits < bytes_in_word_log:
             raise ValueError(

--- a/coreblocks/params/vmem_params.py
+++ b/coreblocks/params/vmem_params.py
@@ -1,15 +1,18 @@
 from typing import Collection
 
-from coreblocks.arch.isa_consts import SatpMode, SatpLayout
+from coreblocks.arch.isa_consts import SatpMode, SatpLayout, PAGE_SIZE_LOG
 
 
 class VirtualMemoryParameters:
     """Parameters for virtual memory support."""
 
     @staticmethod
-    def max_physical_address_bits(xlen: int) -> int:
+    def max_physical_address_bits(xlen: int, supported_schemes: Collection[SatpMode]) -> int:
+        if xlen == 32 and supported_schemes == {SatpMode.BARE}:
+            return 32  # without virtual memory only lower 32 bits of physical addresses are reachable
+
         satp_layout = SatpLayout(xlen)
-        return satp_layout["ppn"].width + 12
+        return satp_layout["ppn"].width + PAGE_SIZE_LOG
 
     def __init__(
         self,
@@ -39,6 +42,13 @@ class VirtualMemoryParameters:
         supported_for_xlen = SatpMode.valid_modes(xlen)
         if not self.supported_schemes <= supported_for_xlen:
             raise ValueError(f"Schemes {self.supported_schemes - supported_for_xlen} are not valid for XLEN={xlen}")
+
+        for mode in self.supported_schemes:
+            dependencies = SatpMode.mode_dependencies(mode)
+            if not dependencies <= self.supported_schemes:
+                raise ValueError(
+                    f"Schemes {dependencies - self.supported_schemes} are required by {mode} but not supported"
+                )
 
         self.xlen = xlen
         self.asidlen = asidlen

--- a/coreblocks/params/vmem_params.py
+++ b/coreblocks/params/vmem_params.py
@@ -6,6 +6,11 @@ from coreblocks.arch.isa_consts import SatpMode, SatpLayout
 class VirtualMemoryParameters:
     """Parameters for virtual memory support."""
 
+    @staticmethod
+    def max_physical_address_bits(xlen: int) -> int:
+        satp_layout = SatpLayout(xlen)
+        return satp_layout["ppn"].width + 12
+
     def __init__(
         self,
         *,

--- a/coreblocks/priv/vmem/__init__.py
+++ b/coreblocks/priv/vmem/__init__.py
@@ -1,0 +1,1 @@
+from .translation import *  # noqa: F401

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -163,7 +163,7 @@ class AddressTranslator(Elaboratable):
 
             resp_fwd.write(
                 m,
-                addr=addr,
+                vaddr=addr,
                 paddr=Cat(poffset, ppn),
                 page_fault=page_fault,
                 access_fault=access_fault,

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -6,7 +6,7 @@ from transactron import Method, TModule, def_method
 from transactron.lib import Forwarder
 from transactron.utils import DependencyContext
 
-from coreblocks.arch.isa_consts import PrivilegeLevel, SatpMode
+from coreblocks.arch.isa_consts import PrivilegeLevel, SatpMode, PAGE_SIZE, PAGE_SIZE_LOG
 from coreblocks.interface.keys import CSRInstancesKey
 from coreblocks.interface.layouts import AddressTranslationLayouts
 from coreblocks.params import GenParams
@@ -51,7 +51,7 @@ def page_table_entry_format(mode: SatpMode) -> StructLayout:
                     "G": 1,
                     "A": 1,
                     "D": 1,
-                    "_rsv": 2,
+                    "RSW": 2,
                     "ppn": 22,
                 }
             )
@@ -66,7 +66,7 @@ def page_table_entry_format(mode: SatpMode) -> StructLayout:
                     "G": 1,
                     "A": 1,
                     "D": 1,
-                    "_rsv": 2,
+                    "RSW": 2,
                     "ppn": 44,
                     "reserved": 7,
                     "PBMT": 2,
@@ -78,7 +78,8 @@ def page_table_entry_format(mode: SatpMode) -> StructLayout:
 
 
 def bits_per_level(mode: SatpMode) -> int:
-    num_entries = (1 << 12) // page_table_entry_format(mode).as_shape().width
+    """Number of virtual address bits translated at each page table level."""
+    num_entries = PAGE_SIZE // page_table_entry_format(mode).as_shape().width
     return num_entries.bit_length() - 1
 
 
@@ -129,14 +130,13 @@ class AddressTranslator(Elaboratable):
                 with m.If(effective_priv_mode < PrivilegeLevel.MACHINE):
                     m.d.av_comb += effective_satp_mode.eq(csr.s_mode.satp_mode)
 
-            poffset = Signal(12)
-            ppn = Signal(self.gen_params.phys_addr_bits - 12)
-            vpn = Signal(self.gen_params.isa.xlen - 12)
+            poffset = Signal(PAGE_SIZE_LOG)
+            ppn = Signal(self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)
+            vpn = Signal(self.gen_params.isa.xlen - PAGE_SIZE_LOG)
 
-            m.d.av_comb += poffset.eq(addr[:12])
-            m.d.av_comb += vpn.eq(addr[12:])
+            m.d.av_comb += Cat(poffset, vpn).eq(addr)
 
-            max_ppn = 1 << (self.gen_params.phys_addr_bits - 12) - 1
+            max_ppn = 1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG) - 1
 
             vpn_invalid = Signal()
             with m.Switch(effective_satp_mode):

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -1,0 +1,176 @@
+from amaranth import *
+from amaranth.lib.data import StructLayout
+from amaranth.lib.enum import Enum, unique, auto
+
+from transactron import Method, TModule, def_method
+from transactron.lib import Forwarder
+from transactron.utils import DependencyContext
+
+from coreblocks.arch.isa_consts import PrivilegeLevel, SatpModeEncoding
+from coreblocks.interface.keys import CSRInstancesKey
+from coreblocks.interface.layouts import AddressTranslationLayouts
+from coreblocks.params import GenParams
+
+__all__ = ["AddressTranslator", "AddressTranslatorMode"]
+
+
+@unique
+class AddressTranslatorMode(Enum):
+    INSTRUCTION = auto()
+    LSU = auto()
+
+
+def level_count(mode: SatpModeEncoding) -> int:
+    match mode:
+        case SatpModeEncoding.BARE:
+            return 0
+        case SatpModeEncoding.SV32:
+            return 2
+        case SatpModeEncoding.SV39:
+            return 3
+        case SatpModeEncoding.SV48:
+            return 4
+        case SatpModeEncoding.SV57:
+            return 5
+        case _:
+            raise ValueError(f"Unsupported SATP mode: {mode}")
+
+
+def page_table_entry_format(mode: SatpModeEncoding) -> StructLayout:
+    match mode:
+        case SatpModeEncoding.BARE:
+            return StructLayout({})
+        case SatpModeEncoding.SV32:
+            return StructLayout(
+                {
+                    "V": 1,
+                    "R": 1,
+                    "W": 1,
+                    "X": 1,
+                    "U": 1,
+                    "G": 1,
+                    "A": 1,
+                    "D": 1,
+                    "_rsv": 2,
+                    "ppn": 22,
+                }
+            )
+        case SatpModeEncoding.SV39 | SatpModeEncoding.SV48 | SatpModeEncoding.SV57:
+            return StructLayout(
+                {
+                    "V": 1,
+                    "R": 1,
+                    "W": 1,
+                    "X": 1,
+                    "U": 1,
+                    "G": 1,
+                    "A": 1,
+                    "D": 1,
+                    "_rsv": 2,
+                    "ppn": 44,
+                    "reserved": 7,
+                    "PBMT": 2,
+                    "N": 1,
+                }
+            )
+        case _:
+            raise ValueError(f"Unsupported SATP mode: {mode}")
+
+
+def bits_per_level(mode: SatpModeEncoding) -> int:
+    num_entries = (1 << 12) // page_table_entry_format(mode).as_shape().width
+    return num_entries.bit_length() - 1
+
+
+class AddressTranslator(Elaboratable):
+    """Address translator from virtual to physical addresses."""
+
+    def __init__(
+        self,
+        gen_params: GenParams,
+        *,
+        mode: AddressTranslatorMode,
+    ) -> None:
+        self.gen_params = gen_params
+        self.mode = mode
+        self.layouts = self.gen_params.get(AddressTranslationLayouts)
+
+        self.request = Method(i=self.layouts.request)
+        self.accept = Method(o=self.layouts.accept)
+
+    def elaborate(self, platform):
+        m = TModule()
+        m.submodules.resp_fwd = resp_fwd = Forwarder(self.layouts.accept)
+        csr = DependencyContext.get().get_dependency(CSRInstancesKey())
+
+        @def_method(m, self.request)
+        def _(addr: Value):
+            access_fault = Signal()
+            page_fault = Signal()
+            effective_priv_mode = Signal(PrivilegeLevel)
+
+            priv_mode = csr.m_mode.priv_mode.read(m).data
+
+            match self.mode:
+                case AddressTranslatorMode.LSU:
+                    mprv = csr.m_mode.mstatus_mprv.read(m).data
+                    mpp = csr.m_mode.mstatus_mpp.read(m).data
+
+                    m.d.av_comb += effective_priv_mode.eq(
+                        (Mux(mprv & (priv_mode == PrivilegeLevel.MACHINE), mpp, priv_mode))
+                    )
+
+                case AddressTranslatorMode.INSTRUCTION:
+                    m.d.av_comb += effective_priv_mode.eq(priv_mode)
+
+            effective_satp_mode = Signal(SatpModeEncoding, init=SatpModeEncoding.BARE)
+
+            if self.gen_params.supervisor_mode:
+                with m.If(effective_priv_mode < PrivilegeLevel.MACHINE):
+                    m.d.av_comb += effective_satp_mode.eq(csr.s_mode.satp_mode)
+
+            poffset = Signal(12)
+            ppn = Signal(self.gen_params.phys_addr_bits - 12)
+            vpn = Signal(self.gen_params.isa.xlen - 12)
+
+            m.d.av_comb += poffset.eq(addr[:12])
+            m.d.av_comb += vpn.eq(addr[12:])
+
+            max_ppn = 1 << (self.gen_params.phys_addr_bits - 12) - 1
+
+            vpn_invalid = Signal()
+            with m.Switch(effective_satp_mode):
+                for mode in self.gen_params.vmem_params.supported_schemes - {SatpModeEncoding.BARE}:
+                    vpn_len = bits_per_level(mode) * level_count(mode)
+
+                    with m.Case(mode):
+                        # virtual modes require sign-extended vaddr
+                        m.d.av_comb += vpn_invalid.eq(vpn[vpn_len:].any() & ~vpn[vpn_len:].all())
+
+            ppn_invalid = Signal()
+            with m.Switch(effective_satp_mode):
+                with m.Case(SatpModeEncoding.BARE):
+                    m.d.av_comb += ppn.eq(vpn)
+                    m.d.av_comb += ppn_invalid.eq(vpn > max_ppn)
+
+                # TODO: implement actual page table walking
+
+            with m.If(vpn_invalid):
+                m.d.av_comb += page_fault.eq(1)
+
+            with m.If(ppn_invalid):
+                m.d.av_comb += access_fault.eq(1)
+
+            resp_fwd.write(
+                m,
+                addr=addr,
+                paddr=Cat(poffset, ppn),
+                page_fault=page_fault,
+                access_fault=access_fault,
+            )
+
+        @def_method(m, self.accept)
+        def _():
+            return resp_fwd.read(m)
+
+        return m

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -6,7 +6,7 @@ from transactron import Method, TModule, def_method
 from transactron.lib import Forwarder
 from transactron.utils import DependencyContext
 
-from coreblocks.arch.isa_consts import PrivilegeLevel, SatpModeEncoding
+from coreblocks.arch.isa_consts import PrivilegeLevel, SatpMode
 from coreblocks.interface.keys import CSRInstancesKey
 from coreblocks.interface.layouts import AddressTranslationLayouts
 from coreblocks.params import GenParams
@@ -20,27 +20,27 @@ class AddressTranslatorMode(Enum):
     LSU = auto()
 
 
-def level_count(mode: SatpModeEncoding) -> int:
+def level_count(mode: SatpMode) -> int:
     match mode:
-        case SatpModeEncoding.BARE:
+        case SatpMode.BARE:
             return 0
-        case SatpModeEncoding.SV32:
+        case SatpMode.SV32:
             return 2
-        case SatpModeEncoding.SV39:
+        case SatpMode.SV39:
             return 3
-        case SatpModeEncoding.SV48:
+        case SatpMode.SV48:
             return 4
-        case SatpModeEncoding.SV57:
+        case SatpMode.SV57:
             return 5
         case _:
             raise ValueError(f"Unsupported SATP mode: {mode}")
 
 
-def page_table_entry_format(mode: SatpModeEncoding) -> StructLayout:
+def page_table_entry_format(mode: SatpMode) -> StructLayout:
     match mode:
-        case SatpModeEncoding.BARE:
+        case SatpMode.BARE:
             return StructLayout({})
-        case SatpModeEncoding.SV32:
+        case SatpMode.SV32:
             return StructLayout(
                 {
                     "V": 1,
@@ -55,7 +55,7 @@ def page_table_entry_format(mode: SatpModeEncoding) -> StructLayout:
                     "ppn": 22,
                 }
             )
-        case SatpModeEncoding.SV39 | SatpModeEncoding.SV48 | SatpModeEncoding.SV57:
+        case SatpMode.SV39 | SatpMode.SV48 | SatpMode.SV57:
             return StructLayout(
                 {
                     "V": 1,
@@ -77,7 +77,7 @@ def page_table_entry_format(mode: SatpModeEncoding) -> StructLayout:
             raise ValueError(f"Unsupported SATP mode: {mode}")
 
 
-def bits_per_level(mode: SatpModeEncoding) -> int:
+def bits_per_level(mode: SatpMode) -> int:
     num_entries = (1 << 12) // page_table_entry_format(mode).as_shape().width
     return num_entries.bit_length() - 1
 
@@ -123,7 +123,7 @@ class AddressTranslator(Elaboratable):
                 case AddressTranslatorMode.INSTRUCTION:
                     m.d.av_comb += effective_priv_mode.eq(priv_mode)
 
-            effective_satp_mode = Signal(SatpModeEncoding, init=SatpModeEncoding.BARE)
+            effective_satp_mode = Signal(SatpMode, init=SatpMode.BARE)
 
             if self.gen_params.supervisor_mode:
                 with m.If(effective_priv_mode < PrivilegeLevel.MACHINE):
@@ -140,7 +140,7 @@ class AddressTranslator(Elaboratable):
 
             vpn_invalid = Signal()
             with m.Switch(effective_satp_mode):
-                for mode in self.gen_params.vmem_params.supported_schemes - {SatpModeEncoding.BARE}:
+                for mode in self.gen_params.vmem_params.supported_schemes - {SatpMode.BARE}:
                     vpn_len = bits_per_level(mode) * level_count(mode)
 
                     with m.Case(mode):
@@ -149,7 +149,7 @@ class AddressTranslator(Elaboratable):
 
             ppn_invalid = Signal()
             with m.Switch(effective_satp_mode):
-                with m.Case(SatpModeEncoding.BARE):
+                with m.Case(SatpMode.BARE):
                     m.d.av_comb += ppn.eq(vpn)
                     m.d.av_comb += ppn_invalid.eq(vpn > max_ppn)
 

--- a/test/cache/test_icache.py
+++ b/test/cache/test_icache.py
@@ -113,14 +113,14 @@ class TestSimpleCommonBusCacheRefiller(TestCaseWithSimulator):
     async def refiller_process(self, sim: TestbenchContext):
         while self.requests:
             req_addr = self.requests.pop()
-            await self.test_module.start_refill.call(sim, addr=req_addr)
+            await self.test_module.start_refill.call(sim, paddr=req_addr)
 
             for i in range(self.cp.fetch_blocks_in_line):
                 ret = await self.test_module.accept_refill.call(sim)
 
                 cur_addr = req_addr + i * self.cp.fetch_block_bytes
 
-                assert ret["addr"] == cur_addr
+                assert ret["paddr"] == cur_addr
 
                 if cur_addr in self.bad_fetch_blocks:
                     assert ret["error"] == 1
@@ -227,7 +227,7 @@ class TestICacheBypass(TestCaseWithSimulator):
     async def user_process(self, sim: TestbenchContext):
         while self.requests:
             req_addr = self.requests.popleft() & ~(self.cp.fetch_block_bytes - 1)
-            await self.m.issue_req.call(sim, addr=req_addr)
+            await self.m.issue_req.call(sim, paddr=req_addr)
 
             await self.random_wait_geom(sim, 0.5)
 
@@ -331,13 +331,13 @@ class TestICache(TestCaseWithSimulator):
         self.m = ICacheTestCircuit(self.gen_params)
 
     @def_method_mock(lambda self: self.m.refiller.start_refill_mock, enable=lambda self: self.accept_refill_request)
-    def start_refill_mock(self, addr):
+    def start_refill_mock(self, paddr):
         @MethodMock.effect
         def eff():
-            self.refill_requests.append(addr)
+            self.refill_requests.append(paddr)
             self.refill_block_cnt = 0
             self.refill_in_fly = True
-            self.refill_addr = addr
+            self.refill_addr = paddr
 
     def enen(self):
         return self.refill_in_fly
@@ -363,7 +363,7 @@ class TestICache(TestCaseWithSimulator):
                 self.refill_in_fly = False
 
         return {
-            "addr": addr,
+            "paddr": addr,
             "fetch_block": fetch_block,
             "error": bad_addr,
             "last": last,
@@ -380,7 +380,7 @@ class TestICache(TestCaseWithSimulator):
 
     async def send_req(self, sim: TestbenchContext, addr: int):
         self.issued_requests.append(addr)
-        await self.m.issue_req.call(sim, addr=addr)
+        await self.m.issue_req.call(sim, paddr=addr)
 
     async def expect_resp(self, sim: TestbenchContext, wait=False):
         if wait:
@@ -487,7 +487,7 @@ class TestICache(TestCaseWithSimulator):
                 self.issued_requests.append(addr)
 
                 # Send the request
-                ret = await self.m.issue_req.call_try(sim, addr=addr)
+                ret = await self.m.issue_req.call_try(sim, paddr=addr)
                 assert ret is not None
 
                 # After a cycle the response should be ready
@@ -498,8 +498,8 @@ class TestICache(TestCaseWithSimulator):
             await self.tick(sim, 4)
 
             # Check how the cache handles queuing the requests
-            await self.send_req(sim, addr=0x00010000 + 3 * self.cp.line_size_bytes)
-            await self.send_req(sim, addr=0x00010004)
+            await self.send_req(sim, 0x00010000 + 3 * self.cp.line_size_bytes)
+            await self.send_req(sim, 0x00010004)
 
             # Wait a few cycles. There are two requests queued
             await self.tick(sim, 4)
@@ -511,7 +511,7 @@ class TestICache(TestCaseWithSimulator):
             await self.expect_resp(
                 sim,
             )
-            await self.send_req(sim, addr=0x0001000C)
+            await self.send_req(sim, 0x0001000C)
             await self.expect_resp(
                 sim,
             )
@@ -521,8 +521,8 @@ class TestICache(TestCaseWithSimulator):
             await self.tick(sim, 4)
 
             # Schedule two requests, the first one causing a cache miss
-            await self.send_req(sim, addr=0x00020000)
-            await self.send_req(sim, addr=0x00010000 + self.cp.line_size_bytes)
+            await self.send_req(sim, 0x00020000)
+            await self.send_req(sim, 0x00010000 + self.cp.line_size_bytes)
 
             self.m.accept_res.enable(sim)
 
@@ -535,8 +535,8 @@ class TestICache(TestCaseWithSimulator):
             await self.tick(sim, 2)
 
             # Schedule two requests, the second one causing a cache miss
-            await self.send_req(sim, addr=0x00020004)
-            await self.send_req(sim, addr=0x00030000 + self.cp.line_size_bytes)
+            await self.send_req(sim, 0x00020004)
+            await self.send_req(sim, 0x00030000 + self.cp.line_size_bytes)
 
             self.m.accept_res.enable(sim)
 
@@ -549,8 +549,8 @@ class TestICache(TestCaseWithSimulator):
             await self.tick(sim, 2)
 
             # Schedule two requests, both causing a cache miss
-            await self.send_req(sim, addr=0x00040000)
-            await self.send_req(sim, addr=0x00050000 + self.cp.line_size_bytes)
+            await self.send_req(sim, 0x00040000)
+            await self.send_req(sim, 0x00050000 + self.cp.line_size_bytes)
 
             self.m.accept_res.enable(sim)
 
@@ -602,11 +602,11 @@ class TestICache(TestCaseWithSimulator):
             # Try to execute issue_req and flush_cache methods at the same time
             self.issued_requests.append(0x00010000)
             issue_req_res, flush_cache_res = (
-                await CallTrigger(sim).call(self.m.issue_req, addr=0x00010000).call(self.m.flush_cache)
+                await CallTrigger(sim).call(self.m.issue_req, paddr=0x00010000).call(self.m.flush_cache)
             )
             assert issue_req_res is None
             assert flush_cache_res is not None
-            await self.m.issue_req.call(sim, addr=0x00010000)
+            await self.m.issue_req.call(sim, paddr=0x00010000)
             self.assert_resp(await self.m.accept_res.call(sim))
             self.expect_refill(0x00010000)
 
@@ -664,8 +664,8 @@ class TestICache(TestCaseWithSimulator):
             self.m.accept_res.disable(sim)
 
             # Schedule two requests, the first one causing an error
-            await self.send_req(sim, addr=0x00020000)
-            await self.send_req(sim, addr=0x00011000)
+            await self.send_req(sim, 0x00020000)
+            await self.send_req(sim, 0x00011000)
 
             self.m.accept_res.enable(sim)
 
@@ -676,8 +676,8 @@ class TestICache(TestCaseWithSimulator):
             await self.tick(sim, 3)
 
             # Schedule two requests, the second one causing an error
-            await self.send_req(sim, addr=0x00021004)
-            await self.send_req(sim, addr=0x00030000)
+            await self.send_req(sim, 0x00021004)
+            await self.send_req(sim, 0x00030000)
 
             await self.tick(sim, 10)
 
@@ -690,8 +690,8 @@ class TestICache(TestCaseWithSimulator):
             await self.tick(sim, 3)
 
             # Schedule two requests, both causing an error
-            await self.send_req(sim, addr=0x00020000)
-            await self.send_req(sim, addr=0x00010000)
+            await self.send_req(sim, 0x00020000)
+            await self.send_req(sim, 0x00010000)
 
             self.m.accept_res.enable(sim)
 
@@ -700,8 +700,8 @@ class TestICache(TestCaseWithSimulator):
             self.m.accept_res.disable(sim)
 
             # The second request will cause an error
-            await self.send_req(sim, addr=0x00021004)
-            await self.send_req(sim, addr=0x00030000)
+            await self.send_req(sim, 0x00021004)
+            await self.send_req(sim, 0x00030000)
 
             await self.tick(sim, 10)
 
@@ -716,7 +716,7 @@ class TestICache(TestCaseWithSimulator):
             await self.expect_resp(sim, wait=True)
 
             # This request should not cause an error
-            await self.send_req(sim, addr=0x00011000)
+            await self.send_req(sim, 0x00011000)
             await self.expect_resp(sim, wait=True)
 
         with self.run_simulation(self.m) as sim:

--- a/test/cache/test_icache.py
+++ b/test/cache/test_icache.py
@@ -81,7 +81,7 @@ class TestSimpleCommonBusCacheRefiller(TestCaseWithSimulator):
         self.requests = deque()
         for _ in range(100):
             # Make the address aligned to the beginning of a cache line
-            addr = random.randrange(2**self.gen_params.isa.xlen) & ~(self.cp.line_size_bytes - 1)
+            addr = random.randrange(2**self.gen_params.phys_addr_bits) & ~(self.cp.line_size_bytes - 1)
             self.requests.append(addr)
 
             if random.random() < 0.21:
@@ -196,7 +196,7 @@ class TestICacheBypass(TestCaseWithSimulator):
         self.requests.append(4)
 
         for _ in range(100):
-            addr = random.randrange(0, 2**self.gen_params.isa.xlen, 4)
+            addr = random.randrange(0, 2**self.gen_params.phys_addr_bits, 4)
             self.requests.append(addr)
 
             if random.random() < 0.10:

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -176,10 +176,10 @@ class TestFetchUnit(TestCaseWithSimulator):
     @def_method_mock(
         lambda self: self.icache.issue_req_io, enable=lambda self: len(self.input_q) < 2
     )  # TODO had sched_prio
-    def issue_req_mock(self, addr):
+    def issue_req_mock(self, paddr):
         @MethodMock.effect
         def eff():
-            self.input_q.append(addr)
+            self.input_q.append(paddr)
 
     @def_method_mock(lambda self: self.icache.accept_res_io, enable=lambda self: len(self.output_q) > 0)
     def accept_res_mock(self):

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -205,12 +205,10 @@ class TestFetchUnit(TestCaseWithSimulator):
 
     async def fetch_out_check(self, sim: TestbenchContext):
         async def check_instr(instr, v):
-            access_fault = FetchLayouts.AccessFaultFlag.ACCESS_FAULT if instr["pc"] in self.memerr else 0
+            access_fault = FetchLayouts.FaultFlag.ACCESS_FAULT if instr["pc"] in self.memerr else 0
             if not instr["rvc"]:
                 if instr["pc"] + 2 in self.memerr:
-                    access_fault = (
-                        FetchLayouts.AccessFaultFlag.ACCESS_FAULT_ON_SECOND_HALF if not access_fault else access_fault
-                    )
+                    access_fault = FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF if not access_fault else access_fault
 
             print(instr, v["pc"], v["access_fault"])
             assert v["pc"] == instr["pc"]
@@ -237,7 +235,7 @@ class TestFetchUnit(TestCaseWithSimulator):
                     resume_pc = (
                         instr["pc"] & ~(self.gen_params.fetch_block_bytes - 1)
                     ) + self.gen_params.fetch_block_bytes * (
-                        2 if access_fault == FetchLayouts.AccessFaultFlag.ACCESS_FAULT_ON_SECOND_HALF else 1
+                        2 if access_fault == FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF else 1
                     )
 
                 self.backend_redirect.append(resume_pc)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -11,6 +11,7 @@ from transactron.core import Method
 from transactron.lib import Adapter, BasicFifo
 from transactron.testing.method_mock import MethodMock
 from transactron.utils import ModuleConnector
+from transactron.utils.dependencies import DependencyContext
 from transactron.testing import (
     TestCaseWithSimulator,
     TestbenchIO,
@@ -26,6 +27,8 @@ from coreblocks.arch import *
 from coreblocks.params import *
 from coreblocks.params.configurations import test_core_config
 from coreblocks.interface.layouts import ICacheLayouts, FetchLayouts
+from coreblocks.interface.keys import CSRInstancesKey
+from coreblocks.priv.csr.csr_instances import CSRInstances
 
 
 class MockedICache(Elaboratable, CacheInterface):
@@ -65,6 +68,9 @@ class TestFetchUnit(TestCaseWithSimulator):
             )
         )
 
+        self.csr = CSRInstances(self.gen_params)
+        DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr)
+
         self.icache = MockedICache(self.gen_params)
         fifo = BasicFifo(self.gen_params.get(FetchLayouts).fetch_result, depth=2)
         self.fifo = SimpleTestCircuit(fifo, exclude={"write"})
@@ -75,7 +81,7 @@ class TestFetchUnit(TestCaseWithSimulator):
 
         self.fetch = SimpleTestCircuit(fetch_unit, exclude={"cont"})
 
-        self.m = ModuleConnector(self.icache, self.fifo, self.fetch)
+        self.m = ModuleConnector(self.icache, self.fifo, self.fetch, self.csr)
 
         self.instr_queue = deque()
         self.mem = {}

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -208,7 +208,11 @@ class TestFetchUnit(TestCaseWithSimulator):
             access_fault = FetchLayouts.FaultFlag.ACCESS_FAULT if instr["pc"] in self.memerr else 0
             if not instr["rvc"]:
                 if instr["pc"] + 2 in self.memerr:
-                    access_fault = FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF if not access_fault else access_fault
+                    access_fault = (
+                        FetchLayouts.FaultFlag.ACCESS_FAULT | FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF
+                        if not access_fault
+                        else access_fault
+                    )
 
             print(instr, v["pc"], v["access_fault"])
             assert v["pc"] == instr["pc"]
@@ -235,7 +239,7 @@ class TestFetchUnit(TestCaseWithSimulator):
                     resume_pc = (
                         instr["pc"] & ~(self.gen_params.fetch_block_bytes - 1)
                     ) + self.gen_params.fetch_block_bytes * (
-                        2 if access_fault == FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF else 1
+                        2 if FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF in access_fault else 1
                     )
 
                 self.backend_redirect.append(resume_pc)

--- a/test/func_blocks/fu/test_exception_unit.py
+++ b/test/func_blocks/fu/test_exception_unit.py
@@ -2,6 +2,7 @@ from coreblocks.func_blocks.fu.exception import ExceptionUnitFn, ExceptionUnitCo
 from coreblocks.arch import ExceptionCause, Funct3
 from coreblocks.arch import OpType
 
+from coreblocks.interface.layouts import FetchLayouts
 from test.func_blocks.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
@@ -24,6 +25,8 @@ class TestExceptionUnit(FunctionalUnitTestCase[ExceptionUnitFn.Fn]):
         cause = None
         mtval = 0
 
+        at_second_half = (i_imm & FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF) != 0
+
         match fn:
             case ExceptionUnitFn.Fn.EBREAK | ExceptionUnitFn.Fn.BREAKPOINT:
                 cause = ExceptionCause.BREAKPOINT
@@ -32,10 +35,10 @@ class TestExceptionUnit(FunctionalUnitTestCase[ExceptionUnitFn.Fn]):
                 cause = ExceptionCause.ENVIRONMENT_CALL_FROM_M
             case ExceptionUnitFn.Fn.INSTR_ACCESS_FAULT:
                 cause = ExceptionCause.INSTRUCTION_ACCESS_FAULT
-                mtval = pc
+                mtval = pc + (2 if at_second_half else 0)
             case ExceptionUnitFn.Fn.INSTR_PAGE_FAULT:
                 cause = ExceptionCause.INSTRUCTION_PAGE_FAULT
-                mtval = pc
+                mtval = pc + (2 if at_second_half else 0)
             case ExceptionUnitFn.Fn.ILLEGAL_INSTRUCTION:
                 cause = ExceptionCause.ILLEGAL_INSTRUCTION
                 mtval = i_imm  # in case of illegal instruction, raw instr bits are passed in imm field

--- a/test/func_blocks/lsu/test_pma.py
+++ b/test/func_blocks/lsu/test_pma.py
@@ -18,7 +18,7 @@ from ...peripherals.bus_mock import BusMockParameters, MockMasterAdapter
 class TestPMADirect(TestCaseWithSimulator):
     async def verify_region(self, sim: TestbenchContext, region: PMARegion):
         for i in range(region.start, region.end + 1):
-            sim.set(self.test_module.addr, i)
+            sim.set(self.test_module.paddr, i)
             mmio = sim.get(self.test_module.result.mmio)
             assert mmio == region.mmio
 

--- a/test/func_blocks/lsu/test_pmp.py
+++ b/test/func_blocks/lsu/test_pmp.py
@@ -51,7 +51,7 @@ class TestPMPDirect(TestCaseWithSimulator):
                 sim.set(csr.m_mode.pmpxcfg[i].value, entry.cfg)
 
             for c in checks:
-                sim.set(pmp.addr, c.addr)
+                sim.set(pmp.paddr, c.addr)
                 result = sim.get(pmp.result)
                 assert result.r == c.r, f"addr=0x{c.addr:08x}: expected r={c.r}, got {result.r}"
                 assert result.w == c.w, f"addr=0x{c.addr:08x}: expected w={c.w}, got {result.w}"


### PR DESCRIPTION
This builds up on #878 and prepares for virtual memory implementation.

Things that this PR tries to do:
- separate physical and virtual addresses:
  - allow for configuration of physical address length independent of XLEN - up to 34 bit for rv32 and 56 bit for rv64
  - rename `addr` to `paddr` where physical addresses are involved
- implement blank address translation module for later implementation of other addressing modes