### PR TITLE
Add .egg-info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
-# Byte-compiled / optimized / DLL files
+# Byte-compiled / optimized / library files
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Package files
+*.egg_info/
 
 # Environments
 .env


### PR DESCRIPTION
produced by `pip install` after migration to pyproject