### PR TITLE
fetch: more explicit access fault handling, test improvements

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -212,7 +212,7 @@ class FetchUnit(Elaboratable):
                 else:
                     m.d.av_comb += expanded_instr[i].eq(cache_resp.fetch_block[i * 32 : (i + 1) * 32])
 
-            # Mask denoting at which offsets an instruction starts
+            # Mask denoting at which offsets expected instructions start (depends on rvc indication and start address)
             instr_start = [Signal() for _ in range(fetch_width)]
             for i in range(fetch_width):
                 if Extension.ZCA in self.gen_params.isa.extensions:
@@ -230,7 +230,7 @@ class FetchUnit(Elaboratable):
                     m.d.av_comb += instr_start[i].eq(fetch_block_offset <= i)
 
             if Extension.ZCA in self.gen_params.isa.extensions:
-                valid_instr_mask = Cat(instr_start[:-1], instr_start[-1] & is_rvc[-1])
+                instr_position_mask = Cat(instr_start[:-1], instr_start[-1] & is_rvc[-1])
 
                 m.d.sync += prev_half_v.eq(
                     (flushing_counter <= 1) & (cache_resp.error == 0) & ~is_rvc[-1] & instr_start[-1]
@@ -238,12 +238,15 @@ class FetchUnit(Elaboratable):
                 m.d.sync += prev_half.eq(cache_resp.fetch_block[-16:])
                 m.d.sync += prev_half_addr.eq(fetch_block_addr)
             else:
-                valid_instr_mask = Cat(instr_start)
+                instr_position_mask = Cat(instr_start)
+
+            # Reported fault pc (signalled by emitting an instruction) must always match first requested instruction
+            access_fault_instr_position = 1 << fetch_block_offset
 
             s1_s2_pipe.write(
                 m,
                 fb_addr=fetch_block_addr,
-                instr_valid=valid_instr_mask,
+                instr_valid=Mux(cache_resp.error, access_fault_instr_position, instr_position_mask),
                 access_fault=cache_resp.error,
                 rvc=is_rvc,
                 instrs=expanded_instr,

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -159,6 +159,10 @@ class TestFetchUnit(TestCaseWithSimulator):
             for i in range(0, self.gen_params.fetch_block_bytes, 2):
                 fetch_block |= load_or_gen_mem(req_addr + i) << (8 * i)
                 if req_addr + i in self.memerr:
+                    if random.random() < 0.3:
+                        fetch_block = 0
+                    elif random.random() < 0.3:
+                        fetch_block = random.randrange(1 << (self.gen_params.fetch_block_bytes * 8))
                     bad_addr = True
 
             self.output_q.append({"fetch_block": fetch_block, "error": bad_addr})
@@ -195,16 +199,21 @@ class TestFetchUnit(TestCaseWithSimulator):
 
     async def fetch_out_check(self, sim: TestbenchContext):
         async def check_instr(instr, v):
-            access_fault = instr["pc"] in self.memerr
+            access_fault = FetchLayouts.AccessFaultFlag.ACCESS_FAULT if instr["pc"] in self.memerr else 0
             if not instr["rvc"]:
-                access_fault |= instr["pc"] + 2 in self.memerr
+                if instr["pc"] + 2 in self.memerr:
+                    access_fault = (
+                        FetchLayouts.AccessFaultFlag.ACCESS_FAULT_ON_SECOND_HALF if not access_fault else access_fault
+                    )
 
+            print(instr, v["pc"], v["access_fault"])
             assert v["pc"] == instr["pc"]
             assert v["access_fault"] == access_fault
 
-            instr_data = instr["instr"]
-            if (instr_data & 0b11) == 0b11:
-                assert v["instr"] == instr_data
+            if not access_fault:
+                instr_data = instr["instr"]
+                if (instr_data & 0b11) == 0b11:
+                    assert v["instr"] == instr_data
 
             if (instr["jumps"] and (instr["branch_taken"] != v["predicted_taken"])) or access_fault:
                 await self.random_wait(sim, 5)
@@ -221,7 +230,10 @@ class TestFetchUnit(TestCaseWithSimulator):
                     # Resume from the next fetch block
                     resume_pc = (
                         instr["pc"] & ~(self.gen_params.fetch_block_bytes - 1)
-                    ) + self.gen_params.fetch_block_bytes
+                    ) + self.gen_params.fetch_block_bytes * (
+                        2 if access_fault == FetchLayouts.AccessFaultFlag.ACCESS_FAULT_ON_SECOND_HALF else 1
+                    )
+
                 self.backend_redirect.append(resume_pc)
 
                 return True
@@ -265,7 +277,7 @@ class TestFetchUnit(TestCaseWithSimulator):
             self.last_redirect = None
 
     def run_sim(self):
-        with self.run_simulation(self.m) as sim:
+        with self.run_simulation(self.m, max_cycles=1000) as sim:
             sim.add_process(self.cache_process)
             sim.add_process(self.requester)
             sim.add_testbench(self.fetch_out_check)
@@ -426,6 +438,16 @@ class TestFetchUnit(TestCaseWithSimulator):
 
         # We will resume from the next fetch block
         self.pc = pc + self.gen_params.fetch_block_bytes
+
+        if self.with_rvc:
+            # Access fault on sencond half on instruction
+            for _ in range(self.gen_params.fetch_width - 1):
+                self.gen_non_branch_instr(rvc=True)
+            pc = self.gen_non_branch_instr(rvc=False)  # 4 byte instruction crossing block
+            self.memerr.add(pc + 2)
+
+            # We will resume from next valid block
+            self.pc = pc + 2 + self.gen_params.fetch_block_bytes
 
         self.gen_non_branch_instr(rvc=False)
 


### PR DESCRIPTION
When investigating #901 I found following things:
1 - fetch access fault test never produces `ACCESS_FAULT_ON_SECOND_HALF` case with 
ZCA

2 - issue claim was wrong, core will never hang because valid instr mask generation doesn't in fact check instruction validity, but only produces positions and will be always non-zero.
I feel this claim is very fragile and it's better to do it explicitly.

There may be a bug instead that will report wrong pc address on access fault, with prepared input data and RVC, however tests didn't catch that.
I think it is possible for this one `(fetch_block_offset <= i) & (~instr_start[i - 1] | is_rvc[i - 1])` to be false for first instruction (`i == fetch_block_offset`) if previous instruction was determined as 2-aligned start and non-rvc on random data. That's another reason for change, but I'm not entirely sure if this can happen now.

Anyway I think depending on that much implicit logic is not great, and may break in future changes.
I made the vector for access fault explicit to emit only one instruction with requested pc, that will have access fault set. 

TLDR
core will never hang, because instr_start is always non-zero.
however, it can possibly have wrong address if first requested one is determined invalid. PR fixes that and makes it explicit.

Closes #901