### PR TITLE
Add a base class for functional units

### DIFF
--- a/coreblocks/func_blocks/fu/alu.py
+++ b/coreblocks/func_blocks/fu/alu.py
@@ -244,22 +244,21 @@ class AluFuncUnit(FuncUnitBase[AluFn]):
         )
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules += [self.perf_instr]
 
         m.submodules.alu = alu = Alu(self.gen_params, alu_fn=self.fn)
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):
-            m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
-            m.d.av_comb += alu.fn.eq(decoder.decode_fn)
+            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
+            m.d.av_comb += alu.fn.eq(self.decoder.decode_fn)
 
             m.d.av_comb += alu.in1.eq(arg.s1_val)
             m.d.av_comb += alu.in2.eq(Mux(arg.imm, arg.imm, arg.s2_val))
 
-            self.perf_instr.incr(m, decoder.decode_fn)
+            self.perf_instr.incr(m, self.decoder.decode_fn)
 
             self.push_result(m, rob_id=arg.rob_id, result=alu.out, rp_dst=arg.rp_dst, exception=0)
 

--- a/coreblocks/func_blocks/fu/alu.py
+++ b/coreblocks/func_blocks/fu/alu.py
@@ -7,11 +7,10 @@ from transactron import *
 from transactron.lib.metrics import *
 
 from coreblocks.arch import OpType, Funct3, Funct7
-from coreblocks.interface.layouts import FuncUnitLayouts
 from coreblocks.params import GenParams, FunctionalComponentParams
 from transactron.utils import OneHotSwitch
 
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 from enum import IntFlag, auto
 
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
@@ -234,15 +233,9 @@ class Alu(Elaboratable):
         return m
 
 
-class AluFuncUnit(FuncUnit, Elaboratable):
-    def __init__(self, gen_params: GenParams, alu_fn=AluFn()):
-        self.gen_params = gen_params
-        self.alu_fn = alu_fn
-
-        layouts = gen_params.get(FuncUnitLayouts)
-
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
+class AluFuncUnit(FuncUnitBase[AluFn]):
+    def __init__(self, gen_params: GenParams, fn=AluFn()):
+        super().__init__(gen_params, fn)
 
         self.perf_instr = TaggedCounter(
             "backend.fu.alu.instr",
@@ -255,8 +248,8 @@ class AluFuncUnit(FuncUnit, Elaboratable):
 
         m.submodules += [self.perf_instr]
 
-        m.submodules.alu = alu = Alu(self.gen_params, alu_fn=self.alu_fn)
-        m.submodules.decoder = decoder = self.alu_fn.get_decoder(self.gen_params)
+        m.submodules.alu = alu = Alu(self.gen_params, alu_fn=self.fn)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):

--- a/coreblocks/func_blocks/fu/common/__init__.py
+++ b/coreblocks/func_blocks/fu/common/__init__.py
@@ -1,0 +1,5 @@
+from .fifo_rs import *  # noqa: F401
+from .fu_decoder import *  # noqa: F401
+from .func_base import *  # noqa: F401
+from .rs import *  # noqa: F401
+from .rs_func_block import *  # noqa: F401

--- a/coreblocks/func_blocks/fu/common/fu_decoder.py
+++ b/coreblocks/func_blocks/fu/common/fu_decoder.py
@@ -9,6 +9,9 @@ from enum import IntFlag
 from coreblocks.arch.optypes import OpType
 
 
+__all__ = ["Decoder", "DecoderManager"]
+
+
 class Decoder(Elaboratable):
     """
     Module responsible for instruction decoding.

--- a/coreblocks/func_blocks/fu/common/func_base.py
+++ b/coreblocks/func_blocks/fu/common/func_base.py
@@ -1,7 +1,7 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 from amaranth import Elaboratable
-from transactron import Method
+from transactron import Method, TModule
 from coreblocks.params import GenParams
 from coreblocks.interface.layouts import FuncUnitLayouts
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
@@ -23,3 +23,12 @@ class FuncUnitBase(ABC, FuncUnit, Elaboratable, Generic[_T_DecoderManager]):
         self.issue = Method(i=self.layouts.issue)
         self.push_result = Method(i=self.layouts.push_result)
         self.fn = fn
+        self.decoder = fn.get_decoder(gen_params)
+
+    @abstractmethod
+    def elaborate(self, platform) -> TModule:
+        m = TModule()
+
+        m.submodules.decoder = self.decoder
+
+        return m

--- a/coreblocks/func_blocks/fu/common/func_base.py
+++ b/coreblocks/func_blocks/fu/common/func_base.py
@@ -23,4 +23,3 @@ class FuncUnitBase(ABC, FuncUnit, Elaboratable, Generic[_T_DecoderManager]):
         self.issue = Method(i=self.layouts.issue)
         self.push_result = Method(i=self.layouts.push_result)
         self.fn = fn
-

--- a/coreblocks/func_blocks/fu/common/func_base.py
+++ b/coreblocks/func_blocks/fu/common/func_base.py
@@ -1,0 +1,26 @@
+from abc import ABC
+from typing import Generic, TypeVar
+from amaranth import Elaboratable
+from transactron import Method
+from coreblocks.params import GenParams
+from coreblocks.interface.layouts import FuncUnitLayouts
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+
+
+__all__ = ["FuncUnitBase"]
+
+
+_T_DecoderManager = TypeVar("_T_DecoderManager", bound=DecoderManager)
+
+
+class FuncUnitBase(ABC, FuncUnit, Elaboratable, Generic[_T_DecoderManager]):
+    fn: _T_DecoderManager
+
+    def __init__(self, gen_params: GenParams, fn: _T_DecoderManager):
+        self.gen_params = gen_params
+        self.layouts = gen_params.get(FuncUnitLayouts)
+        self.issue = Method(i=self.layouts.issue)
+        self.push_result = Method(i=self.layouts.push_result)
+        self.fn = fn
+

--- a/coreblocks/func_blocks/fu/div_unit.py
+++ b/coreblocks/func_blocks/fu/div_unit.py
@@ -8,15 +8,14 @@ from amaranth.lib import data
 from coreblocks.params.fu_params import FunctionalComponentParams
 from coreblocks.params import GenParams
 from coreblocks.arch import OpType, Funct3
-from coreblocks.interface.layouts import FuncUnitLayouts
 from transactron import *
 from transactron.core import def_method
 from transactron.lib import *
 
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 
 from transactron.utils import OneHotSwitch
-from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 from coreblocks.func_blocks.fu.division.long_division import LongDivider
 
 
@@ -40,14 +39,12 @@ def get_input(arg: data.View) -> tuple[Value, Value]:
     return arg.s1_val, Mux(arg.imm, arg.imm, arg.s2_val)
 
 
-class DivUnit(FuncUnitBase):
-    def __init__(self, gen_params: GenParams, ipc: int = 4, div_fn=DivFn()):
-        super().__init__(gen_params)
+class DivUnit(FuncUnitBase[DivFn]):
+    def __init__(self, gen_params: GenParams, ipc: int = 4, fn=DivFn()):
+        super().__init__(gen_params, fn)
         self.ipc = ipc
 
         self.clear = Method()
-
-        self.div_fn = div_fn
 
     def elaborate(self, platform):
         m = TModule()
@@ -61,7 +58,7 @@ class DivUnit(FuncUnitBase):
             ],
             2,
         )
-        m.submodules.decoder = decoder = self.div_fn.get_decoder(self.gen_params)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         m.submodules.divider = divider = LongDivider(self.gen_params, self.ipc)
 

--- a/coreblocks/func_blocks/fu/div_unit.py
+++ b/coreblocks/func_blocks/fu/div_unit.py
@@ -16,7 +16,7 @@ from transactron.lib import *
 from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
 
 from transactron.utils import OneHotSwitch
-from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
 from coreblocks.func_blocks.fu.division.long_division import LongDivider
 
 
@@ -40,15 +40,11 @@ def get_input(arg: data.View) -> tuple[Value, Value]:
     return arg.s1_val, Mux(arg.imm, arg.imm, arg.s2_val)
 
 
-class DivUnit(FuncUnit, Elaboratable):
+class DivUnit(FuncUnitBase):
     def __init__(self, gen_params: GenParams, ipc: int = 4, div_fn=DivFn()):
-        self.gen_params = gen_params
+        super().__init__(gen_params)
         self.ipc = ipc
 
-        layouts = gen_params.get(FuncUnitLayouts)
-
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
         self.clear = Method()
 
         self.div_fn = div_fn

--- a/coreblocks/func_blocks/fu/div_unit.py
+++ b/coreblocks/func_blocks/fu/div_unit.py
@@ -47,7 +47,7 @@ class DivUnit(FuncUnitBase[DivFn]):
         self.clear = Method()
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules.params_fifo = params_fifo = FIFO(
             [
@@ -58,8 +58,6 @@ class DivUnit(FuncUnitBase[DivFn]):
             ],
             2,
         )
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
-
         m.submodules.divider = divider = LongDivider(self.gen_params, self.ipc)
 
         xlen = self.gen_params.isa.xlen
@@ -71,7 +69,7 @@ class DivUnit(FuncUnitBase[DivFn]):
 
         @def_method(m, self.issue)
         def _(arg):
-            m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
+            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
             i1, i2 = get_input(arg)
 
             flip_sign = Signal(1)  # if result is negative number
@@ -83,7 +81,7 @@ class DivUnit(FuncUnitBase[DivFn]):
             def _abs(s: Value) -> Value:
                 return Mux(s.as_signed() < 0, -s, s)
 
-            with OneHotSwitch(m, decoder.decode_fn) as OneHotCase:
+            with OneHotSwitch(m, self.decoder.decode_fn) as OneHotCase:
                 with OneHotCase(DivFn.Fn.DIVU):
                     m.d.av_comb += flip_sign.eq(0)
                     m.d.av_comb += rem_res.eq(0)

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -49,20 +49,18 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
         self.report = self.dm.get_dependency(ExceptionReportKey())()
 
     def elaborate(self, platform):
-        m = TModule()
-
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
+        m = super().elaborate(platform)
 
         @def_method(m, self.issue)
         def _(arg):
-            m.d.comb += decoder.exec_fn.eq(arg.exec_fn)
+            m.d.comb += self.decoder.exec_fn.eq(arg.exec_fn)
 
             cause = Signal(ExceptionCause)
             mtval = Signal(self.gen_params.isa.xlen)
 
             priv_level = self.dm.get_dependency(CSRInstancesKey()).m_mode.priv_mode.read(m).data
 
-            with OneHotSwitch(m, decoder.decode_fn) as OneHotCase:
+            with OneHotSwitch(m, self.decoder.decode_fn) as OneHotCase:
                 with OneHotCase(ExceptionUnitFn.Fn.EBREAK):
                     m.d.av_comb += cause.eq(ExceptionCause.BREAKPOINT)
                     m.d.av_comb += mtval.eq(arg.pc)

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -15,7 +15,7 @@ from coreblocks.interface.keys import ExceptionReportKey, CSRInstancesKey
 from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
 from enum import IntFlag, auto
 
-from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
 
 __all__ = ["ExceptionFuncUnit", "ExceptionUnitComponent"]
 
@@ -41,15 +41,10 @@ class ExceptionUnitFn(DecoderManager):
         ]
 
 
-class ExceptionFuncUnit(FuncUnit, Elaboratable):
+class ExceptionFuncUnit(FuncUnitBase, Elaboratable):
     def __init__(self, gen_params: GenParams, unit_fn=ExceptionUnitFn()):
-        self.gen_params = gen_params
+        super().__init__(gen_params)
         self.fn = unit_fn
-
-        layouts = gen_params.get(FuncUnitLayouts)
-
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
 
         self.dm = DependencyContext.get()
         self.report = self.dm.get_dependency(ExceptionReportKey())()

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -8,14 +8,14 @@ from transactron import *
 
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, Funct3, ExceptionCause
-from coreblocks.interface.layouts import FetchLayouts, FuncUnitLayouts
+from coreblocks.interface.layouts import FetchLayouts
 from transactron.utils import OneHotSwitch
 from coreblocks.interface.keys import ExceptionReportKey, CSRInstancesKey
 
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 from enum import IntFlag, auto
 
-from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 
 __all__ = ["ExceptionFuncUnit", "ExceptionUnitComponent"]
 
@@ -41,10 +41,9 @@ class ExceptionUnitFn(DecoderManager):
         ]
 
 
-class ExceptionFuncUnit(FuncUnitBase, Elaboratable):
-    def __init__(self, gen_params: GenParams, unit_fn=ExceptionUnitFn()):
-        super().__init__(gen_params)
-        self.fn = unit_fn
+class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
+    def __init__(self, gen_params: GenParams, fn=ExceptionUnitFn()):
+        super().__init__(gen_params, fn)
 
         self.dm = DependencyContext.get()
         self.report = self.dm.get_dependency(ExceptionReportKey())()

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -12,7 +12,7 @@ from transactron.lib import logging
 from transactron.utils import DependencyContext, from_method_layout
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import Funct3, OpType, ExceptionCause, Extension
-from coreblocks.interface.layouts import FuncUnitLayouts, JumpBranchLayouts, CommonLayoutFields
+from coreblocks.interface.layouts import JumpBranchLayouts, CommonLayoutFields
 from coreblocks.interface.keys import (
     AsyncInterruptInsertSignalKey,
     BranchVerifyKey,
@@ -21,8 +21,8 @@ from coreblocks.interface.keys import (
 )
 from transactron.utils import OneHotSwitch
 from transactron.utils.transactron_helpers import make_layout
-from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 
 __all__ = ["JumpBranchFuncUnit", "JumpComponent"]
 
@@ -106,13 +106,11 @@ class JumpBranch(Elaboratable):
         return m
 
 
-class JumpBranchFuncUnit(FuncUnitBase):
-    def __init__(self, gen_params: GenParams, jb_fn=JumpBranchFn()):
-        super().__init__(gen_params)
+class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
+    def __init__(self, gen_params: GenParams, fn=JumpBranchFn()):
+        super().__init__(gen_params, fn)
 
         self.fifo_branch_resolved = FIFO(self.gen_params.get(JumpBranchLayouts).verify_branch, 2)
-
-        self.jb_fn = jb_fn
 
         self.dm = DependencyContext.get()
         self.dm.add_dependency(BranchVerifyKey(), self.fifo_branch_resolved.read)
@@ -140,8 +138,8 @@ class JumpBranchFuncUnit(FuncUnitBase):
 
         jump_target_req, jump_target_resp = self.dm.get_dependency(PredictedJumpTargetKey())
 
-        m.submodules.jb = jb = JumpBranch(self.gen_params, fn=self.jb_fn)
-        m.submodules.decoder = decoder = self.jb_fn.get_decoder(self.gen_params)
+        m.submodules.jb = jb = JumpBranch(self.gen_params, fn=self.fn)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
         m.submodules.fifo_branch_resolved = self.fifo_branch_resolved
 
         fields = self.gen_params.get(CommonLayoutFields)

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -21,7 +21,7 @@ from coreblocks.interface.keys import (
 )
 from transactron.utils import OneHotSwitch
 from transactron.utils.transactron_helpers import make_layout
-from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
 from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
 
 __all__ = ["JumpBranchFuncUnit", "JumpComponent"]
@@ -106,14 +106,9 @@ class JumpBranch(Elaboratable):
         return m
 
 
-class JumpBranchFuncUnit(FuncUnit, Elaboratable):
+class JumpBranchFuncUnit(FuncUnitBase):
     def __init__(self, gen_params: GenParams, jb_fn=JumpBranchFn()):
-        self.gen_params = gen_params
-
-        layouts = gen_params.get(FuncUnitLayouts)
-
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
+        super().__init__(gen_params)
 
         self.fifo_branch_resolved = FIFO(self.gen_params.get(JumpBranchLayouts).verify_branch, 2)
 

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -128,7 +128,7 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
         self.exception_report = self.dm.get_dependency(ExceptionReportKey())()
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules += [
             self.perf_instr,
@@ -139,7 +139,6 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
         jump_target_req, jump_target_resp = self.dm.get_dependency(PredictedJumpTargetKey())
 
         m.submodules.jb = jb = JumpBranch(self.gen_params, fn=self.fn)
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
         m.submodules.fifo_branch_resolved = self.fifo_branch_resolved
 
         fields = self.gen_params.get(CommonLayoutFields)
@@ -233,8 +232,8 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
 
         @def_method(m, self.issue)
         def _(arg):
-            m.d.top_comb += decoder.exec_fn.eq(arg.exec_fn)
-            m.d.top_comb += jb.fn.eq(decoder.decode_fn)
+            m.d.top_comb += self.decoder.exec_fn.eq(arg.exec_fn)
+            m.d.top_comb += jb.fn.eq(self.decoder.decode_fn)
 
             m.d.top_comb += jb.in1.eq(arg.s1_val)
             m.d.top_comb += jb.in2.eq(arg.s2_val)
@@ -252,14 +251,14 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
                 rob_id=arg.rob_id,
                 pc=arg.pc,
                 rp_dst=arg.rp_dst,
-                type=decoder.decode_fn,
+                type=self.decoder.decode_fn,
                 jmp_addr=jb.jmp_addr,
                 reg_res=jb.reg_res,
                 taken=jb.taken,
                 predicted_taken=funct7_info.predicted_taken,
                 tag=arg.tag,
             )
-            self.perf_instr.incr(m, decoder.decode_fn)
+            self.perf_instr.incr(m, self.decoder.decode_fn)
 
         return m
 

--- a/coreblocks/func_blocks/fu/mul_unit.py
+++ b/coreblocks/func_blocks/fu/mul_unit.py
@@ -101,7 +101,7 @@ class MulUnit(FuncUnitBase[MulFn]):
         self.dsp_number = dsp_number
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules.params_fifo = params_fifo = FIFO(
             [
@@ -112,7 +112,6 @@ class MulUnit(FuncUnitBase[MulFn]):
             ],
             2,
         )
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         # Selecting unsigned integer multiplication module
         match self.mul_type:
@@ -135,7 +134,7 @@ class MulUnit(FuncUnitBase[MulFn]):
 
         @def_method(m, self.issue)
         def _(arg):
-            m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
+            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
             i1, i2 = get_input(arg)
 
             value1 = Signal(self.gen_params.isa.xlen)  # input value for multiplier submodule
@@ -148,7 +147,7 @@ class MulUnit(FuncUnitBase[MulFn]):
             # which part of result we want upper or lower part. In the future, it would be a great improvement
             # to save result for chain multiplication of this same numbers, but with different parts as
             # results
-            with OneHotSwitch(m, decoder.decode_fn) as OneHotCase:
+            with OneHotSwitch(m, self.decoder.decode_fn) as OneHotCase:
                 with OneHotCase(MulFn.Fn.MUL):  # MUL
                     # In this case we care only about lower part of number, so it does not matter if it is
                     # interpreted as binary number or U2 encoded number, so we set result to be interpreted as

--- a/coreblocks/func_blocks/fu/mul_unit.py
+++ b/coreblocks/func_blocks/fu/mul_unit.py
@@ -8,22 +8,18 @@ from coreblocks.func_blocks.fu.unsigned_multiplication.fast_recursive import Rec
 from coreblocks.func_blocks.fu.unsigned_multiplication.sequence import SequentialUnsignedMul
 from coreblocks.func_blocks.fu.unsigned_multiplication.shift import ShiftUnsignedMul
 from coreblocks.func_blocks.fu.unsigned_multiplication.pipelined import PipelinedUnsignedMul
+from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
+from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, Funct3
 from coreblocks.interface.layouts import FuncUnitLayouts
 from transactron import *
 from transactron.core import def_method
 from transactron.lib import *
-from transactron.utils import MethodStruct
-
-
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from transactron.utils import MethodStruct, OneHotSwitch
 
 
 __all__ = ["MulUnit", "MulFn", "MulComponent", "MulType"]
-
-from transactron.utils import OneHotSwitch
-from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 
 
 class MulFn(DecoderManager):
@@ -81,7 +77,7 @@ class MulType(IntEnum):
     RECURSIVE_MUL = 3
 
 
-class MulUnit(FuncUnit, Elaboratable):
+class MulUnit(FuncUnitBase):
     """
     Module responsible for handling every kind of multiplication based on selected unsigned integer multiplication
     module. It uses standard FuncUnitLayout.
@@ -108,15 +104,10 @@ class MulUnit(FuncUnit, Elaboratable):
         gen_params: GenParams
             Core generation parameters.
         """
-        self.gen_params = gen_params
+        super().__init__(gen_params)
         self.mul_type = mul_type
         self.dsp_width = dsp_width
         self.dsp_number = dsp_number
-
-        layouts = gen_params.get(FuncUnitLayouts)
-
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
 
         self.mul_fn = mul_fn
 

--- a/coreblocks/func_blocks/fu/mul_unit.py
+++ b/coreblocks/func_blocks/fu/mul_unit.py
@@ -8,11 +8,10 @@ from coreblocks.func_blocks.fu.unsigned_multiplication.fast_recursive import Rec
 from coreblocks.func_blocks.fu.unsigned_multiplication.sequence import SequentialUnsignedMul
 from coreblocks.func_blocks.fu.unsigned_multiplication.shift import ShiftUnsignedMul
 from coreblocks.func_blocks.fu.unsigned_multiplication.pipelined import PipelinedUnsignedMul
-from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, Funct3
-from coreblocks.interface.layouts import FuncUnitLayouts
 from transactron import *
 from transactron.core import def_method
 from transactron.lib import *
@@ -77,17 +76,9 @@ class MulType(IntEnum):
     RECURSIVE_MUL = 3
 
 
-class MulUnit(FuncUnitBase):
+class MulUnit(FuncUnitBase[MulFn]):
     """
-    Module responsible for handling every kind of multiplication based on selected unsigned integer multiplication
-    module. It uses standard FuncUnitLayout.
-
-    Attributes
-    ----------
-    issue: Method(i=gen.get(FuncUnitLayouts).issue)
-        Method used for requesting computation.
-    push_result: Method(i=gen.get(FuncUnitLayouts).push_result)
-        Method called for pushing result of requested computation.
+    Handles multiplication instructions. Delegates to one of selectable unsigned multiplication instructions.
     """
 
     def __init__(
@@ -96,7 +87,7 @@ class MulUnit(FuncUnitBase):
         mul_type: MulType,
         dsp_width: int = 18,
         dsp_number: int = 7,
-        mul_fn=MulFn(),
+        fn=MulFn(),
     ):
         """
         Parameters
@@ -104,12 +95,10 @@ class MulUnit(FuncUnitBase):
         gen_params: GenParams
             Core generation parameters.
         """
-        super().__init__(gen_params)
+        super().__init__(gen_params, fn)
         self.mul_type = mul_type
         self.dsp_width = dsp_width
         self.dsp_number = dsp_number
-
-        self.mul_fn = mul_fn
 
     def elaborate(self, platform):
         m = TModule()
@@ -123,7 +112,7 @@ class MulUnit(FuncUnitBase):
             ],
             2,
         )
-        m.submodules.decoder = decoder = self.mul_fn.get_decoder(self.gen_params)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         # Selecting unsigned integer multiplication module
         match self.mul_type:

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -26,7 +26,7 @@ from coreblocks.interface.keys import (
     FlushICacheKey,
     WaitForInterruptResumeKey,
 )
-from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
 
 from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
 
@@ -45,16 +45,12 @@ class PrivilegedFn(DecoderManager):
         return [(self.Fn.MRET, OpType.MRET), (self.Fn.FENCEI, OpType.FENCEI), (self.Fn.WFI, OpType.WFI)]
 
 
-class PrivilegedFuncUnit(FuncUnit, Elaboratable):
+class PrivilegedFuncUnit(FuncUnitBase):
     def __init__(self, gen_params: GenParams, priv_fn=PrivilegedFn()):
-        self.gen_params = gen_params
+        super().__init__(gen_params)
         self.priv_fn = priv_fn
 
-        self.layouts = layouts = gen_params.get(FuncUnitLayouts)
         self.dm = DependencyContext.get()
-
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
 
         self.perf_instr = TaggedCounter(
             "backend.fu.priv.instr",

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -15,7 +15,6 @@ from transactron.utils import DependencyContext, OneHotSwitch
 from coreblocks.params import *
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, ExceptionCause
-from coreblocks.interface.layouts import FuncUnitLayouts
 from coreblocks.interface.keys import (
     MretKey,
     AsyncInterruptInsertSignalKey,
@@ -26,9 +25,9 @@ from coreblocks.interface.keys import (
     FlushICacheKey,
     WaitForInterruptResumeKey,
 )
-from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 
 
 log = logging.HardwareLogger("backend.fu.priv")
@@ -45,10 +44,9 @@ class PrivilegedFn(DecoderManager):
         return [(self.Fn.MRET, OpType.MRET), (self.Fn.FENCEI, OpType.FENCEI), (self.Fn.WFI, OpType.WFI)]
 
 
-class PrivilegedFuncUnit(FuncUnitBase):
-    def __init__(self, gen_params: GenParams, priv_fn=PrivilegedFn()):
-        super().__init__(gen_params)
-        self.priv_fn = priv_fn
+class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
+    def __init__(self, gen_params: GenParams, fn=PrivilegedFn()):
+        super().__init__(gen_params, fn)
 
         self.dm = DependencyContext.get()
 
@@ -65,7 +63,7 @@ class PrivilegedFuncUnit(FuncUnitBase):
 
         m.submodules += [self.perf_instr]
 
-        m.submodules.decoder = decoder = self.priv_fn.get_decoder(self.gen_params)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         instr_valid = Signal()
         finished = Signal()
@@ -73,7 +71,7 @@ class PrivilegedFuncUnit(FuncUnitBase):
 
         instr_rob = Signal(self.gen_params.rob_entries_bits)
         instr_pc = Signal(self.gen_params.isa.xlen)
-        instr_fn = self.priv_fn.get_function()
+        instr_fn = self.fn.get_function()
 
         mret = self.dm.get_dependency(MretKey())
         async_interrupt_active = self.dm.get_dependency(AsyncInterruptInsertSignalKey())

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -59,11 +59,9 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
         self.exception_report = self.dm.get_dependency(ExceptionReportKey())()
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules += [self.perf_instr]
-
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         instr_valid = Signal()
         finished = Signal()
@@ -83,12 +81,12 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
 
         @def_method(m, self.issue, ready=~instr_valid)
         def _(arg):
-            m.d.comb += decoder.exec_fn.eq(arg.exec_fn)
+            m.d.comb += self.decoder.exec_fn.eq(arg.exec_fn)
             m.d.sync += [
                 instr_valid.eq(1),
                 instr_rob.eq(arg.rob_id),
                 instr_pc.eq(arg.pc),
-                instr_fn.eq(decoder.decode_fn),
+                instr_fn.eq(self.decoder.decode_fn),
             ]
 
         with Transaction().body(m, ready=instr_valid & ~finished):

--- a/coreblocks/func_blocks/fu/shift_unit.py
+++ b/coreblocks/func_blocks/fu/shift_unit.py
@@ -12,7 +12,7 @@ from transactron.utils import OneHotSwitch
 from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
 from enum import IntFlag, auto
 
-from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
 
 __all__ = ["ShiftFuncUnit", "ShiftUnitComponent"]
 
@@ -75,15 +75,10 @@ class ShiftUnit(Elaboratable):
         return m
 
 
-class ShiftFuncUnit(FuncUnit, Elaboratable):
+class ShiftFuncUnit(FuncUnitBase):
     def __init__(self, gen_params: GenParams, shift_unit_fn=ShiftUnitFn()):
-        self.gen_params = gen_params
+        super().__init__(gen_params)
         self.shift_unit_fn = shift_unit_fn
-
-        layouts = gen_params.get(FuncUnitLayouts)
-
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
 
     def elaborate(self, platform):
         m = TModule()

--- a/coreblocks/func_blocks/fu/shift_unit.py
+++ b/coreblocks/func_blocks/fu/shift_unit.py
@@ -6,13 +6,12 @@ from transactron import *
 
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, Funct3, Funct7
-from coreblocks.interface.layouts import FuncUnitLayouts
 from transactron.utils import OneHotSwitch
 
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 from enum import IntFlag, auto
 
-from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 
 __all__ = ["ShiftFuncUnit", "ShiftUnitComponent"]
 
@@ -75,16 +74,15 @@ class ShiftUnit(Elaboratable):
         return m
 
 
-class ShiftFuncUnit(FuncUnitBase):
-    def __init__(self, gen_params: GenParams, shift_unit_fn=ShiftUnitFn()):
-        super().__init__(gen_params)
-        self.shift_unit_fn = shift_unit_fn
+class ShiftFuncUnit(FuncUnitBase[ShiftUnitFn]):
+    def __init__(self, gen_params: GenParams, fn=ShiftUnitFn()):
+        super().__init__(gen_params, fn)
 
     def elaborate(self, platform):
         m = TModule()
 
-        m.submodules.shift_alu = shift_alu = ShiftUnit(self.gen_params, shift_unit_fn=self.shift_unit_fn)
-        m.submodules.decoder = decoder = self.shift_unit_fn.get_decoder(self.gen_params)
+        m.submodules.shift_alu = shift_alu = ShiftUnit(self.gen_params, shift_unit_fn=self.fn)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):

--- a/coreblocks/func_blocks/fu/shift_unit.py
+++ b/coreblocks/func_blocks/fu/shift_unit.py
@@ -79,15 +79,14 @@ class ShiftFuncUnit(FuncUnitBase[ShiftUnitFn]):
         super().__init__(gen_params, fn)
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules.shift_alu = shift_alu = ShiftUnit(self.gen_params, shift_unit_fn=self.fn)
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):
-            m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
-            m.d.av_comb += shift_alu.fn.eq(decoder.decode_fn)
+            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
+            m.d.av_comb += shift_alu.fn.eq(self.decoder.decode_fn)
 
             m.d.av_comb += shift_alu.in1.eq(arg.s1_val)
             m.d.av_comb += shift_alu.in2.eq(Mux(arg.imm, arg.imm, arg.s2_val))

--- a/coreblocks/func_blocks/fu/zbc.py
+++ b/coreblocks/func_blocks/fu/zbc.py
@@ -8,7 +8,7 @@ from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, Funct3
-from transactron import Transaction, def_method, TModule
+from transactron import Transaction, def_method
 from transactron.lib import FIFO
 from transactron.utils import OneHotSwitch
 
@@ -158,7 +158,7 @@ class ZbcUnit(FuncUnitBase[ZbcFn]):
         self.recursion_depth = recursion_depth
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules.params_fifo = params_fifo = FIFO(
             [
@@ -169,7 +169,6 @@ class ZbcUnit(FuncUnitBase[ZbcFn]):
             ],
             1,
         )
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
         m.submodules.clmul = clmul = ClMultiplier(self.gen_params.isa.xlen, self.recursion_depth)
 
         m.d.comb += clmul.reset.eq(0)
@@ -187,7 +186,7 @@ class ZbcUnit(FuncUnitBase[ZbcFn]):
 
         @def_method(m, self.issue)
         def _(exec_fn, imm, s1_val, s2_val, rob_id, rp_dst, pc, tag):
-            m.d.av_comb += decoder.exec_fn.eq(exec_fn)
+            m.d.av_comb += self.decoder.exec_fn.eq(exec_fn)
 
             i1 = s1_val
             i2 = Mux(imm, imm, s2_val)
@@ -197,7 +196,7 @@ class ZbcUnit(FuncUnitBase[ZbcFn]):
             high_res = Signal(1)
             rev_res = Signal(1)
 
-            with OneHotSwitch(m, decoder.decode_fn) as OneHotCase:
+            with OneHotSwitch(m, self.decoder.decode_fn) as OneHotCase:
                 with OneHotCase(ZbcFn.Fn.CLMUL):
                     m.d.av_comb += high_res.eq(0)
                     m.d.av_comb += rev_res.eq(0)

--- a/coreblocks/func_blocks/fu/zbc.py
+++ b/coreblocks/func_blocks/fu/zbc.py
@@ -11,7 +11,7 @@ from coreblocks.interface.layouts import FuncUnitLayouts
 from transactron import Method, Transaction, def_method, TModule
 from transactron.lib import FIFO
 from transactron.utils import OneHotSwitch
-from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
 
 
 class ZbcFn(DecoderManager):
@@ -148,26 +148,16 @@ class ClMultiplier(Elaboratable):
         return m
 
 
-class ZbcUnit(FuncUnit, Elaboratable):
+class ZbcUnit(FuncUnitBase):
     """
-    Module responsible for executing Zbc instructions (carry-less multiplication)
-
-    Attributes
-    ----------
-    issue: Method(i=FuncUnitLayouts.issue)
-        Method used for requesting computation.
-    push_result: Method(i=FuncUnitLayouts.push_result)
-        Method called for pushing result of requested computation.
+    Executes Zbc instructions (carry-less multiplication).
     """
 
     def __init__(self, gen_params: GenParams, recursion_depth: int, zbc_fn: ZbcFn):
-        layouts = gen_params.get(FuncUnitLayouts)
+        super().__init__(gen_params)
 
         self.zbc_fn = zbc_fn
         self.recursion_depth = recursion_depth
-        self.gen_params = gen_params
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
 
     def elaborate(self, platform):
         m = TModule()

--- a/coreblocks/func_blocks/fu/zbc.py
+++ b/coreblocks/func_blocks/fu/zbc.py
@@ -4,14 +4,13 @@ from typing import Sequence
 
 from amaranth import *
 
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, Funct3
-from coreblocks.interface.layouts import FuncUnitLayouts
-from transactron import Method, Transaction, def_method, TModule
+from transactron import Transaction, def_method, TModule
 from transactron.lib import FIFO
 from transactron.utils import OneHotSwitch
-from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
 
 
 class ZbcFn(DecoderManager):
@@ -148,15 +147,14 @@ class ClMultiplier(Elaboratable):
         return m
 
 
-class ZbcUnit(FuncUnitBase):
+class ZbcUnit(FuncUnitBase[ZbcFn]):
     """
     Executes Zbc instructions (carry-less multiplication).
     """
 
-    def __init__(self, gen_params: GenParams, recursion_depth: int, zbc_fn: ZbcFn):
-        super().__init__(gen_params)
+    def __init__(self, gen_params: GenParams, recursion_depth: int, fn: ZbcFn):
+        super().__init__(gen_params, fn)
 
-        self.zbc_fn = zbc_fn
         self.recursion_depth = recursion_depth
 
     def elaborate(self, platform):
@@ -171,7 +169,7 @@ class ZbcUnit(FuncUnitBase):
             ],
             1,
         )
-        m.submodules.decoder = decoder = self.zbc_fn.get_decoder(self.gen_params)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
         m.submodules.clmul = clmul = ClMultiplier(self.gen_params.isa.xlen, self.recursion_depth)
 
         m.d.comb += clmul.reset.eq(0)

--- a/coreblocks/func_blocks/fu/zbkx.py
+++ b/coreblocks/func_blocks/fu/zbkx.py
@@ -5,15 +5,14 @@ from typing import Sequence
 from amaranth import *
 
 from coreblocks.arch import OpType, Funct3, Funct7
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
-from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
-from coreblocks.interface.layouts import FuncUnitLayouts
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
+from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 from coreblocks.params import FunctionalComponentParams, GenParams
-from transactron import Method, TModule, def_method
+from transactron import TModule, def_method
 from transactron.utils import OneHotSwitch
 
 
-class ZbkxFunction(DecoderManager):
+class ZbkxFn(DecoderManager):
     class Fn(IntFlag):
         XPERM4 = auto()
         XPERM8 = auto()
@@ -26,11 +25,11 @@ class ZbkxFunction(DecoderManager):
 
 
 class Zbkx(Elaboratable):
-    def __init__(self, gen_params: GenParams, function=ZbkxFunction()):
+    def __init__(self, gen_params: GenParams, fn=ZbkxFn()):
         self.gen_params = gen_params
         self.xlen = gen_params.isa.xlen
 
-        self.function = function.get_function()
+        self.fn = fn.get_function()
         self.in1 = Signal(self.xlen)
         self.in2 = Signal(self.xlen)
         self.result = Signal(self.xlen)
@@ -38,15 +37,15 @@ class Zbkx(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        with OneHotSwitch(m, self.function) as OneHotCase:
-            with OneHotCase(ZbkxFunction.Fn.XPERM4):
+        with OneHotSwitch(m, self.fn) as OneHotCase:
+            with OneHotCase(ZbkxFn.Fn.XPERM4):
                 lane_count = self.xlen // 4
                 for lane in range(lane_count):
                     idx = self.in2.word_select(lane, 4)
                     selected = Mux(idx < lane_count, self.in1.word_select(idx, 4), C(0, 4))
                     m.d.comb += self.result.word_select(lane, 4).eq(selected)
 
-            with OneHotCase(ZbkxFunction.Fn.XPERM8):
+            with OneHotCase(ZbkxFn.Fn.XPERM8):
                 lane_count = self.xlen // 8
                 for lane in range(lane_count):
                     idx = self.in2.word_select(lane, 8)
@@ -56,23 +55,21 @@ class Zbkx(Elaboratable):
         return m
 
 
-class ZbkxUnit(FuncUnitBase):
-    def __init__(self, gen_params: GenParams, zbkx_fn=ZbkxFunction()):
-        super().__init__(gen_params)
-
-        self.zbkx_fn = zbkx_fn
+class ZbkxUnit(FuncUnitBase[ZbkxFn]):
+    def __init__(self, gen_params: GenParams, fn=ZbkxFn()):
+        super().__init__(gen_params, fn)
 
     def elaborate(self, platform):
         m = TModule()
 
-        m.submodules.zbkx = zbkx = Zbkx(self.gen_params, function=self.zbkx_fn)
-        m.submodules.decoder = decoder = self.zbkx_fn.get_decoder(self.gen_params)
+        m.submodules.zbkx = zbkx = Zbkx(self.gen_params, fn=self.fn)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):
             m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
 
-            m.d.av_comb += zbkx.function.eq(decoder.decode_fn)
+            m.d.av_comb += zbkx.fn.eq(decoder.decode_fn)
             m.d.av_comb += zbkx.in1.eq(arg.s1_val)
             m.d.av_comb += zbkx.in2.eq(arg.s2_val)
 
@@ -84,7 +81,7 @@ class ZbkxUnit(FuncUnitBase):
 @dataclass(frozen=True)
 class ZbkxComponent(FunctionalComponentParams):
     _: KW_ONLY
-    decoder_manager: ZbkxFunction = ZbkxFunction()
+    decoder_manager: ZbkxFn = ZbkxFn()
     result_fifo: bool = True
 
     def get_module(self, gen_params: GenParams) -> FuncUnit:

--- a/coreblocks/func_blocks/fu/zbkx.py
+++ b/coreblocks/func_blocks/fu/zbkx.py
@@ -6,7 +6,7 @@ from amaranth import *
 
 from coreblocks.arch import OpType, Funct3, Funct7
 from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
-from coreblocks.func_blocks.interface.func_protocols import FuncUnit
+from coreblocks.func_blocks.interface import FuncUnit, FuncUnitBase
 from coreblocks.interface.layouts import FuncUnitLayouts
 from coreblocks.params import FunctionalComponentParams, GenParams
 from transactron import Method, TModule, def_method
@@ -56,13 +56,9 @@ class Zbkx(Elaboratable):
         return m
 
 
-class ZbkxUnit(FuncUnit, Elaboratable):
+class ZbkxUnit(FuncUnitBase):
     def __init__(self, gen_params: GenParams, zbkx_fn=ZbkxFunction()):
-        layouts = gen_params.get(FuncUnitLayouts)
-
-        self.gen_params = gen_params
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
+        super().__init__(gen_params)
 
         self.zbkx_fn = zbkx_fn
 

--- a/coreblocks/func_blocks/fu/zbkx.py
+++ b/coreblocks/func_blocks/fu/zbkx.py
@@ -60,16 +60,15 @@ class ZbkxUnit(FuncUnitBase[ZbkxFn]):
         super().__init__(gen_params, fn)
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules.zbkx = zbkx = Zbkx(self.gen_params, fn=self.fn)
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):
-            m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
+            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
 
-            m.d.av_comb += zbkx.fn.eq(decoder.decode_fn)
+            m.d.av_comb += zbkx.fn.eq(self.decoder.decode_fn)
             m.d.av_comb += zbkx.in1.eq(arg.s1_val)
             m.d.av_comb += zbkx.in2.eq(arg.s2_val)
 

--- a/coreblocks/func_blocks/fu/zbs.py
+++ b/coreblocks/func_blocks/fu/zbs.py
@@ -5,15 +5,14 @@ from amaranth import *
 
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, Funct3, Funct7
-from coreblocks.interface.layouts import FuncUnitLayouts
-from transactron import Method, TModule, def_method
+from transactron import TModule, def_method
 from transactron.utils import OneHotSwitch
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
+from coreblocks.func_blocks.fu.common import DecoderManager, FuncUnitBase
 
 
-class ZbsFunction(DecoderManager):
+class ZbsFn(DecoderManager):
     """
     Enum of Zbs functions.
     """
@@ -39,7 +38,7 @@ class Zbs(Elaboratable):
 
     Attributes
     ----------
-    function: ZbsFunction, in
+    fn: ZbsFunction, in
         Function to be executed.
     in1: Signal(xlen), in
         First input.
@@ -47,7 +46,7 @@ class Zbs(Elaboratable):
         Second input.
     """
 
-    def __init__(self, gen_params: GenParams, function=ZbsFunction()):
+    def __init__(self, gen_params: GenParams, fn=ZbsFn()):
         """
         Parameters
         ----------
@@ -59,7 +58,7 @@ class Zbs(Elaboratable):
         self.gen_params = gen_params
 
         self.xlen = gen_params.isa.xlen
-        self.function = function.get_function()
+        self.function = fn.get_function()
         self.in1 = Signal(self.xlen)
         self.in2 = Signal(self.xlen)
 
@@ -71,44 +70,31 @@ class Zbs(Elaboratable):
         xlen_log = self.gen_params.isa.xlen_log
 
         with OneHotSwitch(m, self.function) as OneHotCase:
-            with OneHotCase(ZbsFunction.Fn.BCLR):
+            with OneHotCase(ZbsFn.Fn.BCLR):
                 m.d.comb += self.result.eq(self.in1 & ~(1 << self.in2[0:xlen_log]))
-            with OneHotCase(ZbsFunction.Fn.BEXT):
+            with OneHotCase(ZbsFn.Fn.BEXT):
                 m.d.comb += self.result.eq((self.in1 >> self.in2[0:xlen_log]) & 1)
-            with OneHotCase(ZbsFunction.Fn.BINV):
+            with OneHotCase(ZbsFn.Fn.BINV):
                 m.d.comb += self.result.eq(self.in1 ^ (1 << self.in2[0:xlen_log]))
-            with OneHotCase(ZbsFunction.Fn.BSET):
+            with OneHotCase(ZbsFn.Fn.BSET):
                 m.d.comb += self.result.eq(self.in1 | (1 << self.in2[0:xlen_log]))
 
         return m
 
 
-class ZbsUnit(FuncUnit, Elaboratable):
+class ZbsUnit(FuncUnitBase[ZbsFn]):
     """
-    Module responsible for executing Zbs instructions.
-
-    Attributes
-    ----------
-    issue: Method(i=FuncUnitLayouts.issue)
-        Method used for requesting computation.
-    push_result: Method(i=FuncUnitLayouts.push_result)
-        Method called for pushing result of requested computation.
+    Executes Zbs instructions.
     """
 
-    def __init__(self, gen_params: GenParams, zbs_fn=ZbsFunction()):
-        layouts = gen_params.get(FuncUnitLayouts)
-
-        self.gen_params = gen_params
-        self.issue = Method(i=layouts.issue)
-        self.push_result = Method(i=layouts.push_result)
-
-        self.zbs_fn = zbs_fn
+    def __init__(self, gen_params: GenParams, fn=ZbsFn()):
+        super().__init__(gen_params, fn)
 
     def elaborate(self, platform):
         m = TModule()
 
-        m.submodules.zbs = zbs = Zbs(self.gen_params, function=self.zbs_fn)
-        m.submodules.decoder = decoder = self.zbs_fn.get_decoder(self.gen_params)
+        m.submodules.zbs = zbs = Zbs(self.gen_params, fn=self.fn)
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):
@@ -126,7 +112,7 @@ class ZbsUnit(FuncUnit, Elaboratable):
 @dataclass(frozen=True)
 class ZbsComponent(FunctionalComponentParams):
     _: KW_ONLY
-    decoder_manager: ZbsFunction = ZbsFunction()
+    decoder_manager: ZbsFn = ZbsFn()
     result_fifo: bool = True
 
     def get_module(self, gen_params: GenParams) -> FuncUnit:

--- a/coreblocks/func_blocks/fu/zbs.py
+++ b/coreblocks/func_blocks/fu/zbs.py
@@ -91,16 +91,15 @@ class ZbsUnit(FuncUnitBase[ZbsFn]):
         super().__init__(gen_params, fn)
 
     def elaborate(self, platform):
-        m = TModule()
+        m = super().elaborate(platform)
 
         m.submodules.zbs = zbs = Zbs(self.gen_params, fn=self.fn)
-        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
 
         @def_method(m, self.issue)
         def _(arg):
-            m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
+            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
 
-            m.d.av_comb += zbs.fn.eq(decoder.decode_fn)
+            m.d.av_comb += zbs.fn.eq(self.decoder.decode_fn)
             m.d.av_comb += zbs.in1.eq(arg.s1_val)
             m.d.av_comb += zbs.in2.eq(Mux(arg.imm, arg.imm, arg.s2_val))
 

--- a/coreblocks/func_blocks/fu/zbs.py
+++ b/coreblocks/func_blocks/fu/zbs.py
@@ -58,7 +58,7 @@ class Zbs(Elaboratable):
         self.gen_params = gen_params
 
         self.xlen = gen_params.isa.xlen
-        self.function = fn.get_function()
+        self.fn = fn.get_function()
         self.in1 = Signal(self.xlen)
         self.in2 = Signal(self.xlen)
 
@@ -69,7 +69,7 @@ class Zbs(Elaboratable):
 
         xlen_log = self.gen_params.isa.xlen_log
 
-        with OneHotSwitch(m, self.function) as OneHotCase:
+        with OneHotSwitch(m, self.fn) as OneHotCase:
             with OneHotCase(ZbsFn.Fn.BCLR):
                 m.d.comb += self.result.eq(self.in1 & ~(1 << self.in2[0:xlen_log]))
             with OneHotCase(ZbsFn.Fn.BEXT):
@@ -100,7 +100,7 @@ class ZbsUnit(FuncUnitBase[ZbsFn]):
         def _(arg):
             m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
 
-            m.d.av_comb += zbs.function.eq(decoder.decode_fn)
+            m.d.av_comb += zbs.fn.eq(decoder.decode_fn)
             m.d.av_comb += zbs.in1.eq(arg.s1_val)
             m.d.av_comb += zbs.in2.eq(Mux(arg.imm, arg.imm, arg.s2_val))
 

--- a/coreblocks/func_blocks/interface/func_protocols.py
+++ b/coreblocks/func_blocks/interface/func_protocols.py
@@ -1,6 +1,5 @@
 from typing import Protocol
 from transactron import Method, Methods, Provided, Required
-from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
 from amaranth_types import HasElaborate
 
 

--- a/coreblocks/func_blocks/interface/func_protocols.py
+++ b/coreblocks/func_blocks/interface/func_protocols.py
@@ -1,5 +1,6 @@
 from typing import Protocol
 from transactron import Method, Methods, Provided, Required
+from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
 from amaranth_types import HasElaborate
 
 
@@ -8,7 +9,10 @@ __all__ = ["FuncUnit", "FuncBlock"]
 
 class FuncUnit(HasElaborate, Protocol):
     issue: Provided[Method]
+    """Called by RS to send new instruction to the functional unit."""
+
     push_result: Required[Method]
+    """Called by the functional unit to broadcast the result."""
 
 
 class FuncBlock(HasElaborate, Protocol):

--- a/test/func_blocks/fu/test_zbkx.py
+++ b/test/func_blocks/fu/test_zbkx.py
@@ -1,31 +1,31 @@
 from coreblocks.arch import Funct3, Funct7, OpType
-from coreblocks.func_blocks.fu.zbkx import ZbkxFunction, ZbkxComponent
+from coreblocks.func_blocks.fu.zbkx import ZbkxFn, ZbkxComponent
 
 from test.func_blocks.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
-class TestZbkxUnit(FunctionalUnitTestCase[ZbkxFunction.Fn]):
+class TestZbkxUnit(FunctionalUnitTestCase[ZbkxFn.Fn]):
     func_unit = ZbkxComponent()
     zero_imm = False
 
     ops = {
-        ZbkxFunction.Fn.XPERM4: ExecFn(OpType.CROSSBAR_PERMUTATION, Funct3.XPERM4, Funct7.XPERM),
-        ZbkxFunction.Fn.XPERM8: ExecFn(OpType.CROSSBAR_PERMUTATION, Funct3.XPERM8, Funct7.XPERM),
+        ZbkxFn.Fn.XPERM4: ExecFn(OpType.CROSSBAR_PERMUTATION, Funct3.XPERM4, Funct7.XPERM),
+        ZbkxFn.Fn.XPERM8: ExecFn(OpType.CROSSBAR_PERMUTATION, Funct3.XPERM8, Funct7.XPERM),
     }
 
     @staticmethod
-    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbkxFunction.Fn, xlen: int) -> dict[str, int]:
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbkxFn.Fn, xlen: int) -> dict[str, int]:
         result = 0
 
         match fn:
-            case ZbkxFunction.Fn.XPERM4:
+            case ZbkxFn.Fn.XPERM4:
                 lane_count = xlen // 4
                 for lane in range(lane_count):
                     idx = (i2 >> (lane * 4)) & 0xF
                     nibble = ((i1 >> (idx * 4)) & 0xF) if idx < lane_count else 0
                     result |= nibble << (lane * 4)
 
-            case ZbkxFunction.Fn.XPERM8:
+            case ZbkxFn.Fn.XPERM8:
                 lane_count = xlen // 8
                 for lane in range(lane_count):
                     idx = (i2 >> (lane * 8)) & 0xFF

--- a/test/func_blocks/fu/test_zbs.py
+++ b/test/func_blocks/fu/test_zbs.py
@@ -1,35 +1,35 @@
 from coreblocks.arch import Funct3, Funct7, OpType
-from coreblocks.func_blocks.fu.zbs import ZbsFunction, ZbsComponent
+from coreblocks.func_blocks.fu.zbs import ZbsFn, ZbsComponent
 
 from test.func_blocks.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
-class TestZbsUnit(FunctionalUnitTestCase[ZbsFunction.Fn]):
+class TestZbsUnit(FunctionalUnitTestCase[ZbsFn.Fn]):
     func_unit = ZbsComponent()
     zero_imm = False
 
     ops = {
-        ZbsFunction.Fn.BCLR: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BCLR, Funct7.BCLR),
-        ZbsFunction.Fn.BEXT: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BEXT, Funct7.BEXT),
-        ZbsFunction.Fn.BINV: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BINV, Funct7.BINV),
-        ZbsFunction.Fn.BSET: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BSET, Funct7.BSET),
+        ZbsFn.Fn.BCLR: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BCLR, Funct7.BCLR),
+        ZbsFn.Fn.BEXT: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BEXT, Funct7.BEXT),
+        ZbsFn.Fn.BINV: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BINV, Funct7.BINV),
+        ZbsFn.Fn.BSET: ExecFn(OpType.SINGLE_BIT_MANIPULATION, Funct3.BSET, Funct7.BSET),
     }
 
     @staticmethod
-    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbsFunction.Fn, xlen: int) -> dict[str, int]:
+    def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: ZbsFn.Fn, xlen: int) -> dict[str, int]:
         val2 = i_imm if i_imm else i2
 
         match fn:
-            case ZbsFunction.Fn.BCLR:
+            case ZbsFn.Fn.BCLR:
                 index = val2 & (xlen - 1)
                 return {"result": i1 & ~(1 << index)}
-            case ZbsFunction.Fn.BEXT:
+            case ZbsFn.Fn.BEXT:
                 index = val2 & (xlen - 1)
                 return {"result": (i1 >> index) & 1}
-            case ZbsFunction.Fn.BINV:
+            case ZbsFn.Fn.BINV:
                 index = val2 & (xlen - 1)
                 return {"result": i1 ^ (1 << index)}
-            case ZbsFunction.Fn.BSET:
+            case ZbsFn.Fn.BSET:
                 index = val2 & (xlen - 1)
                 return {"result": i1 | (1 << index)}
 


### PR DESCRIPTION
A base class for functional units is added, which factors out common parts. Naming is made consistent across FU implementations.

Replaces #803. Prerequisite for #890. Closes #793.