### PR TITLE
Implement MMU

### DIFF
--- a/coreblocks/arch/isa_consts.py
+++ b/coreblocks/arch/isa_consts.py
@@ -242,6 +242,11 @@ class SatpMode(IntEnum, shape=4):
             case _:
                 raise ValueError(f"Unsupported XLEN for SATP mode encoding: {xlen}")
 
+    @staticmethod
+    def bits_per_page_table_level(xlen: int) -> int:
+        """Number of virtual address bits translated at each page table level for a given XLEN."""
+        return 10 if xlen == 32 else 9
+
     @classmethod
     def mode_dependencies(cls, mode: "SatpMode") -> Set["SatpMode"]:
         match mode:
@@ -251,6 +256,23 @@ class SatpMode(IntEnum, shape=4):
                 return frozenset({cls.SV39})
             case cls.SV57:
                 return frozenset({cls.SV48})
+            case _:
+                raise ValueError(f"Unsupported SATP mode: {mode}")
+
+    @classmethod
+    def level_count(cls, mode: "SatpMode") -> int:
+        """Number of page table levels for a given SATP mode."""
+        match mode:
+            case cls.BARE:
+                return 0
+            case cls.SV32:
+                return 2
+            case cls.SV39:
+                return 3
+            case cls.SV48:
+                return 4
+            case cls.SV57:
+                return 5
             case _:
                 raise ValueError(f"Unsupported SATP mode: {mode}")
 

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -152,7 +152,7 @@ class FetchUnit(Elaboratable):
             log.info(m, True, "[IFU] request pc=0x{:x}", pc)
             req_counter.acquire(m)
 
-            addr_translator.request(m, addr=pc)
+            addr_translator.request(m, addr=pc, write_aspect=0)
 
         with Transaction().body(m):
             translated = addr_translator.accept(m)

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -96,7 +96,7 @@ class LSUDummy(FuncUnit, Elaboratable):
                 addr = Signal(self.gen_params.isa.xlen)
                 m.d.av_comb += addr.eq(arg.s1_val + arg.imm)
 
-                addr_translator.request(m, addr=addr)
+                addr_translator.request(m, addr=addr, write_aspect=arg.exec_fn.op_type == OpType.STORE)
                 requests.write(m, arg)
             with m.Else():
                 results_noop.write(m, data=0, exception=0, cause=0, addr=0)

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -4,7 +4,7 @@ from amaranth.lib import data
 
 from enum import IntFlag, auto, unique
 from typing import Sequence
-from coreblocks.arch.isa_consts import Funct12, Funct3, Funct7, Opcode, PrivilegeLevel
+from coreblocks.arch.isa_consts import Funct12, Funct3, Funct7, Opcode, PrivilegeLevel, SatpMode
 
 
 from transactron import *

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -4,7 +4,7 @@ from amaranth.lib import data
 
 from enum import IntFlag, auto, unique
 from typing import Sequence
-from coreblocks.arch.isa_consts import Funct12, Funct3, Funct7, Opcode, PrivilegeLevel, SatpMode
+from coreblocks.arch.isa_consts import Funct12, Funct3, Funct7, Opcode, PrivilegeLevel
 
 
 from transactron import *
@@ -27,6 +27,7 @@ from coreblocks.interface.keys import (
     UnsafeInstructionResolvedKey,
     FlushICacheKey,
     WaitForInterruptResumeKey,
+    SFenceVMAKey,
 )
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 
@@ -89,6 +90,8 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
         instr_imm = Signal(self.gen_params.isa.xlen)
         instr_s1_val = Signal(self.gen_params.isa.xlen)
         instr_s2_val = Signal(self.gen_params.isa.xlen)
+        instr_s1_x0 = Signal()
+        instr_s2_x0 = Signal()
 
         mret = self.dm.get_dependency(MretKey())
         sret = self.dm.get_optional_dependency(SretKey())
@@ -97,6 +100,7 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
         csr = self.dm.get_dependency(CSRInstancesKey())
         priv_mode = csr.m_mode.priv_mode
         flush_icache = self.dm.get_dependency(FlushICacheKey())
+        sfence_vma = self.dm.get_optional_dependency(SFenceVMAKey())
         resume_core = self.dm.get_dependency(UnsafeInstructionResolvedKey())
 
         @def_method(m, self.issue_decoded, ready=~instr_valid)
@@ -108,6 +112,8 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
                 instr_fn.eq(arg.decode_fn),
                 instr_s1_val.eq(arg.s1_val),
                 instr_s2_val.eq(arg.s2_val),
+                instr_s1_x0.eq(arg.rp_s1_reg == 0),
+                instr_s2_x0.eq(arg.rp_s2_reg == 0),
                 instr_imm.eq(arg.imm),
             ]
 
@@ -150,8 +156,10 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
                     with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.SRET) & ~illegal_sret):
                         sret(m)
 
-                    # TODO: implement proper SFENCE.VMA, for BARE only - NO-OP is ok
-                    assert self.gen_params.vmem_params.supported_schemes == {SatpMode.BARE}
+                    if self.gen_params.vmem_params.supported_schemes > {SatpMode.BARE}:
+                        assert sfence_vma is not None
+                        with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.SFENCEVMA) & ~illegal_sfencevma):
+                            sfence_vma[0](m, vaddr=instr_s1_val, asid=instr_s2_val, all_vaddrs=instr_s1_x0, all_asids=instr_s2_x0)
 
                 with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.FENCEI)):
                     flush_icache(m)

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -159,7 +159,9 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
                     if self.gen_params.vmem_params.supported_schemes > {SatpMode.BARE}:
                         assert sfence_vma is not None
                         with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.SFENCEVMA) & ~illegal_sfencevma):
-                            sfence_vma[0](m, vaddr=instr_s1_val, asid=instr_s2_val, all_vaddrs=instr_s1_x0, all_asids=instr_s2_x0)
+                            sfence_vma[0](
+                                m, vaddr=instr_s1_val, asid=instr_s2_val, all_vaddrs=instr_s1_x0, all_asids=instr_s2_x0
+                            )
 
                 with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.FENCEI)):
                     flush_icache(m)

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -90,8 +90,6 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
         instr_imm = Signal(self.gen_params.isa.xlen)
         instr_s1_val = Signal(self.gen_params.isa.xlen)
         instr_s2_val = Signal(self.gen_params.isa.xlen)
-        instr_s1_x0 = Signal()
-        instr_s2_x0 = Signal()
 
         mret = self.dm.get_dependency(MretKey())
         sret = self.dm.get_optional_dependency(SretKey())
@@ -112,8 +110,6 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
                 instr_fn.eq(arg.decode_fn),
                 instr_s1_val.eq(arg.s1_val),
                 instr_s2_val.eq(arg.s2_val),
-                instr_s1_x0.eq(arg.rp_s1_reg == 0),
-                instr_s2_x0.eq(arg.rp_s2_reg == 0),
                 instr_imm.eq(arg.imm),
             ]
 
@@ -159,8 +155,14 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
                     if self.gen_params.vmem_params.supported_schemes > {SatpMode.BARE}:
                         assert sfence_vma is not None
                         with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.SFENCEVMA) & ~illegal_sfencevma):
+                            imm_view = data.View(self.gen_params.get(PrivUnitLayouts).sfencevma_imm_layout, instr_imm)
+
                             sfence_vma[0](
-                                m, vaddr=instr_s1_val, asid=instr_s2_val, all_vaddrs=instr_s1_x0, all_asids=instr_s2_x0
+                                m,
+                                vaddr=instr_s1_val,
+                                asid=instr_s2_val,
+                                all_vaddrs=imm_view.rs1 == 0,
+                                all_asids=imm_view.rs2 == 0,
                             )
 
                 with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.FENCEI)):

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -7,11 +7,11 @@ from transactron.lib.transformers import MethodProduct
 from transactron import Method, TModule
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
 from coreblocks.func_blocks.csr.csr_protocol import RegisteredCSRProtocol
-from amaranth import Elaboratable, Signal
+from amaranth import Signal
 
 if TYPE_CHECKING:
     from coreblocks.priv.csr.csr_instances import CSRInstances  # noqa: F401
-    from coreblocks.priv.vmem.tlb import PageTableWalker, TLB  # noqa: F401
+    from coreblocks.priv.vmem.iface import TLBBackingDevice  # noqa: F401
 
 __all__ = [
     "CommonBusDataKey",
@@ -29,7 +29,7 @@ __all__ = [
     "CSRListKey",
     "FlushICacheKey",
     "SFenceVMAKey",
-    "L1TLBBackingDevice",
+    "L1TLBBackingDeviceKey",
     "RollbackKey",
     "InstructionTaggedCounterKey",
 ]
@@ -129,7 +129,7 @@ class SFenceVMAKey(UnifierKey, unifier=MethodProduct.create):
 
 
 @dataclass(frozen=True)
-class L1TLBBackingDevice(SimpleKey[Elaboratable]):
+class L1TLBBackingDeviceKey(SimpleKey["TLBBackingDevice"]):
     """Used to provide a component that can be used as a backing device for the L1 TLB."""
 
     pass

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -27,6 +27,7 @@ __all__ = [
     "CoreStateKey",
     "CSRListKey",
     "FlushICacheKey",
+    "SFenceVMAKey",
     "RollbackKey",
     "InstructionTaggedCounterKey",
 ]
@@ -114,6 +115,16 @@ class CSRListKey(ListKey[tuple[int, RegisteredCSRProtocol]]):
 
 @dataclass(frozen=True)
 class FlushICacheKey(SimpleKey[Method]):
+    pass
+
+
+@dataclass(frozen=True)
+class SFenceVMAKey(UnifierKey, unifier=MethodProduct.create):
+    """
+    Collects SFENCE.VMA handlers to invalidate translation caches.
+    Expected layout is `AddressTranslationLayouts.sfence_vma`.
+    """
+
     pass
 
 

--- a/coreblocks/interface/keys.py
+++ b/coreblocks/interface/keys.py
@@ -7,10 +7,11 @@ from transactron.lib.transformers import MethodProduct
 from transactron import Method, TModule
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
 from coreblocks.func_blocks.csr.csr_protocol import RegisteredCSRProtocol
-from amaranth import Signal
+from amaranth import Elaboratable, Signal
 
 if TYPE_CHECKING:
     from coreblocks.priv.csr.csr_instances import CSRInstances  # noqa: F401
+    from coreblocks.priv.vmem.tlb import PageTableWalker, TLB  # noqa: F401
 
 __all__ = [
     "CommonBusDataKey",
@@ -28,6 +29,7 @@ __all__ = [
     "CSRListKey",
     "FlushICacheKey",
     "SFenceVMAKey",
+    "L1TLBBackingDevice",
     "RollbackKey",
     "InstructionTaggedCounterKey",
 ]
@@ -124,6 +126,11 @@ class SFenceVMAKey(UnifierKey, unifier=MethodProduct.create):
     Collects SFENCE.VMA handlers to invalidate translation caches.
     Expected layout is `AddressTranslationLayouts.sfence_vma`.
     """
+
+
+@dataclass(frozen=True)
+class L1TLBBackingDevice(SimpleKey[Elaboratable]):
+    """Used to provide a component that can be used as a backing device for the L1 TLB."""
 
     pass
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -181,6 +181,13 @@ class AddressTranslationLayouts:
             ("access_fault", 1),
         )
 
+        self.sfence_vma = make_layout(
+            fields.vaddr,
+            ("asid", gen_params.vmem_params.asidlen),
+            ("all_vaddrs", 1),
+            ("all_asids", 1),
+        )
+
 
 class SchedulerLayouts:
     """Layouts used in the scheduler."""

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -203,7 +203,6 @@ class AddressTranslationLayouts:
 
         self.tlb_request = make_layout(
             self.vpn,
-            self.asid,
             ("write_aspect", 1),
         )
         self.tlb_accept = make_layout(

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -1,6 +1,6 @@
 from amaranth import signed
 from amaranth.lib.data import ArrayLayout
-from amaranth.lib.enum import IntFlag, auto
+from amaranth.lib.enum import IntFlag, IntEnum, auto
 from coreblocks.params import GenParams
 from coreblocks.arch import *
 from transactron.utils import LayoutList, LayoutListField, layout_subset
@@ -169,7 +169,7 @@ class CommonLayoutFields:
 class AddressTranslationLayouts:
     """Layouts used by virtual-to-physical address translation methods."""
 
-    class TLBResult(IntFlag):
+    class TLBResult(IntEnum, shape=2):
         HIT = auto()
         PAGE_FAULT = auto()
         ACCESS_FAULT = auto()

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -169,11 +169,31 @@ class CommonLayoutFields:
 class AddressTranslationLayouts:
     """Layouts used by virtual-to-physical address translation methods."""
 
+    class TLBResult(IntFlag):
+        HIT = auto()
+        PAGE_FAULT = auto()
+        ACCESS_FAULT = auto()
+
     def __init__(self, gen_params: GenParams):
         fields = gen_params.get(CommonLayoutFields)
 
-        self.request = make_layout(fields.addr)
+        self.ppn = ("ppn", gen_params.phys_addr_bits - PAGE_SIZE_LOG)
+        self.vpn = ("vpn", gen_params.vmem_params.max_tlb_vpn_bits)
+        self.asid = ("asid", gen_params.vmem_params.asidlen)
+        self.permissions = make_layout(
+            ("r", 1),
+            ("w", 1),
+            ("x", 1),
+            ("u", 1),
+            ("d", 1),
+            ("g", 1),
+        )
+        self.size_class = ("size_class", gen_params.vmem_params.tlb_size_class_bits)
 
+        self.request = make_layout(
+            fields.addr,
+            ("write_aspect", 1),
+        )
         self.accept = make_layout(
             fields.vaddr,
             fields.paddr,
@@ -181,9 +201,21 @@ class AddressTranslationLayouts:
             ("access_fault", 1),
         )
 
+        self.tlb_request = make_layout(
+            self.vpn,
+            self.asid,
+            ("write_aspect", 1),
+        )
+        self.tlb_accept = make_layout(
+            ("result", self.TLBResult),
+            self.ppn,
+            ("permissions", self.permissions),
+            self.size_class,
+        )
+
         self.sfence_vma = make_layout(
             fields.vaddr,
-            ("asid", gen_params.vmem_params.asidlen),
+            self.asid,
             ("all_vaddrs", 1),
             ("all_asids", 1),
         )

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -10,6 +10,7 @@ from amaranth.lib.memory import Memory
 
 from coreblocks.arch.isa import Extension
 from coreblocks.params.fu_params import BlockComponentParams
+from coreblocks.params.vmem_params import TLBCacheConfiguration
 
 from coreblocks.func_blocks.fu.common.rs_func_block import RSBlockComponent
 from coreblocks.func_blocks.fu.common.fifo_rs import FifoRS
@@ -128,6 +129,8 @@ class _CoreConfigurationDataClass:
         SV32 enabled, 32 for RV32 with only BARE mode and 56 for RV64.
     hpm_counters_count: int
         Number of implemented HPM counters (mhpmcounter3..mhpmcounter31).
+    tlb_config: TLBCacheConfiguration
+        Grouped TLB configuration for L1I, L1D, and shared L2.
     pmp_register_count: int
         Number of Physical Memory Protection CSR entries. Valid values are: 0, 16, and 64.
     pmp_grain_log: int
@@ -196,6 +199,8 @@ class _CoreConfigurationDataClass:
     supported_vm_schemes: Collection[SatpMode] = (SatpMode.BARE,)
     phys_addr_bits: int | None = None
     hpm_counters_count: int = 0
+
+    tlb_config: TLBCacheConfiguration = field(default_factory=TLBCacheConfiguration)
 
     pmp_register_count: int = 0
     pmp_grain_log: int = 5

--- a/coreblocks/params/core_configuration.py
+++ b/coreblocks/params/core_configuration.py
@@ -24,6 +24,7 @@ from coreblocks.func_blocks.fu.lsu.dummyLsu import LSUComponent
 from coreblocks.func_blocks.fu.lsu.pma import PMARegion
 from coreblocks.func_blocks.csr.csr_unit import CSRBlockComponent
 from coreblocks.arch.isa_consts import SatpMode
+from coreblocks.params.vmem_params import TLBCacheConfiguration
 
 __all__ = [
     "CoreConfiguration",
@@ -119,6 +120,8 @@ class _CoreConfigurationDataClass:
         SV32 enabled, 32 for RV32 with only BARE mode and 56 for RV64.
     hpm_counters_count: int
         Number of implemented HPM counters (mhpmcounter3..mhpmcounter31).
+    tlb_config: TLBCacheConfiguration
+        Grouped TLB configuration for L1I, L1D, and shared L2 - only applicable when SV* modes are supported.
     pmp_register_count: int
         Number of Physical Memory Protection CSR entries. Valid values are: 0, 16, and 64.
     pmp_grain_log: int
@@ -187,6 +190,8 @@ class _CoreConfigurationDataClass:
     supported_vm_schemes: Collection[SatpMode] = (SatpMode.BARE,)
     phys_addr_bits: int | None = None
     hpm_counters_count: int = 0
+
+    tlb_config: TLBCacheConfiguration = TLBCacheConfiguration()
 
     pmp_register_count: int = 0
     pmp_grain_log: int = 5

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -125,6 +125,20 @@ class GenParams(DependentCache):
         self.supervisor_mode = cfg.supervisor_mode
         self.hpm_counters_count = cfg.hpm_counters_count
 
+        self.tlb_config = cfg.tlb_config
+
+        for name, tlb_cfg in (
+            ("itlb", self.tlb_config.itlb),
+            ("dtlb", self.tlb_config.dtlb),
+            ("l2tlb", self.tlb_config.l2tlb),
+        ):
+            if tlb_cfg.entries <= 0:
+                raise ValueError(f"{name} entries must be positive")
+            if tlb_cfg.ways <= 0:
+                raise ValueError(f"{name} ways must be positive")
+            if tlb_cfg.entries % tlb_cfg.ways != 0:
+                raise ValueError(f"{name} entries must be divisible by ways")
+
         if self.hpm_counters_count < 0 or self.hpm_counters_count > 29:
             raise ValueError("HPM counters count must be in range [0, 29]")
 

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -127,17 +127,16 @@ class GenParams(DependentCache):
 
         self.tlb_config = cfg.tlb_config
 
-        for name, tlb_cfg in (
-            ("itlb", self.tlb_config.itlb),
-            ("dtlb", self.tlb_config.dtlb),
-            ("l2tlb", self.tlb_config.l2tlb),
-        ):
-            if tlb_cfg.entries <= 0:
-                raise ValueError(f"{name} entries must be positive")
-            if tlb_cfg.ways <= 0:
-                raise ValueError(f"{name} ways must be positive")
-            if tlb_cfg.entries % tlb_cfg.ways != 0:
-                raise ValueError(f"{name} entries must be divisible by ways")
+        if self.tlb_config.itlb_entries <= 0:
+            raise ValueError("ITLB entries must be positive")
+        if self.tlb_config.dtlb_entries <= 0:
+            raise ValueError("DTLB entries must be positive")
+        if self.tlb_config.l2tlb_entries <= 0:
+            raise ValueError("L2 TLB entries must be positive")
+        if self.tlb_config.l2tlb_ways <= 0:
+            raise ValueError("L2 TLB ways must be positive")
+        if self.tlb_config.l2tlb_entries % self.tlb_config.l2tlb_ways != 0:
+            raise ValueError("L2 TLB entries must be divisible by L2 TLB ways")
 
         if self.hpm_counters_count < 0 or self.hpm_counters_count > 29:
             raise ValueError("HPM counters count must be in range [0, 29]")

--- a/coreblocks/params/vmem_params.py
+++ b/coreblocks/params/vmem_params.py
@@ -12,9 +12,16 @@ __all__ = [
 @dataclass(frozen=True)
 class TLBCacheConfiguration:
     itlb_entries: int = 16
+    """Number of L1i TLB entries"""
+
     dtlb_entries: int = 16
-    l2tlb_entries: int = 64
-    l2tlb_ways: int = 4
+    """Number of L1d TLB entries"""
+
+    l2tlb_entries: int = 128
+    """Number of L2 TLB entries"""
+
+    l2tlb_ways: int = 8
+    """Number of L2 TLB ways (must divide l2tlb_entries)"""
 
 
 class VirtualMemoryParameters:

--- a/coreblocks/params/vmem_params.py
+++ b/coreblocks/params/vmem_params.py
@@ -1,6 +1,26 @@
+from dataclasses import dataclass, field
 from typing import Collection
 
 from coreblocks.arch.isa_consts import SatpMode, SatpLayout, PAGE_SIZE_LOG
+
+__all__ = [
+    "TLBLineConfiguration",
+    "TLBCacheConfiguration",
+    "VirtualMemoryParameters",
+]
+
+
+@dataclass(frozen=True)
+class TLBLineConfiguration:
+    entries: int = 16
+    ways: int = 4
+
+
+@dataclass(frozen=True)
+class TLBCacheConfiguration:
+    itlb: TLBLineConfiguration = field(default_factory=TLBLineConfiguration)
+    dtlb: TLBLineConfiguration = field(default_factory=TLBLineConfiguration)
+    l2tlb: TLBLineConfiguration = field(default_factory=lambda: TLBLineConfiguration(entries=64, ways=8))
 
 
 class VirtualMemoryParameters:
@@ -13,6 +33,14 @@ class VirtualMemoryParameters:
 
         satp_layout = SatpLayout(xlen)
         return satp_layout["ppn"].width + PAGE_SIZE_LOG
+
+    @staticmethod
+    def vpn_bits_for_mode(xlen: int, mode: SatpMode) -> int:
+        return SatpMode.bits_per_page_table_level(xlen) * SatpMode.level_count(mode)
+
+    @staticmethod
+    def size_class_shift(xlen: int, size_class: int) -> int:
+        return SatpMode.bits_per_page_table_level(xlen) * size_class
 
     def __init__(
         self,
@@ -53,3 +81,17 @@ class VirtualMemoryParameters:
         self.xlen = xlen
         self.asidlen = asidlen
         self.max_asid = (1 << asidlen) - 1
+        self.page_table_level_bits = SatpMode.bits_per_page_table_level(xlen)
+        self.max_tlb_vpn_bits = max(
+            (self.vpn_bits_for_mode(xlen, mode) for mode in self.supported_non_bare_schemes),
+            default=0,
+        )
+        self.max_tlb_size_class = max(
+            (SatpMode.level_count(mode) - 1 for mode in self.supported_non_bare_schemes),
+            default=0,
+        )
+        self.tlb_size_class_bits = self.max_tlb_size_class.bit_length()
+
+    @property
+    def supported_non_bare_schemes(self) -> Collection[SatpMode]:
+        return [scheme for scheme in self.supported_schemes if scheme != SatpMode.BARE]

--- a/coreblocks/params/vmem_params.py
+++ b/coreblocks/params/vmem_params.py
@@ -1,26 +1,20 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Collection
 
 from coreblocks.arch.isa_consts import SatpMode, SatpLayout, PAGE_SIZE_LOG
 
 __all__ = [
-    "TLBLineConfiguration",
     "TLBCacheConfiguration",
     "VirtualMemoryParameters",
 ]
 
 
 @dataclass(frozen=True)
-class TLBLineConfiguration:
-    entries: int = 16
-    ways: int = 4
-
-
-@dataclass(frozen=True)
 class TLBCacheConfiguration:
-    itlb: TLBLineConfiguration = field(default_factory=TLBLineConfiguration)
-    dtlb: TLBLineConfiguration = field(default_factory=TLBLineConfiguration)
-    l2tlb: TLBLineConfiguration = field(default_factory=lambda: TLBLineConfiguration(entries=64, ways=8))
+    itlb_entries: int = 16
+    dtlb_entries: int = 16
+    l2tlb_entries: int = 64
+    l2tlb_ways: int = 4
 
 
 class VirtualMemoryParameters:

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -10,6 +10,7 @@ from coreblocks.arch.csr_address import (
 )
 from coreblocks.arch.isa import Extension
 from coreblocks.arch.isa_consts import (
+    PAGE_SIZE_LOG,
     SatpMode,
 )
 from coreblocks.arch.isa_consts import PrivilegeLevel, XlenEncoding, TrapVectorMode, PMPAFlagEncoding, PMPCfgLayout
@@ -429,7 +430,7 @@ class SupervisorModeCSRRegisters(Elaboratable):
                 {
                     "mode": 0,
                     "asid": -(1 << gen_params.vmem_params.asidlen),
-                    "ppn": 0,
+                    "ppn": -(1 << (gen_params.phys_addr_bits - PAGE_SIZE_LOG)),
                 }
             ).as_bits()
 

--- a/coreblocks/priv/vmem/__init__.py
+++ b/coreblocks/priv/vmem/__init__.py
@@ -1,1 +1,2 @@
 from .translation import *  # noqa: F401
+from .tlb import *  # noqa: F401

--- a/coreblocks/priv/vmem/iface.py
+++ b/coreblocks/priv/vmem/iface.py
@@ -3,6 +3,7 @@ from typing import Protocol
 from amaranth_types import HasElaborate
 from transactron import Method, Provided
 
+
 class TLBBackingDevice(HasElaborate, Protocol):
     """Protocol for devices that can be used as a backing device for TLBs."""
 

--- a/coreblocks/priv/vmem/iface.py
+++ b/coreblocks/priv/vmem/iface.py
@@ -1,0 +1,15 @@
+from typing import Protocol
+
+from transactron import Method, Provided
+
+
+class TLBBackingDevice(Protocol):
+    """Protocol for devices that can be used as a backing device for TLBs."""
+
+    request: Provided[Method]
+    """Method for requesting a translation.
+    Expected layout is `AddressTranslationLayouts.tlb_request`."""
+
+    accept: Provided[Method]
+    """Method for accepting a translation response.
+    Expected layout is `AddressTranslationLayouts.tlb_accept`."""

--- a/coreblocks/priv/vmem/iface.py
+++ b/coreblocks/priv/vmem/iface.py
@@ -1,10 +1,9 @@
 from typing import Protocol
 
-from amaranth_types import HasElaborate
 from transactron import Method, Provided
 
 
-class TLBBackingDevice(HasElaborate, Protocol):
+class TLBBackingDevice(Protocol):
     """Protocol for devices that can be used as a backing device for TLBs."""
 
     request: Provided[Method]

--- a/coreblocks/priv/vmem/iface.py
+++ b/coreblocks/priv/vmem/iface.py
@@ -1,9 +1,9 @@
 from typing import Protocol
 
+from amaranth_types import HasElaborate
 from transactron import Method, Provided
 
-
-class TLBBackingDevice(Protocol):
+class TLBBackingDevice(HasElaborate, Protocol):
     """Protocol for devices that can be used as a backing device for TLBs."""
 
     request: Provided[Method]

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -4,7 +4,7 @@ import amaranth.lib.memory as memory
 
 from transactron import Method, TModule, def_method, Priority, Transaction
 from transactron.utils import DependencyContext, mod_incr
-from transactron.lib import Forwarder, condition, Pipe
+from transactron.lib import Forwarder, Pipe
 
 from coreblocks.arch.isa_consts import PAGE_SIZE_LOG, SatpMode
 from coreblocks.interface.layouts import AddressTranslationLayouts
@@ -197,7 +197,7 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
             m.d.comb += cam.checked_vpn.eq(requested_vpn)
             m.d.comb += cam.checked_asid.eq(current_asid)
 
-            fwd.write(m, resp)            
+            fwd.write(m, resp)
 
             with m.If(resp.result == AddressTranslationLayouts.TLBResult.HIT):
                 new_entry = Signal(TLBEntry(self.gen_params))
@@ -286,7 +286,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
         rd_rd = rd_mem.read_port()
         rd_wr = rd_mem.write_port()
         m.d.comb += cam.replacement_data.eq(rd_rd.data)
-        
+
         m.submodules.fwd = fwd = Forwarder(self.layout.tlb_accept)
 
         flushing = Signal(init=1)

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -49,9 +49,9 @@ class TLBCAM(Elaboratable):
         self.layout = gen_params.get(AddressTranslationLayouts)
 
         self.ways_data = Signal(ArrayLayout(TLBEntry(gen_params), ways))
-        self.rr_index = Signal(range(ways))  # round-robin pointer for replacement
         self.checked_asid = Signal(gen_params.vmem_params.asidlen)
         self.checked_vpn = Signal(gen_params.vmem_params.max_tlb_vpn_bits)
+        self.replacement_data = Signal(range(ways))
 
         self.addr_match = Signal(ways)
         self.asid_match = Signal(ways)
@@ -61,6 +61,7 @@ class TLBCAM(Elaboratable):
         self.full_match = Signal(ways)
 
         self.replace_candidate = Signal(range(ways))
+        self.next_replacement_data = Signal.like(self.replacement_data)
 
     def elaborate(self, platform):
         m = TModule()
@@ -86,7 +87,7 @@ class TLBCAM(Elaboratable):
 
         # Replacement candidate is the first invalid entry, or the round-robin entry if all are valid
         # The order of checks: currently present entry -> invalid entry -> round-robin.
-        m.d.comb += self.replace_candidate.eq(self.rr_index)
+        m.d.comb += self.replace_candidate.eq(self.replacement_data)
 
         for way in range(self.ways):
             with m.If(~self.valid_match[way]):
@@ -95,6 +96,8 @@ class TLBCAM(Elaboratable):
         for way in range(self.ways):
             with m.If(self.full_match[way]):
                 m.d.comb += self.replace_candidate.eq(way)
+
+        m.d.comb += self.next_replacement_data.eq(mod_incr(self.replacement_data, self.ways))
 
         return m
 
@@ -143,6 +146,7 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
         m.d.comb += cam.ways_data.eq(entries)
 
         m.submodules.fwd = fwd = Forwarder(self.layout.tlb_accept)
+        m.submodules.slow_fwd = slow_fwd = Forwarder(self.layout.tlb_request)
 
         request_in_flight = Signal()
         requested_vpn = Signal(vpn_bits)
@@ -153,12 +157,10 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
             m.d.comb += cam.checked_vpn.eq(vpn)
 
             found_entry = Signal(TLBEntry(self.gen_params))
-            found_entry_idx = Signal(range(self.entries))
 
             for way in range(self.entries):
                 with m.If(cam.full_match[way]):
                     m.d.av_comb += found_entry.eq(cam.ways_data[way])
-                    m.d.av_comb += found_entry_idx.eq(way)
 
             ask_backing = Signal()
             with m.If(~cam.full_match.any()):
@@ -169,15 +171,12 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
                 #   as we only implement Svade, so if this happens, we are almost sure
                 #   the re-walk will not fix the issue.
                 m.d.av_comb += ask_backing.eq(1)
-                m.d.sync += entries[found_entry_idx].valid.eq(0)
 
-            with condition(m, nonblocking=True) as branch:
-                with branch(ask_backing):
-                    m.d.sync += request_in_flight.eq(1)
-                    m.d.sync += requested_vpn.eq(vpn)
-                    self.backing_resolver.request(m, vpn=vpn, write_aspect=write_aspect)
-
-            with m.If(~ask_backing):
+            with m.If(ask_backing):
+                m.d.sync += request_in_flight.eq(1)
+                m.d.sync += requested_vpn.eq(vpn)
+                slow_fwd.write(m, vpn=vpn, write_aspect=write_aspect)
+            with m.Else():
                 fwd.write(
                     m,
                     result=AddressTranslationLayouts.TLBResult.HIT,
@@ -186,9 +185,9 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
                     size_class=found_entry.size_class,
                 )
 
-        @def_method(m, self.accept)
-        def _():
-            return fwd.read(m)
+        with Transaction().body(m):
+            req = slow_fwd.read(m)
+            self.backing_resolver.request(m, vpn=req.vpn, write_aspect=req.write_aspect)
 
         # Slow path - refill from backing resolver
         with Transaction().body(m, ready=request_in_flight):
@@ -198,7 +197,7 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
             m.d.comb += cam.checked_vpn.eq(requested_vpn)
             m.d.comb += cam.checked_asid.eq(current_asid)
 
-            fwd.write(m, resp)
+            fwd.write(m, resp)            
 
             with m.If(resp.result == AddressTranslationLayouts.TLBResult.HIT):
                 new_entry = Signal(TLBEntry(self.gen_params))
@@ -210,8 +209,10 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
                     new_entry.size_class.eq(resp.size_class),
                     new_entry.permissions.eq(resp.permissions),
                 ]
-                m.d.sync += cam.rr_index.eq(mod_incr(cam.replace_candidate, self.entries))
+                m.d.sync += cam.replacement_data.eq(cam.next_replacement_data)
                 m.d.sync += entries[cam.replace_candidate].eq(new_entry)
+
+        self.accept.provide(fwd.read)
 
         @def_method(m, self.sfence_vma, ready=~request_in_flight)
         def _(vaddr, asid, all_vaddrs, all_asids):
@@ -268,6 +269,9 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
         current_asid = Signal(asid_bits)
         m.d.comb += current_asid.eq(csr.s_mode.satp_asid)
 
+        # Single CAM instance that will be used to check each set
+        m.submodules.cam = cam = TLBCAM(self.gen_params, self.ways)
+
         # All sets stored in synchronous memory
         # entries_array[set_index][way_index] = TLBEntry
         m.submodules.mem = mem = memory.Memory(
@@ -275,18 +279,15 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
         )
         set_rd = mem.read_port()
         set_wr = mem.write_port()
-
-        # Round robin pointers for each set
-        m.submodules.rr_mem = rr_mem = memory.Memory(shape=range(self.ways), depth=self.sets, init=[])
-        rr_rd = rr_mem.read_port()
-        rr_wr = rr_mem.write_port()
-
-        m.submodules.fwd = fwd = Forwarder(self.layout.tlb_accept)
-
-        # Single CAM instance that will be used to check each set
-        m.submodules.cam = cam = TLBCAM(self.gen_params, self.ways)
         m.d.comb += cam.ways_data.eq(set_rd.data)
-        m.d.comb += cam.rr_index.eq(rr_rd.data)
+
+        # replacement data for each set
+        m.submodules.rd_mem = rd_mem = memory.Memory(shape=cam.replacement_data.shape(), depth=self.sets, init=[])
+        rd_rd = rd_mem.read_port()
+        rd_wr = rd_mem.write_port()
+        m.d.comb += cam.replacement_data.eq(rd_rd.data)
+        
+        m.submodules.fwd = fwd = Forwarder(self.layout.tlb_accept)
 
         flushing = Signal(init=1)
 
@@ -324,12 +325,10 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
             m.d.av_comb += valid_vec.eq(cam.valid_match & cam.addr_match & (cam.asid_match | cam.global_match))
 
             found_entry = Signal(TLBEntry(self.gen_params))
-            found_entry_idx = Signal(range(self.ways))
 
             for way in range(self.ways):
                 with m.If(valid_vec[way]):
                     m.d.av_comb += found_entry.eq(cam.ways_data[way])
-                    m.d.av_comb += found_entry_idx.eq(way)
 
             miss = Signal()
             ask_backing = Signal()
@@ -338,11 +337,6 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
 
             with m.If(~miss & req.write_aspect & ~found_entry.permissions.d):
                 m.d.av_comb += ask_backing.eq(1)
-                # invalidate the entry
-                m.d.comb += set_wr.addr.eq(requested_set)
-                m.d.comb += set_wr.data.eq(set_rd.data)
-                m.d.comb += set_wr.data[found_entry_idx].valid.eq(0)
-                m.d.comb += set_wr.en.eq(1)
 
             max_class = self.gen_params.vmem_params.max_tlb_size_class
             with m.If(miss & (requested_class == max_class)):
@@ -385,9 +379,9 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                     m.d.sync += refill_response.eq(resp)
 
                     m.d.comb += set_rd.addr.eq(set_idx)
-                    m.d.comb += rr_rd.addr.eq(set_idx)
+                    m.d.comb += rd_rd.addr.eq(set_idx)
                     m.d.comb += set_rd.en.eq(1)
-                    m.d.comb += rr_rd.en.eq(1)
+                    m.d.comb += rd_rd.en.eq(1)
 
                     with m.If(resp.result == AddressTranslationLayouts.TLBResult.HIT):
                         m.next = "REFILL"
@@ -414,9 +408,9 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                         new_entry.permissions.eq(refill_response.permissions),
                     ]
 
-                    m.d.comb += rr_wr.data.eq(mod_incr(cam.replace_candidate, self.ways))
-                    m.d.comb += rr_wr.addr.eq(refill_set_idx)
-                    m.d.comb += rr_wr.en.eq(1)
+                    m.d.comb += rd_wr.data.eq(cam.next_replacement_data)
+                    m.d.comb += rd_wr.addr.eq(refill_set_idx)
+                    m.d.comb += rd_wr.en.eq(1)
 
                     m.d.comb += set_wr.data.eq(set_rd.data)
                     m.d.comb += set_wr.data[cam.replace_candidate].eq(new_entry)

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -4,7 +4,7 @@ import amaranth.lib.memory as memory
 
 from transactron import Method, TModule, def_method, Priority, Transaction
 from transactron.utils import DependencyContext, mod_incr
-from transactron.lib import Forwarder, Pipe, condition
+from transactron.lib import Forwarder, Pipe, condition, HwCounter
 
 from coreblocks.arch.isa_consts import PAGE_SIZE_LOG, SatpMode
 from coreblocks.interface.layouts import AddressTranslationLayouts
@@ -113,6 +113,7 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
         *,
         entries: int,
         backing_resolver: TLBBackingDevice,
+        perf_name_prefix: str = "mmu.tlb",
     ):
         if entries <= 0:
             raise ValueError("entries must be positive")
@@ -121,6 +122,7 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
         self.entries = entries
         self.backing_resolver = backing_resolver
         self.layout = gen_params.get(AddressTranslationLayouts)
+        self.perf_name_prefix = perf_name_prefix
 
         self.request = Method(i=self.layout.tlb_request)
         self.accept = Method(o=self.layout.tlb_accept)
@@ -129,8 +131,22 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
         self.dm = DependencyContext.get()
         self.dm.add_dependency(SFenceVMAKey(), self.sfence_vma)
 
+        self.perf_loads = HwCounter(
+            f"{self.perf_name_prefix}.loads", "Number of requests to the TLB"
+        )
+        self.perf_hits = HwCounter(f"{self.perf_name_prefix}.hits")
+        self.perf_misses = HwCounter(f"{self.perf_name_prefix}.misses")
+        self.perf_flushes = HwCounter(f"{self.perf_name_prefix}.flushes")
+
     def elaborate(self, platform):
         m = TModule()
+
+        m.submodules += [
+            self.perf_loads,
+            self.perf_hits,
+            self.perf_misses,
+            self.perf_flushes,
+        ]
 
         csr = self.dm.get_dependency(CSRInstancesKey())
 
@@ -162,6 +178,8 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
 
         @def_method(m, self.request, ready=~request_in_flight)
         def _(vpn, write_aspect):
+            self.perf_loads.incr(m)
+
             found_entry = Signal(TLBEntry(self.gen_params))
 
             for way in range(self.entries):
@@ -180,10 +198,12 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
 
             with condition(m) as branch:
                 with branch(ask_backing):
+                    self.perf_misses.incr(m)
                     m.d.sync += request_in_flight.eq(1)
                     m.d.sync += requested_vpn.eq(vpn)
                     self.backing_resolver.request(m, vpn=vpn, write_aspect=write_aspect)
                 with branch():
+                    self.perf_hits.incr(m)
                     fwd.write(
                         m,
                         result=AddressTranslationLayouts.TLBResult.HIT,
@@ -216,6 +236,8 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
 
         @def_method(m, self.sfence_vma, ready=~request_in_flight)
         def _(vaddr, asid, all_vaddrs, all_asids):
+            self.perf_flushes.incr(m)
+
             for way in range(self.entries):
                 with m.If((all_asids | cam.asid_match[way]) & (all_vaddrs | cam.addr_match[way])):
                     m.d.sync += entries[way].valid.eq(0)
@@ -233,6 +255,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
         entries: int,
         ways: int,
         backing_resolver: TLBBackingDevice,
+        perf_name_prefix: str = "mmu.tlb",
     ):
         if entries <= 0:
             raise ValueError("entries must be positive")
@@ -247,6 +270,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
         self.sets = entries // ways
         self.backing_resolver = backing_resolver
         self.layout = gen_params.get(AddressTranslationLayouts)
+        self.perf_name_prefix = perf_name_prefix
 
         self.request = Method(i=self.layout.tlb_request)
         self.accept = Method(o=self.layout.tlb_accept)
@@ -254,8 +278,22 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
         self.dm = DependencyContext.get()
         self.dm.add_dependency(SFenceVMAKey(), self.sfence_vma)
 
+        self.perf_loads = HwCounter(
+            f"{self.perf_name_prefix}.loads", "Number of requests to the TLB"
+        )
+        self.perf_hits = HwCounter(f"{self.perf_name_prefix}.hits")
+        self.perf_misses = HwCounter(f"{self.perf_name_prefix}.misses")
+        self.perf_flushes = HwCounter(f"{self.perf_name_prefix}.flushes")
+
     def elaborate(self, platform):
         m = TModule()
+
+        m.submodules += [
+            self.perf_loads,
+            self.perf_hits,
+            self.perf_misses,
+            self.perf_flushes,
+        ]
 
         csr = self.dm.get_dependency(CSRInstancesKey())
 
@@ -301,6 +339,8 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
 
         @def_method(m, self.request, ready=~flushing)
         def _(vpn, write_aspect):
+            self.perf_loads.incr(m)
+
             set_idx = vpn_to_set_idx(vpn, 0)
             m.d.sync += requested_set.eq(set_idx)
             m.d.sync += requested_class.eq(0)
@@ -340,6 +380,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                 m.d.av_comb += ask_backing.eq(1)
 
             with m.If(ask_backing):
+                self.perf_misses.incr(m)
                 m.d.sync += slow_path.eq(1)
                 self.backing_resolver.request(m, vpn=req.vpn, write_aspect=req.write_aspect)
             with m.Elif(miss & (requested_class < max_class)):
@@ -353,6 +394,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
             with m.Else():
                 # consume the request and return the hit result
                 request_pipe.read(m)
+                self.perf_hits.incr(m)
 
                 fwd.write(
                     m,
@@ -431,6 +473,8 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
 
         @def_method(m, self.sfence_vma, ready=~flushing)
         def _(vaddr, asid, all_vaddrs, all_asids):
+            self.perf_flushes.incr(m)
+
             m.d.sync += flushing.eq(1)
             m.d.sync += flush_vpn.eq(vaddr >> PAGE_SIZE_LOG)
             m.d.sync += flush_asid.eq(asid)

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -310,14 +310,15 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
             m.d.comb += set_rd.addr.eq(set_idx)
             m.d.comb += set_rd.en.eq(1)
 
+            m.d.sync += cam.checked_asid.eq(current_asid)
+            m.d.sync += cam.checked_vpn.eq(vpn)
+
             request_pipe.write(m, vpn=vpn, write_aspect=write_aspect)
 
         slow_path = Signal()
 
         with Transaction(name="TLBLookup").body(m, ready=~slow_path):
             req = request_pipe.peek(m)
-            m.d.comb += cam.checked_asid.eq(current_asid)
-            m.d.comb += cam.checked_vpn.eq(req.vpn)
 
             valid_vec = Signal(self.ways)
             m.d.av_comb += valid_vec.eq(cam.valid_match & cam.addr_match & (cam.asid_match | cam.global_match))
@@ -399,8 +400,6 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                 with Transaction().body(m):
                     # We have received a valid PTE from the backing resolver and have the correct set index
                     req = request_pipe.read(m)
-                    m.d.comb += cam.checked_asid.eq(current_asid)
-                    m.d.comb += cam.checked_vpn.eq(req.vpn)
 
                     fwd.write(m, arg=refill_response)
                     m.d.sync += slow_path.eq(0)
@@ -433,6 +432,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
         flush_all_vaddrs = Signal(init=1)
         flush_all_asids = Signal(init=1)
         flush_set = Signal(set_index_bits)
+        flush_size_class = Signal(self.gen_params.vmem_params.tlb_size_class_bits)
         flush_fetched = Signal()
 
         @def_method(m, self.sfence_vma, ready=~flushing)
@@ -445,20 +445,22 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
 
             m.d.sync += flush_set.eq(Mux(flush_all_vaddrs, 0, vpn_to_set_idx(flush_vpn, 0)))
             m.d.sync += flush_fetched.eq(0)
+            m.d.sync += flush_size_class.eq(0)
 
             # we block new inputs, wait for the current lookup to finish and then perform flush routine
+
+        self.sfence_vma.add_conflict(self.request, Priority.LEFT)
 
         with Transaction(name="flush").body(m, ready=flushing & ~slow_path):
             with m.If(~flush_fetched):
                 m.d.comb += set_rd.addr.eq(flush_set)
                 m.d.comb += set_rd.en.eq(1)
+                m.d.sync += cam.checked_asid.eq(flush_asid)
+                m.d.sync += cam.checked_vpn.eq(flush_vpn)
 
                 m.d.sync += flush_fetched.eq(1)
             with m.Else():
                 # we have flush_set opened - invalidate the matching entries and move to the next set
-                m.d.comb += cam.checked_asid.eq(flush_asid)
-                m.d.comb += cam.checked_vpn.eq(flush_vpn)
-
                 m.d.comb += set_wr.data.eq(set_rd.data)
                 for way in range(self.ways):
                     with m.If((flush_all_asids | cam.asid_match[way]) & (flush_all_vaddrs | cam.addr_match[way])):
@@ -467,10 +469,25 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                 m.d.comb += set_wr.addr.eq(flush_set)
                 m.d.comb += set_wr.en.eq(1)
 
-                m.d.comb += set_rd.addr.eq(flush_set + 1)
+                next_flush_set = Signal(set_index_bits)
+                flush_done = Signal()
+
+                with m.If(flush_all_vaddrs):
+                    m.d.av_comb += next_flush_set.eq(flush_set + 1)
+                    m.d.av_comb += flush_done.eq(flush_set == self.sets - 1)
+                with m.Else():
+                    with m.If(flush_size_class == self.gen_params.gen_params.vmem_params.max_tlb_size_class):
+                        m.d.av_comb += flush_done.eq(1)
+                    with m.Else():
+                        m.d.av_comb += next_flush_set.eq(vpn_to_set_idx(flush_vpn, flush_size_class + 1))
+                        m.d.sync += flush_size_class.eq(flush_size_class + 1)
+
+                m.d.sync += flush_set.eq(next_flush_set)
+
+                m.d.comb += set_rd.addr.eq(next_flush_set)
                 m.d.comb += set_rd.en.eq(1)
 
-                with m.If(~flush_all_vaddrs | (flush_set == self.sets - 1)):
+                with m.If(flush_done):
                     m.d.sync += flushing.eq(0)
 
         return m

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -198,10 +198,10 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
             m.d.comb += cam.checked_vpn.eq(requested_vpn)
             m.d.comb += cam.checked_asid.eq(current_asid)
 
-            fwd.write(m, arg=resp)
+            fwd.write(m, resp)
 
             with m.If(resp.result == AddressTranslationLayouts.TLBResult.HIT):
-                new_entry = TLBEntry(self.gen_params)
+                new_entry = Signal(TLBEntry(self.gen_params))
                 m.d.av_comb += [
                     new_entry.valid.eq(1),
                     new_entry.asid.eq(current_asid),
@@ -380,7 +380,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                     req = request_pipe.peek(m)
                     resp = self.backing_resolver.accept(m)
 
-                    set_idx = vpn_to_set_idx(req.vpn, req.size_class)
+                    set_idx = vpn_to_set_idx(req.vpn, resp.size_class)
                     m.d.sync += refill_set_idx.eq(set_idx)
                     m.d.sync += refill_response.eq(resp)
 
@@ -394,14 +394,14 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                     with m.Else():
                         # Miss in the backing resolver - just forward the miss response
                         request_pipe.read(m)
-                        fwd.write(m, arg=resp)
+                        fwd.write(m, resp)
 
             with m.State("REFILL"):
                 with Transaction().body(m):
                     # We have received a valid PTE from the backing resolver and have the correct set index
                     req = request_pipe.read(m)
 
-                    fwd.write(m, arg=refill_response)
+                    fwd.write(m, refill_response)
                     m.d.sync += slow_path.eq(0)
 
                     new_entry = Signal(TLBEntry(self.gen_params))

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -150,13 +150,18 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
         request_in_flight = Signal()
         requested_vpn = Signal(vpn_bits)
 
+        with m.If(self.sfence_vma.run):
+            m.d.comb += cam.checked_asid.eq(self.sfence_vma.data_in.asid)
+            m.d.comb += cam.checked_vpn.eq(self.sfence_vma.data_in.vaddr >> PAGE_SIZE_LOG)
+        with m.Elif(request_in_flight):
+            m.d.comb += cam.checked_asid.eq(current_asid)
+            m.d.comb += cam.checked_vpn.eq(requested_vpn)
+        with m.Else():
+            m.d.comb += cam.checked_asid.eq(current_asid)
+            m.d.comb += cam.checked_vpn.eq(self.request.data_in.vpn)
+
         @def_method(m, self.request, ready=~request_in_flight)
         def _(vpn, write_aspect):
-            # Set CAM data as request's VPN and ASID by default, so condition will not create a cycle.
-            # As all other uses of CAM are exclusive with this method, other places should use m.d.comb
-            m.d.av_comb += cam.checked_asid.eq(current_asid)
-            m.d.av_comb += cam.checked_vpn.eq(vpn)
-
             found_entry = Signal(TLBEntry(self.gen_params))
 
             for way in range(self.entries):
@@ -192,9 +197,6 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
             resp = self.backing_resolver.accept(m)
             m.d.sync += request_in_flight.eq(0)
 
-            m.d.comb += cam.checked_vpn.eq(requested_vpn)
-            m.d.comb += cam.checked_asid.eq(current_asid)
-
             fwd.write(m, resp)
 
             with m.If(resp.result == AddressTranslationLayouts.TLBResult.HIT):
@@ -214,9 +216,6 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
 
         @def_method(m, self.sfence_vma, ready=~request_in_flight)
         def _(vaddr, asid, all_vaddrs, all_asids):
-            m.d.comb += cam.checked_asid.eq(asid)
-            m.d.comb += cam.checked_vpn.eq(vaddr >> PAGE_SIZE_LOG)
-
             for way in range(self.entries):
                 with m.If((all_asids | cam.asid_match[way]) & (all_vaddrs | cam.addr_match[way])):
                     m.d.sync += entries[way].valid.eq(0)

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -16,30 +16,20 @@ from coreblocks.params import GenParams
 from coreblocks.priv.vmem.iface import TLBBackingDevice
 
 __all__ = [
-    "TLBEntry",
     "TLB",
 ]
 
 
 class TLBEntry(StructLayout):
     def __init__(self, gen_params: GenParams):
-        vpn_width = gen_params.vmem_params.max_tlb_vpn_bits
-        ppn_width = gen_params.phys_addr_bits - PAGE_SIZE_LOG
-        asid_width = max(1, gen_params.vmem_params.asidlen)
-
         super().__init__(
             {
                 "valid": 1,
-                "global_mapping": 1,
-                "asid": asid_width,
+                "asid": gen_params.vmem_params.asidlen,
                 "size_class": gen_params.vmem_params.tlb_size_class_bits,
-                "vpn": vpn_width,
-                "ppn": ppn_width,
-                "r": 1,
-                "w": 1,
-                "x": 1,
-                "u": 1,
-                "d": 1,
+                "vpn": gen_params.vmem_params.max_tlb_vpn_bits,
+                "ppn": gen_params.phys_addr_bits - PAGE_SIZE_LOG,
+                "permissions": gen_params.get(AddressTranslationLayouts).permissions
             }
         )
 

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -476,7 +476,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                     m.d.av_comb += next_flush_set.eq(flush_set + 1)
                     m.d.av_comb += flush_done.eq(flush_set == self.sets - 1)
                 with m.Else():
-                    with m.If(flush_size_class == self.gen_params.gen_params.vmem_params.max_tlb_size_class):
+                    with m.If(flush_size_class == self.gen_params.vmem_params.max_tlb_size_class):
                         m.d.av_comb += flush_done.eq(1)
                     with m.Else():
                         m.d.av_comb += next_flush_set.eq(vpn_to_set_idx(flush_vpn, flush_size_class + 1))

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -1,9 +1,10 @@
 from amaranth import *
 from amaranth.lib.data import StructLayout, ArrayLayout
+import amaranth.lib.memory as memory
 
 from transactron import Method, TModule, def_method, Priority, Transaction
 from transactron.utils import DependencyContext, mod_incr
-from transactron.lib import Forwarder, condition
+from transactron.lib import Forwarder, condition, Pipe
 
 from coreblocks.arch.isa_consts import PAGE_SIZE_LOG, SatpMode
 from coreblocks.interface.layouts import AddressTranslationLayouts
@@ -13,7 +14,8 @@ from coreblocks.params import GenParams
 from coreblocks.priv.vmem.iface import TLBBackingDevice
 
 __all__ = [
-    "TLB",
+    "FullyAssociativeTLB",
+    "SetAssociativeTLB",
 ]
 
 
@@ -50,17 +52,18 @@ class TLBCAM(Elaboratable):
         self.rr_index = Signal(range(ways))  # round-robin pointer for replacement
         self.checked_asid = Signal(gen_params.vmem_params.asidlen)
         self.checked_vpn = Signal(gen_params.vmem_params.max_tlb_vpn_bits)
+
         self.addr_match = Signal(ways)
         self.asid_match = Signal(ways)
         self.valid_match = Signal(ways)
         self.global_match = Signal(ways)
 
+        self.full_match = Signal(ways)
+
         self.replace_candidate = Signal(range(ways))
 
     def elaborate(self, platform):
         m = TModule()
-
-        m.d.comb += self.replace_candidate.eq(self.rr_index)
 
         for way in range(self.ways):
             m.d.comb += self.valid_match[way].eq(self.ways_data[way].valid)
@@ -79,13 +82,28 @@ class TLBCAM(Elaboratable):
                             self.checked_vpn[match_bits:] == self.ways_data[way].vpn[match_bits:]
                         )
 
-            with m.If(~self.ways_data[way].valid):
+        m.d.comb += self.full_match.eq(self.valid_match & self.addr_match & (self.asid_match | self.global_match))
+
+        # Replacement candidate is the first invalid entry, or the round-robin entry if all are valid
+        # The order of checks: currently present entry -> invalid entry -> round-robin.
+        m.d.comb += self.replace_candidate.eq(self.rr_index)
+
+        for way in range(self.ways):
+            with m.If(~self.valid_match[way]):
+                m.d.comb += self.replace_candidate.eq(way)
+
+        for way in range(self.ways):
+            with m.If(self.full_match[way]):
                 m.d.comb += self.replace_candidate.eq(way)
 
         return m
 
 
-class FullyAssociativeTLB(TLBBackingDevice):
+class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
+    """Fully associative TLB capable of same-cycle operations.
+    Meant for L1 TLBs.
+    """
+
     def __init__(
         self,
         gen_params: GenParams,
@@ -134,24 +152,24 @@ class FullyAssociativeTLB(TLBBackingDevice):
             m.d.comb += cam.checked_asid.eq(current_asid)
             m.d.comb += cam.checked_vpn.eq(vpn)
 
-            valid_vec = Signal(self.entries)
-            m.d.comb += valid_vec.eq(cam.valid_match & cam.addr_match & (cam.asid_match | cam.global_match))
-
             found_entry = Signal(TLBEntry(self.gen_params))
+            found_entry_idx = Signal(range(self.entries))
 
             for way in range(self.entries):
-                with m.If(valid_vec[way]):
-                    m.d.comb += found_entry.eq(cam.ways_data[way])
+                with m.If(cam.full_match[way]):
+                    m.d.av_comb += found_entry.eq(cam.ways_data[way])
+                    m.d.av_comb += found_entry_idx.eq(way)
 
             ask_backing = Signal()
-            with m.If(~valid_vec.any()):
-                m.d.comb += ask_backing.eq(1)
+            with m.If(~cam.full_match.any()):
+                m.d.av_comb += ask_backing.eq(1)
             with m.Elif(write_aspect & ~found_entry.permissions.d):
                 # We have found an entry, but it doesn't have the dirty bit set
                 # NOTE: currently we would never actually need to ask the backing device,
                 #   as we only implement Svade, so if this happens, we are almost sure
                 #   the re-walk will not fix the issue.
-                m.d.comb += ask_backing.eq(1)
+                m.d.av_comb += ask_backing.eq(1)
+                m.d.sync += entries[found_entry_idx].valid.eq(0)
 
             with condition(m, nonblocking=True) as branch:
                 with branch(ask_backing):
@@ -173,15 +191,18 @@ class FullyAssociativeTLB(TLBBackingDevice):
             return fwd.read(m)
 
         # Slow path - refill from backing resolver
-        with Transaction().body(m) as t:
+        with Transaction().body(m, ready=request_in_flight):
             resp = self.backing_resolver.accept(m)
             m.d.sync += request_in_flight.eq(0)
+
+            m.d.comb += cam.checked_vpn.eq(requested_vpn)
+            m.d.comb += cam.checked_asid.eq(current_asid)
 
             fwd.write(m, arg=resp)
 
             with m.If(resp.result == AddressTranslationLayouts.TLBResult.HIT):
                 new_entry = TLBEntry(self.gen_params)
-                m.d.comb += [
+                m.d.av_comb += [
                     new_entry.valid.eq(1),
                     new_entry.asid.eq(current_asid),
                     new_entry.vpn.eq(requested_vpn),
@@ -192,7 +213,7 @@ class FullyAssociativeTLB(TLBBackingDevice):
                 m.d.sync += cam.rr_index.eq(mod_incr(cam.replace_candidate, self.entries))
                 m.d.sync += entries[cam.replace_candidate].eq(new_entry)
 
-        @def_method(m, self.sfence_vma)
+        @def_method(m, self.sfence_vma, ready=~request_in_flight)
         def _(vaddr, asid, all_vaddrs, all_asids):
             m.d.comb += cam.checked_asid.eq(asid)
             m.d.comb += cam.checked_vpn.eq(vaddr >> PAGE_SIZE_LOG)
@@ -202,11 +223,11 @@ class FullyAssociativeTLB(TLBBackingDevice):
                     m.d.sync += entries[way].valid.eq(0)
 
         self.sfence_vma.add_conflict(self.request, Priority.LEFT)
-        self.sfence_vma.add_conflict(self.accept, Priority.LEFT)
-        self.sfence_vma.add_conflict(t, Priority.LEFT)
+
+        return m
 
 
-class SetAssociativeTLB(TLBBackingDevice):
+class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
     def __init__(
         self,
         gen_params: GenParams,
@@ -225,6 +246,7 @@ class SetAssociativeTLB(TLBBackingDevice):
         self.gen_params = gen_params
         self.entries = entries
         self.ways = ways
+        self.sets = entries // ways
         self.backing_resolver = backing_resolver
         self.layout = gen_params.get(AddressTranslationLayouts)
 
@@ -237,6 +259,218 @@ class SetAssociativeTLB(TLBBackingDevice):
     def elaborate(self, platform):
         m = TModule()
 
-        # TODO
+        csr = self.dm.get_dependency(CSRInstancesKey())
+
+        vpn_bits = self.gen_params.vmem_params.max_tlb_vpn_bits
+        asid_bits = self.gen_params.vmem_params.asidlen
+        set_index_bits = (self.sets - 1).bit_length()
+
+        current_asid = Signal(asid_bits)
+        m.d.comb += current_asid.eq(csr.s_mode.satp_asid)
+
+        # All sets stored in synchronous memory
+        # entries_array[set_index][way_index] = TLBEntry
+        m.submodules.mem = mem = memory.Memory(
+            shape=ArrayLayout(TLBEntry(self.gen_params), self.ways), depth=self.sets, init=[]
+        )
+        set_rd = mem.read_port()
+        set_wr = mem.write_port()
+
+        # Round robin pointers for each set
+        m.submodules.rr_mem = rr_mem = memory.Memory(shape=range(self.ways), depth=self.sets, init=[])
+        rr_rd = rr_mem.read_port()
+        rr_wr = rr_mem.write_port()
+
+        m.submodules.fwd = fwd = Forwarder(self.layout.tlb_accept)
+
+        # Single CAM instance that will be used to check each set
+        m.submodules.cam = cam = TLBCAM(self.gen_params, self.ways)
+        m.d.comb += cam.ways_data.eq(set_rd.data)
+        m.d.comb += cam.rr_index.eq(rr_rd.data)
+
+        flushing = Signal(init=1)
+
+        m.submodules.request_pipe = request_pipe = Pipe(self.layout.tlb_request)
+
+        requested_set = Signal(set_index_bits)
+        requested_class = Signal(self.gen_params.vmem_params.tlb_size_class_bits)
+
+        def vpn_to_set_idx(vpn, size_class):
+            # The set index bits are taken from the VPN bits above the page offset, starting from
+            # the bit corresponding to the size class
+            bits_per_level = SatpMode.bits_per_page_table_level(self.gen_params.isa.xlen)
+            return vpn.word_select(size_class, bits_per_level)
+
+        @def_method(m, self.request, ready=~flushing)
+        def _(vpn, write_aspect):
+            set_idx = vpn_to_set_idx(vpn, 0)
+            m.d.sync += requested_set.eq(set_idx)
+            m.d.sync += requested_class.eq(0)
+
+            m.d.comb += set_rd.addr.eq(set_idx)
+            m.d.comb += set_rd.en.eq(1)
+
+            request_pipe.write(m, vpn=vpn, write_aspect=write_aspect)
+
+        slow_path = Signal()
+
+        with Transaction(name="TLBLookup").body(m, ready=~slow_path):
+            req = request_pipe.peek(m)
+            m.d.comb += cam.checked_asid.eq(current_asid)
+            m.d.comb += cam.checked_vpn.eq(req.vpn)
+
+            valid_vec = Signal(self.ways)
+            m.d.av_comb += valid_vec.eq(cam.valid_match & cam.addr_match & (cam.asid_match | cam.global_match))
+
+            found_entry = Signal(TLBEntry(self.gen_params))
+            found_entry_idx = Signal(range(self.ways))
+
+            for way in range(self.ways):
+                with m.If(valid_vec[way]):
+                    m.d.av_comb += found_entry.eq(cam.ways_data[way])
+                    m.d.av_comb += found_entry_idx.eq(way)
+
+            miss = Signal()
+            ask_backing = Signal()
+
+            m.d.av_comb += miss.eq(~valid_vec.any())
+
+            with m.If(~miss & req.write_aspect & ~found_entry.permissions.d):
+                m.d.av_comb += ask_backing.eq(1)
+                # invalidate the entry
+                m.d.comb += set_wr.addr.eq(requested_set)
+                m.d.comb += set_wr.data.eq(set_rd.data)
+                m.d.comb += set_wr.data[found_entry_idx].valid.eq(0)
+                m.d.comb += set_wr.en.eq(1)
+
+            max_class = self.gen_params.vmem_params.max_tlb_size_class
+            with m.If(miss & (requested_class == max_class)):
+                m.d.av_comb += ask_backing.eq(1)
+
+            with m.If(ask_backing):
+                m.d.sync += slow_path.eq(1)
+                self.backing_resolver.request(m, vpn=req.vpn, write_aspect=req.write_aspect)
+            with m.Elif(miss & (requested_class < max_class)):
+                # We have a miss, but the bigger page classes may still hit
+                set_idx = vpn_to_set_idx(req.vpn, requested_class + 1)
+                m.d.sync += requested_set.eq(set_idx)
+                m.d.sync += requested_class.eq(requested_class + 1)
+
+                m.d.comb += set_rd.addr.eq(set_idx)
+                m.d.comb += set_rd.en.eq(1)
+            with m.Else():
+                # consume the request and return the hit result
+                request_pipe.read(m)
+
+                fwd.write(
+                    m,
+                    result=AddressTranslationLayouts.TLBResult.HIT,
+                    permissions=found_entry.permissions,
+                    ppn=found_entry.ppn,
+                    size_class=found_entry.size_class,
+                )
+
+        refill_set_idx = Signal(set_index_bits)
+        refill_response = Signal(self.layout.tlb_accept)
+
+        with m.FSM():
+            with m.State("IDLE"):
+                with Transaction().body(m):
+                    req = request_pipe.peek(m)
+                    resp = self.backing_resolver.accept(m)
+
+                    set_idx = vpn_to_set_idx(req.vpn, req.size_class)
+                    m.d.sync += refill_set_idx.eq(set_idx)
+                    m.d.sync += refill_response.eq(resp)
+
+                    m.d.comb += set_rd.addr.eq(set_idx)
+                    m.d.comb += rr_rd.addr.eq(set_idx)
+                    m.d.comb += set_rd.en.eq(1)
+                    m.d.comb += rr_rd.en.eq(1)
+
+                    with m.If(resp.result == AddressTranslationLayouts.TLBResult.HIT):
+                        m.next = "REFILL"
+                    with m.Else():
+                        # Miss in the backing resolver - just forward the miss response
+                        request_pipe.read(m)
+                        fwd.write(m, arg=resp)
+
+            with m.State("REFILL"):
+                with Transaction().body(m):
+                    # We have received a valid PTE from the backing resolver and have the correct set index
+                    req = request_pipe.read(m)
+                    m.d.comb += cam.checked_asid.eq(current_asid)
+                    m.d.comb += cam.checked_vpn.eq(req.vpn)
+
+                    fwd.write(m, arg=refill_response)
+                    m.d.sync += slow_path.eq(0)
+
+                    new_entry = Signal(TLBEntry(self.gen_params))
+                    m.d.av_comb += [
+                        new_entry.valid.eq(1),
+                        new_entry.asid.eq(current_asid),
+                        new_entry.vpn.eq(req.vpn),
+                        new_entry.ppn.eq(refill_response.ppn),
+                        new_entry.size_class.eq(refill_response.size_class),
+                        new_entry.permissions.eq(refill_response.permissions),
+                    ]
+
+                    m.d.comb += rr_wr.data.eq(mod_incr(cam.replace_candidate, self.ways))
+                    m.d.comb += rr_wr.addr.eq(refill_set_idx)
+                    m.d.comb += rr_wr.en.eq(1)
+
+                    m.d.comb += set_wr.data.eq(set_rd.data)
+                    m.d.comb += set_wr.data[cam.replace_candidate].eq(new_entry)
+                    m.d.comb += set_wr.addr.eq(refill_set_idx)
+                    m.d.comb += set_wr.en.eq(1)
+
+        @def_method(m, self.accept)
+        def _():
+            return fwd.read(m)
+
+        flush_vpn = Signal(vpn_bits)
+        flush_asid = Signal(asid_bits)
+        flush_all_vaddrs = Signal(init=1)
+        flush_all_asids = Signal(init=1)
+        flush_set = Signal(set_index_bits)
+        flush_fetched = Signal()
+
+        @def_method(m, self.sfence_vma, ready=~flushing)
+        def _(vaddr, asid, all_vaddrs, all_asids):
+            m.d.sync += flushing.eq(1)
+            m.d.sync += flush_vpn.eq(vaddr >> PAGE_SIZE_LOG)
+            m.d.sync += flush_asid.eq(asid)
+            m.d.sync += flush_all_vaddrs.eq(all_vaddrs)
+            m.d.sync += flush_all_asids.eq(all_asids)
+
+            m.d.sync += flush_set.eq(Mux(flush_all_vaddrs, 0, vpn_to_set_idx(flush_vpn, 0)))
+            m.d.sync += flush_fetched.eq(0)
+
+            # we block new inputs, wait for the current lookup to finish and then perform flush routine
+
+        with Transaction(name="flush").body(m, ready=flushing & ~slow_path):
+            with m.If(~flush_fetched):
+                m.d.comb += set_rd.addr.eq(flush_set)
+                m.d.comb += set_rd.en.eq(1)
+
+                m.d.sync += flush_fetched.eq(1)
+            with m.Else():
+                # we have flush_set opened - invalidate the matching entries and move to the next set
+                m.d.comb += cam.checked_asid.eq(flush_asid)
+                m.d.comb += cam.checked_vpn.eq(flush_vpn)
+
+                m.d.comb += set_wr.data.eq(set_rd.data)
+                for way in range(self.ways):
+                    with m.If((flush_all_asids | cam.asid_match[way]) & (flush_all_vaddrs | cam.addr_match[way])):
+                        m.d.av_comb += set_wr.data[way].valid.eq(0)
+
+                m.d.comb += set_wr.addr.eq(flush_set)
+                m.d.comb += set_wr.en.eq(1)
+
+                m.d.comb += set_rd.addr.eq(flush_set + 1)
+                m.d.comb += set_rd.en.eq(1)
+
+                with m.If(~flush_all_vaddrs | (flush_set == self.sets - 1)):
+                    m.d.sync += flushing.eq(0)
 
         return m

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -389,6 +389,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                         # Miss in the backing resolver - just forward the miss response
                         request_pipe.read(m)
                         fwd.write(m, resp)
+                        m.d.sync += slow_path.eq(0)
 
             with m.State("REFILL"):
                 with Transaction().body(m):
@@ -416,6 +417,8 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                     m.d.comb += set_wr.data[cam.replace_candidate].eq(new_entry)
                     m.d.comb += set_wr.addr.eq(refill_set_idx)
                     m.d.comb += set_wr.en.eq(1)
+
+                    m.next = "IDLE"
 
         @def_method(m, self.accept)
         def _():

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -1,16 +1,13 @@
-"""Generic set-associative TLB with a backing page resolver."""
-
-from __future__ import annotations
-
 from amaranth import *
-from amaranth.lib.data import StructLayout
+from amaranth.lib.data import StructLayout, ArrayLayout
 
-from transactron import Method, TModule, def_method
-from transactron.utils import DependencyContext
+from transactron import Method, TModule, def_method, Priority, Transaction
+from transactron.utils import DependencyContext, mod_incr
+from transactron.lib import Forwarder, condition
 
-from coreblocks.arch.isa_consts import PAGE_SIZE_LOG
+from coreblocks.arch.isa_consts import PAGE_SIZE_LOG, SatpMode
 from coreblocks.interface.layouts import AddressTranslationLayouts
-from coreblocks.interface.keys import SFenceVMAKey
+from coreblocks.interface.keys import SFenceVMAKey, CSRInstancesKey
 from coreblocks.params import GenParams
 
 from coreblocks.priv.vmem.iface import TLBBackingDevice
@@ -21,6 +18,13 @@ __all__ = [
 
 
 class TLBEntry(StructLayout):
+    valid: Value
+    asid: Value
+    vpn: Value
+    ppn: Value
+    size_class: Value
+    permissions: Value
+
     def __init__(self, gen_params: GenParams):
         super().__init__(
             {
@@ -29,33 +33,72 @@ class TLBEntry(StructLayout):
                 "size_class": gen_params.vmem_params.tlb_size_class_bits,
                 "vpn": gen_params.vmem_params.max_tlb_vpn_bits,
                 "ppn": gen_params.phys_addr_bits - PAGE_SIZE_LOG,
-                "permissions": gen_params.get(AddressTranslationLayouts).permissions
+                "permissions": gen_params.get(AddressTranslationLayouts).permissions,
             }
         )
 
 
-class TLB(TLBBackingDevice, Elaboratable):
+class TLBCAM(Elaboratable):
+    """A single set of a TLB CAM, containing multiple ways."""
+
+    def __init__(self, gen_params: GenParams, ways: int):
+        self.gen_params = gen_params
+        self.ways = ways
+        self.layout = gen_params.get(AddressTranslationLayouts)
+
+        self.ways_data = Signal(ArrayLayout(TLBEntry(gen_params), ways))
+        self.rr_index = Signal(range(ways))  # round-robin pointer for replacement
+        self.checked_asid = Signal(gen_params.vmem_params.asidlen)
+        self.checked_vpn = Signal(gen_params.vmem_params.max_tlb_vpn_bits)
+        self.addr_match = Signal(ways)
+        self.asid_match = Signal(ways)
+        self.valid_match = Signal(ways)
+        self.global_match = Signal(ways)
+
+        self.replace_candidate = Signal(range(ways))
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.d.comb += self.replace_candidate.eq(self.rr_index)
+
+        for way in range(self.ways):
+            m.d.comb += self.valid_match[way].eq(self.ways_data[way].valid)
+            m.d.comb += self.global_match[way].eq(self.ways_data[way].permissions.g)
+            m.d.comb += self.asid_match[way].eq(
+                ~self.global_match[way] & (self.ways_data[way].asid == self.checked_asid)
+            )
+
+            # Address matches if the specified suffix on VPN matches based on size class
+            bits_per_level = SatpMode.bits_per_page_table_level(self.gen_params.isa.xlen)
+            with m.Switch(self.ways_data[way].size_class):
+                for sz_class in range(self.gen_params.vmem_params.max_tlb_size_class + 1):
+                    with m.Case(sz_class):
+                        match_bits = bits_per_level * sz_class
+                        m.d.comb += self.addr_match[way].eq(
+                            self.checked_vpn[match_bits:] == self.ways_data[way].vpn[match_bits:]
+                        )
+
+            with m.If(~self.ways_data[way].valid):
+                m.d.comb += self.replace_candidate.eq(way)
+
+        return m
+
+
+class FullyAssociativeTLB(TLBBackingDevice):
     def __init__(
         self,
         gen_params: GenParams,
         *,
         entries: int,
-        ways: int,
         backing_resolver: TLBBackingDevice,
-    ) -> None:
+    ):
         if entries <= 0:
             raise ValueError("entries must be positive")
-        if ways <= 0:
-            raise ValueError("ways must be positive")
-        if entries % ways != 0:
-            raise ValueError("entries must be divisible by ways")
 
         self.gen_params = gen_params
         self.entries = entries
-        self.ways = ways
-        self.sets = entries // ways
         self.backing_resolver = backing_resolver
-        self.entry_layout = TLBEntry(gen_params)
         self.layout = gen_params.get(AddressTranslationLayouts)
 
         self.request = Method(i=self.layout.tlb_request)
@@ -68,18 +111,132 @@ class TLB(TLBBackingDevice, Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        m.submodules.backing_resolver = self.backing_resolver
+        csr = self.dm.get_dependency(CSRInstancesKey())
 
-        @def_method(m, self.request)
-        def _(arg):
-            pass
+        vpn_bits = self.gen_params.vmem_params.max_tlb_vpn_bits
+        asid_bits = self.gen_params.vmem_params.asidlen
+
+        current_asid = Signal(asid_bits)
+        m.d.comb += current_asid.eq(csr.s_mode.satp_asid)
+
+        entries = Signal(ArrayLayout(TLBEntry(self.gen_params), self.entries))
+
+        m.submodules.cam = cam = TLBCAM(self.gen_params, self.entries)
+        m.d.comb += cam.ways_data.eq(entries)
+
+        m.submodules.fwd = fwd = Forwarder(self.layout.tlb_accept)
+
+        request_in_flight = Signal()
+        requested_vpn = Signal(vpn_bits)
+
+        @def_method(m, self.request, ready=~request_in_flight)
+        def _(vpn, write_aspect):
+            m.d.comb += cam.checked_asid.eq(current_asid)
+            m.d.comb += cam.checked_vpn.eq(vpn)
+
+            valid_vec = Signal(self.entries)
+            m.d.comb += valid_vec.eq(cam.valid_match & cam.addr_match & (cam.asid_match | cam.global_match))
+
+            found_entry = Signal(TLBEntry(self.gen_params))
+
+            for way in range(self.entries):
+                with m.If(valid_vec[way]):
+                    m.d.comb += found_entry.eq(cam.ways_data[way])
+
+            ask_backing = Signal()
+            with m.If(~valid_vec.any()):
+                m.d.comb += ask_backing.eq(1)
+            with m.Elif(write_aspect & ~found_entry.permissions.d):
+                # We have found an entry, but it doesn't have the dirty bit set
+                # NOTE: currently we would never actually need to ask the backing device,
+                #   as we only implement Svade, so if this happens, we are almost sure
+                #   the re-walk will not fix the issue.
+                m.d.comb += ask_backing.eq(1)
+
+            with condition(m, nonblocking=True) as branch:
+                with branch(ask_backing):
+                    m.d.sync += request_in_flight.eq(1)
+                    m.d.sync += requested_vpn.eq(vpn)
+                    self.backing_resolver.request(m, vpn=vpn, write_aspect=write_aspect)
+
+            with m.If(~ask_backing):
+                fwd.write(
+                    m,
+                    result=AddressTranslationLayouts.TLBResult.HIT,
+                    permissions=found_entry.permissions,
+                    ppn=found_entry.ppn,
+                    size_class=found_entry.size_class,
+                )
 
         @def_method(m, self.accept)
-        def _(arg):
-            pass
+        def _():
+            return fwd.read(m)
+
+        # Slow path - refill from backing resolver
+        with Transaction().body(m) as t:
+            resp = self.backing_resolver.accept(m)
+            m.d.sync += request_in_flight.eq(0)
+
+            fwd.write(m, arg=resp)
+
+            with m.If(resp.result == AddressTranslationLayouts.TLBResult.HIT):
+                new_entry = TLBEntry(self.gen_params)
+                m.d.comb += [
+                    new_entry.valid.eq(1),
+                    new_entry.asid.eq(current_asid),
+                    new_entry.vpn.eq(requested_vpn),
+                    new_entry.ppn.eq(resp.ppn),
+                    new_entry.size_class.eq(resp.size_class),
+                    new_entry.permissions.eq(resp.permissions),
+                ]
+                m.d.sync += cam.rr_index.eq(mod_incr(cam.replace_candidate, self.entries))
+                m.d.sync += entries[cam.replace_candidate].eq(new_entry)
 
         @def_method(m, self.sfence_vma)
-        def _(arg):
-            pass
+        def _(vaddr, asid, all_vaddrs, all_asids):
+            m.d.comb += cam.checked_asid.eq(asid)
+            m.d.comb += cam.checked_vpn.eq(vaddr >> PAGE_SIZE_LOG)
+
+            for way in range(self.entries):
+                with m.If((all_asids | cam.asid_match[way]) & (all_vaddrs | cam.addr_match[way])):
+                    m.d.sync += entries[way].valid.eq(0)
+
+        self.sfence_vma.add_conflict(self.request, Priority.LEFT)
+        self.sfence_vma.add_conflict(self.accept, Priority.LEFT)
+        self.sfence_vma.add_conflict(t, Priority.LEFT)
+
+
+class SetAssociativeTLB(TLBBackingDevice):
+    def __init__(
+        self,
+        gen_params: GenParams,
+        *,
+        entries: int,
+        ways: int,
+        backing_resolver: TLBBackingDevice,
+    ):
+        if entries <= 0:
+            raise ValueError("entries must be positive")
+        if ways <= 0:
+            raise ValueError("ways must be positive")
+        if entries % ways != 0:
+            raise ValueError("entries must be divisible by ways")
+
+        self.gen_params = gen_params
+        self.entries = entries
+        self.ways = ways
+        self.backing_resolver = backing_resolver
+        self.layout = gen_params.get(AddressTranslationLayouts)
+
+        self.request = Method(i=self.layout.tlb_request)
+        self.accept = Method(o=self.layout.tlb_accept)
+        self.sfence_vma = Method(i=self.layout.sfence_vma)
+        self.dm = DependencyContext.get()
+        self.dm.add_dependency(SFenceVMAKey(), self.sfence_vma)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        # TODO
 
         return m

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -66,7 +66,7 @@ class TLB(TLBBackingDevice, Elaboratable):
         self.sets = entries // ways
         self.backing_resolver = backing_resolver
         self.entry_layout = TLBEntry(gen_params)
-        self.layout = AddressTranslationLayouts(gen_params)
+        self.layout = gen_params.get(AddressTranslationLayouts)
 
         self.request = Method(i=self.layout.tlb_request)
         self.accept = Method(o=self.layout.tlb_accept)

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -440,7 +440,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
             m.d.sync += flush_all_vaddrs.eq(all_vaddrs)
             m.d.sync += flush_all_asids.eq(all_asids)
 
-            m.d.sync += flush_set.eq(Mux(flush_all_vaddrs, 0, vpn_to_set_idx(flush_vpn, 0)))
+            m.d.sync += flush_set.eq(Mux(all_vaddrs, 0, vpn_to_set_idx(vaddr >> PAGE_SIZE_LOG, 0)))
             m.d.sync += flush_fetched.eq(0)
             m.d.sync += flush_size_class.eq(0)
 
@@ -461,7 +461,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                 m.d.comb += set_wr.data.eq(set_rd.data)
                 for way in range(self.ways):
                     with m.If((flush_all_asids | cam.asid_match[way]) & (flush_all_vaddrs | cam.addr_match[way])):
-                        m.d.av_comb += set_wr.data[way].valid.eq(0)
+                        m.d.comb += set_wr.data[way].valid.eq(0)
 
                 m.d.comb += set_wr.addr.eq(flush_set)
                 m.d.comb += set_wr.en.eq(1)
@@ -473,11 +473,11 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
                     m.d.av_comb += next_flush_set.eq(flush_set + 1)
                     m.d.av_comb += flush_done.eq(flush_set == self.sets - 1)
                 with m.Else():
+                    m.d.av_comb += next_flush_set.eq(vpn_to_set_idx(flush_vpn, flush_size_class + 1))
+                    m.d.sync += flush_size_class.eq(flush_size_class + 1)
+
                     with m.If(flush_size_class == self.gen_params.vmem_params.max_tlb_size_class):
                         m.d.av_comb += flush_done.eq(1)
-                    with m.Else():
-                        m.d.av_comb += next_flush_set.eq(vpn_to_set_idx(flush_vpn, flush_size_class + 1))
-                        m.d.sync += flush_size_class.eq(flush_size_class + 1)
 
                 m.d.sync += flush_set.eq(next_flush_set)
 

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -131,9 +131,7 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
         self.dm = DependencyContext.get()
         self.dm.add_dependency(SFenceVMAKey(), self.sfence_vma)
 
-        self.perf_loads = HwCounter(
-            f"{self.perf_name_prefix}.loads", "Number of requests to the TLB"
-        )
+        self.perf_loads = HwCounter(f"{self.perf_name_prefix}.loads", "Number of requests to the TLB")
         self.perf_hits = HwCounter(f"{self.perf_name_prefix}.hits")
         self.perf_misses = HwCounter(f"{self.perf_name_prefix}.misses")
         self.perf_flushes = HwCounter(f"{self.perf_name_prefix}.flushes")
@@ -278,9 +276,7 @@ class SetAssociativeTLB(TLBBackingDevice, Elaboratable):
         self.dm = DependencyContext.get()
         self.dm.add_dependency(SFenceVMAKey(), self.sfence_vma)
 
-        self.perf_loads = HwCounter(
-            f"{self.perf_name_prefix}.loads", "Number of requests to the TLB"
-        )
+        self.perf_loads = HwCounter(f"{self.perf_name_prefix}.loads", "Number of requests to the TLB")
         self.perf_hits = HwCounter(f"{self.perf_name_prefix}.hits")
         self.perf_misses = HwCounter(f"{self.perf_name_prefix}.misses")
         self.perf_flushes = HwCounter(f"{self.perf_name_prefix}.flushes")

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -1,0 +1,95 @@
+"""Generic set-associative TLB with a backing page resolver."""
+
+from __future__ import annotations
+
+from amaranth import *
+from amaranth.lib.data import StructLayout
+
+from transactron import Method, TModule, def_method
+from transactron.utils import DependencyContext
+
+from coreblocks.arch.isa_consts import PAGE_SIZE_LOG
+from coreblocks.interface.layouts import AddressTranslationLayouts
+from coreblocks.interface.keys import SFenceVMAKey
+from coreblocks.params import GenParams
+
+from coreblocks.priv.vmem.iface import TLBBackingDevice
+
+__all__ = [
+    "TLBEntry",
+    "TLB",
+]
+
+
+class TLBEntry(StructLayout):
+    def __init__(self, gen_params: GenParams):
+        vpn_width = gen_params.vmem_params.max_tlb_vpn_bits
+        ppn_width = gen_params.phys_addr_bits - PAGE_SIZE_LOG
+        asid_width = max(1, gen_params.vmem_params.asidlen)
+
+        super().__init__(
+            {
+                "valid": 1,
+                "global_mapping": 1,
+                "asid": asid_width,
+                "size_class": gen_params.vmem_params.tlb_size_class_bits,
+                "vpn": vpn_width,
+                "ppn": ppn_width,
+                "r": 1,
+                "w": 1,
+                "x": 1,
+                "u": 1,
+                "d": 1,
+            }
+        )
+
+
+class TLB(TLBBackingDevice, Elaboratable):
+    def __init__(
+        self,
+        gen_params: GenParams,
+        *,
+        entries: int,
+        ways: int,
+        backing_resolver: TLBBackingDevice,
+    ) -> None:
+        if entries <= 0:
+            raise ValueError("entries must be positive")
+        if ways <= 0:
+            raise ValueError("ways must be positive")
+        if entries % ways != 0:
+            raise ValueError("entries must be divisible by ways")
+
+        self.gen_params = gen_params
+        self.entries = entries
+        self.ways = ways
+        self.sets = entries // ways
+        self.backing_resolver = backing_resolver
+        self.entry_layout = TLBEntry(gen_params)
+        self.layout = AddressTranslationLayouts(gen_params)
+
+        self.request = Method(i=self.layout.tlb_request)
+        self.accept = Method(o=self.layout.tlb_accept)
+
+        self.sfence_vma = Method(i=self.layout.sfence_vma)
+        self.dm = DependencyContext.get()
+        self.dm.add_dependency(SFenceVMAKey(), self.sfence_vma)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.backing_resolver = self.backing_resolver
+
+        @def_method(m, self.request)
+        def _(arg):
+            pass
+
+        @def_method(m, self.accept)
+        def _(arg):
+            pass
+
+        @def_method(m, self.sfence_vma)
+        def _(arg):
+            pass
+
+        return m

--- a/coreblocks/priv/vmem/tlb.py
+++ b/coreblocks/priv/vmem/tlb.py
@@ -4,7 +4,7 @@ import amaranth.lib.memory as memory
 
 from transactron import Method, TModule, def_method, Priority, Transaction
 from transactron.utils import DependencyContext, mod_incr
-from transactron.lib import Forwarder, Pipe
+from transactron.lib import Forwarder, Pipe, condition
 
 from coreblocks.arch.isa_consts import PAGE_SIZE_LOG, SatpMode
 from coreblocks.interface.layouts import AddressTranslationLayouts
@@ -146,15 +146,16 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
         m.d.comb += cam.ways_data.eq(entries)
 
         m.submodules.fwd = fwd = Forwarder(self.layout.tlb_accept)
-        m.submodules.slow_fwd = slow_fwd = Forwarder(self.layout.tlb_request)
 
         request_in_flight = Signal()
         requested_vpn = Signal(vpn_bits)
 
         @def_method(m, self.request, ready=~request_in_flight)
         def _(vpn, write_aspect):
-            m.d.comb += cam.checked_asid.eq(current_asid)
-            m.d.comb += cam.checked_vpn.eq(vpn)
+            # Set CAM data as request's VPN and ASID by default, so condition will not create a cycle.
+            # As all other uses of CAM are exclusive with this method, other places should use m.d.comb
+            m.d.av_comb += cam.checked_asid.eq(current_asid)
+            m.d.av_comb += cam.checked_vpn.eq(vpn)
 
             found_entry = Signal(TLBEntry(self.gen_params))
 
@@ -172,22 +173,19 @@ class FullyAssociativeTLB(TLBBackingDevice, Elaboratable):
                 #   the re-walk will not fix the issue.
                 m.d.av_comb += ask_backing.eq(1)
 
-            with m.If(ask_backing):
-                m.d.sync += request_in_flight.eq(1)
-                m.d.sync += requested_vpn.eq(vpn)
-                slow_fwd.write(m, vpn=vpn, write_aspect=write_aspect)
-            with m.Else():
-                fwd.write(
-                    m,
-                    result=AddressTranslationLayouts.TLBResult.HIT,
-                    permissions=found_entry.permissions,
-                    ppn=found_entry.ppn,
-                    size_class=found_entry.size_class,
-                )
-
-        with Transaction().body(m):
-            req = slow_fwd.read(m)
-            self.backing_resolver.request(m, vpn=req.vpn, write_aspect=req.write_aspect)
+            with condition(m) as branch:
+                with branch(ask_backing):
+                    m.d.sync += request_in_flight.eq(1)
+                    m.d.sync += requested_vpn.eq(vpn)
+                    self.backing_resolver.request(m, vpn=vpn, write_aspect=write_aspect)
+                with branch():
+                    fwd.write(
+                        m,
+                        result=AddressTranslationLayouts.TLBResult.HIT,
+                        permissions=found_entry.permissions,
+                        ppn=found_entry.ppn,
+                        size_class=found_entry.size_class,
+                    )
 
         # Slow path - refill from backing resolver
         with Transaction().body(m, ready=request_in_flight):

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -79,7 +79,6 @@ class AddressTranslator(Elaboratable):
 
         effective_priv_mode = Signal(PrivilegeLevel, init=PrivilegeLevel.MACHINE)
         effective_satp_mode = Signal(SatpMode, init=SatpMode.BARE)
-        current_asid = Signal(self.gen_params.vmem_params.asidlen)
 
         mxr = Signal()
         sum_ = Signal()
@@ -100,8 +99,6 @@ class AddressTranslator(Elaboratable):
             if self.gen_params.supervisor_mode:
                 with m.If(effective_priv_mode < PrivilegeLevel.MACHINE):
                     m.d.av_comb += effective_satp_mode.eq(csr.s_mode.satp_mode)
-
-                m.d.av_comb += current_asid.eq(csr.s_mode.satp_asid)
 
             m.d.av_comb += mxr.eq(csr.m_mode.mstatus_mxr.read(m).data)
             m.d.av_comb += sum_.eq(csr.m_mode.mstatus_sum.read(m).data)
@@ -139,7 +136,6 @@ class AddressTranslator(Elaboratable):
                     self.tlb.request(
                         m,
                         vpn=vpn,
-                        asid=current_asid,
                         write_aspect=write_aspect,
                     )
 
@@ -183,7 +179,8 @@ class AddressTranslator(Elaboratable):
             with m.Else():
                 with m.Switch(tlb_data.result):
                     with m.Case(AddressTranslationLayouts.TLBResult.HIT):
-                        pass
+                        with m.If(tlb_data.write_aspect):
+                            log.assertion(m, tlb_data.permissions.d, "TLB entry must have dirty bit set if we are writing")
                     with m.Case(AddressTranslationLayouts.TLBResult.PAGE_FAULT):
                         m.d.av_comb += page_fault.eq(1)
                     with m.Case(AddressTranslationLayouts.TLBResult.ACCESS_FAULT):

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -1,86 +1,30 @@
 from amaranth import *
-from amaranth.lib.data import StructLayout
 from amaranth.lib.enum import Enum, unique, auto
 
-from transactron import Method, TModule, def_method
-from transactron.lib import Forwarder
-from transactron.utils import DependencyContext
+from transactron import Method, TModule, def_method, Transaction
+from transactron.lib import Forwarder, condition
+from transactron.utils import DependencyContext, make_layout
+from transactron.lib.logging import HardwareLogger
 
-from coreblocks.arch.isa_consts import PrivilegeLevel, SatpMode, PAGE_SIZE, PAGE_SIZE_LOG
-from coreblocks.interface.keys import CSRInstancesKey
+from coreblocks.arch.isa_consts import PrivilegeLevel, SatpMode, PAGE_SIZE_LOG
+from coreblocks.interface.keys import CSRInstancesKey, L1TLBBackingDevice
 from coreblocks.interface.layouts import AddressTranslationLayouts
 from coreblocks.params import GenParams
 
+from coreblocks.priv.vmem import tlb
+from coreblocks.priv.vmem.tlb import TLB
+
+
 __all__ = ["AddressTranslator", "AddressTranslatorMode"]
+
+
+log = HardwareLogger("mmu.translation")
 
 
 @unique
 class AddressTranslatorMode(Enum):
     INSTRUCTION = auto()
     LSU = auto()
-
-
-def level_count(mode: SatpMode) -> int:
-    match mode:
-        case SatpMode.BARE:
-            return 0
-        case SatpMode.SV32:
-            return 2
-        case SatpMode.SV39:
-            return 3
-        case SatpMode.SV48:
-            return 4
-        case SatpMode.SV57:
-            return 5
-        case _:
-            raise ValueError(f"Unsupported SATP mode: {mode}")
-
-
-def page_table_entry_format(mode: SatpMode) -> StructLayout:
-    match mode:
-        case SatpMode.BARE:
-            return StructLayout({})
-        case SatpMode.SV32:
-            return StructLayout(
-                {
-                    "V": 1,
-                    "R": 1,
-                    "W": 1,
-                    "X": 1,
-                    "U": 1,
-                    "G": 1,
-                    "A": 1,
-                    "D": 1,
-                    "RSW": 2,
-                    "ppn": 22,
-                }
-            )
-        case SatpMode.SV39 | SatpMode.SV48 | SatpMode.SV57:
-            return StructLayout(
-                {
-                    "V": 1,
-                    "R": 1,
-                    "W": 1,
-                    "X": 1,
-                    "U": 1,
-                    "G": 1,
-                    "A": 1,
-                    "D": 1,
-                    "RSW": 2,
-                    "ppn": 44,
-                    "reserved": 7,
-                    "PBMT": 2,
-                    "N": 1,
-                }
-            )
-        case _:
-            raise ValueError(f"Unsupported SATP mode: {mode}")
-
-
-def bits_per_level(mode: SatpMode) -> int:
-    """Number of virtual address bits translated at each page table level."""
-    num_entries = PAGE_SIZE // page_table_entry_format(mode).as_shape().width
-    return num_entries.bit_length() - 1
 
 
 class AddressTranslator(Elaboratable):
@@ -98,18 +42,49 @@ class AddressTranslator(Elaboratable):
 
         self.request = Method(i=self.layouts.request)
         self.accept = Method(o=self.layouts.accept)
+        self.sfence_vma = Method(i=self.layouts.sfence_vma)
+
+        self.tlb = None
+        if gen_params.vmem_params.supported_non_bare_schemes:
+            tlb_cfg = (
+                gen_params.tlb_config.itlb
+                if mode == AddressTranslatorMode.INSTRUCTION
+                else gen_params.tlb_config.dtlb
+            )
+
+            self.tlb = TLB(
+                gen_params,
+                entries=tlb_cfg.entries,
+                ways=tlb_cfg.ways,
+                backing_resolver=gen_params.get(L1TLBBackingDevice),
+            )
 
     def elaborate(self, platform):
         m = TModule()
-        m.submodules.resp_fwd = resp_fwd = Forwarder(self.layouts.accept)
+
+        bits_per_level = SatpMode.bits_per_page_table_level(self.gen_params.isa.xlen)
+
+        fwd_layout = make_layout(
+            ("vaddr", self.gen_params.isa.xlen),
+            ("access_fault", 1),
+            ("page_fault", 1),
+            ("write_aspect", 1),
+        )
+        m.submodules.resp_fwd = resp_fwd = Forwarder(fwd_layout)
+
+        if self.tlb is not None:
+            m.submodules.tlb = self.tlb
+
         csr = DependencyContext.get().get_dependency(CSRInstancesKey())
 
-        @def_method(m, self.request)
-        def _(addr: Value):
-            access_fault = Signal()
-            page_fault = Signal()
-            effective_priv_mode = Signal(PrivilegeLevel)
+        effective_priv_mode = Signal(PrivilegeLevel, init=PrivilegeLevel.MACHINE)
+        effective_satp_mode = Signal(SatpMode, init=SatpMode.BARE)
+        current_asid = Signal(self.gen_params.vmem_params.asidlen)
 
+        mxr = Signal()
+        sum_ = Signal()
+
+        with Transaction().body(m) as t:
             priv_mode = csr.m_mode.priv_mode.read(m).data
 
             match self.mode:
@@ -122,53 +97,140 @@ class AddressTranslator(Elaboratable):
                 case AddressTranslatorMode.INSTRUCTION:
                     m.d.av_comb += effective_priv_mode.eq(priv_mode)
 
-            effective_satp_mode = Signal(SatpMode, init=SatpMode.BARE)
-
             if self.gen_params.supervisor_mode:
                 with m.If(effective_priv_mode < PrivilegeLevel.MACHINE):
                     m.d.av_comb += effective_satp_mode.eq(csr.s_mode.satp_mode)
 
+                m.d.av_comb += current_asid.eq(csr.s_mode.satp_asid)
+
+            m.d.av_comb += mxr.eq(csr.m_mode.mstatus_mxr.read(m).data)
+            m.d.av_comb += sum_.eq(csr.m_mode.mstatus_sum.read(m).data)
+
+        log.error(m, ~t.run, "Transaction must always run")
+
+        @def_method(m, self.request)
+        def _(addr: Value, write_aspect: Value):
+            access_fault = Signal()
+            page_fault = Signal()
+
             poffset = Signal(PAGE_SIZE_LOG)
-            ppn = Signal(self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)
             vpn = Signal(self.gen_params.isa.xlen - PAGE_SIZE_LOG)
 
             m.d.av_comb += Cat(poffset, vpn).eq(addr)
 
-            max_ppn = 1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG) - 1
-
             vpn_invalid = Signal()
             with m.Switch(effective_satp_mode):
-                for mode in self.gen_params.vmem_params.supported_schemes - {SatpMode.BARE}:
-                    vpn_len = bits_per_level(mode) * level_count(mode)
+                for vm_mode in self.gen_params.vmem_params.supported_non_bare_schemes:
+                    vm_vpn_len = bits_per_level * SatpMode.level_count(vm_mode)
 
-                    with m.Case(mode):
-                        # virtual modes require sign-extended vaddr
-                        m.d.av_comb += vpn_invalid.eq(vpn[vpn_len:].any() & ~vpn[vpn_len:].all())
+                    with m.Case(vm_mode):
+                        m.d.av_comb += vpn_invalid.eq(
+                            vpn[vm_vpn_len - 1:].any() & ~vpn[vm_vpn_len - 1:].all()
+                        )
 
-            ppn_invalid = Signal()
-            with m.Switch(effective_satp_mode):
-                with m.Case(SatpMode.BARE):
-                    m.d.av_comb += ppn.eq(vpn)
-                    m.d.av_comb += ppn_invalid.eq(vpn > max_ppn)
+            max_ppn = (1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1
 
-                # TODO: implement actual page table walking
-
-            with m.If(vpn_invalid):
+            with m.If(effective_satp_mode == SatpMode.BARE):
+                m.d.av_comb += access_fault.eq(vpn > max_ppn)
+            with m.Elif(vpn_invalid):
                 m.d.av_comb += page_fault.eq(1)
-
-            with m.If(ppn_invalid):
-                m.d.av_comb += access_fault.eq(1)
+            with m.Else():
+                if self.tlb is not None:
+                    self.tlb.request(
+                        m,
+                        vpn=vpn,
+                        asid=current_asid,
+                        write_aspect=write_aspect,
+                    )
 
             resp_fwd.write(
                 m,
                 vaddr=addr,
-                paddr=Cat(poffset, ppn),
-                page_fault=page_fault,
+                page_fault=vpn_invalid,
                 access_fault=access_fault,
+                write_aspect=write_aspect,
             )
 
         @def_method(m, self.accept)
         def _():
-            return resp_fwd.read(m)
+            ppn = Signal(self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)
+            page_fault = Signal()
+            access_fault = Signal()
+
+            data = resp_fwd.read(m)
+            tlb_data = Signal(self.layouts.tlb_accept)
+
+            vpn = Signal(self.gen_params.isa.xlen - PAGE_SIZE_LOG)
+            poffset = Signal(PAGE_SIZE_LOG)
+
+            m.d.av_comb += Cat(poffset, vpn).eq(data.vaddr)
+
+            with m.If(data.page_fault):
+                m.d.av_comb += page_fault.eq(1)
+
+            with m.If(data.access_fault):
+                m.d.av_comb += access_fault.eq(1)
+
+            if self.tlb is not None:
+                with condition(m) as branch:
+                    with branch((effective_satp_mode != SatpMode.BARE) & ~data.page_fault):
+                        m.d.av_comb += tlb_data.eq(self.tlb.accept(m))
+                    with branch():
+                        pass
+
+            with m.If(effective_satp_mode == SatpMode.BARE):
+                m.d.av_comb += ppn.eq(vpn)
+            with m.Else():
+                with m.Switch(tlb_data.result):
+                    with m.Case(AddressTranslationLayouts.TLBResult.HIT):
+                        pass
+                    with m.Case(AddressTranslationLayouts.TLBResult.PAGE_FAULT):
+                        m.d.av_comb += page_fault.eq(1)
+                    with m.Case(AddressTranslationLayouts.TLBResult.ACCESS_FAULT):
+                        m.d.av_comb += access_fault.eq(1)
+
+                # apply lower bits from VPN if we have hit to a non-leaf
+                with m.Switch(tlb_data.size_class):
+                    for size_class in range(self.gen_params.vmem_params.max_tlb_size_class + 1):
+                        level_bits = bits_per_level * size_class
+                        with m.Case(size_class):
+                            m.d.av_comb += ppn.eq(Cat(vpn[:level_bits], tlb_data.ppn[level_bits:]))
+
+                # check RWX permissions
+                match self.mode:
+                    case AddressTranslatorMode.INSTRUCTION:
+                        log.assertion(m, ~data.write_aspect, "Instruction fetch cannot have write aspect")
+
+                        with m.If(~tlb_data.permissions.x):
+                            m.d.av_comb += page_fault.eq(1)
+                    case AddressTranslatorMode.LSU:
+                        with m.If(data.write_aspect):
+                            with m.If(~tlb_data.permissions.w):
+                                m.d.av_comb += page_fault.eq(1)
+                        with m.Else():
+                            with m.If(~tlb_data.permissions.r & (~mxr | ~tlb_data.permissions.x)):
+                                m.d.av_comb += page_fault.eq(1)
+
+                # check U/S permissions
+                is_user = effective_priv_mode == PrivilegeLevel.USER
+                match self.mode:
+                    case AddressTranslatorMode.INSTRUCTION:
+                        # SUM does not affect instruction fetches
+                        with m.If(is_user == tlb_data.permissions.u):
+                            m.d.av_comb += page_fault.eq(1)
+                    case AddressTranslatorMode.LSU:
+                        with m.If(is_user):
+                            with m.If(~tlb_data.permissions.u):
+                                m.d.av_comb += page_fault.eq(1)
+                        with m.Else():
+                            with m.If(~tlb_data.permissions.u & ~sum_):
+                                m.d.av_comb += page_fault.eq(1)
+
+            return {
+                "vaddr": data.vaddr,
+                "paddr": Cat(ppn, poffset),
+                "page_fault": page_fault,
+                "access_fault": access_fault,
+            }
 
         return m

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -3,8 +3,7 @@ from amaranth.lib.enum import Enum, unique, auto
 
 from transactron import Method, TModule, def_method, Transaction
 from transactron.lib import Forwarder, condition
-from transactron.utils import DependencyContext, make_layout
-from transactron.lib.logging import HardwareLogger
+from transactron.utils import DependencyContext, make_layout, HardwareLogger
 
 from coreblocks.arch.isa_consts import PrivilegeLevel, SatpMode, PAGE_SIZE_LOG
 from coreblocks.interface.keys import CSRInstancesKey, L1TLBBackingDeviceKey

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -53,9 +53,7 @@ class AddressTranslator(Elaboratable):
                     else gen_params.tlb_config.dtlb_entries
                 ),
                 backing_resolver=self.dm.get_dependency(L1TLBBackingDeviceKey()),
-                perf_name_prefix=(
-                    "mmu.itlb" if mode == AddressTranslatorMode.INSTRUCTION else "mmu.dtlb"
-                ),
+                perf_name_prefix=("mmu.itlb" if mode == AddressTranslatorMode.INSTRUCTION else "mmu.dtlb"),
             )
 
     def elaborate(self, platform):

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -7,7 +7,7 @@ from transactron.utils import DependencyContext, make_layout
 from transactron.lib.logging import HardwareLogger
 
 from coreblocks.arch.isa_consts import PrivilegeLevel, SatpMode, PAGE_SIZE_LOG
-from coreblocks.interface.keys import CSRInstancesKey, L1TLBBackingDevice
+from coreblocks.interface.keys import CSRInstancesKey, L1TLBBackingDeviceKey
 from coreblocks.interface.layouts import AddressTranslationLayouts
 from coreblocks.params import GenParams
 
@@ -43,6 +43,8 @@ class AddressTranslator(Elaboratable):
         self.accept = Method(o=self.layouts.accept)
         self.sfence_vma = Method(i=self.layouts.sfence_vma)
 
+        self.dm = DependencyContext.get()
+
         self.tlb = None
         if gen_params.vmem_params.supported_non_bare_schemes:
             tlb_cfg = (
@@ -53,7 +55,7 @@ class AddressTranslator(Elaboratable):
                 gen_params,
                 entries=tlb_cfg.entries,
                 ways=tlb_cfg.ways,
-                backing_resolver=gen_params.get(L1TLBBackingDevice),
+                backing_resolver=self.dm.get_dependency(L1TLBBackingDeviceKey()),
             )
 
     def elaborate(self, platform):
@@ -72,7 +74,7 @@ class AddressTranslator(Elaboratable):
         if self.tlb is not None:
             m.submodules.tlb = self.tlb
 
-        csr = DependencyContext.get().get_dependency(CSRInstancesKey())
+        csr = self.dm.get_dependency(CSRInstancesKey())
 
         effective_priv_mode = Signal(PrivilegeLevel, init=PrivilegeLevel.MACHINE)
         effective_satp_mode = Signal(SatpMode, init=SatpMode.BARE)

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -53,6 +53,9 @@ class AddressTranslator(Elaboratable):
                     else gen_params.tlb_config.dtlb_entries
                 ),
                 backing_resolver=self.dm.get_dependency(L1TLBBackingDeviceKey()),
+                perf_name_prefix=(
+                    "mmu.itlb" if mode == AddressTranslatorMode.INSTRUCTION else "mmu.dtlb"
+                ),
             )
 
     def elaborate(self, platform):

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -176,7 +176,7 @@ class AddressTranslator(Elaboratable):
             with m.Else():
                 with m.Switch(tlb_data.result):
                     with m.Case(AddressTranslationLayouts.TLBResult.HIT):
-                        with m.If(tlb_data.write_aspect):
+                        with m.If(data.write_aspect):
                             log.assertion(
                                 m, tlb_data.permissions.d, "TLB entry must have dirty bit set if we are writing"
                             )

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -11,7 +11,6 @@ from coreblocks.interface.keys import CSRInstancesKey, L1TLBBackingDevice
 from coreblocks.interface.layouts import AddressTranslationLayouts
 from coreblocks.params import GenParams
 
-from coreblocks.priv.vmem import tlb
 from coreblocks.priv.vmem.tlb import TLB
 
 
@@ -47,9 +46,7 @@ class AddressTranslator(Elaboratable):
         self.tlb = None
         if gen_params.vmem_params.supported_non_bare_schemes:
             tlb_cfg = (
-                gen_params.tlb_config.itlb
-                if mode == AddressTranslatorMode.INSTRUCTION
-                else gen_params.tlb_config.dtlb
+                gen_params.tlb_config.itlb if mode == AddressTranslatorMode.INSTRUCTION else gen_params.tlb_config.dtlb
             )
 
             self.tlb = TLB(
@@ -121,9 +118,7 @@ class AddressTranslator(Elaboratable):
                     vm_vpn_len = bits_per_level * SatpMode.level_count(vm_mode)
 
                     with m.Case(vm_mode):
-                        m.d.av_comb += vpn_invalid.eq(
-                            vpn[vm_vpn_len - 1:].any() & ~vpn[vm_vpn_len - 1:].all()
-                        )
+                        m.d.av_comb += vpn_invalid.eq(vpn[vm_vpn_len - 1 :].any() & ~vpn[vm_vpn_len - 1 :].all())
 
             max_ppn = (1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1
 
@@ -180,7 +175,9 @@ class AddressTranslator(Elaboratable):
                 with m.Switch(tlb_data.result):
                     with m.Case(AddressTranslationLayouts.TLBResult.HIT):
                         with m.If(tlb_data.write_aspect):
-                            log.assertion(m, tlb_data.permissions.d, "TLB entry must have dirty bit set if we are writing")
+                            log.assertion(
+                                m, tlb_data.permissions.d, "TLB entry must have dirty bit set if we are writing"
+                            )
                     with m.Case(AddressTranslationLayouts.TLBResult.PAGE_FAULT):
                         m.d.av_comb += page_fault.eq(1)
                     with m.Case(AddressTranslationLayouts.TLBResult.ACCESS_FAULT):

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -11,7 +11,7 @@ from coreblocks.interface.keys import CSRInstancesKey, L1TLBBackingDeviceKey
 from coreblocks.interface.layouts import AddressTranslationLayouts
 from coreblocks.params import GenParams
 
-from coreblocks.priv.vmem.tlb import TLB
+from coreblocks.priv.vmem.tlb import FullyAssociativeTLB
 
 
 __all__ = ["AddressTranslator", "AddressTranslatorMode"]
@@ -47,14 +47,13 @@ class AddressTranslator(Elaboratable):
 
         self.tlb = None
         if gen_params.vmem_params.supported_non_bare_schemes:
-            tlb_cfg = (
-                gen_params.tlb_config.itlb if mode == AddressTranslatorMode.INSTRUCTION else gen_params.tlb_config.dtlb
-            )
-
-            self.tlb = TLB(
+            self.tlb = FullyAssociativeTLB(
                 gen_params,
-                entries=tlb_cfg.entries,
-                ways=tlb_cfg.ways,
+                entries=(
+                    gen_params.tlb_config.itlb_entries
+                    if mode == AddressTranslatorMode.INSTRUCTION
+                    else gen_params.tlb_config.dtlb_entries
+                ),
                 backing_resolver=self.dm.get_dependency(L1TLBBackingDeviceKey()),
             )
 

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -41,7 +41,6 @@ class AddressTranslator(Elaboratable):
 
         self.request = Method(i=self.layouts.request)
         self.accept = Method(o=self.layouts.accept)
-        self.sfence_vma = Method(i=self.layouts.sfence_vma)
 
         self.dm = DependencyContext.get()
 
@@ -65,7 +64,7 @@ class AddressTranslator(Elaboratable):
         fwd_layout = make_layout(
             ("vaddr", self.gen_params.isa.xlen),
             ("access_fault", 1),
-            ("page_fault", 1),
+            ("vpn_invalid", 1),
             ("write_aspect", 1),
         )
         m.submodules.resp_fwd = resp_fwd = Forwarder(fwd_layout)
@@ -106,29 +105,27 @@ class AddressTranslator(Elaboratable):
         @def_method(m, self.request)
         def _(addr: Value, write_aspect: Value):
             access_fault = Signal()
-            page_fault = Signal()
+            vpn_invalid = Signal()
 
             poffset = Signal(PAGE_SIZE_LOG)
             vpn = Signal(self.gen_params.isa.xlen - PAGE_SIZE_LOG)
 
+            max_ppn = (1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1
+
             m.d.av_comb += Cat(poffset, vpn).eq(addr)
 
-            vpn_invalid = Signal()
             with m.Switch(effective_satp_mode):
+                with m.Case(SatpMode.BARE):
+                    m.d.av_comb += access_fault.eq(vpn > max_ppn)
+
                 for vm_mode in self.gen_params.vmem_params.supported_non_bare_schemes:
                     vm_vpn_len = bits_per_level * SatpMode.level_count(vm_mode)
 
                     with m.Case(vm_mode):
                         m.d.av_comb += vpn_invalid.eq(vpn[vm_vpn_len - 1 :].any() & ~vpn[vm_vpn_len - 1 :].all())
 
-            max_ppn = (1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1
-
-            with m.If(effective_satp_mode == SatpMode.BARE):
-                m.d.av_comb += access_fault.eq(vpn > max_ppn)
-            with m.Elif(vpn_invalid):
-                m.d.av_comb += page_fault.eq(1)
-            with m.Else():
-                if self.tlb is not None:
+            if self.tlb is not None:
+                with m.If((effective_satp_mode != SatpMode.BARE) & ~vpn_invalid):
                     self.tlb.request(
                         m,
                         vpn=vpn,
@@ -138,7 +135,7 @@ class AddressTranslator(Elaboratable):
             resp_fwd.write(
                 m,
                 vaddr=addr,
-                page_fault=vpn_invalid,
+                vpn_invalid=vpn_invalid,
                 access_fault=access_fault,
                 write_aspect=write_aspect,
             )
@@ -157,18 +154,16 @@ class AddressTranslator(Elaboratable):
 
             m.d.av_comb += Cat(poffset, vpn).eq(data.vaddr)
 
-            with m.If(data.page_fault):
-                m.d.av_comb += page_fault.eq(1)
-
             with m.If(data.access_fault):
                 m.d.av_comb += access_fault.eq(1)
 
+            with m.If(data.vpn_invalid):
+                m.d.av_comb += page_fault.eq(1)
+
             if self.tlb is not None:
-                with condition(m) as branch:
-                    with branch((effective_satp_mode != SatpMode.BARE) & ~data.page_fault):
+                with condition(m, nonblocking=True) as branch:
+                    with branch((effective_satp_mode != SatpMode.BARE) & ~data.vpn_invalid):
                         m.d.av_comb += tlb_data.eq(self.tlb.accept(m))
-                    with branch():
-                        pass
 
             with m.If(effective_satp_mode == SatpMode.BARE):
                 m.d.av_comb += ppn.eq(vpn)
@@ -184,7 +179,7 @@ class AddressTranslator(Elaboratable):
                     with m.Case(AddressTranslationLayouts.TLBResult.ACCESS_FAULT):
                         m.d.av_comb += access_fault.eq(1)
 
-                # apply lower bits from VPN if we have hit to a non-leaf
+                # apply lower bits from VPN if we have hit a superpage
                 with m.Switch(tlb_data.size_class):
                     for size_class in range(self.gen_params.vmem_params.max_tlb_size_class + 1):
                         level_bits = bits_per_level * size_class
@@ -203,7 +198,7 @@ class AddressTranslator(Elaboratable):
                             with m.If(~tlb_data.permissions.w):
                                 m.d.av_comb += page_fault.eq(1)
                         with m.Else():
-                            with m.If(~tlb_data.permissions.r & (~mxr | ~tlb_data.permissions.x)):
+                            with m.If(~tlb_data.permissions.r & ~(mxr & tlb_data.permissions.x)):
                                 m.d.av_comb += page_fault.eq(1)
 
                 # check U/S permissions
@@ -211,19 +206,19 @@ class AddressTranslator(Elaboratable):
                 match self.mode:
                     case AddressTranslatorMode.INSTRUCTION:
                         # SUM does not affect instruction fetches
-                        with m.If(is_user == tlb_data.permissions.u):
+                        with m.If(is_user != tlb_data.permissions.u):
                             m.d.av_comb += page_fault.eq(1)
                     case AddressTranslatorMode.LSU:
                         with m.If(is_user):
                             with m.If(~tlb_data.permissions.u):
                                 m.d.av_comb += page_fault.eq(1)
                         with m.Else():
-                            with m.If(~tlb_data.permissions.u & ~sum_):
+                            with m.If(tlb_data.permissions.u & ~sum_):
                                 m.d.av_comb += page_fault.eq(1)
 
             return {
                 "vaddr": data.vaddr,
-                "paddr": Cat(ppn, poffset),
+                "paddr": Cat(poffset, ppn),
                 "page_fault": page_fault,
                 "access_fault": access_fault,
             }

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -101,18 +101,18 @@ class PTEView(View):
 
 class PageTableWalker(TLBBackingDevice, Elaboratable):
     """Hardware page table walker for RISC-V virtual memory translation.
-    
+
     This module implements a page table walker that translates virtual page numbers (VPN)
     to physical page numbers (PPN) by walking through the page table hierarchy according
     to the current SATP configuration.
-    
+
     Supported virtual memory modes:
     - BARE: No translation (immediate page fault)
     - SV32: 32-bit virtual addresses, 2-level page table
     - SV39: 64-bit virtual addresses, 3-level page table
     - SV48: 64-bit virtual addresses, 4-level page table
     - SV57: 64-bit virtual addresses, 5-level page table
-    
+
     Implements Svade semantics (exception on missing A/D bits).
     """
 
@@ -178,7 +178,7 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
                     fetched = bus.get_read_response(m)
                     pte = Signal(pte_layout)
                     m.d.av_comb += pte.eq(fetched.data)
-                    
+
                     m.d.sync += [
                         permissions.r.eq(pte.R),
                         permissions.w.eq(pte.W),

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -12,8 +12,7 @@ from coreblocks.peripherals.bus_adapter import BusMasterInterface
 from coreblocks.priv.pmp import PMPChecker, PMPOperationMode
 
 from transactron import *
-from transactron.utils import DependencyContext
-from transactron.lib.logging import HardwareLogger
+from transactron.utils import DependencyContext, HardwareLogger
 
 from coreblocks.priv.vmem.iface import TLBBackingDevice
 

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -7,7 +7,8 @@ from amaranth.utils import exact_log2
 from coreblocks.arch.isa_consts import PAGE_SIZE, SatpMode, PAGE_SIZE_LOG
 from coreblocks.params.genparams import GenParams
 from coreblocks.interface.layouts import AddressTranslationLayouts
-from coreblocks.interface.keys import CSRInstancesKey, CommonBusDataKey
+from coreblocks.interface.keys import CSRInstancesKey
+from coreblocks.peripherals.bus_adapter import BusMasterInterface
 from coreblocks.priv.pmp import PMPChecker, PMPOperationMode
 
 from transactron import *
@@ -15,6 +16,9 @@ from transactron.utils import DependencyContext
 from transactron.lib.logging import HardwareLogger
 
 from coreblocks.priv.vmem.iface import TLBBackingDevice
+
+
+__all__ = ["PageTableWalker"]
 
 
 log = HardwareLogger("mmu.walker")
@@ -116,17 +120,17 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
     Implements Svade semantics (exception on missing A/D bits).
     """
 
-    def __init__(self, gen_params: GenParams) -> None:
+    def __init__(self, gen_params: GenParams, bus: BusMasterInterface) -> None:
         self.gen_params = gen_params
         self.layout = gen_params.get(AddressTranslationLayouts)
         self.request = Method(i=self.layout.tlb_request)
         self.accept = Method(o=self.layout.tlb_accept)
         self.dm = DependencyContext.get()
+        self.bus = bus
 
     def elaborate(self, platform):
         m = TModule()
 
-        bus = self.dm.get_dependency(CommonBusDataKey())
         csr = self.dm.get_dependency(CSRInstancesKey())
         m.submodules.pmp_checker = pmp_checker = PMPChecker(self.gen_params, mode=PMPOperationMode.MMU)
 
@@ -171,11 +175,11 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
                         m.next = "DONE"
                     with m.Else():
                         assert xlen == pte_bytes * 8
-                        bus.request_read(m, addr=pte_addr >> exact_log2(xlen), sel=~0)
+                        self.bus.request_read(m, addr=pte_addr >> exact_log2(xlen), sel=~0)
                         m.next = "EVAL"
             with m.State("EVAL"):
                 with Transaction().body(m):
-                    fetched = bus.get_read_response(m)
+                    fetched = self.bus.get_read_response(m)
                     pte = Signal(pte_layout)
                     m.d.av_comb += pte.eq(fetched.data)
 

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -1,0 +1,125 @@
+from amaranth import *
+from amaranth.lib.data import StructLayout, View
+
+from coreblocks.arch.isa_consts import SatpMode
+from coreblocks.params.genparams import GenParams
+from coreblocks.interface.layouts import AddressTranslationLayouts
+from coreblocks.interface.keys import SFenceVMAKey
+
+from transactron import *
+from transactron.utils import DependencyContext
+
+from coreblocks.priv.vmem.iface import TLBBackingDevice
+
+
+class PTELayout(StructLayout):
+    def __init__(self, gen_params: GenParams):
+        # We assume all supported modes have the same PTE format.
+        if not gen_params.vmem_params.supported_non_bare_schemes:
+            raise ValueError("PTE layout cannot be determined without supported virtual memory schemes")
+
+        assert SatpMode.SV64 not in gen_params.vmem_params.supported_schemes, "SV64 is not supported"
+
+        self.gen_params = gen_params
+
+        # there is only one vmem scheme for RV32, and all RV64 schemes share the same PTE format
+        if self.gen_params.isa.xlen == 32:
+            layout = {
+                "V": 1,
+                "R": 1,
+                "W": 1,
+                "X": 1,
+                "U": 1,
+                "G": 1,
+                "A": 1,
+                "D": 1,
+                "RSW": 2,
+                "ppn": 22,
+            }
+        else:
+            layout = {
+                "V": 1,
+                "R": 1,
+                "W": 1,
+                "X": 1,
+                "U": 1,
+                "G": 1,
+                "A": 1,
+                "D": 1,
+                "RSW": 2,
+                "ppn": 44,
+                "reserved": 7,
+                "PBMT": 2,
+                "N": 1,
+            }
+
+        super().__init__(layout)
+
+    def __call__(self, value):
+        return PTEView(value, self)
+
+
+class PTEView(View):
+    def __init__(self, value, layout):
+        self.xlen = layout.xlen
+        super().__init__(value, layout)
+
+    def permissions(self):
+        return {
+            "r": self.R,
+            "w": self.W,
+            "x": self.X,
+            "u": self.U,
+            "d": self.D,
+        }
+
+    def non_leaf(self):
+        return ~self.R | ~self.W | ~self.X
+
+    def bad_encoding(self):
+        """Whether page-fault should be raised due to invalid PTE encoding."""
+        is_bad = 0
+
+        # W needs R
+        is_bad |= self.W & ~self.R
+
+        # RSW is reserved for software - ignored
+
+        if self.gen_params.isa.xlen == 64:
+            # Reserved bits must be zero
+            is_bad |= self.reserved.any()
+            is_bad |= self.PBMT.any()
+            is_bad |= self.N
+
+        return is_bad
+
+
+class PageTableWalker(TLBBackingDevice, Elaboratable):
+    """Hardware page table walker for virtual address translation."""
+
+    def __init__(self, gen_params: GenParams) -> None:
+        self.gen_params = gen_params
+        self.layout = AddressTranslationLayouts(gen_params)
+        self.request = Method(i=self.layout.tlb_request)
+        self.accept = Method(o=self.layout.tlb_accept)
+
+        self.sfence_vma = Method(i=self.layout.sfence_vma)
+        self.dm = DependencyContext.get()
+        self.dm.add_dependency(SFenceVMAKey(), self.sfence_vma)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        @def_method(m, self.request)
+        def _(arg):
+            pass
+
+        @def_method(m, self.accept)
+        def _(arg):
+            pass
+
+        @def_method(m, self.sfence_vma)
+        def _(arg):
+            pass
+
+        return m

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -1,18 +1,28 @@
+"""Page Table Walker - Hardware implementation of RISC-V page table walking."""
+
 from amaranth import *
 from amaranth.lib.data import StructLayout, View
+from amaranth.utils import exact_log2
 
-from coreblocks.arch.isa_consts import SatpMode
+from coreblocks.arch.isa_consts import PAGE_SIZE, SatpMode, PAGE_SIZE_LOG
 from coreblocks.params.genparams import GenParams
 from coreblocks.interface.layouts import AddressTranslationLayouts
-from coreblocks.interface.keys import SFenceVMAKey
+from coreblocks.interface.keys import CSRInstancesKey, CommonBusDataKey
+from coreblocks.priv.pmp import PMPChecker, PMPOperationMode
 
 from transactron import *
 from transactron.utils import DependencyContext
+from transactron.lib.logging import HardwareLogger
 
 from coreblocks.priv.vmem.iface import TLBBackingDevice
 
 
+log = HardwareLogger("mmu.walker")
+
+
 class PTELayout(StructLayout):
+    """Page Table Entry layout for RISC-V."""
+
     def __init__(self, gen_params: GenParams):
         # We assume all supported modes have the same PTE format.
         if not gen_params.vmem_params.supported_non_bare_schemes:
@@ -60,25 +70,17 @@ class PTELayout(StructLayout):
 
 
 class PTEView(View):
+    """View of a Page Table Entry with helper methods."""
+
     def __init__(self, value, layout):
-        self.xlen = layout.xlen
+        self.gen_params: GenParams = layout.gen_params
         super().__init__(value, layout)
 
-    def permissions(self):
-        return {
-            "r": self.R,
-            "w": self.W,
-            "x": self.X,
-            "u": self.U,
-            "d": self.D,
-        }
+    def is_leaf(self):
+        return self.R | self.X
 
-    def non_leaf(self):
-        return ~self.R | ~self.W | ~self.X
-
-    def bad_encoding(self):
-        """Whether page-fault should be raised due to invalid PTE encoding."""
-        is_bad = 0
+    def invalid(self):
+        is_bad = ~self.V
 
         # W needs R
         is_bad |= self.W & ~self.R
@@ -91,35 +93,173 @@ class PTEView(View):
             is_bad |= self.PBMT.any()
             is_bad |= self.N
 
+        # Non-leaf PTEs have A and D bits reserved
+        is_bad |= self.is_leaf() & (self.A | self.D)
+
         return is_bad
 
 
 class PageTableWalker(TLBBackingDevice, Elaboratable):
-    """Hardware page table walker for virtual address translation."""
+    """Hardware page table walker for RISC-V virtual memory translation.
+    
+    This module implements a page table walker that translates virtual page numbers (VPN)
+    to physical page numbers (PPN) by walking through the page table hierarchy according
+    to the current SATP configuration.
+    
+    Supported virtual memory modes:
+    - BARE: No translation (immediate page fault)
+    - SV32: 32-bit virtual addresses, 2-level page table
+    - SV39: 64-bit virtual addresses, 3-level page table
+    - SV48: 64-bit virtual addresses, 4-level page table
+    - SV57: 64-bit virtual addresses, 5-level page table
+    
+    Implements Svade semantics (exception on missing A/D bits).
+    """
 
     def __init__(self, gen_params: GenParams) -> None:
         self.gen_params = gen_params
-        self.layout = AddressTranslationLayouts(gen_params)
+        self.layout = gen_params.get(AddressTranslationLayouts)
         self.request = Method(i=self.layout.tlb_request)
         self.accept = Method(o=self.layout.tlb_accept)
-
-        self.sfence_vma = Method(i=self.layout.sfence_vma)
         self.dm = DependencyContext.get()
-        self.dm.add_dependency(SFenceVMAKey(), self.sfence_vma)
 
     def elaborate(self, platform):
         m = TModule()
 
-        @def_method(m, self.request)
-        def _(arg):
-            pass
+        bus = self.dm.get_dependency(CommonBusDataKey())
+        csr = self.dm.get_dependency(CSRInstancesKey())
+        m.submodules.pmp_checker = pmp_checker = PMPChecker(self.gen_params, mode=PMPOperationMode.MMU)
 
-        @def_method(m, self.accept)
-        def _(arg):
-            pass
+        pte_layout = PTELayout(self.gen_params)
+        xlen = self.gen_params.isa.xlen
+        bits_per_level = SatpMode.bits_per_page_table_level(xlen)
+        pte_bytes = pte_layout.as_shape().width // 8
 
-        @def_method(m, self.sfence_vma)
+        assert (pte_bytes << bits_per_level) == PAGE_SIZE
+
+        max_levels = max(SatpMode.level_count(mode) for mode in self.gen_params.vmem_params.supported_non_bare_schemes)
+
+        walk_level = Signal(range(max_levels))
+        walk_vpn = Signal(self.gen_params.vmem_params.max_tlb_vpn_bits)
+        write_aspect = Signal()
+        pte_addr = Signal(self.gen_params.phys_addr_bits)
+        ppn = Signal(self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)
+        access_fault = Signal()
+        page_fault = Signal()
+
+        accessed = Signal()
+        permissions = Signal(self.layout.permissions)
+
+        vpn_index = Signal(bits_per_level)
+        m.d.comb += [
+            vpn_index.eq(walk_vpn.word_select(walk_level, bits_per_level)),
+            pte_addr.eq((ppn << PAGE_SIZE_LOG) | (vpn_index * pte_bytes)),
+            pmp_checker.paddr.eq(pte_addr),
+        ]
+
+        with m.FSM() as fsm:
+            with m.State("IDLE"):
+                with m.If(self.request.run):
+                    m.next = "ISSUE"
+            with m.State("DONE"):
+                with m.If(self.accept.run):
+                    m.next = "IDLE"
+            with m.State("ISSUE"):
+                with Transaction().body(m):
+                    with m.If(~pmp_checker.result.r):
+                        m.d.sync += access_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Else():
+                        assert xlen == pte_bytes * 8
+                        bus.request_read(m, addr=pte_addr >> exact_log2(xlen), sel=~0)
+                        m.next = "EVAL"
+            with m.State("EVAL"):
+                with Transaction().body(m):
+                    fetched = bus.get_read_response(m)
+                    pte = Signal(pte_layout)
+                    m.d.av_comb += pte.eq(fetched.data)
+                    
+                    m.d.sync += [
+                        permissions.r.eq(pte.R),
+                        permissions.w.eq(pte.W),
+                        permissions.x.eq(pte.X),
+                        permissions.u.eq(pte.U),
+                        permissions.d.eq(pte.D),
+                        permissions.g.eq(pte.G),
+                        accessed.eq(pte.A),
+                    ]
+
+                    m.d.sync += ppn.eq(pte.ppn)
+
+                    max_ppn = (1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1
+                    with m.If(fetched.err):
+                        m.d.sync += access_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Elif(pte.invalid()):
+                        m.d.sync += page_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Elif(pte.ppn > max_ppn):
+                        m.d.sync += access_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Elif(pte.is_leaf()):
+                        m.next = "DONE"
+                    with m.Elif(walk_level == 0):
+                        m.d.sync += page_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Else():
+                        m.d.sync += walk_level.eq(walk_level - 1)
+                        m.next = "ISSUE"
+
+        @def_method(m, self.request, ready=fsm.ongoing("IDLE"))
         def _(arg):
-            pass
+            m.d.sync += [
+                walk_vpn.eq(arg.vpn),
+                write_aspect.eq(arg.write_aspect),
+                access_fault.eq(0),
+                page_fault.eq(0),
+            ]
+
+            with m.Switch(csr.s_mode.satp_mode):
+                for mode in self.gen_params.vmem_params.supported_non_bare_schemes:
+                    with m.Case(mode):
+                        m.d.sync += walk_level.eq(SatpMode.level_count(mode) - 1)
+                with m.Default():
+                    log.error(m, 1, "Unsupported SATP mode in page table walker")
+                    m.d.sync += walk_level.eq(0)
+
+            m.d.sync += ppn.eq(csr.s_mode.satp_ppn)
+
+        @def_method(m, self.accept, ready=fsm.ongoing("DONE"))
+        def _():
+            result = Signal(AddressTranslationLayouts.TLBResult)
+
+            ppn_misaligned = Signal()
+            with m.Switch(walk_level):
+                for level in range(max_levels):
+                    with m.Case(level):
+                        level_vpn_bits = bits_per_level * level
+                        m.d.comb += ppn_misaligned.eq(ppn[:level_vpn_bits].any())
+
+            bad_ad = Signal()
+            m.d.av_comb += bad_ad.eq(~accessed | (write_aspect & ~permissions.d))
+
+            with m.If(access_fault):
+                m.d.av_comb += result.eq(AddressTranslationLayouts.TLBResult.ACCESS_FAULT)
+            with m.Elif(page_fault | ppn_misaligned):
+                m.d.av_comb += result.eq(AddressTranslationLayouts.TLBResult.PAGE_FAULT)
+            with m.Elif(bad_ad):
+                # Svade semantics: if A/D bits are not properly set, treat it as a page fault
+                m.d.av_comb += result.eq(AddressTranslationLayouts.TLBResult.PAGE_FAULT)
+                # TODO: implement Svadu once LSU gets real atomic support
+                #  -> just a CAS on last PTE with A/D bits set, and if it fails, restart the walk
+            with m.Else():
+                m.d.av_comb += result.eq(AddressTranslationLayouts.TLBResult.HIT)
+
+            return {
+                "result": result,
+                "ppn": ppn,
+                "permissions": permissions,
+                "size_class": walk_level,
+            }
 
         return m

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -94,7 +94,7 @@ class PTEView(View):
             is_bad |= self.N
 
         # Non-leaf PTEs have A and D bits reserved
-        is_bad |= self.is_leaf() & (self.A | self.D)
+        is_bad |= ~self.is_leaf() & (self.A | self.D)
 
         return is_bad
 

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -216,19 +216,20 @@ class TestTLBCache(TestCaseWithSimulator):
     def matches_lookup(self, response, vpn, asid):
         def entry_matches(e):
             e_ppn, e_permissions, e_size_class, e_result, e_global = e
+            e_perm_dict = {
+                "r": e_permissions.r,
+                "w": e_permissions.w,
+                "x": e_permissions.x,
+                "u": e_permissions.u,
+                "d": e_permissions.d,
+                "g": e_global,
+            }
+
             return (
                 response["result"] == e_result
                 and response["ppn"] == e_ppn
                 and response["size_class"] == e_size_class
-                and response["permissions"]
-                == {
-                    "r": e_permissions.r,
-                    "w": e_permissions.w,
-                    "x": e_permissions.x,
-                    "u": e_permissions.u,
-                    "d": e_permissions.d,
-                    "g": e_global,
-                }
+                and response["permissions"] == e_perm_dict
             )
 
         return any(entry_matches(e) for e in self.backing.lookup(vpn, asid))
@@ -262,6 +263,101 @@ class TestTLBCache(TestCaseWithSimulator):
 
         assert self.matches_lookup(response_after_sfence, vpn, asid)
         assert len(self.backing.translated) == 2
+
+        # Additional sfence_vma variants and multi-entry cache tests
+        # Prepare multiple entries across ASIDs
+        base = len(self.backing.translated)
+
+        vpn0 = 0x11111
+        ppn0 = 0x22222
+        vpn1 = 0x22222
+        ppn1 = 0x33333
+        vpn2 = 0x33333
+        ppn2 = 0x44444
+
+        asid_a = 7
+        asid_b = 9
+
+        self.backing.add_translation(vpn0, ppn0, permissions=permissions, asid=asid_a)
+        self.backing.add_translation(vpn1, ppn1, permissions=permissions, asid=asid_a)
+        self.backing.add_translation(vpn2, ppn2, permissions=permissions, asid=asid_b)
+
+        # Cache vpn0 and vpn1 for asid_a
+        sim.set(self.csr_instances.s_mode.satp_asid, asid_a)
+        await sim.tick()
+
+        await self.dut.request.call(sim, vpn=vpn0, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        await self.dut.request.call(sim, vpn=vpn1, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 2
+
+        # Cache vpn2 for asid_b
+        sim.set(self.csr_instances.s_mode.satp_asid, asid_b)
+        await sim.tick()
+        await self.dut.request.call(sim, vpn=vpn2, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 3
+
+        # Add a global (asid=None) entry and cache it. Global entries should
+        # not be flushed by an sfence targeting a specific ASID.
+        vpn_g = 0x44444
+        ppn_g = 0x55555
+        self.backing.add_translation(vpn_g, ppn_g, permissions=permissions, asid=None)
+        sim.set(self.csr_instances.s_mode.satp_asid, asid_a)
+        await sim.tick()
+        await self.dut.request.call(sim, vpn=vpn_g, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 4
+
+        # 1) sfence for single vaddr+asid should only flush that mapping
+        await self.sfence_vma.call(
+            sim, vaddr=vpn0 << PAGE_SIZE_LOG, asid=asid_a, all_vaddrs=0, all_asids=0
+        )
+        sim.set(self.csr_instances.s_mode.satp_asid, asid_a)
+        await sim.tick()
+
+        # vpn0 should be re-translated
+        await self.dut.request.call(sim, vpn=vpn0, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 5
+
+        # vpn1 for same ASID should still be cached
+        await self.dut.request.call(sim, vpn=vpn1, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 5
+
+        # 2) sfence with all_vaddrs=1 and asid specified flushes all vaddrs for that ASID
+        await self.sfence_vma.call(sim, vaddr=0, asid=asid_a, all_vaddrs=1, all_asids=0)
+        sim.set(self.csr_instances.s_mode.satp_asid, asid_a)
+        await sim.tick()
+
+        await self.dut.request.call(sim, vpn=vpn1, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 6
+
+        # vpn2 for asid_b remains cached
+        sim.set(self.csr_instances.s_mode.satp_asid, asid_b)
+        await sim.tick()
+        await self.dut.request.call(sim, vpn=vpn2, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 6
+
+        # 3) sfence with all_asids=1 and vaddr specified flushes that vaddr across all ASIDs
+        await self.sfence_vma.call(sim, vaddr=vpn2 << PAGE_SIZE_LOG, asid=0, all_vaddrs=0, all_asids=1)
+        sim.set(self.csr_instances.s_mode.satp_asid, asid_b)
+        await sim.tick()
+        await self.dut.request.call(sim, vpn=vpn2, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 7
+
+        # 4) sfence all (all_vaddrs=1, all_asids=1) flushes everything
+        await self.sfence_vma.call(sim, vaddr=0, asid=0, all_vaddrs=1, all_asids=1)
+        sim.set(self.csr_instances.s_mode.satp_asid, asid_a)
+        await sim.tick()
+        await self.dut.request.call(sim, vpn=vpn0, write_aspect=0)
+        _ = await self.dut.accept.call(sim)
+        assert len(self.backing.translated) == base + 8
 
     async def randomized_process(self, sim: TestbenchContext):
         # fill the backing device with random translations

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -1,5 +1,3 @@
-"""Unit tests for TLB implementations (FullyAssociativeTLB and SetAssociativeTLB)."""
-
 from typing import Optional
 
 from attr import dataclass
@@ -7,24 +5,28 @@ from parameterized import parameterized_class
 
 from amaranth import *
 
+import pytest
 from transactron import *
-from transactron.lib import Adapter, AdapterTrans
+from transactron.lib import Adapter, Pipe
+from transactron.utils import DependencyContext, ModuleConnector, make_layout
 from transactron.testing import (
+    ProcessContext,
     TestCaseWithSimulator,
     TestbenchContext,
     TestbenchIO,
     def_method_mock,
+    SimpleTestCircuit,
     MethodMock,
 )
-from transactron.utils import DependencyContext
 
-from coreblocks.arch.isa_consts import PAGE_SIZE_LOG, SatpMode
+from coreblocks.arch.isa_consts import SatpMode
 from coreblocks.interface.keys import CSRInstancesKey
 from coreblocks.interface.layouts import AddressTranslationLayouts
 from coreblocks.params import GenParams, configurations
 from coreblocks.priv.csr.csr_instances import CSRInstances
 from coreblocks.priv.vmem.iface import TLBBackingDevice
 from coreblocks.priv.vmem.tlb import FullyAssociativeTLB, SetAssociativeTLB
+from test.regression.pysim import PySimulation
 
 
 @dataclass(frozen=True)
@@ -41,6 +43,8 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
 
     def __init__(self, gen_params: GenParams):
         self.gen_params = gen_params
+        self.csr_instances = DependencyContext.get().get_dependency(CSRInstancesKey())
+
         self.layout = gen_params.get(AddressTranslationLayouts)
 
         self.request_mock = TestbenchIO(Adapter(i=self.layout.tlb_request))
@@ -51,17 +55,19 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
 
         # Storage for mock translations: (vpn, asid) -> (ppn, permissions, size_class, result)
         self.translations = dict()
-        self.request_count = 0
-        self.accept_count = 0
 
-    def add_translation(
-        self,
-        vpn: int,
-        ppn: int,
-        permissions: Permissions = Permissions(),
-        size_class: int = 0,
-        asid: Optional[int] = None,
-    ):
+        self.ready = False
+        self.translated = []
+        
+        self.asid = -1
+
+    def add_translation(self,
+                        vpn: int,
+                        ppn: int,
+                        permissions: Permissions = Permissions(),
+                        size_class: int = 0,
+                        asid: Optional[int] = None
+                        ):
         """Add a translation to the backing device.
         asid == None means global entry.
         """
@@ -88,51 +94,45 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
             AddressTranslationLayouts.TLBResult.ACCESS_FAULT,
         )
 
-    def elaborate(self, platform):
-        m = TModule()
+    async def asid_get(self, sim: ProcessContext):
+        async for *_, asid in sim.tick().sample(self.csr_instances.s_mode.satp_asid):  # type: ignore
+            self.asid = asid
 
-        m.submodules.request_mock = request_mock = self.request_mock
-        m.submodules.accept_mock = accept_mock = self.accept_mock
-
-        bits_per_size_class = self.gen_params.vmem_params.page_table_level_bits
-
-        results = [
-            {
-                "result": AddressTranslationLayouts.TLBResult.PAGE_FAULT,
-                "ppn": 0,
-                "permissions": Permissions(),
-                "size_class": 0,
-            }
-        ]
-        requested = False
-
-        @def_method_mock(lambda: request_mock, enable=lambda: not requested)
-        def process_request(vpn: int, asid: int):
+    @def_method_mock(lambda self: self.request_mock, enable=lambda self: not self.ready)
+    def process_request(self, vpn, write_aspect):
+        @MethodMock.effect
+        def _():
             found_key = None
 
+            bits_per_size_class = self.gen_params.vmem_params.page_table_level_bits
+
             for size_class in range(self.gen_params.vmem_params.max_tlb_size_class + 1):
-                mask = (1 << bits_per_size_class * size_class) - 1
+                mask = (1 << (bits_per_size_class * size_class)) - 1
                 vpn_masked = vpn & ~mask
-                if (vpn_masked, asid) in self.translations:
-                    found_key = (vpn_masked, asid)
+                if (vpn_masked, self.asid) in self.translations:
+                    found_key = (vpn_masked, self.asid)
                     break
                 if (vpn_masked, None) in self.translations:
                     found_key = (vpn_masked, None)
                     break
 
-            ret_val = None
-
             if found_key is None:
-                ret_val = {
+                res_dict = {
                     "result": AddressTranslationLayouts.TLBResult.PAGE_FAULT,
                     "ppn": 0,
-                    "permissions": Permissions(),
+                    "permissions": {
+                        "r": 0,
+                        "w": 0,
+                        "x": 0,
+                        "u": 0,
+                        "d": 0,
+                        "g": 0,
+                    },
                     "size_class": 0,
                 }
             else:
                 ppn, permissions, size_class, result = self.translations[found_key]
-
-                ret_val = {
+                res_dict = {
                     "result": result,
                     "ppn": ppn,
                     "permissions": {
@@ -146,79 +146,61 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
                     "size_class": size_class,
                 }
 
-            @MethodMock.effect
-            def eff():
-                nonlocal requested
-                requested = True
-                self.request_count += 1
-                results.append(ret_val)
+            self.ready = True
+            print("!!!")
+            self.translated.append(res_dict)
 
-        @def_method_mock(lambda: accept_mock, enable=lambda: requested)
-        def process_accept():
-            @MethodMock.effect
-            def eff():
-                nonlocal requested
-                requested = False
-                self.accept_count += 1
+    @def_method_mock(lambda self: self.accept_mock, enable=lambda self: self.ready)
+    def process_accept(self):
+        @MethodMock.effect
+        def _():
+            self.ready = False
 
-            return results[-1]
-
-        return m
-
-
-class TLBTestCircuit(Elaboratable):
-    def __init__(self, gen_params: GenParams, dut_kind: str):
-        self.gen_params = gen_params
-        self.dut_kind = dut_kind
-
-    def create_dut(self, backing: TLBBackingDevice) -> Elaboratable:
-        if self.dut_kind == "fully_associative":
-            return FullyAssociativeTLB(self.gen_params, entries=4, backing_resolver=backing)
-
-        if self.dut_kind == "set_associative":
-            return SetAssociativeTLB(self.gen_params, entries=4, ways=2, backing_resolver=backing)
-
-        raise ValueError(f"Unknown TLB kind: {self.dut_kind}")
+        if self.translated:
+            return self.translated[-1]
 
     def elaborate(self, platform):
         m = TModule()
-
-        self.csr_instances = CSRInstances(self.gen_params)
-        DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
-
-        self.backing = MockTLBBackingDevice(self.gen_params)
-        self.dut = self.create_dut(self.backing)
-
-        m.submodules.csr_instances = self.csr_instances
-        m.submodules.backing = self.backing
-        m.submodules.dut = self.dut
-        m.submodules.request = self.request = TestbenchIO(AdapterTrans.create(self.dut.request))
-        m.submodules.accept = self.accept = TestbenchIO(AdapterTrans.create(self.dut.accept))
-
+        m.submodules += [self.request_mock, self.accept_mock]
         return m
 
 
 @parameterized_class(
-    ("name", "dut_kind"),
+    ("name",),
     [
-        ("fully_associative", "fully_associative"),
-        ("set_associative", "set_associative"),
+        ("fully_associative",),
+        ("set_associative",),
     ],
 )
 class TestTLBCache(TestCaseWithSimulator):
-    dut_kind: str
+    name: str
 
+    @pytest.fixture(autouse=True)
     def setup_method(self):
         self.gen_params = GenParams(
             configurations.test.replace(
-                xlen=64,
                 supervisor_mode=True,
                 asidlen=4,
-                supported_vm_schemes=(SatpMode.BARE, SatpMode.SV39),
+                supported_vm_schemes=(SatpMode.BARE, SatpMode.SV32),
                 fetch_block_bytes_log=3,
             )
         )
-        self.tc = TLBTestCircuit(self.gen_params, self.dut_kind)
+        self.csr_instances = CSRInstances(self.gen_params)
+        DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
+
+        self.backing = MockTLBBackingDevice(self.gen_params)
+
+        if self.name == "fully_associative":
+            dut = FullyAssociativeTLB(self.gen_params, entries=16, backing_resolver=self.backing)
+        elif self.name == "set_associative":
+            dut = SetAssociativeTLB(self.gen_params, ways=4, entries=16, backing_resolver=self.backing)
+        else:
+            print(self.name)
+            assert False, "Invalid TLB type"
+
+        self.dut = SimpleTestCircuit(dut)
+
+        self.m = ModuleConnector(self.dut, backing=self.backing, csrs=self.csr_instances)
 
     def assert_hit(
         self, response, *, ppn: int, permissions: Permissions, size_class: int = 0, global_entry: bool = False
@@ -236,37 +218,42 @@ class TestTLBCache(TestCaseWithSimulator):
         }
 
     async def set_satp_asid(self, sim: TestbenchContext, asid: int):
-        sim.set(self.tc.csr_instances.s_mode.satp_asid.value, asid)
         await sim.tick()
 
     async def translation_is_cached_process(self, sim: TestbenchContext):
-        vpn = 0x12345 & ((1 << self.gen_params.vmem_params.max_tlb_vpn_bits) - 1)
-        ppn = 0x23456 & ((1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1)
+        vpn = 0x12345
+        ppn = 0x23456
         asid = 3
         permissions = Permissions(r=1, w=1, x=0, u=1, d=1)
 
-        self.tc.backing.add_translation(vpn, ppn, permissions=permissions, asid=asid)
-        await self.set_satp_asid(sim, asid)
+        self.backing.add_translation(vpn, ppn, permissions=permissions, asid=asid)
+        sim.set(self.csr_instances.s_mode.satp_asid, asid)
 
-        await self.tc.request.call(sim, vpn=vpn, write_aspect=0)
-        response = await self.tc.accept.call(sim)
+        print("Starting translation_is_cached_process")
+        await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
+        print("Requested translation")
+        response = await self.dut.accept.call(sim)
+        print("Received response")
         self.assert_hit(response, ppn=ppn, permissions=permissions)
-        assert self.tc.backing.request_count == 1
+        assert len(self.backing.translated) == 1
 
-        await self.tc.request.call(sim, vpn=vpn, write_aspect=0)
-        cached_response = await self.tc.accept.call(sim)
+        print("Requesting translation again to test caching")
+        await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
+        print("Requested translation again")
+        cached_response = await self.dut.accept.call(sim)
+        print("Received cached response")
         self.assert_hit(cached_response, ppn=ppn, permissions=permissions)
-        assert self.tc.backing.request_count == 1
+        assert len(self.backing.translated) == 1
 
     async def access_fault_is_forwarded_process(self, sim: TestbenchContext):
-        vpn = 0x5A5A & ((1 << self.gen_params.vmem_params.max_tlb_vpn_bits) - 1)
+        vpn = 0x5A5A
         asid = 2
 
-        self.tc.backing.add_access_fault(vpn, asid=asid)
-        await self.set_satp_asid(sim, asid)
+        self.backing.add_access_fault(vpn, asid=asid)
+        sim.set(self.csr_instances.s_mode.satp_asid, asid)
 
-        await self.tc.request.call(sim, vpn=vpn, write_aspect=0)
-        response = await self.tc.accept.call(sim)
+        await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
+        response = await self.dut.accept.call(sim)
 
         assert response["result"] == AddressTranslationLayouts.TLBResult.ACCESS_FAULT
         assert response["ppn"] == 0
@@ -279,12 +266,17 @@ class TestTLBCache(TestCaseWithSimulator):
             "d": 0,
             "g": False,
         }
-        assert self.tc.backing.request_count == 1
 
     def test_translation_is_cached(self):
-        with self.run_simulation(self.tc) as sim:
+        with self.run_simulation(self.m, max_cycles=300) as sim:
+            sim.add_process(self.backing.asid_get)
+            self.add_mock(sim, self.backing.process_request())  # type: ignore
+            self.add_mock(sim, self.backing.process_accept())  # type: ignore
             sim.add_testbench(self.translation_is_cached_process)
 
     def test_access_fault_is_forwarded(self):
-        with self.run_simulation(self.tc) as sim:
+        with self.run_simulation(self.m, max_cycles=300) as sim:
+            sim.add_process(self.backing.asid_get)
+            self.add_mock(sim, self.backing.process_request())  # type: ignore
+            self.add_mock(sim, self.backing.process_accept())  # type: ignore
             sim.add_testbench(self.access_fault_is_forwarded_process)

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -208,26 +208,23 @@ class TestTLBCache(TestCaseWithSimulator):
 
         self.m = ModuleConnector(self.dut, backing=self.backing, csrs=self.csr_instances)
 
-    def assert_hit(
-        self,
-        response,
-        *,
-        ppn: int,
-        permissions: Permissions,
-        size_class: int = 0,
-        global_entry: bool = False,
-    ):
-        assert response["result"] == AddressTranslationLayouts.TLBResult.HIT
-        assert response["ppn"] == ppn
-        assert response["size_class"] == size_class
-        assert response["permissions"] == {
-            "r": permissions.r,
-            "w": permissions.w,
-            "x": permissions.x,
-            "u": permissions.u,
-            "d": permissions.d,
-            "g": global_entry,
-        }
+    def matches_lookup(self, response, vpn, asid):
+        for (e_ppn, e_permissions, e_size_class, e_result, e_global) in self.backing.lookup(vpn, asid):
+            if (
+                response["result"] == e_result
+                and response["ppn"] == e_ppn
+                and response["size_class"] == e_size_class
+                and response["permissions"] == {
+                    "r": e_permissions.r,
+                    "w": e_permissions.w,
+                    "x": e_permissions.x,
+                    "u": e_permissions.u,
+                    "d": e_permissions.d,
+                    "g": e_global,
+                }
+            ):
+                return True
+        return False
 
     async def set_satp_asid(self, sim: TestbenchContext, asid: int):
         await sim.tick()
@@ -244,17 +241,17 @@ class TestTLBCache(TestCaseWithSimulator):
 
         await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
         response = await self.dut.accept.call(sim)
-        self.assert_hit(response, ppn=ppn, permissions=permissions)
+        self.matches_lookup(response, vpn, asid)
         assert len(self.backing.translated) == 1
 
         await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
         cached_response = await self.dut.accept.call(sim)
-        self.assert_hit(cached_response, ppn=ppn, permissions=permissions)
+        self.matches_lookup(cached_response, vpn, asid)
         assert len(self.backing.translated) == 1
 
     async def randomized_process(self, sim: TestbenchContext):
         # fill the backing device with random translations
-        for _ in range(128):
+        for _ in range(64):
             vpn = random.randint(0, 0xFFFFF)
             ppn = random.randint(0, 0xFFFFF)
             asid = random.randint(0, 0xF)
@@ -279,66 +276,20 @@ class TestTLBCache(TestCaseWithSimulator):
             asid = random.randint(0, 0xF)
             self.backing.add_access_fault(vpn, asid=asid)
 
-        def matches_lookup(response, expected):
-            expected_ppn, expected_permissions, expected_size_class, expected_result, expected_global = expected
+        test_cases = list(self.backing.translations.keys()) * 4
+        test_cases.extend((random.randint(0, 0xFFFFF), random.randint(0, 0xF)) for _ in range(64))
+        random.shuffle(test_cases)
 
-            if response["result"] != expected_result:
-                return False
-            if response["ppn"] != expected_ppn:
-                return False
-            if response["size_class"] != expected_size_class:
-                return False
-            if response["permissions"] != {
-                "r": expected_permissions.r,
-                "w": expected_permissions.w,
-                "x": expected_permissions.x,
-                "u": expected_permissions.u,
-                "d": expected_permissions.d,
-                "g": expected_global,
-            }:
-                return False
-            return True
-
-        # check that each vpn in the backing device is translated correctly
-        for vpn, asid in self.backing.translations.keys():
-            sim.set(self.csr_instances.s_mode.satp_asid, asid if asid is not None else 0xF)
-            await sim.tick()
-
-            await self.dut.request.call(sim, vpn=vpn, write_aspect=random.randint(0, 1))
-            response = await self.dut.accept.call(sim)
-            matches = self.backing.lookup(vpn, asid if asid is not None else 0xF)
-            print(f"VPN: {vpn:X}, ASID: {asid}")
-            # print response and matches for debugging
-            perms = response.permissions
-            print(
-                f"Response: {response.ppn:x}, "
-                f"{perms.r}{perms.w}{perms.x}{perms.u}{perms.d}, "
-                f"{response.size_class}, {response.result}"
-            )
-            print("Matches:")
-            for match in matches:
-                perms = match[1]
-                print(
-                    f"{match[0]:x}, "
-                    f"{perms.r}{perms.w}{perms.x}{perms.u}{perms.d}, "
-                    f"{match[2]}, {match[3]}, global={match[4]}"
-                )
-
-            assert any(matches_lookup(response, expected) for expected in matches)
-
-        # check some random VPNs that are not in the backing device to ensure they cause page faults
-        for _ in range(128):
-            vpn = random.randint(0, 0xFFFFF)
-            asid = random.randint(0, 0xF)
-
+        for vpn, asid in test_cases:
             sim.set(self.csr_instances.s_mode.satp_asid, asid)
             await sim.tick()
 
-            await self.dut.request.call(sim, vpn=vpn, write_aspect=random.randint(0, 1))
+            await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
             response = await self.dut.accept.call(sim)
-            matches = self.backing.lookup(vpn, asid)
-
-            assert any(matches_lookup(response, expected) for expected in matches)
+            assert self.matches_lookup(response, vpn, asid)
+            
+        # check that we actually cached anything
+        assert len(self.backing.translated) < len(test_cases)
 
     def test_translation_is_cached(self):
         with self.run_simulation(self.m) as sim:

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -7,8 +7,8 @@ from amaranth import *
 
 import pytest
 from transactron import *
-from transactron.lib import Adapter, Pipe
-from transactron.utils import DependencyContext, ModuleConnector, make_layout
+from transactron.lib import Adapter
+from transactron.utils import DependencyContext, ModuleConnector
 from transactron.testing import (
     ProcessContext,
     TestCaseWithSimulator,
@@ -26,7 +26,6 @@ from coreblocks.params import GenParams, configurations
 from coreblocks.priv.csr.csr_instances import CSRInstances
 from coreblocks.priv.vmem.iface import TLBBackingDevice
 from coreblocks.priv.vmem.tlb import FullyAssociativeTLB, SetAssociativeTLB
-from test.regression.pysim import PySimulation
 
 
 @dataclass(frozen=True)
@@ -58,16 +57,17 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
 
         self.ready = False
         self.translated = []
-        
+
         self.asid = -1
 
-    def add_translation(self,
-                        vpn: int,
-                        ppn: int,
-                        permissions: Permissions = Permissions(),
-                        size_class: int = 0,
-                        asid: Optional[int] = None
-                        ):
+    def add_translation(
+        self,
+        vpn: int,
+        ppn: int,
+        permissions: Permissions = Permissions(),
+        size_class: int = 0,
+        asid: Optional[int] = None,
+    ):
         """Add a translation to the backing device.
         asid == None means global entry.
         """

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -1,4 +1,3 @@
-from ftplib import all_errors
 import random
 from typing import Optional
 

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -1,0 +1,286 @@
+"""Unit tests for TLB implementations (FullyAssociativeTLB and SetAssociativeTLB)."""
+
+from typing import Optional
+
+from attr import dataclass
+from parameterized import parameterized_class
+
+from amaranth import *
+
+from transactron import *
+from transactron.lib import Adapter, AdapterTrans
+from transactron.testing import (
+    TestCaseWithSimulator,
+    TestbenchContext,
+    TestbenchIO,
+    def_method_mock,
+    MethodMock,
+)
+from transactron.utils import DependencyContext
+
+from coreblocks.arch.isa_consts import PAGE_SIZE_LOG, SatpMode
+from coreblocks.interface.keys import CSRInstancesKey
+from coreblocks.interface.layouts import AddressTranslationLayouts
+from coreblocks.params import GenParams, configurations
+from coreblocks.priv.csr.csr_instances import CSRInstances
+from coreblocks.priv.vmem.iface import TLBBackingDevice
+from coreblocks.priv.vmem.tlb import FullyAssociativeTLB, SetAssociativeTLB
+
+
+@dataclass(frozen=True)
+class Permissions:
+    r: int = 0
+    w: int = 0
+    x: int = 0
+    u: int = 0
+    d: int = 0
+
+
+class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
+    """Mock backing device for TLB testing."""
+
+    def __init__(self, gen_params: GenParams):
+        self.gen_params = gen_params
+        self.layout = gen_params.get(AddressTranslationLayouts)
+
+        self.request_mock = TestbenchIO(Adapter(i=self.layout.tlb_request))
+        self.accept_mock = TestbenchIO(Adapter(o=self.layout.tlb_accept))
+
+        self.request = self.request_mock.adapter.iface
+        self.accept = self.accept_mock.adapter.iface
+
+        # Storage for mock translations: (vpn, asid) -> (ppn, permissions, size_class, result)
+        self.translations = dict()
+        self.request_count = 0
+        self.accept_count = 0
+
+    def add_translation(
+        self,
+        vpn: int,
+        ppn: int,
+        permissions: Permissions = Permissions(),
+        size_class: int = 0,
+        asid: Optional[int] = None,
+    ):
+        """Add a translation to the backing device.
+        asid == None means global entry.
+        """
+
+        assert 0 <= size_class <= self.gen_params.vmem_params.max_tlb_size_class
+        size_class_mask = -(1 << (self.gen_params.vmem_params.page_table_level_bits * size_class))
+        assert (ppn & ~size_class_mask) == 0, "PPN must be aligned to the size class"
+        vpn = vpn & size_class_mask  # Align VPN to the size class
+        assert permissions.r or not permissions.w
+
+        self.translations[(vpn, asid)] = (
+            ppn,
+            permissions,
+            size_class,
+            AddressTranslationLayouts.TLBResult.HIT,
+        )
+
+    def add_access_fault(self, vpn: int, asid: Optional[int] = None):
+        """Add an access fault for the given VPN and ASID."""
+        self.translations[(vpn, asid)] = (
+            0,
+            Permissions(),
+            0,
+            AddressTranslationLayouts.TLBResult.ACCESS_FAULT,
+        )
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.request_mock = request_mock = self.request_mock
+        m.submodules.accept_mock = accept_mock = self.accept_mock
+
+        bits_per_size_class = self.gen_params.vmem_params.page_table_level_bits
+
+        results = [{
+            "result": AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+            "ppn": 0,
+            "permissions": Permissions(),
+            "size_class": 0,
+        }]
+        requested = False
+
+        @def_method_mock(lambda: request_mock, enable=lambda: not requested)
+        def process_request(vpn: int, asid: int):
+            found_key = None
+
+            for size_class in range(self.gen_params.vmem_params.max_tlb_size_class + 1):
+                mask = (1 << bits_per_size_class * size_class) - 1
+                vpn_masked = vpn & ~mask
+                if (vpn_masked, asid) in self.translations:
+                    found_key = (vpn_masked, asid)
+                    break
+                if (vpn_masked, None) in self.translations:
+                    found_key = (vpn_masked, None)
+                    break
+
+            ret_val = None
+
+            if found_key is None:
+                ret_val = {
+                    "result": AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+                    "ppn": 0,
+                    "permissions": Permissions(),
+                    "size_class": 0,
+                }
+            else:
+                ppn, permissions, size_class, result = self.translations[found_key]
+
+                ret_val = {
+                    "result": result,
+                    "ppn": ppn,
+                    "permissions": {
+                        "r": permissions.r,
+                        "w": permissions.w,
+                        "x": permissions.x,
+                        "u": permissions.u,
+                        "d": permissions.d,
+                        "g": found_key[1] is None,
+                    },
+                    "size_class": size_class,
+                }
+
+            @MethodMock.effect
+            def eff():
+                nonlocal requested
+                requested = True
+                self.request_count += 1
+                results.append(ret_val)
+
+        @def_method_mock(lambda: accept_mock, enable=lambda: requested)
+        def process_accept():
+            @MethodMock.effect
+            def eff():
+                nonlocal requested
+                requested = False
+                self.accept_count += 1
+
+            return results[-1]
+
+        return m
+
+
+class TLBTestCircuit(Elaboratable):
+    def __init__(self, gen_params: GenParams, dut_kind: str):
+        self.gen_params = gen_params
+        self.dut_kind = dut_kind
+
+    def create_dut(self, backing: TLBBackingDevice) -> Elaboratable:
+        if self.dut_kind == "fully_associative":
+            return FullyAssociativeTLB(self.gen_params, entries=4, backing_resolver=backing)
+
+        if self.dut_kind == "set_associative":
+            return SetAssociativeTLB(self.gen_params, entries=4, ways=2, backing_resolver=backing)
+
+        raise ValueError(f"Unknown TLB kind: {self.dut_kind}")
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        self.csr_instances = CSRInstances(self.gen_params)
+        DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
+
+        self.backing = MockTLBBackingDevice(self.gen_params)
+        self.dut = self.create_dut(self.backing)
+
+        m.submodules.csr_instances = self.csr_instances
+        m.submodules.backing = self.backing
+        m.submodules.dut = self.dut
+        m.submodules.request = self.request = TestbenchIO(AdapterTrans.create(self.dut.request))
+        m.submodules.accept = self.accept = TestbenchIO(AdapterTrans.create(self.dut.accept))
+
+        return m
+
+
+@parameterized_class(
+    ("name", "dut_kind"),
+    [
+        ("fully_associative", "fully_associative"),
+        ("set_associative", "set_associative"),
+    ],
+)
+class TestTLBCache(TestCaseWithSimulator):
+    dut_kind: str
+
+    def setup_method(self):
+        self.gen_params = GenParams(
+            configurations.test.replace(
+                xlen=64,
+                supervisor_mode=True,
+                asidlen=4,
+                supported_vm_schemes=(SatpMode.BARE, SatpMode.SV39),
+                fetch_block_bytes_log=3,
+            )
+        )
+        self.tc = TLBTestCircuit(self.gen_params, self.dut_kind)
+
+    def assert_hit(self, response, *, ppn: int, permissions: Permissions, size_class: int = 0, global_entry: bool = False):
+        assert response["result"] == AddressTranslationLayouts.TLBResult.HIT
+        assert response["ppn"] == ppn
+        assert response["size_class"] == size_class
+        assert response["permissions"] == {
+            "r": permissions.r,
+            "w": permissions.w,
+            "x": permissions.x,
+            "u": permissions.u,
+            "d": permissions.d,
+            "g": global_entry,
+        }
+
+    async def set_satp_asid(self, sim: TestbenchContext, asid: int):
+        sim.set(self.tc.csr_instances.s_mode.satp_asid.value, asid)
+        await sim.tick()
+
+    async def translation_is_cached_process(self, sim: TestbenchContext):
+        vpn = 0x12345 & ((1 << self.gen_params.vmem_params.max_tlb_vpn_bits) - 1)
+        ppn = 0x23456 & ((1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1)
+        asid = 3
+        permissions = Permissions(r=1, w=1, x=0, u=1, d=1)
+
+        self.tc.backing.add_translation(vpn, ppn, permissions=permissions, asid=asid)
+        await self.set_satp_asid(sim, asid)
+
+        await self.tc.request.call(sim, vpn=vpn, write_aspect=0)
+        response = await self.tc.accept.call(sim)
+        self.assert_hit(response, ppn=ppn, permissions=permissions)
+        assert self.tc.backing.request_count == 1
+
+        await self.tc.request.call(sim, vpn=vpn, write_aspect=0)
+        cached_response = await self.tc.accept.call(sim)
+        self.assert_hit(cached_response, ppn=ppn, permissions=permissions)
+        assert self.tc.backing.request_count == 1
+
+    async def access_fault_is_forwarded_process(self, sim: TestbenchContext):
+        vpn = 0x5A5A & ((1 << self.gen_params.vmem_params.max_tlb_vpn_bits) - 1)
+        asid = 2
+
+        self.tc.backing.add_access_fault(vpn, asid=asid)
+        await self.set_satp_asid(sim, asid)
+
+        await self.tc.request.call(sim, vpn=vpn, write_aspect=0)
+        response = await self.tc.accept.call(sim)
+
+        assert response["result"] == AddressTranslationLayouts.TLBResult.ACCESS_FAULT
+        assert response["ppn"] == 0
+        assert response["size_class"] == 0
+        assert response["permissions"] == {
+            "r": 0,
+            "w": 0,
+            "x": 0,
+            "u": 0,
+            "d": 0,
+            "g": False,
+        }
+        assert self.tc.backing.request_count == 1
+
+    def test_translation_is_cached(self):
+        with self.run_simulation(self.tc) as sim:
+            sim.add_testbench(self.translation_is_cached_process)
+
+    def test_access_fault_is_forwarded(self):
+        with self.run_simulation(self.tc) as sim:
+            sim.add_testbench(self.access_fault_is_forwarded_process)

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -311,9 +311,7 @@ class TestTLBCache(TestCaseWithSimulator):
         assert len(self.backing.translated) == base + 4
 
         # 1) sfence for single vaddr+asid should only flush that mapping
-        await self.sfence_vma.call(
-            sim, vaddr=vpn0 << PAGE_SIZE_LOG, asid=asid_a, all_vaddrs=0, all_asids=0
-        )
+        await self.sfence_vma.call(sim, vaddr=vpn0 << PAGE_SIZE_LOG, asid=asid_a, all_vaddrs=0, all_asids=0)
         sim.set(self.csr_instances.s_mode.satp_asid, asid_a)
         await sim.tick()
 

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -112,20 +112,20 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
                     matching.append((*self.translations[(vpn_masked, None)], True))
 
         if not matching:
-            matching.append((
-                0,
-                Permissions(),
-                0,
-                AddressTranslationLayouts.TLBResult.PAGE_FAULT,
-                0,
-            ))
+            matching.append(
+                (
+                    0,
+                    Permissions(),
+                    0,
+                    AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+                    0,
+                )
+            )
 
         return matching
 
     async def asid_get(self, sim: ProcessContext):
-        async for *_, asid in (
-            sim.tick().sample(self.csr_instances.s_mode.satp_asid)  # type: ignore
-        ):
+        async for *_, asid in sim.tick().sample(self.csr_instances.s_mode.satp_asid):  # type: ignore
             self.asid = asid
 
     @def_method_mock(lambda self: self.request_mock, enable=lambda self: not self.ready)
@@ -135,19 +135,21 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
             ppn, permissions, size_class, result, global_ = self.lookup(vpn, self.asid)[0]
 
             self.ready = True
-            self.translated.append({
-                "ppn": ppn,
-                "permissions": {
-                    "r": permissions.r,
-                    "w": permissions.w,
-                    "x": permissions.x,
-                    "u": permissions.u,
-                    "d": permissions.d,
-                    "g": global_,
-                },
-                "size_class": size_class,
-                "result": result,
-            })
+            self.translated.append(
+                {
+                    "ppn": ppn,
+                    "permissions": {
+                        "r": permissions.r,
+                        "w": permissions.w,
+                        "x": permissions.x,
+                        "u": permissions.u,
+                        "d": permissions.d,
+                        "g": global_,
+                    },
+                    "size_class": size_class,
+                    "result": result,
+                }
+            )
 
     @def_method_mock(lambda self: self.accept_mock, enable=lambda self: self.ready)
     def process_accept(self):
@@ -298,7 +300,7 @@ class TestTLBCache(TestCaseWithSimulator):
             return True
 
         # check that each vpn in the backing device is translated correctly
-        for (vpn, asid) in self.backing.translations.keys():
+        for vpn, asid in self.backing.translations.keys():
             sim.set(self.csr_instances.s_mode.satp_asid, asid if asid is not None else 0xF)
             await sim.tick()
 
@@ -307,10 +309,20 @@ class TestTLBCache(TestCaseWithSimulator):
             matches = self.backing.lookup(vpn, asid if asid is not None else 0xF)
             print(f"VPN: {vpn:X}, ASID: {asid}")
             # print response and matches for debugging
-            print(f"Response: {response.ppn:x}, {response.permissions.r}{response.permissions.w}{response.permissions.x}{response.permissions.u}{response.permissions.d}, {response.size_class}, {response.result}")
+            perms = response.permissions
+            print(
+                f"Response: {response.ppn:x}, "
+                f"{perms.r}{perms.w}{perms.x}{perms.u}{perms.d}, "
+                f"{response.size_class}, {response.result}"
+            )
             print("Matches:")
             for match in matches:
-                print(f"{match[0]:x}, {match[1].r}{match[1].w}{match[1].x}{match[1].u}{match[1].d}, {match[2]}, {match[3]}, global={match[4]}")
+                perms = match[1]
+                print(
+                    f"{match[0]:x}, "
+                    f"{perms.r}{perms.w}{perms.x}{perms.u}{perms.d}, "
+                    f"{match[2]}, {match[3]}, global={match[4]}"
+                )
 
             assert any(matches_lookup(response, expected) for expected in matches)
 

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -1,3 +1,4 @@
+import random
 from typing import Optional
 
 from attr import dataclass
@@ -60,6 +61,10 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
 
         self.asid = -1
 
+    def size_class_mask(self, size_class: int):
+        bits_per_size_class = self.gen_params.vmem_params.page_table_level_bits
+        return -(1 << (bits_per_size_class * size_class))
+
     def add_translation(
         self,
         vpn: int,
@@ -73,7 +78,7 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
         """
 
         assert 0 <= size_class <= self.gen_params.vmem_params.max_tlb_size_class
-        size_class_mask = -(1 << (self.gen_params.vmem_params.page_table_level_bits * size_class))
+        size_class_mask = self.size_class_mask(size_class)
         assert (ppn & ~size_class_mask) == 0, "PPN must be aligned to the size class"
         vpn = vpn & size_class_mask  # Align VPN to the size class
         assert permissions.r or not permissions.w
@@ -94,61 +99,55 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
             AddressTranslationLayouts.TLBResult.ACCESS_FAULT,
         )
 
+    def lookup(self, vpn: int, asid: int):
+        matching = []
+
+        for size_class in range(self.gen_params.vmem_params.max_tlb_size_class + 1):
+            vpn_masked = vpn & self.size_class_mask(size_class)
+            if (vpn_masked, asid) in self.translations:
+                if self.translations[(vpn_masked, asid)][2] == size_class:
+                    matching.append((*self.translations[(vpn_masked, asid)], False))
+            if (vpn_masked, None) in self.translations:
+                if self.translations[(vpn_masked, None)][2] == size_class:
+                    matching.append((*self.translations[(vpn_masked, None)], True))
+
+        if not matching:
+            matching.append((
+                0,
+                Permissions(),
+                0,
+                AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+                0,
+            ))
+
+        return matching
+
     async def asid_get(self, sim: ProcessContext):
-        async for *_, asid in sim.tick().sample(self.csr_instances.s_mode.satp_asid):  # type: ignore
+        async for *_, asid in (
+            sim.tick().sample(self.csr_instances.s_mode.satp_asid)  # type: ignore
+        ):
             self.asid = asid
 
     @def_method_mock(lambda self: self.request_mock, enable=lambda self: not self.ready)
     def process_request(self, vpn, write_aspect):
         @MethodMock.effect
         def _():
-            found_key = None
-
-            bits_per_size_class = self.gen_params.vmem_params.page_table_level_bits
-
-            for size_class in range(self.gen_params.vmem_params.max_tlb_size_class + 1):
-                mask = (1 << (bits_per_size_class * size_class)) - 1
-                vpn_masked = vpn & ~mask
-                if (vpn_masked, self.asid) in self.translations:
-                    found_key = (vpn_masked, self.asid)
-                    break
-                if (vpn_masked, None) in self.translations:
-                    found_key = (vpn_masked, None)
-                    break
-
-            if found_key is None:
-                res_dict = {
-                    "result": AddressTranslationLayouts.TLBResult.PAGE_FAULT,
-                    "ppn": 0,
-                    "permissions": {
-                        "r": 0,
-                        "w": 0,
-                        "x": 0,
-                        "u": 0,
-                        "d": 0,
-                        "g": 0,
-                    },
-                    "size_class": 0,
-                }
-            else:
-                ppn, permissions, size_class, result = self.translations[found_key]
-                res_dict = {
-                    "result": result,
-                    "ppn": ppn,
-                    "permissions": {
-                        "r": permissions.r,
-                        "w": permissions.w,
-                        "x": permissions.x,
-                        "u": permissions.u,
-                        "d": permissions.d,
-                        "g": found_key[1] is None,
-                    },
-                    "size_class": size_class,
-                }
+            ppn, permissions, size_class, result, global_ = self.lookup(vpn, self.asid)[0]
 
             self.ready = True
-            print("!!!")
-            self.translated.append(res_dict)
+            self.translated.append({
+                "ppn": ppn,
+                "permissions": {
+                    "r": permissions.r,
+                    "w": permissions.w,
+                    "x": permissions.x,
+                    "u": permissions.u,
+                    "d": permissions.d,
+                    "g": global_,
+                },
+                "size_class": size_class,
+                "result": result,
+            })
 
     @def_method_mock(lambda self: self.accept_mock, enable=lambda self: self.ready)
     def process_accept(self):
@@ -193,7 +192,12 @@ class TestTLBCache(TestCaseWithSimulator):
         if self.name == "fully_associative":
             dut = FullyAssociativeTLB(self.gen_params, entries=16, backing_resolver=self.backing)
         elif self.name == "set_associative":
-            dut = SetAssociativeTLB(self.gen_params, ways=4, entries=16, backing_resolver=self.backing)
+            dut = SetAssociativeTLB(
+                self.gen_params,
+                ways=4,
+                entries=16,
+                backing_resolver=self.backing,
+            )
         else:
             print(self.name)
             assert False, "Invalid TLB type"
@@ -203,7 +207,13 @@ class TestTLBCache(TestCaseWithSimulator):
         self.m = ModuleConnector(self.dut, backing=self.backing, csrs=self.csr_instances)
 
     def assert_hit(
-        self, response, *, ppn: int, permissions: Permissions, size_class: int = 0, global_entry: bool = False
+        self,
+        response,
+        *,
+        ppn: int,
+        permissions: Permissions,
+        size_class: int = 0,
+        global_entry: bool = False,
     ):
         assert response["result"] == AddressTranslationLayouts.TLBResult.HIT
         assert response["ppn"] == ppn
@@ -228,55 +238,106 @@ class TestTLBCache(TestCaseWithSimulator):
 
         self.backing.add_translation(vpn, ppn, permissions=permissions, asid=asid)
         sim.set(self.csr_instances.s_mode.satp_asid, asid)
+        await sim.tick()
 
-        print("Starting translation_is_cached_process")
         await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
-        print("Requested translation")
         response = await self.dut.accept.call(sim)
-        print("Received response")
         self.assert_hit(response, ppn=ppn, permissions=permissions)
         assert len(self.backing.translated) == 1
 
-        print("Requesting translation again to test caching")
         await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
-        print("Requested translation again")
         cached_response = await self.dut.accept.call(sim)
-        print("Received cached response")
         self.assert_hit(cached_response, ppn=ppn, permissions=permissions)
         assert len(self.backing.translated) == 1
 
-    async def access_fault_is_forwarded_process(self, sim: TestbenchContext):
-        vpn = 0x5A5A
-        asid = 2
+    async def randomized_process(self, sim: TestbenchContext):
+        # fill the backing device with random translations
+        for _ in range(128):
+            vpn = random.randint(0, 0xFFFFF)
+            ppn = random.randint(0, 0xFFFFF)
+            asid = random.randint(0, 0xF)
+            rw = random.randint(0, 2)
+            permissions = Permissions(
+                r=1 * (rw >= 1),
+                w=1 * (rw >= 2),
+                x=random.randint(0, 1),
+                u=random.randint(0, 1),
+                d=random.randint(0, 1),
+            )
 
-        self.backing.add_access_fault(vpn, asid=asid)
-        sim.set(self.csr_instances.s_mode.satp_asid, asid)
+            size_class = random.randint(0, self.gen_params.vmem_params.max_tlb_size_class)
 
-        await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
-        response = await self.dut.accept.call(sim)
+            ppn = ppn & self.backing.size_class_mask(size_class)
 
-        assert response["result"] == AddressTranslationLayouts.TLBResult.ACCESS_FAULT
-        assert response["ppn"] == 0
-        assert response["size_class"] == 0
-        assert response["permissions"] == {
-            "r": 0,
-            "w": 0,
-            "x": 0,
-            "u": 0,
-            "d": 0,
-            "g": False,
-        }
+            self.backing.add_translation(vpn, ppn, permissions=permissions, size_class=size_class, asid=asid)
+
+        # add some access faults
+        for _ in range(16):
+            vpn = random.randint(0, 0xFFFFF)
+            asid = random.randint(0, 0xF)
+            self.backing.add_access_fault(vpn, asid=asid)
+
+        def matches_lookup(response, expected):
+            expected_ppn, expected_permissions, expected_size_class, expected_result, expected_global = expected
+
+            if response["result"] != expected_result:
+                return False
+            if response["ppn"] != expected_ppn:
+                return False
+            if response["size_class"] != expected_size_class:
+                return False
+            if response["permissions"] != {
+                "r": expected_permissions.r,
+                "w": expected_permissions.w,
+                "x": expected_permissions.x,
+                "u": expected_permissions.u,
+                "d": expected_permissions.d,
+                "g": expected_global,
+            }:
+                return False
+            return True
+
+        # check that each vpn in the backing device is translated correctly
+        for (vpn, asid) in self.backing.translations.keys():
+            sim.set(self.csr_instances.s_mode.satp_asid, asid if asid is not None else 0xF)
+            await sim.tick()
+
+            await self.dut.request.call(sim, vpn=vpn, write_aspect=random.randint(0, 1))
+            response = await self.dut.accept.call(sim)
+            matches = self.backing.lookup(vpn, asid if asid is not None else 0xF)
+            print(f"VPN: {vpn:X}, ASID: {asid}")
+            # print response and matches for debugging
+            print(f"Response: {response.ppn:x}, {response.permissions.r}{response.permissions.w}{response.permissions.x}{response.permissions.u}{response.permissions.d}, {response.size_class}, {response.result}")
+            print("Matches:")
+            for match in matches:
+                print(f"{match[0]:x}, {match[1].r}{match[1].w}{match[1].x}{match[1].u}{match[1].d}, {match[2]}, {match[3]}, global={match[4]}")
+
+            assert any(matches_lookup(response, expected) for expected in matches)
+
+        # check some random VPNs that are not in the backing device to ensure they cause page faults
+        for _ in range(128):
+            vpn = random.randint(0, 0xFFFFF)
+            asid = random.randint(0, 0xF)
+
+            sim.set(self.csr_instances.s_mode.satp_asid, asid)
+            await sim.tick()
+
+            await self.dut.request.call(sim, vpn=vpn, write_aspect=random.randint(0, 1))
+            response = await self.dut.accept.call(sim)
+            matches = self.backing.lookup(vpn, asid)
+
+            assert any(matches_lookup(response, expected) for expected in matches)
 
     def test_translation_is_cached(self):
-        with self.run_simulation(self.m, max_cycles=300) as sim:
+        with self.run_simulation(self.m) as sim:
             sim.add_process(self.backing.asid_get)
             self.add_mock(sim, self.backing.process_request())  # type: ignore
             self.add_mock(sim, self.backing.process_accept())  # type: ignore
             sim.add_testbench(self.translation_is_cached_process)
 
-    def test_access_fault_is_forwarded(self):
-        with self.run_simulation(self.m, max_cycles=300) as sim:
+    def test_randomized(self):
+        with self.run_simulation(self.m) as sim:
             sim.add_process(self.backing.asid_get)
             self.add_mock(sim, self.backing.process_request())  # type: ignore
             self.add_mock(sim, self.backing.process_accept())  # type: ignore
-            sim.add_testbench(self.access_fault_is_forwarded_process)
+            sim.add_testbench(self.randomized_process)

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -1,3 +1,4 @@
+from ftplib import all_errors
 import random
 from typing import Optional
 
@@ -8,7 +9,7 @@ from amaranth import *
 
 import pytest
 from transactron import *
-from transactron.lib import Adapter
+from transactron.lib import Adapter, AdapterTrans
 from transactron.utils import DependencyContext, ModuleConnector
 from transactron.testing import (
     ProcessContext,
@@ -20,8 +21,8 @@ from transactron.testing import (
     MethodMock,
 )
 
-from coreblocks.arch.isa_consts import SatpMode
-from coreblocks.interface.keys import CSRInstancesKey
+from coreblocks.arch.isa_consts import PAGE_SIZE_LOG, SatpMode
+from coreblocks.interface.keys import CSRInstancesKey, SFenceVMAKey
 from coreblocks.interface.layouts import AddressTranslationLayouts
 from coreblocks.params import GenParams, configurations
 from coreblocks.priv.csr.csr_instances import CSRInstances
@@ -191,26 +192,32 @@ class TestTLBCache(TestCaseWithSimulator):
 
         self.backing = MockTLBBackingDevice(self.gen_params)
 
-        if self.name == "fully_associative":
-            dut = FullyAssociativeTLB(self.gen_params, entries=16, backing_resolver=self.backing)
-        elif self.name == "set_associative":
-            dut = SetAssociativeTLB(
-                self.gen_params,
-                ways=4,
-                entries=16,
-                backing_resolver=self.backing,
-            )
-        else:
-            print(self.name)
-            assert False, "Invalid TLB type"
+        match self.name:
+            case "fully_associative":
+                dut = FullyAssociativeTLB(self.gen_params, entries=16, backing_resolver=self.backing)
+            case "set_associative":
+                dut = SetAssociativeTLB(
+                    self.gen_params,
+                    ways=4,
+                    entries=16,
+                    backing_resolver=self.backing,
+                )
+            case _:
+                assert False, f"{self.name}: Invalid TLB type"
 
         self.dut = SimpleTestCircuit(dut)
 
-        self.m = ModuleConnector(self.dut, backing=self.backing, csrs=self.csr_instances)
+        sfence_vma, _ = DependencyContext.get().get_dependency(SFenceVMAKey())
+        self.sfence_vma = TestbenchIO(AdapterTrans.create(sfence_vma))
+
+        self.m = ModuleConnector(
+            dut=self.dut, sfence_vma=self.sfence_vma, backing=self.backing, csrs=self.csr_instances
+        )
 
     def matches_lookup(self, response, vpn, asid):
-        for e_ppn, e_permissions, e_size_class, e_result, e_global in self.backing.lookup(vpn, asid):
-            if (
+        def entry_matches(e):
+            e_ppn, e_permissions, e_size_class, e_result, e_global = e
+            return (
                 response["result"] == e_result
                 and response["ppn"] == e_ppn
                 and response["size_class"] == e_size_class
@@ -223,12 +230,9 @@ class TestTLBCache(TestCaseWithSimulator):
                     "d": e_permissions.d,
                     "g": e_global,
                 }
-            ):
-                return True
-        return False
+            )
 
-    async def set_satp_asid(self, sim: TestbenchContext, asid: int):
-        await sim.tick()
+        return any(entry_matches(e) for e in self.backing.lookup(vpn, asid))
 
     async def translation_is_cached_process(self, sim: TestbenchContext):
         vpn = 0x12345
@@ -242,13 +246,23 @@ class TestTLBCache(TestCaseWithSimulator):
 
         await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
         response = await self.dut.accept.call(sim)
-        self.matches_lookup(response, vpn, asid)
+        assert self.matches_lookup(response, vpn, asid)
         assert len(self.backing.translated) == 1
 
         await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
         cached_response = await self.dut.accept.call(sim)
-        self.matches_lookup(cached_response, vpn, asid)
+        assert self.matches_lookup(cached_response, vpn, asid)
         assert len(self.backing.translated) == 1
+
+        # update entry and invalidate TLB
+        ppn = 0x34567
+        self.backing.add_translation(vpn, ppn, permissions=permissions, asid=asid)
+        await self.sfence_vma.call(sim, vaddr=vpn << PAGE_SIZE_LOG, asid=asid, all_vaddrs=0, all_asids=0)
+        await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
+        response_after_sfence = await self.dut.accept.call(sim)
+
+        assert self.matches_lookup(response_after_sfence, vpn, asid)
+        assert len(self.backing.translated) == 2
 
     async def randomized_process(self, sim: TestbenchContext):
         # fill the backing device with random translations

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -96,12 +96,14 @@ class MockTLBBackingDevice(TLBBackingDevice, Elaboratable):
 
         bits_per_size_class = self.gen_params.vmem_params.page_table_level_bits
 
-        results = [{
-            "result": AddressTranslationLayouts.TLBResult.PAGE_FAULT,
-            "ppn": 0,
-            "permissions": Permissions(),
-            "size_class": 0,
-        }]
+        results = [
+            {
+                "result": AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+                "ppn": 0,
+                "permissions": Permissions(),
+                "size_class": 0,
+            }
+        ]
         requested = False
 
         @def_method_mock(lambda: request_mock, enable=lambda: not requested)
@@ -218,7 +220,9 @@ class TestTLBCache(TestCaseWithSimulator):
         )
         self.tc = TLBTestCircuit(self.gen_params, self.dut_kind)
 
-    def assert_hit(self, response, *, ppn: int, permissions: Permissions, size_class: int = 0, global_entry: bool = False):
+    def assert_hit(
+        self, response, *, ppn: int, permissions: Permissions, size_class: int = 0, global_entry: bool = False
+    ):
         assert response["result"] == AddressTranslationLayouts.TLBResult.HIT
         assert response["ppn"] == ppn
         assert response["size_class"] == size_class

--- a/test/priv/vmem/test_tlb.py
+++ b/test/priv/vmem/test_tlb.py
@@ -209,12 +209,13 @@ class TestTLBCache(TestCaseWithSimulator):
         self.m = ModuleConnector(self.dut, backing=self.backing, csrs=self.csr_instances)
 
     def matches_lookup(self, response, vpn, asid):
-        for (e_ppn, e_permissions, e_size_class, e_result, e_global) in self.backing.lookup(vpn, asid):
+        for e_ppn, e_permissions, e_size_class, e_result, e_global in self.backing.lookup(vpn, asid):
             if (
                 response["result"] == e_result
                 and response["ppn"] == e_ppn
                 and response["size_class"] == e_size_class
-                and response["permissions"] == {
+                and response["permissions"]
+                == {
                     "r": e_permissions.r,
                     "w": e_permissions.w,
                     "x": e_permissions.x,
@@ -287,7 +288,7 @@ class TestTLBCache(TestCaseWithSimulator):
             await self.dut.request.call(sim, vpn=vpn, write_aspect=0)
             response = await self.dut.accept.call(sim)
             assert self.matches_lookup(response, vpn, asid)
-            
+
         # check that we actually cached anything
         assert len(self.backing.translated) < len(test_cases)
 


### PR DESCRIPTION
Based on #884 and #916

Implement MMU featuring:
- [x] L1D and L1I TLB storing entries available for same-cycle translation - fully associative
- [x] L2 TLB - set-associative
- [x] PTW - implementing `Svade` samantics (`Svadu` would require LSU atomics redesign)