### PR TITLE
Generalized instruction metric

### DIFF
--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -18,6 +18,7 @@ from coreblocks.core_structs.crat import CheckpointRAT
 from coreblocks.core_structs.rat import RRAT
 from coreblocks.core_structs.rob import ReorderBuffer
 from coreblocks.core_structs.rf import RegisterFile
+from coreblocks.func_blocks.instruction_metrics import InstructionMetrics
 from coreblocks.priv.csr.csr_instances import CSRInstances
 from coreblocks.frontend.frontend import CoreFrontend
 from coreblocks.priv.traps.exception import ExceptionInformationRegister
@@ -120,6 +121,8 @@ class Core(Component):
         m.d.comb += self.interrupt_controller.custom_report.eq(self.interrupts[16:])
 
         m.submodules.core_counter = core_counter = CoreInstructionCounter(self.gen_params)
+
+        m.submodules.instruction_metrics = InstructionMetrics()
 
         get_instr = Method.like(self.frontend.consume_instr)
 

--- a/coreblocks/func_blocks/fu/alu.py
+++ b/coreblocks/func_blocks/fu/alu.py
@@ -237,16 +237,8 @@ class AluFuncUnit(FuncUnitBase[AluFn]):
     def __init__(self, gen_params: GenParams, fn=AluFn()):
         super().__init__(gen_params, fn)
 
-        self.perf_instr = TaggedCounter(
-            "backend.fu.alu.instr",
-            "Counts of instructions executed by the jumpbranch unit",
-            tags=AluFn.Fn,
-        )
-
     def elaborate(self, platform):
         m = super().elaborate(platform)
-
-        m.submodules += [self.perf_instr]
 
         m.submodules.alu = alu = Alu(self.gen_params, alu_fn=self.fn)
 
@@ -255,8 +247,6 @@ class AluFuncUnit(FuncUnitBase[AluFn]):
             m.d.av_comb += alu.fn.eq(arg.decode_fn)
             m.d.av_comb += alu.in1.eq(arg.s1_val)
             m.d.av_comb += alu.in2.eq(Mux(arg.imm, arg.imm, arg.s2_val))
-
-            self.perf_instr.incr(m, arg.decode_fn)
 
             self.push_result(m, rob_id=arg.rob_id, result=alu.out, rp_dst=arg.rp_dst, exception=0)
 

--- a/coreblocks/func_blocks/fu/alu.py
+++ b/coreblocks/func_blocks/fu/alu.py
@@ -250,15 +250,13 @@ class AluFuncUnit(FuncUnitBase[AluFn]):
 
         m.submodules.alu = alu = Alu(self.gen_params, alu_fn=self.fn)
 
-        @def_method(m, self.issue)
+        @def_method(m, self.issue_decoded)
         def _(arg):
-            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
-            m.d.av_comb += alu.fn.eq(self.decoder.decode_fn)
-
+            m.d.av_comb += alu.fn.eq(arg.decode_fn)
             m.d.av_comb += alu.in1.eq(arg.s1_val)
             m.d.av_comb += alu.in2.eq(Mux(arg.imm, arg.imm, arg.s2_val))
 
-            self.perf_instr.incr(m, self.decoder.decode_fn)
+            self.perf_instr.incr(m, arg.decode_fn)
 
             self.push_result(m, rob_id=arg.rob_id, result=alu.out, rp_dst=arg.rp_dst, exception=0)
 

--- a/coreblocks/func_blocks/fu/common/func_base.py
+++ b/coreblocks/func_blocks/fu/common/func_base.py
@@ -29,8 +29,9 @@ class FuncUnitBase(ABC, FuncUnit, Elaboratable, Generic[_T_DecoderManager]):
         self.increment_counter = HwMetric.wrap_method(Method(i=[("tag", fn.Fn)]))
         self.fn = fn
 
-        dm = DependencyContext.get()
-        dm.add_dependency(InstructionTaggedCounterKey(), (self.__class__.__name__, self.increment_counter))
+        if HwMetric.metrics_enabled():
+            dm = DependencyContext.get()
+            dm.add_dependency(InstructionTaggedCounterKey(), (self.__class__.__name__, self.increment_counter))
 
     @abstractmethod
     def elaborate(self, platform) -> TModule:

--- a/coreblocks/func_blocks/fu/common/func_base.py
+++ b/coreblocks/func_blocks/fu/common/func_base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 from amaranth import Elaboratable, Signal
 from transactron import Method, TModule, def_method
+from transactron.lib import HwMetric
 from transactron.utils import DependencyContext, assign, extend_layout
 from coreblocks.params import GenParams
 from coreblocks.interface.keys import InstructionTaggedCounterKey
@@ -25,7 +26,7 @@ class FuncUnitBase(ABC, FuncUnit, Elaboratable, Generic[_T_DecoderManager]):
         self.issue = Method(i=self.layouts.issue)
         self.issue_decoded = Method(i=extend_layout(self.layouts.issue, ("decode_fn", fn.Fn)))
         self.push_result = Method(i=self.layouts.push_result)
-        self.increment_counter = Method(i=[("tag", fn.Fn)])
+        self.increment_counter = HwMetric.wrap_method(Method(i=[("tag", fn.Fn)]))
         self.fn = fn
 
         dm = DependencyContext.get()

--- a/coreblocks/func_blocks/fu/common/func_base.py
+++ b/coreblocks/func_blocks/fu/common/func_base.py
@@ -2,8 +2,9 @@ from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 from amaranth import Elaboratable, Signal
 from transactron import Method, TModule, def_method
-from transactron.utils import assign, extend_layout
+from transactron.utils import DependencyContext, assign, extend_layout
 from coreblocks.params import GenParams
+from coreblocks.interface.keys import InstructionTaggedCounterKey
 from coreblocks.interface.layouts import FuncUnitLayouts
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 from coreblocks.func_blocks.fu.common.fu_decoder import DecoderManager
@@ -24,7 +25,11 @@ class FuncUnitBase(ABC, FuncUnit, Elaboratable, Generic[_T_DecoderManager]):
         self.issue = Method(i=self.layouts.issue)
         self.issue_decoded = Method(i=extend_layout(self.layouts.issue, ("decode_fn", fn.Fn)))
         self.push_result = Method(i=self.layouts.push_result)
+        self.increment_counter = Method(i=[("tag", fn.Fn)])
         self.fn = fn
+
+        dm = DependencyContext.get()
+        dm.add_dependency(InstructionTaggedCounterKey(), (self.__class__.__name__, self.increment_counter))
 
     @abstractmethod
     def elaborate(self, platform) -> TModule:
@@ -39,5 +44,7 @@ class FuncUnitBase(ABC, FuncUnit, Elaboratable, Generic[_T_DecoderManager]):
             m.d.av_comb += assign(new_arg, arg)
             m.d.av_comb += new_arg.decode_fn.eq(decoder.decode_fn)
             self.issue_decoded(m, new_arg)
+
+            self.increment_counter(m, decoder.decode_fn)
 
         return m

--- a/coreblocks/func_blocks/fu/common/func_base.py
+++ b/coreblocks/func_blocks/fu/common/func_base.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
-from amaranth import Elaboratable
-from transactron import Method, TModule
+from amaranth import Elaboratable, Signal
+from transactron import Method, TModule, def_method
+from transactron.utils import assign, extend_layout
 from coreblocks.params import GenParams
 from coreblocks.interface.layouts import FuncUnitLayouts
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
@@ -21,14 +22,22 @@ class FuncUnitBase(ABC, FuncUnit, Elaboratable, Generic[_T_DecoderManager]):
         self.gen_params = gen_params
         self.layouts = gen_params.get(FuncUnitLayouts)
         self.issue = Method(i=self.layouts.issue)
+        self.issue_decoded = Method(i=extend_layout(self.layouts.issue, ("decode_fn", fn.Fn)))
         self.push_result = Method(i=self.layouts.push_result)
         self.fn = fn
-        self.decoder = fn.get_decoder(gen_params)
 
     @abstractmethod
     def elaborate(self, platform) -> TModule:
         m = TModule()
 
-        m.submodules.decoder = self.decoder
+        m.submodules.decoder = decoder = self.fn.get_decoder(self.gen_params)
+
+        @def_method(m, self.issue)
+        def _(arg):
+            new_arg = Signal(self.issue_decoded.layout_in)
+            m.d.av_comb += decoder.exec_fn.eq(arg.exec_fn)
+            m.d.av_comb += assign(new_arg, arg)
+            m.d.av_comb += new_arg.decode_fn.eq(decoder.decode_fn)
+            self.issue_decoded(m, new_arg)
 
         return m

--- a/coreblocks/func_blocks/fu/div_unit.py
+++ b/coreblocks/func_blocks/fu/div_unit.py
@@ -67,9 +67,8 @@ class DivUnit(FuncUnitBase[DivFn]):
         def _():
             divider.clear(m)
 
-        @def_method(m, self.issue)
+        @def_method(m, self.issue_decoded)
         def _(arg):
-            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
             i1, i2 = get_input(arg)
 
             flip_sign = Signal(1)  # if result is negative number
@@ -81,7 +80,7 @@ class DivUnit(FuncUnitBase[DivFn]):
             def _abs(s: Value) -> Value:
                 return Mux(s.as_signed() < 0, -s, s)
 
-            with OneHotSwitch(m, self.decoder.decode_fn) as OneHotCase:
+            with OneHotSwitch(m, arg.decode_fn) as OneHotCase:
                 with OneHotCase(DivFn.Fn.DIVU):
                     m.d.av_comb += flip_sign.eq(0)
                     m.d.av_comb += rem_res.eq(0)

--- a/coreblocks/func_blocks/fu/exception.py
+++ b/coreblocks/func_blocks/fu/exception.py
@@ -51,16 +51,14 @@ class ExceptionFuncUnit(FuncUnitBase[ExceptionUnitFn]):
     def elaborate(self, platform):
         m = super().elaborate(platform)
 
-        @def_method(m, self.issue)
+        @def_method(m, self.issue_decoded)
         def _(arg):
-            m.d.comb += self.decoder.exec_fn.eq(arg.exec_fn)
-
             cause = Signal(ExceptionCause)
             mtval = Signal(self.gen_params.isa.xlen)
 
             priv_level = self.dm.get_dependency(CSRInstancesKey()).m_mode.priv_mode.read(m).data
 
-            with OneHotSwitch(m, self.decoder.decode_fn) as OneHotCase:
+            with OneHotSwitch(m, arg.decode_fn) as OneHotCase:
                 with OneHotCase(ExceptionUnitFn.Fn.EBREAK):
                     m.d.av_comb += cause.eq(ExceptionCause.BREAKPOINT)
                     m.d.av_comb += mtval.eq(arg.pc)

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -230,11 +230,9 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
                 exception=exception,
             )
 
-        @def_method(m, self.issue)
+        @def_method(m, self.issue_decoded)
         def _(arg):
-            m.d.top_comb += self.decoder.exec_fn.eq(arg.exec_fn)
-            m.d.top_comb += jb.fn.eq(self.decoder.decode_fn)
-
+            m.d.top_comb += jb.fn.eq(arg.decode_fn)
             m.d.top_comb += jb.in1.eq(arg.s1_val)
             m.d.top_comb += jb.in2.eq(arg.s2_val)
             m.d.top_comb += jb.in_pc.eq(arg.pc)
@@ -251,14 +249,14 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
                 rob_id=arg.rob_id,
                 pc=arg.pc,
                 rp_dst=arg.rp_dst,
-                type=self.decoder.decode_fn,
+                type=arg.decode_fn,
                 jmp_addr=jb.jmp_addr,
                 reg_res=jb.reg_res,
                 taken=jb.taken,
                 predicted_taken=funct7_info.predicted_taken,
                 tag=arg.tag,
             )
-            self.perf_instr.incr(m, self.decoder.decode_fn)
+            self.perf_instr.incr(m, arg.decode_fn)
 
         return m
 

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -115,11 +115,6 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
         self.dm = DependencyContext.get()
         self.dm.add_dependency(BranchVerifyKey(), self.fifo_branch_resolved.read)
 
-        self.perf_instr = TaggedCounter(
-            "backend.fu.jumpbranch.instr",
-            "Counts of instructions executed by the jumpbranch unit",
-            tags=JumpBranchFn.Fn,
-        )
         self.perf_misaligned = HwCounter(
             "backend.fu.jumpbranch.misaligned", "Number of instructions with misaligned target address"
         )
@@ -131,7 +126,6 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
         m = super().elaborate(platform)
 
         m.submodules += [
-            self.perf_instr,
             self.perf_misaligned,
             self.perf_mispredictions,
         ]
@@ -256,7 +250,6 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
                 predicted_taken=funct7_info.predicted_taken,
                 tag=arg.tag,
             )
-            self.perf_instr.incr(m, arg.decode_fn)
 
         return m
 

--- a/coreblocks/func_blocks/fu/mul_unit.py
+++ b/coreblocks/func_blocks/fu/mul_unit.py
@@ -132,9 +132,8 @@ class MulUnit(FuncUnitBase[MulFn]):
         #
         # half_sign_bit = xlen // 2 - 1  # position of sign bit considering only half of input being used
 
-        @def_method(m, self.issue)
+        @def_method(m, self.issue_decoded)
         def _(arg):
-            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
             i1, i2 = get_input(arg)
 
             value1 = Signal(self.gen_params.isa.xlen)  # input value for multiplier submodule
@@ -147,7 +146,7 @@ class MulUnit(FuncUnitBase[MulFn]):
             # which part of result we want upper or lower part. In the future, it would be a great improvement
             # to save result for chain multiplication of this same numbers, but with different parts as
             # results
-            with OneHotSwitch(m, self.decoder.decode_fn) as OneHotCase:
+            with OneHotSwitch(m, arg.decode_fn) as OneHotCase:
                 with OneHotCase(MulFn.Fn.MUL):  # MUL
                     # In this case we care only about lower part of number, so it does not matter if it is
                     # interpreted as binary number or U2 encoded number, so we set result to be interpreted as

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -79,14 +79,13 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
         flush_icache = self.dm.get_dependency(FlushICacheKey())
         resume_core = self.dm.get_dependency(UnsafeInstructionResolvedKey())
 
-        @def_method(m, self.issue, ready=~instr_valid)
+        @def_method(m, self.issue_decoded, ready=~instr_valid)
         def _(arg):
-            m.d.comb += self.decoder.exec_fn.eq(arg.exec_fn)
             m.d.sync += [
                 instr_valid.eq(1),
                 instr_rob.eq(arg.rob_id),
                 instr_pc.eq(arg.pc),
-                instr_fn.eq(self.decoder.decode_fn),
+                instr_fn.eq(arg.decode_fn),
             ]
 
         with Transaction().body(m, ready=instr_valid & ~finished):

--- a/coreblocks/func_blocks/fu/shift_unit.py
+++ b/coreblocks/func_blocks/fu/shift_unit.py
@@ -83,11 +83,9 @@ class ShiftFuncUnit(FuncUnitBase[ShiftUnitFn]):
 
         m.submodules.shift_alu = shift_alu = ShiftUnit(self.gen_params, shift_unit_fn=self.fn)
 
-        @def_method(m, self.issue)
+        @def_method(m, self.issue_decoded)
         def _(arg):
-            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
-            m.d.av_comb += shift_alu.fn.eq(self.decoder.decode_fn)
-
+            m.d.av_comb += shift_alu.fn.eq(arg.decode_fn)
             m.d.av_comb += shift_alu.in1.eq(arg.s1_val)
             m.d.av_comb += shift_alu.in2.eq(Mux(arg.imm, arg.imm, arg.s2_val))
 

--- a/coreblocks/func_blocks/fu/zbc.py
+++ b/coreblocks/func_blocks/fu/zbc.py
@@ -184,10 +184,8 @@ class ZbcUnit(FuncUnitBase[ZbcFn]):
 
             self.push_result(m, rob_id=params.rob_id, rp_dst=params.rp_dst, result=reversed_result, exception=0)
 
-        @def_method(m, self.issue)
-        def _(exec_fn, imm, s1_val, s2_val, rob_id, rp_dst, pc, tag):
-            m.d.av_comb += self.decoder.exec_fn.eq(exec_fn)
-
+        @def_method(m, self.issue_decoded)
+        def _(exec_fn, decode_fn, imm, s1_val, s2_val, rob_id, rp_dst, pc, tag):
             i1 = s1_val
             i2 = Mux(imm, imm, s2_val)
 
@@ -196,7 +194,7 @@ class ZbcUnit(FuncUnitBase[ZbcFn]):
             high_res = Signal(1)
             rev_res = Signal(1)
 
-            with OneHotSwitch(m, self.decoder.decode_fn) as OneHotCase:
+            with OneHotSwitch(m, decode_fn) as OneHotCase:
                 with OneHotCase(ZbcFn.Fn.CLMUL):
                     m.d.av_comb += high_res.eq(0)
                     m.d.av_comb += rev_res.eq(0)

--- a/coreblocks/func_blocks/fu/zbkx.py
+++ b/coreblocks/func_blocks/fu/zbkx.py
@@ -64,11 +64,9 @@ class ZbkxUnit(FuncUnitBase[ZbkxFn]):
 
         m.submodules.zbkx = zbkx = Zbkx(self.gen_params, fn=self.fn)
 
-        @def_method(m, self.issue)
+        @def_method(m, self.issue_decoded)
         def _(arg):
-            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
-
-            m.d.av_comb += zbkx.fn.eq(self.decoder.decode_fn)
+            m.d.av_comb += zbkx.fn.eq(arg.decode_fn)
             m.d.av_comb += zbkx.in1.eq(arg.s1_val)
             m.d.av_comb += zbkx.in2.eq(arg.s2_val)
 

--- a/coreblocks/func_blocks/fu/zbs.py
+++ b/coreblocks/func_blocks/fu/zbs.py
@@ -95,11 +95,9 @@ class ZbsUnit(FuncUnitBase[ZbsFn]):
 
         m.submodules.zbs = zbs = Zbs(self.gen_params, fn=self.fn)
 
-        @def_method(m, self.issue)
+        @def_method(m, self.issue_decoded)
         def _(arg):
-            m.d.av_comb += self.decoder.exec_fn.eq(arg.exec_fn)
-
-            m.d.av_comb += zbs.fn.eq(self.decoder.decode_fn)
+            m.d.av_comb += zbs.fn.eq(arg.decode_fn)
             m.d.av_comb += zbs.in1.eq(arg.s1_val)
             m.d.av_comb += zbs.in2.eq(Mux(arg.imm, arg.imm, arg.s2_val))
 

--- a/coreblocks/func_blocks/instruction_metrics.py
+++ b/coreblocks/func_blocks/instruction_metrics.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+from enum import Enum
+from amaranth import Elaboratable
+from transactron import Method, TModule
+from transactron.utils import DependencyContext
+from transactron.lib.metrics import TaggedCounter
+from coreblocks.interface.keys import InstructionTaggedCounterKey
+
+
+__all__ = ["InstructionMetrics"]
+
+
+class InstructionMetrics(Elaboratable):
+    def elaborate(self, platform):
+        m = TModule()
+
+        dm = DependencyContext.get()
+        incr_methods = dm.get_dependency(InstructionTaggedCounterKey())
+
+        incr_methods_by_tag_type: defaultdict[tuple[str, type[Enum]], list[Method]] = defaultdict(list)
+        for fu_name, method in incr_methods:
+            tag_type = method.layout_in.members["tag"]
+            assert isinstance(tag_type, type) and issubclass(tag_type, Enum)
+            incr_methods_by_tag_type[(fu_name, tag_type)].append(method)
+
+        for (fu_name, tag_type), methods in incr_methods_by_tag_type.items():
+            m.submodules[f"counter_{fu_name}_{tag_type.__qualname__}"] = counter = TaggedCounter(
+                f"backend.fu.{fu_name}.{tag_type.__qualname__}",
+                f"Counts of instructions executed by {fu_name} for tag {tag_type.__qualname__}",
+                tags=tag_type,
+                ways=len(methods),
+            )
+
+            for incr_method, method in zip(counter.incr, methods):
+                method.provide(incr_method)
+
+        return m

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -26,6 +26,7 @@ __all__ = [
     "CSRListKey",
     "FlushICacheKey",
     "RollbackKey",
+    "InstructionTaggedCounterKey",
 ]
 
 
@@ -113,6 +114,17 @@ class RollbackKey(UnifierKey, unifier=MethodProduct.create):
     """
     Collects method that want to be notifed about tag rollback event.
     Expected layout is `RATLayouts.rollback_in`.
+    """
+
+    pass
+
+
+@dataclass(frozen=True)
+class InstructionTaggedCounterKey(ListKey[tuple[str, Method]]):
+    """
+    Collects methods called on instruction issue, paired with FU name.
+    The method must have a tag argument, which will be passed to a `TaggedCounter`.
+    A separate counter will be created for different tag types.
     """
 
     pass

--- a/test/func_blocks/fu/functional_common.py
+++ b/test/func_blocks/fu/functional_common.py
@@ -113,7 +113,7 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
         DependencyContext.get().add_dependency(AsyncInterruptInsertSignalKey(), Signal())
         DependencyContext.get().add_dependency(CSRInstancesKey(), self.csrs)
 
-        self.m = SimpleTestCircuit(self.func_unit.get_module(self.gen_params))
+        self.m = SimpleTestCircuit(self.func_unit.get_module(self.gen_params), exclude=["increment_counter"])
         self.circ = ModuleConnector(dut=self.m, report_mock=self.report_mock, csrs=self.csrs)
 
         random.seed(self.seed)


### PR DESCRIPTION
Adds superscalar-ready, generalized instruction count metrics.

Accuracy is not yet solved - the module counts all issued instructions, including rollbacked ones.

TODO:
* [x] Fix tests.

Closes #890. Required for #889.