### PR TITLE
Big CSR refactor - CSR Register ABC, Protocol, misc clean-ups

### DIFF
--- a/coreblocks/arch/csr_address.py
+++ b/coreblocks/arch/csr_address.py
@@ -448,6 +448,10 @@ class CSRAddress(IntEnum, shape=12):
     COREBLOCKS_TEST_PRIV_MODE = 0x8FF
 
 
+# Width of pmpXcfg subfields in pmpcfgX registers
+PMPXCFG_WIDTH = 8
+
+
 @unique
 class MstatusFieldOffsets(IntEnum):
     SIE = 1  # Supervisor Interrupt Enable

--- a/coreblocks/func_blocks/csr/csr_protocol.py
+++ b/coreblocks/func_blocks/csr/csr_protocol.py
@@ -1,0 +1,18 @@
+from typing import Protocol
+
+from transactron.core import Method, Provided
+from transactron.utils import SrcLoc
+
+__all__ = [
+    "RegisteredCSRProtocol",
+]
+
+
+class RegisteredCSRProtocol(Protocol):
+    """Protocol required to be included as a public CSR via `CSRListKey`"""
+
+    _fu_read: Provided[Method]
+    _fu_write: Provided[Method]
+    _fu_access_valid: Provided[Method]
+
+    src_loc: SrcLoc

--- a/coreblocks/func_blocks/csr/csr_unit.py
+++ b/coreblocks/func_blocks/csr/csr_unit.py
@@ -1,8 +1,10 @@
 from amaranth import *
 from amaranth.lib.data import StructLayout
-from dataclasses import dataclass
 
-from transactron import Method, Methods, def_method, def_methods, Transaction, TModule
+from dataclasses import dataclass
+from typing import Protocol
+
+from transactron import Method, Methods, def_method, def_methods, Transaction, TModule, Provided
 from transactron.utils import assign
 from transactron.utils.data_repr import bits_from_int
 from transactron.utils.dependencies import DependencyContext
@@ -22,6 +24,18 @@ from coreblocks.interface.keys import (
     ExceptionReportKey,
     AsyncInterruptInsertSignalKey,
 )
+
+__all__ = [
+    "CSRUnit",
+    "CSRBlockComponent",
+    "RegisteredCSRProtocol",
+]
+
+
+class RegisteredCSRProtocol(Protocol):
+    _fu_read: Provided[Method]
+    _fu_write: Provided[Method]
+    _fu_access_valid: Provided[Method]
 
 
 def csr_access_privilege(csr_addr: int) -> tuple[PrivilegeLevel, bool]:
@@ -85,12 +99,11 @@ class CSRUnit(FuncBlock, Elaboratable):
         self.report = self.dependency_manager.get_dependency(ExceptionReportKey())()
 
     def _create_regfile(self):
-        # Fills `self.regfile` with `CSRRegister`s provided by `CSRListKey` dependency.
-        for csr in self.dependency_manager.get_dependency(CSRListKey()):
-            assert csr.csr_number is not None
-            if csr.csr_number in self.regfile:
-                raise RuntimeError(f"CSR number {csr.csr_number} already registered")
-            self.regfile[csr.csr_number] = (csr._fu_read, csr._fu_write, csr.access_valid)
+        # Fills `self.regfile` with CSR registers provided by `CSRListKey` dependency.
+        for csr_number, csr in self.dependency_manager.get_dependency(CSRListKey()):
+            if csr_number in self.regfile:
+                raise RuntimeError(f"CSR number {csr_number} already registered")
+            self.regfile[csr_number] = (csr._fu_read, csr._fu_write, csr._fu_access_valid)
 
     def elaborate(self, platform):
         self._create_regfile()

--- a/coreblocks/func_blocks/csr/csr_unit.py
+++ b/coreblocks/func_blocks/csr/csr_unit.py
@@ -1,5 +1,6 @@
 from amaranth import *
 from amaranth.lib.data import StructLayout
+from amaranth_types import SrcLoc
 
 from dataclasses import dataclass
 from typing import Protocol
@@ -33,23 +34,13 @@ __all__ = [
 
 
 class RegisteredCSRProtocol(Protocol):
+    """Protocol required to be included as a public CSR via `CSRListKey`"""
+
     _fu_read: Provided[Method]
     _fu_write: Provided[Method]
     _fu_access_valid: Provided[Method]
 
-
-def csr_access_privilege(csr_addr: int) -> tuple[PrivilegeLevel, bool]:
-    read_only = bits_from_int(csr_addr, 10, 2) == 0b11
-
-    match bits_from_int(csr_addr, 8, 2):
-        case 0b00:
-            return (PrivilegeLevel.USER, read_only)
-        case 0b01:
-            return (PrivilegeLevel.SUPERVISOR, read_only)
-        case 0b10:  # Hypervisior CSRs - accessible with VS mode (S with extension)
-            return (PrivilegeLevel.SUPERVISOR, read_only)
-        case _:
-            return (PrivilegeLevel.MACHINE, read_only)
+    src_loc: SrcLoc
 
 
 class CSRUnit(FuncBlock, Elaboratable):
@@ -94,7 +85,7 @@ class CSRUnit(FuncBlock, Elaboratable):
         self.update = Methods(gen_params.announcement_superscalarity, i=self.csr_layouts.rs.update_in)
         self.get_result = Method(o=self.fu_layouts.push_result)
 
-        self.regfile: dict[int, tuple[Method, Method, Method]] = {}
+        self.regfile: dict[int, RegisteredCSRProtocol] = {}
 
         self.report = self.dependency_manager.get_dependency(ExceptionReportKey())()
 
@@ -102,8 +93,23 @@ class CSRUnit(FuncBlock, Elaboratable):
         # Fills `self.regfile` with CSR registers provided by `CSRListKey` dependency.
         for csr_number, csr in self.dependency_manager.get_dependency(CSRListKey()):
             if csr_number in self.regfile:
-                raise RuntimeError(f"CSR number {csr_number} already registered")
-            self.regfile[csr_number] = (csr._fu_read, csr._fu_write, csr._fu_access_valid)
+                raise RuntimeError(
+                    f"CSR number {csr_number} already registered (at {self.regfile[csr_number].src_loc} {csr.src_loc}"
+                )
+            self.regfile[csr_number] = csr
+
+    def _csr_access_privilege(self, csr_addr: int) -> tuple[PrivilegeLevel, bool]:
+        read_only = bits_from_int(csr_addr, 10, 2) == 0b11
+
+        match bits_from_int(csr_addr, 8, 2):
+            case 0b00:
+                return (PrivilegeLevel.USER, read_only)
+            case 0b01:
+                return (PrivilegeLevel.SUPERVISOR, read_only)
+            case 0b10:  # Hypervisior CSRs - accessible with VS mode (S with extension)
+                return (PrivilegeLevel.SUPERVISOR, read_only)
+            case _:
+                return (PrivilegeLevel.MACHINE, read_only)
 
     def elaborate(self, platform):
         self._create_regfile()
@@ -155,13 +161,12 @@ class CSRUnit(FuncBlock, Elaboratable):
             # Use condition() as a workaround for kuznia-rdzeni/transactron#10, as _fu_(read|write) methods
             # are called multiple times, as some CSRs are aliased call other CSR's _fu_* methods.
             with condition(m) as branch:
-                for csr_number, methods in self.regfile.items():
-                    read, write, access_valid = methods
-                    priv_level_required, read_only = csr_access_privilege(csr_number)
+                for csr_number, csr in self.regfile.items():
+                    priv_level_required, read_only = self._csr_access_privilege(csr_number)
 
                     with branch(instr.csr == csr_number):
                         priv_valid = Signal()
-                        csr_access_valid = access_valid(m, current_priv_mode).valid
+                        csr_access_valid = csr._fu_access_valid(m, current_priv_mode).valid
 
                         m.d.comb += priv_valid.eq(priv_level_required <= current_priv_mode)
 
@@ -169,7 +174,7 @@ class CSRUnit(FuncBlock, Elaboratable):
                             read_val = Signal(self.gen_params.isa.xlen)
                             with m.If(should_read_csr & ~done):
                                 with m.If(exe_side_fx):
-                                    m.d.comb += read_val.eq(read(m))
+                                    m.d.comb += read_val.eq(csr._fu_read(m))
                                 m.d.sync += current_result.eq(read_val)
 
                             if read_only:
@@ -187,7 +192,7 @@ class CSRUnit(FuncBlock, Elaboratable):
                                         with m.Case(Funct3.CSRRC, Funct3.CSRRCI):
                                             m.d.comb += write_val.eq(read_val & (~instr.s1_val))
                                     with m.If(exe_side_fx):
-                                        write(m, write_val)
+                                        csr._fu_write(m, write_val)
 
                         with m.Else():
                             # Missing privilege

--- a/coreblocks/func_blocks/csr/csr_unit.py
+++ b/coreblocks/func_blocks/csr/csr_unit.py
@@ -1,11 +1,9 @@
 from amaranth import *
 from amaranth.lib.data import StructLayout
-from amaranth_types import SrcLoc
 
 from dataclasses import dataclass
-from typing import Protocol
 
-from transactron import Method, Methods, def_method, def_methods, Transaction, TModule, Provided
+from transactron import Method, Methods, def_method, def_methods, Transaction, TModule
 from transactron.utils import assign
 from transactron.utils.data_repr import bits_from_int
 from transactron.utils.dependencies import DependencyContext
@@ -15,6 +13,7 @@ from coreblocks.arch import OpType, Funct3, ExceptionCause, PrivilegeLevel
 from coreblocks.arch.isa_consts import Opcode
 from coreblocks.params import GenParams
 from coreblocks.params.fu_params import BlockComponentParams
+from coreblocks.func_blocks.csr.csr_protocol import RegisteredCSRProtocol
 from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 from coreblocks.interface.layouts import FuncUnitLayouts, CSRUnitLayouts, RSInterfaceLayouts
 from coreblocks.interface.keys import (
@@ -29,18 +28,7 @@ from coreblocks.interface.keys import (
 __all__ = [
     "CSRUnit",
     "CSRBlockComponent",
-    "RegisteredCSRProtocol",
 ]
-
-
-class RegisteredCSRProtocol(Protocol):
-    """Protocol required to be included as a public CSR via `CSRListKey`"""
-
-    _fu_read: Provided[Method]
-    _fu_write: Provided[Method]
-    _fu_access_valid: Provided[Method]
-
-    src_loc: SrcLoc
 
 
 class CSRUnit(FuncBlock, Elaboratable):
@@ -94,11 +82,13 @@ class CSRUnit(FuncBlock, Elaboratable):
         for csr_number, csr in self.dependency_manager.get_dependency(CSRListKey()):
             if csr_number in self.regfile:
                 raise RuntimeError(
-                    f"CSR number {csr_number} already registered (at {self.regfile[csr_number].src_loc} {csr.src_loc}"
+                    f"CSR number 0x{csr_number:03x} already registered at {self.regfile[csr_number].src_loc}"
+                    f" and {csr.src_loc}"
                 )
             self.regfile[csr_number] = csr
 
-    def _csr_access_privilege(self, csr_addr: int) -> tuple[PrivilegeLevel, bool]:
+    @staticmethod
+    def _csr_access_privilege(csr_addr: int) -> tuple[PrivilegeLevel, bool]:
         read_only = bits_from_int(csr_addr, 10, 2) == 0b11
 
         match bits_from_int(csr_addr, 8, 2):

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -6,11 +6,11 @@ from transactron.lib.dependencies import SimpleKey, UnifierKey, ListKey
 from transactron.lib.transformers import MethodProduct
 from transactron import Method, TModule
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
+from coreblocks.func_blocks.csr.csr_protocol import RegisteredCSRProtocol
 from amaranth import Signal
 
 if TYPE_CHECKING:
     from coreblocks.priv.csr.csr_instances import CSRInstances  # noqa: F401
-    from coreblocks.func_blocks.csr.csr_unit import RegisteredCSRProtocol  # noqa: F401
 
 __all__ = [
     "CommonBusDataKey",
@@ -97,7 +97,7 @@ class CoreStateKey(SimpleKey[Method]):
 
 
 @dataclass(frozen=True)
-class CSRListKey(ListKey[tuple[int, "RegisteredCSRProtocol"]]):
+class CSRListKey(ListKey[tuple[int, RegisteredCSRProtocol]]):
     """DependencyManager key collecting CSR registers globally as a list.
     Requires tuple of architectural CSR number to register and the register itself."""
 

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -10,7 +10,7 @@ from amaranth import Signal
 
 if TYPE_CHECKING:
     from coreblocks.priv.csr.csr_instances import CSRInstances  # noqa: F401
-    from coreblocks.priv.csr.csr_register import CSRRegister  # noqa: F401
+    from coreblocks.func_blocks.csr.csr_unit import RegisteredCSRProtocol  # noqa: F401
 
 __all__ = [
     "CommonBusDataKey",
@@ -97,8 +97,9 @@ class CoreStateKey(SimpleKey[Method]):
 
 
 @dataclass(frozen=True)
-class CSRListKey(ListKey["CSRRegister"]):
-    """DependencyManager key collecting CSR registers globally as a list."""
+class CSRListKey(ListKey[tuple[int, "RegisteredCSRProtocol"]]):
+    """DependencyManager key collecting CSR registers globally as a list.
+    Requires tuple of architectural CSR number to register and the register itself."""
 
     pass
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -738,14 +738,13 @@ class CSRRegisterLayouts:
             ("read", 1),
             ("written", 1),
         )
-        self.access_valid_i = make_layout(("priv_mode", PrivilegeLevel))
-
-        self.access_valid_o = make_layout(("valid", 1))
 
         self.write = make_layout(self.data)
 
-        self._fu_read = make_layout(self.data)
-        self._fu_write = make_layout(self.data)
+        self.fu_read = make_layout(self.data)
+        self.fu_write = make_layout(self.data)
+        self.fu_access_valid_i = make_layout(("priv_mode", PrivilegeLevel))
+        self.fu_access_valid_o = make_layout(("valid", 1))
 
 
 class CSRUnitLayouts:

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from amaranth import signed
 from amaranth.lib.data import ArrayLayout
 from amaranth.lib.enum import IntFlag, auto
@@ -728,9 +727,7 @@ class LSULayouts:
 class CSRRegisterLayouts:
     """Layouts used in the control and status registers."""
 
-    def __init__(self, gen_params: GenParams, *, data_width: Optional[int] = None):
-        data_width = data_width if data_width is not None else gen_params.isa.xlen
-
+    def __init__(self, gen_params: GenParams, *, data_width: int):
         self.data: LayoutListField = ("data", data_width)
 
         self.read = make_layout(

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -26,7 +26,7 @@ from coreblocks.func_blocks.fu.priv import PrivilegedUnitComponent
 from coreblocks.func_blocks.fu.lsu.dummyLsu import LSUComponent
 from coreblocks.func_blocks.fu.lsu.pma import PMARegion
 from coreblocks.func_blocks.fu.lsu.lsu_atomic_wrapper import LSUAtomicWrapperComponent
-from coreblocks.func_blocks.csr.csr import CSRBlockComponent
+from coreblocks.func_blocks.csr.csr_unit import CSRBlockComponent
 from coreblocks.arch.isa_consts import SatpMode
 
 __all__ = [

--- a/coreblocks/priv/csr/aliased.py
+++ b/coreblocks/priv/csr/aliased.py
@@ -1,31 +1,34 @@
 from amaranth import *
+from amaranth_types import SrcLoc
 
 from typing import Optional
 from enum import Enum
 
 from coreblocks.params.genparams import GenParams
 from coreblocks.priv.csr.csr_register import CSRRegister, CSRRegisterBase
-from coreblocks.func_blocks.csr.csr import CSRListKey
+
 from transactron.core.sugar import def_method
 from transactron.core.tmodule import TModule
-from transactron.utils.dependencies import DependencyContext
+from transactron.utils import get_src_loc
 
 
 class AliasedCSR(CSRRegisterBase):
-    def __init__(self, csr_number: Optional[int], gen_params: GenParams, width: Optional[int] = None):
+    def __init__(
+        self,
+        csr_number: Optional[int],
+        gen_params: GenParams,
+        width: Optional[int] = None,
+        src_loc: int | SrcLoc = 0,
+    ):
         if width is None:
             width = gen_params.isa.xlen
 
-        super().__init__(gen_params, csr_number, width)
+        super().__init__(gen_params, csr_number, width, get_src_loc(src_loc))
 
         self.fields: list[tuple[int, CSRRegisterBase]] = []
         self.ro_values: list[tuple[int, int, int | Enum]] = []
 
         self.elaborated = False
-
-        # append to global CSR list
-        if csr_number is not None:
-            DependencyContext.get().add_dependency(CSRListKey(), (csr_number, self))
 
         # TODO: WPRI defult mode
 

--- a/coreblocks/priv/csr/aliased.py
+++ b/coreblocks/priv/csr/aliased.py
@@ -3,42 +3,29 @@ from amaranth import *
 from typing import Optional
 from enum import Enum
 
-from coreblocks.interface.layouts import CSRRegisterLayouts
 from coreblocks.params.genparams import GenParams
-from coreblocks.priv.csr.csr_register import CSRRegister
+from coreblocks.priv.csr.csr_register import CSRRegister, CSRRegisterBase
 from coreblocks.func_blocks.csr.csr import CSRListKey
-from transactron.core.method import Method
 from transactron.core.sugar import def_method
 from transactron.core.tmodule import TModule
 from transactron.utils.dependencies import DependencyContext
 
 
-class AliasedCSR(CSRRegister):  # TODO: CSR interface protocol
+class AliasedCSR(CSRRegisterBase):
     def __init__(self, csr_number: Optional[int], gen_params: GenParams, width: Optional[int] = None):
-        self.gen_params = gen_params
-        self.csr_number = csr_number
-        self.width = width if width is not None else gen_params.isa.xlen
+        if width is None:
+            width = gen_params.isa.xlen
 
-        self.fields: list[tuple[int, CSRRegister]] = []
+        super().__init__(gen_params, csr_number, width)
+
+        self.fields: list[tuple[int, CSRRegisterBase]] = []
         self.ro_values: list[tuple[int, int, int | Enum]] = []
-
-        csr_layouts = gen_params.get(CSRRegisterLayouts)
-
-        self._fu_read = Method(o=csr_layouts._fu_read)
-        self._fu_write = Method(i=csr_layouts._fu_write)
-
-        self.read = Method(o=csr_layouts.read)
-        self.read_comb = Method(o=csr_layouts.read)
-        self.write = Method(i=csr_layouts.write)
-        self.access_valid = Method(i=csr_layouts.access_valid_i, o=csr_layouts.access_valid_o)
-
-        self.value = Signal(self.width)  # part of public CSR interface, useful for debugging
 
         self.elaborated = False
 
         # append to global CSR list
         if csr_number is not None:
-            DependencyContext.get().add_dependency(CSRListKey(), self)
+            DependencyContext.get().add_dependency(CSRListKey(), (csr_number, self))
 
         # TODO: WPRI defult mode
 
@@ -100,11 +87,11 @@ class AliasedCSR(CSRRegister):  # TODO: CSR interface protocol
         def _():
             return read_def(lambda m, csr: csr.read_comb(m))
 
-        @def_method(m, self.access_valid)
+        @def_method(m, self._fu_access_valid)
         def _(priv_mode):
             valid = 1
             for _, csr in self.fields:
-                valid &= csr.access_valid(m, priv_mode).valid
+                valid &= csr._fu_access_valid(m, priv_mode).valid
 
             return {"valid": valid}
 

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -22,7 +22,7 @@ from coreblocks.arch.isa_consts import (
 )
 from coreblocks.params.genparams import GenParams
 from coreblocks.priv.csr.aliased import AliasedCSR
-from coreblocks.priv.csr.csr_register import CSRRegister
+from coreblocks.priv.csr.csr_register import CSRRegister, CSRRegisterBase
 from coreblocks.priv.csr.double_counter import DoubleCounterCSR
 from coreblocks.priv.csr.shadow import ShadowCSR
 from coreblocks.socks.clint import ClintMtimeKey
@@ -154,7 +154,7 @@ class MachineModeCSRRegisters(Elaboratable):
         m = TModule()
 
         for name, value in vars(self).items():
-            if isinstance(value, CSRRegister) or isinstance(value, DoubleCounterCSR):
+            if isinstance(value, (CSRRegisterBase, DoubleCounterCSR)):
                 m.submodules[name] = value
 
         with Transaction().body(m):
@@ -445,7 +445,7 @@ class SupervisorModeCSRRegisters(Elaboratable):
         m = TModule()
 
         for name, value in vars(self).items():
-            if isinstance(value, (CSRRegister, DoubleCounterCSR)):
+            if isinstance(value, (CSRRegisterBase, DoubleCounterCSR)):
                 m.submodules[name] = value
 
         return m

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -1,8 +1,9 @@
-from typing import Optional
-
 from amaranth import *
 from amaranth_types import ValueLike
-from transactron.core import Method, TModule, Transaction, def_method
+from typing import Optional
+
+from transactron.core import TModule, Transaction
+from transactron.utils import DependencyContext
 
 from coreblocks.arch import CSRAddress
 from coreblocks.arch.csr_address import (
@@ -10,6 +11,7 @@ from coreblocks.arch.csr_address import (
     MenvcfgFieldOffsets,
     MstatusFieldOffsets,
     sstatus_field_subset,
+    PMPXCFG_WIDTH,
 )
 from coreblocks.arch.isa import Extension
 from coreblocks.arch.isa_consts import (
@@ -21,12 +23,10 @@ from coreblocks.arch.isa_consts import (
 from coreblocks.params.genparams import GenParams
 from coreblocks.priv.csr.aliased import AliasedCSR
 from coreblocks.priv.csr.csr_register import CSRRegister
+from coreblocks.priv.csr.double_counter import DoubleCounterCSR
 from coreblocks.priv.csr.shadow import ShadowCSR
 from coreblocks.socks.clint import ClintMtimeKey
 from coreblocks.interface.keys import CSRInstancesKey
-from transactron.utils import DependencyContext
-
-PMPXCFG_WIDTH = 8
 
 
 def counteren_writable_mask(hpm_counters_count: int) -> int:
@@ -57,100 +57,6 @@ def counteren_access_filter(gen_params: GenParams, counteren_bit: int):
         return ~(machine_disallowed | supervisor_disallowed)
 
     return _filter
-
-
-class DoubleCounterCSR(Elaboratable):
-    """DoubleCounterCSR
-    Groups two `CSRRegisters` to form counter with double `isa.xlen` width.
-
-    Attributes
-    ----------
-    increment: Method
-        Increments the counter by 1. At overflow, counter value is set to 0.
-    """
-
-    def __init__(
-        self,
-        gen_params: GenParams,
-        low_addr: CSRAddress,
-        high_addr: Optional[CSRAddress] = None,
-        shadow_low_addr: Optional[CSRAddress] = None,
-        shadow_high_addr: Optional[CSRAddress] = None,
-        shadow_access_filter=None,
-    ):
-        """
-        Parameters
-        ----------
-        gen_params: GenParams
-            Core generation parameters.
-        low_addr: CSRAddress
-            Address of the CSR register representing lower part of the counter (bits `[isa.xlen-1 : 0]`).
-        high_addr: CSRAddress or None, optional
-            Address of the CSR register representing higher part of the counter (bits `[2*isa.xlen-1 : isa.xlen]`).
-            If high_addr is None or not provided, then higher CSR is not synthetised and only the width of
-            low_addr CSR is available to the counter.
-        shadow_low_addr: CSRAddress or None, optional
-            Address of the shadow CSR register for the lower part of the counter. If provided, shadow CSR is
-            synthetised with read-only access to the counter value.
-        shadow_high_addr: CSRAddress or None, optional
-            Address of the shadow CSR register for the higher part of the counter. If provided, shadow CSR is
-            synthetised with read-only access to the counter value. If high_addr is None, providing shadow_high_addr
-            will raise an error.
-        """
-        self.gen_params = gen_params
-
-        self.increment = Method()
-
-        self.register_low = CSRRegister(low_addr, gen_params)
-        self.register_high = CSRRegister(high_addr, gen_params) if high_addr is not None else None
-
-        self.shadow_low = self.shadow_high = None
-        if shadow_low_addr is not None:
-            self.shadow_low = ShadowCSR(
-                shadow_low_addr,
-                gen_params,
-                self.register_low,
-                write_mask=0,
-                access_filter=shadow_access_filter,
-            )
-        if shadow_high_addr is not None:
-            if not self.register_high:
-                raise ValueError("shadow_high_addr provided but high_addr is None")
-
-            if not shadow_low_addr:
-                raise ValueError("shadow_high_addr provided but shadow_low_addr is None")
-
-            self.shadow_high = ShadowCSR(
-                shadow_high_addr,
-                gen_params,
-                self.register_high,
-                write_mask=0,
-                access_filter=shadow_access_filter,
-            )
-
-    def elaborate(self, platform):
-        m = TModule()
-
-        m.submodules.register_low = self.register_low
-        if self.register_high is not None:
-            m.submodules.register_high = self.register_high
-
-        @def_method(m, self.increment)
-        def _():
-            register_read = self.register_low.read(m).data
-            self.register_low.write(m, data=register_read + 1)
-
-            if self.register_high is not None:
-                with m.If(register_read == (1 << self.gen_params.isa.xlen) - 1):
-                    self.register_high.write(m, data=self.register_high.read(m).data + 1)
-
-        if self.shadow_low is not None:
-            m.submodules.shadow_low = self.shadow_low
-
-        if self.shadow_high is not None:
-            m.submodules.shadow_high = self.shadow_high
-
-        return m
 
 
 class MachineModeCSRRegisters(Elaboratable):

--- a/coreblocks/priv/csr/csr_register.py
+++ b/coreblocks/priv/csr/csr_register.py
@@ -3,8 +3,9 @@ from amaranth.lib.data import StructLayout
 from amaranth.lib.enum import Enum
 from amaranth_types import ValueLike, SrcLoc
 
-from typing import Optional
+from abc import ABC, abstractmethod
 from collections.abc import Callable
+from typing import Optional
 
 from coreblocks.params.genparams import GenParams
 from coreblocks.interface.keys import CSRListKey
@@ -16,7 +17,39 @@ from transactron.utils.dependencies import DependencyContext
 from transactron.utils.transactron_helpers import get_src_loc
 
 
-class CSRRegister(Elaboratable):
+class CSRRegisterBase(ABC, Elaboratable):
+    def __init__(self, gen_params: GenParams, csr_number: Optional[int], width: int):
+        self.gen_params = gen_params
+        self.csr_number = csr_number
+        self.width = width
+        self.public = csr_number is not None
+
+        self.csr_layouts = gen_params.get(CSRRegisterLayouts, data_width=self.width)
+        self.read = Method(o=self.csr_layouts.read)
+        self.read_comb = Method(o=self.csr_layouts.read)
+        self.write = Method(i=self.csr_layouts.write)
+
+        self._fu_read = Method(o=self.csr_layouts._fu_read)
+        self._fu_write = Method(i=self.csr_layouts._fu_write)
+        self._fu_access_valid = Method(i=self.csr_layouts.access_valid_i, o=self.csr_layouts.access_valid_o)
+
+        if self.width != gen_params.isa.xlen:
+            raise RuntimeError(f"Width of public CSR register is different than {gen_params.isa.xlen}")
+
+        self.value = Signal(self.width)  # part of public CSR interface, useful for debugging
+
+        # append to global CSR list (accessible from CSRUnit)
+        if self.public:
+            assert csr_number is not None
+            dm = DependencyContext.get()
+            dm.add_dependency(CSRListKey(), (csr_number, self))
+
+    @abstractmethod
+    def elaborate(self, platform):
+        raise NotImplementedError
+
+
+class CSRRegister(CSRRegisterBase):
     """CSR Register
     Used to define a CSR register and specify its behaviour.
     `CSRRegisters` are automatically assigned to `CSRListKey` dependency key, to be accessed from `CSRUnits`.
@@ -105,50 +138,40 @@ class CSRRegister(Elaboratable):
             Alternatively, the source location to use instead of the default.
         """
         self.gen_params = gen_params
-        self.csr_number = csr_number
-        self.width = width if width is not None else gen_params.isa.xlen
+
+        if width is None:
+            width = gen_params.isa.xlen
+
+        super().__init__(gen_params, csr_number, width)
+
         self.ro_bits = ro_bits
-        self.fu_write_priority = fu_write_priority
         fu_write_filtermap = fu_write_filtermap if fu_write_filtermap else (lambda _, ms: (C(1), ms))
         fu_read_map = fu_read_map if fu_read_map else (lambda _, ms: ms)
         self.fu_access_filter = fu_access_filter if fu_access_filter else (lambda _, __: C(1))
+        self.fu_write_priority = fu_write_priority
         self.src_loc = get_src_loc(src_loc)
 
-        csr_layouts = gen_params.get(CSRRegisterLayouts, data_width=self.width)
+        self._internal_fu_read = Method(o=self.csr_layouts._fu_read)
+        self._internal_fu_write = Method(i=self.csr_layouts._fu_write)
 
-        self.read = Method(o=csr_layouts.read)
-        self.read_comb = Method(o=csr_layouts.read)
-        self.write = Method(i=csr_layouts.write)
-        self.access_valid = Method(i=csr_layouts.access_valid_i, o=csr_layouts.access_valid_o)
-
-        self._internal_fu_read = Method(o=csr_layouts._fu_read)
-        self._internal_fu_write = Method(i=csr_layouts._fu_write)
         self.fu_write_map = MethodMap.create(
             self._internal_fu_write,
-            i_transform=(csr_layouts._fu_write, lambda tm, ms: {"data": fu_write_filtermap(tm, ms["data"])[1]}),
+            i_transform=(self.csr_layouts._fu_write, lambda tm, ms: {"data": fu_write_filtermap(tm, ms["data"])[1]}),
         )
         self.fu_write_filter = MethodFilter.create(
             self.fu_write_map.method, lambda tm, ms: fu_write_filtermap(tm, ms["data"])[0]
         )
         self.fu_read_map = MethodMap.create(
             self._internal_fu_read,
-            o_transform=(csr_layouts._fu_read, lambda tm, ms: {"data": fu_read_map(tm, ms["data"])}),
+            o_transform=(self.csr_layouts._fu_read, lambda tm, ms: {"data": fu_read_map(tm, ms["data"])}),
         )
 
-        # Methods connected automatically by CSRUnit
-        self._fu_read = self.fu_read_map.method
-        self._fu_write = self.fu_write_filter.method
+        # Methods required to be connected automatically by CSRUnit
+        self._fu_read.provide(self.fu_read_map.method)
+        self._fu_write.provide(self.fu_write_filter.method)
 
         self.value = Signal(self.width, init=init)
         self.side_effects = Signal(StructLayout({"read": 1, "write": 1}))
-
-        # append to global CSR list
-        if csr_number is not None:
-            dm = DependencyContext.get()
-            dm.add_dependency(CSRListKey(), self)
-
-        if csr_number and self.width != gen_params.isa.xlen:
-            raise RuntimeError(f"Width of public CSR register is different than {gen_params.isa.xlen}")
 
     def elaborate(self, platform):
         m = TModule()
@@ -187,7 +210,7 @@ class CSRRegister(Elaboratable):
                 "written": self._internal_fu_write.run,
             }
 
-        @def_method(m, self.access_valid)
+        @def_method(m, self._fu_access_valid)
         def _(priv_mode):
             return {"valid": self.fu_access_filter(m, priv_mode)}
 

--- a/coreblocks/priv/csr/csr_register.py
+++ b/coreblocks/priv/csr/csr_register.py
@@ -18,41 +18,9 @@ from transactron.utils.transactron_helpers import get_src_loc
 
 
 class CSRRegisterBase(ABC, Elaboratable):
-    def __init__(self, gen_params: GenParams, csr_number: Optional[int], width: int):
-        self.gen_params = gen_params
-        self.csr_number = csr_number
-        self.width = width
-        self.public = csr_number is not None
-
-        self.csr_layouts = gen_params.get(CSRRegisterLayouts, data_width=self.width)
-        self.read = Method(o=self.csr_layouts.read)
-        self.read_comb = Method(o=self.csr_layouts.read)
-        self.write = Method(i=self.csr_layouts.write)
-
-        self._fu_read = Method(o=self.csr_layouts._fu_read)
-        self._fu_write = Method(i=self.csr_layouts._fu_write)
-        self._fu_access_valid = Method(i=self.csr_layouts.access_valid_i, o=self.csr_layouts.access_valid_o)
-
-        if self.width != gen_params.isa.xlen:
-            raise RuntimeError(f"Width of public CSR register is different than {gen_params.isa.xlen}")
-
-        self.value = Signal(self.width)  # part of public CSR interface, useful for debugging
-
-        # append to global CSR list (accessible from CSRUnit)
-        if self.public:
-            assert csr_number is not None
-            dm = DependencyContext.get()
-            dm.add_dependency(CSRListKey(), (csr_number, self))
-
-    @abstractmethod
-    def elaborate(self, platform):
-        raise NotImplementedError
-
-
-class CSRRegister(CSRRegisterBase):
-    """CSR Register
-    Used to define a CSR register and specify its behaviour.
-    `CSRRegisters` are automatically assigned to `CSRListKey` dependency key, to be accessed from `CSRUnits`.
+    """RISC-V Control and Status Register base class
+    Abstract class defining basic internal CSR register interface, that all CSR variations should implement.
+    Provides constructor defining required methods and signals.
 
     Attributes
     ----------
@@ -71,8 +39,67 @@ class CSRRegister(CSRRegisterBase):
         Method connected automatically by `CSRUnit`. Reads register value.
     _fu_write: Method
         Method connected automatically by `CSRUnit`. Updates register value. Always ready.
-    access_valid: Method
-        Method connected automatically by `CSRUnit`. Returns whether CSR access is legal for current context.
+    _fu_access_valid: Method
+        Method connected automatically by `CSRUnit`. Returns whether CSR access is legal for a provided privilege level,
+        or should an instruction access cause an exception.
+    value: Signal
+        Represents current value of a CSR register. Useful for debugging and traces.
+    """
+
+    def __init__(self, gen_params: GenParams, csr_number: Optional[int], width: int, src_loc: SrcLoc):
+        """
+        Parameters
+        ----------
+        gen_params: GenParams
+            Core generation parameters.
+        csr_number: Optional[int]
+            Address of this CSR Register.
+            If `None` is given, CSR is virtual - not registerable to `CSRUnit`.
+            Otherwise it's registered under provided address to `CSRUnit` using `CSRListKey`.
+        width: Optional[int]
+            Bit width of CSR register.
+        src_loc: SrcLoc
+            CSR location in source code for error reporting.
+        """
+        self.gen_params = gen_params
+        self.csr_number = csr_number
+        self.width = width
+        self.src_loc = src_loc
+        self.public = csr_number is not None
+
+        self.csr_layouts = gen_params.get(CSRRegisterLayouts, data_width=self.width)
+        self.read = Method(o=self.csr_layouts.read)
+        self.read_comb = Method(o=self.csr_layouts.read)
+        self.write = Method(i=self.csr_layouts.write)
+
+        self._fu_read = Method(o=self.csr_layouts.fu_read)
+        self._fu_write = Method(i=self.csr_layouts.fu_write)
+        self._fu_access_valid = Method(i=self.csr_layouts.fu_access_valid_i, o=self.csr_layouts.fu_access_valid_o)
+
+        self.value = Signal(self.width)  # part of public CSR interface, useful for debugging
+
+        # append to global CSR list (accessible from CSRUnit)
+        if self.public:
+            if self.width != gen_params.isa.xlen:
+                raise RuntimeError(f"Width of public CSR register is different than {gen_params.isa.xlen}")
+            assert csr_number is not None
+            dm = DependencyContext.get()
+            dm.add_dependency(CSRListKey(), (csr_number, self))
+
+    @abstractmethod
+    def elaborate(self, platform):
+        raise NotImplementedError
+
+
+class CSRRegister(CSRRegisterBase):
+    """CSR Register
+    Flexible implementation of a general purpose CSR register.
+
+    Used to define a basic CSR register and specify its behaviour.
+    `CSRRegisters` with csr_number defined are automatically assigned to `CSRListKey` dependency key,
+    to be accessed from `CSRUnits`.
+
+    See `CSRRegisterBase` for class attributes.
 
     Examples
     --------
@@ -142,28 +169,27 @@ class CSRRegister(CSRRegisterBase):
         if width is None:
             width = gen_params.isa.xlen
 
-        super().__init__(gen_params, csr_number, width)
+        super().__init__(gen_params, csr_number, width, get_src_loc(src_loc))
 
         self.ro_bits = ro_bits
         fu_write_filtermap = fu_write_filtermap if fu_write_filtermap else (lambda _, ms: (C(1), ms))
         fu_read_map = fu_read_map if fu_read_map else (lambda _, ms: ms)
         self.fu_access_filter = fu_access_filter if fu_access_filter else (lambda _, __: C(1))
         self.fu_write_priority = fu_write_priority
-        self.src_loc = get_src_loc(src_loc)
 
-        self._internal_fu_read = Method(o=self.csr_layouts._fu_read)
-        self._internal_fu_write = Method(i=self.csr_layouts._fu_write)
+        self._internal_fu_read = Method(o=self.csr_layouts.fu_read)
+        self._internal_fu_write = Method(i=self.csr_layouts.fu_write)
 
         self.fu_write_map = MethodMap.create(
             self._internal_fu_write,
-            i_transform=(self.csr_layouts._fu_write, lambda tm, ms: {"data": fu_write_filtermap(tm, ms["data"])[1]}),
+            i_transform=(self.csr_layouts.fu_write, lambda tm, ms: {"data": fu_write_filtermap(tm, ms["data"])[1]}),
         )
         self.fu_write_filter = MethodFilter.create(
             self.fu_write_map.method, lambda tm, ms: fu_write_filtermap(tm, ms["data"])[0]
         )
         self.fu_read_map = MethodMap.create(
             self._internal_fu_read,
-            o_transform=(self.csr_layouts._fu_read, lambda tm, ms: {"data": fu_read_map(tm, ms["data"])}),
+            o_transform=(self.csr_layouts.fu_read, lambda tm, ms: {"data": fu_read_map(tm, ms["data"])}),
         )
 
         # Methods required to be connected automatically by CSRUnit

--- a/coreblocks/priv/csr/double_counter.py
+++ b/coreblocks/priv/csr/double_counter.py
@@ -2,6 +2,7 @@ from amaranth import *
 from typing import Optional
 
 from transactron.core import Method, TModule, def_method
+from transactron.utils import get_src_loc
 
 from coreblocks.arch import CSRAddress
 from coreblocks.params.genparams import GenParams
@@ -64,6 +65,7 @@ class DoubleCounterCSR(Elaboratable):
                 self.register_low,
                 write_mask=0,
                 access_filter=shadow_access_filter,
+                src_loc=get_src_loc(1),
             )
         if shadow_high_addr is not None:
             if not self.register_high:
@@ -78,6 +80,7 @@ class DoubleCounterCSR(Elaboratable):
                 self.register_high,
                 write_mask=0,
                 access_filter=shadow_access_filter,
+                src_loc=get_src_loc(1),
             )
 
     def elaborate(self, platform):

--- a/coreblocks/priv/csr/double_counter.py
+++ b/coreblocks/priv/csr/double_counter.py
@@ -1,0 +1,105 @@
+from amaranth import *
+from typing import Optional
+
+from transactron.core import Method, TModule, def_method
+
+from coreblocks.arch import CSRAddress
+from coreblocks.params.genparams import GenParams
+from coreblocks.priv.csr.csr_register import CSRRegister
+from coreblocks.priv.csr.shadow import ShadowCSR
+
+__all__ = ["DoubleCounterCSR"]
+
+
+class DoubleCounterCSR(Elaboratable):
+    """DoubleCounterCSR
+    Groups two `CSRRegisters` to form counter with double `isa.xlen` width.
+
+    Attributes
+    ----------
+    increment: Method
+        Increments the counter by 1. At overflow, counter value is set to 0.
+    """
+
+    def __init__(
+        self,
+        gen_params: GenParams,
+        low_addr: CSRAddress,
+        high_addr: Optional[CSRAddress] = None,
+        shadow_low_addr: Optional[CSRAddress] = None,
+        shadow_high_addr: Optional[CSRAddress] = None,
+        shadow_access_filter=None,
+    ):
+        """
+        Parameters
+        ----------
+        gen_params: GenParams
+            Core generation parameters.
+        low_addr: CSRAddress
+            Address of the CSR register representing lower part of the counter (bits `[isa.xlen-1 : 0]`).
+        high_addr: CSRAddress or None, optional
+            Address of the CSR register representing higher part of the counter (bits `[2*isa.xlen-1 : isa.xlen]`).
+            If high_addr is None or not provided, then higher CSR is not synthetised and only the width of
+            low_addr CSR is available to the counter.
+        shadow_low_addr: CSRAddress or None, optional
+            Address of the shadow CSR register for the lower part of the counter. If provided, shadow CSR is
+            synthetised with read-only access to the counter value.
+        shadow_high_addr: CSRAddress or None, optional
+            Address of the shadow CSR register for the higher part of the counter. If provided, shadow CSR is
+            synthetised with read-only access to the counter value. If high_addr is None, providing shadow_high_addr
+            will raise an error.
+        """
+        self.gen_params = gen_params
+
+        self.increment = Method()
+
+        self.register_low = CSRRegister(low_addr, gen_params)
+        self.register_high = CSRRegister(high_addr, gen_params) if high_addr is not None else None
+
+        self.shadow_low = self.shadow_high = None
+        if shadow_low_addr is not None:
+            self.shadow_low = ShadowCSR(
+                shadow_low_addr,
+                gen_params,
+                self.register_low,
+                write_mask=0,
+                access_filter=shadow_access_filter,
+            )
+        if shadow_high_addr is not None:
+            if not self.register_high:
+                raise ValueError("shadow_high_addr provided but high_addr is None")
+
+            if not shadow_low_addr:
+                raise ValueError("shadow_high_addr provided but shadow_low_addr is None")
+
+            self.shadow_high = ShadowCSR(
+                shadow_high_addr,
+                gen_params,
+                self.register_high,
+                write_mask=0,
+                access_filter=shadow_access_filter,
+            )
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.register_low = self.register_low
+        if self.register_high is not None:
+            m.submodules.register_high = self.register_high
+
+        @def_method(m, self.increment)
+        def _():
+            register_read = self.register_low.read(m).data
+            self.register_low.write(m, data=register_read + 1)
+
+            if self.register_high is not None:
+                with m.If(register_read == (1 << self.gen_params.isa.xlen) - 1):
+                    self.register_high.write(m, data=self.register_high.read(m).data + 1)
+
+        if self.shadow_low is not None:
+            m.submodules.shadow_low = self.shadow_low
+
+        if self.shadow_high is not None:
+            m.submodules.shadow_high = self.shadow_high
+
+        return m

--- a/coreblocks/priv/csr/shadow.py
+++ b/coreblocks/priv/csr/shadow.py
@@ -2,14 +2,14 @@ from typing import Optional, Callable
 
 from amaranth import *
 from amaranth import ValueLike
+from amaranth_types import SrcLoc
 from transactron.core.method import Method
 from transactron.core.transaction import Transaction
 from transactron.core.sugar import def_method
 from transactron.core.tmodule import TModule
-from transactron.utils.dependencies import DependencyContext
+from transactron.utils import get_src_loc
 from transactron.lib import logging
 
-from coreblocks.func_blocks.csr.csr import CSRListKey
 from coreblocks.params.genparams import GenParams
 from coreblocks.priv.csr.csr_register import CSRRegisterBase
 
@@ -37,8 +37,9 @@ class ShadowCSR(CSRRegisterBase):
         read_mask: Optional[ValueLike | Method] = None,
         write_mask: Optional[ValueLike | Method] = None,
         access_filter: Optional[Callable[[TModule, Value], ValueLike]] = None,
+        src_loc: int | SrcLoc = 0,
     ):
-        super().__init__(gen_params, csr_number, width=shadowed.width)
+        super().__init__(gen_params, csr_number, width=shadowed.width, src_loc=get_src_loc(src_loc))
 
         if mask is not None:
             assert (
@@ -52,9 +53,6 @@ class ShadowCSR(CSRRegisterBase):
         self.read_mask: ValueLike | Method = full_mask if read_mask is None else read_mask
         self.write_mask: ValueLike | Method = full_mask if write_mask is None else write_mask
         self.access_filter = access_filter if access_filter is not None else (lambda _, __: C(1))
-
-        if csr_number is not None:
-            DependencyContext.get().add_dependency(CSRListKey(), (csr_number, self))
 
     def elaborate(self, platform):
         m = TModule()

--- a/coreblocks/priv/csr/shadow.py
+++ b/coreblocks/priv/csr/shadow.py
@@ -10,9 +10,8 @@ from transactron.utils.dependencies import DependencyContext
 from transactron.lib import logging
 
 from coreblocks.func_blocks.csr.csr import CSRListKey
-from coreblocks.interface.layouts import CSRRegisterLayouts
 from coreblocks.params.genparams import GenParams
-from coreblocks.priv.csr.csr_register import CSRRegister
+from coreblocks.priv.csr.csr_register import CSRRegisterBase
 
 __all__ = ["ShadowCSR"]
 
@@ -20,7 +19,7 @@ __all__ = ["ShadowCSR"]
 log = logging.HardwareLogger("priv.csr.shadow")
 
 
-class ShadowCSR(CSRRegister):  # TODO: CSR register protocol
+class ShadowCSR(CSRRegisterBase):
     """CSR shadow register.
 
     Exposes an instruction-visible CSR number that reads/writes another CSR.
@@ -32,41 +31,30 @@ class ShadowCSR(CSRRegister):  # TODO: CSR register protocol
         self,
         csr_number: Optional[int],
         gen_params: GenParams,
-        shadowed: CSRRegister,
+        shadowed: CSRRegisterBase,
         *,
         mask: Optional[ValueLike | Method] = None,
         read_mask: Optional[ValueLike | Method] = None,
         write_mask: Optional[ValueLike | Method] = None,
         access_filter: Optional[Callable[[TModule, Value], ValueLike]] = None,
     ):
+        super().__init__(gen_params, csr_number, width=shadowed.width)
+
         if mask is not None:
             assert (
                 read_mask is None and write_mask is None
             ), "Cannot specify both full mask and separate read/write masks"
             read_mask = write_mask = mask
 
-        self.gen_params = gen_params
-        self.csr_number = csr_number
         self.shadowed = shadowed
-        self.width = shadowed.width
 
         full_mask = (1 << self.width) - 1
         self.read_mask: ValueLike | Method = full_mask if read_mask is None else read_mask
         self.write_mask: ValueLike | Method = full_mask if write_mask is None else write_mask
         self.access_filter = access_filter if access_filter is not None else (lambda _, __: C(1))
 
-        csr_layouts = gen_params.get(CSRRegisterLayouts)
-        self._fu_read = Method(o=csr_layouts._fu_read)
-        self._fu_write = Method(i=csr_layouts._fu_write)
-        self.value = Signal(self.width)
-
-        self.read = Method(o=csr_layouts.read)
-        self.read_comb = Method(o=csr_layouts.read)
-        self.write = Method(i=csr_layouts.write)
-        self.access_valid = Method(i=csr_layouts.access_valid_i, o=csr_layouts.access_valid_o)
-
         if csr_number is not None:
-            DependencyContext.get().add_dependency(CSRListKey(), self)
+            DependencyContext.get().add_dependency(CSRListKey(), (csr_number, self))
 
     def elaborate(self, platform):
         m = TModule()
@@ -126,8 +114,8 @@ class ShadowCSR(CSRRegister):  # TODO: CSR register protocol
                 "written": result.written,
             }
 
-        @def_method(m, self.access_valid)
+        @def_method(m, self._fu_access_valid)
         def _(priv_mode):
-            return {"valid": self.access_filter(m, priv_mode) & self.shadowed.access_valid(m, priv_mode).valid}
+            return {"valid": self.access_filter(m, priv_mode) & self.shadowed._fu_access_valid(m, priv_mode).valid}
 
         return m

--- a/test/func_blocks/csr/test_csr.py
+++ b/test/func_blocks/csr/test_csr.py
@@ -3,7 +3,7 @@ import random
 
 from transactron.lib import Adapter
 from transactron.core.tmodule import TModule
-from coreblocks.func_blocks.csr.csr import CSRUnit
+from coreblocks.func_blocks.csr.csr_unit import CSRUnit
 from coreblocks.priv.csr.csr_register import CSRRegister
 from coreblocks.priv.csr.csr_instances import CSRInstances
 from coreblocks.params import GenParams


### PR DESCRIPTION
- Removes duplication on creation of typical CSR methods
- Defines how CSR register should look like
- Removes dubious use of `CSRRegister` as a base class
- Defines what we expect from FU registerable CSR 
- Clean-ups, move of classes to new files, changes to unify things

- [X] todo docstrings