### PR TITLE
Bump github actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 45
     container: ghcr.io/kuznia-rdzeni/amaranth-synth:ecp5-2025.01.31
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set ownership (Github Actions workaround)
         run: |
@@ -62,7 +62,7 @@ jobs:
           ./scripts/parse_benchmark_info.py -o synth-benchmark-${{ matrix.config }}.json
           cat ./synth-benchmark-${{ matrix.config }}.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: synth_benchmark_results-${{ matrix.config }}
           path: synth-benchmark-${{ matrix.config }}.json
@@ -83,14 +83,14 @@ jobs:
     container: ghcr.io/kuznia-rdzeni/riscv-toolchain:2024.12.07
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Build embench
         run: cd test/external/embench && make
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: "embench"
           path: |
@@ -104,7 +104,7 @@ jobs:
     needs: build-perf-benchmarks
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set ownership (Github Actions workaround)
         run: |
@@ -128,7 +128,7 @@ jobs:
           . venv/bin/activate
           PYTHONHASHSEED=0 TRANSACTRON_VERBOSE=1 ./scripts/gen_verilog.py --verbose --config full
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: "embench"
           path: test/external/embench/build
@@ -139,7 +139,7 @@ jobs:
           scripts/run_benchmarks.py -o perf_benchmark.json --summary perf.md
           cat perf.md >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: perf_benchmark_results
           path: perf_benchmark.json
@@ -152,7 +152,7 @@ jobs:
     needs: [run-perf-benchmarks, synthesis]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set ownership (Github Actions workaround)
         run: |
@@ -182,15 +182,15 @@ jobs:
             synth-benchmark-basic.json
             synth-benchmark-full.json
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: perf_benchmark_results
           path: artifacts
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: synth_benchmark_results-basic
           path: artifacts
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: synth_benchmark_results-full
           path: artifacts
@@ -230,17 +230,17 @@ jobs:
     timeout-minutes: 5
     needs: [run-perf-benchmarks, synthesis]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: perf_benchmark_results
           path: .
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: synth_benchmark_results-basic
           path: .
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: synth_benchmark_results-full
           path: .

--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -21,7 +21,7 @@ jobs:
       BUILD_DIR: "build"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -37,7 +37,7 @@ jobs:
           . venv/bin/activate
           PYTHONHASHSEED=0 TRANSACTRON_VERBOSE=1 ./scripts/gen_verilog.py --verbose --config full
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: "verilog-full-core"
           path: |
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get submodules HEAD hash
         working-directory: .
@@ -93,7 +93,7 @@ jobs:
 
       - if: ${{ steps.cache-riscv-arch-test.outputs.cache-hit != 'true' }}
         name: Checkout with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -127,7 +127,7 @@ jobs:
 
       - if: ${{ steps.cache-riscv-arch-test.outputs.cache-hit != 'true' }}
         name: Upload compiled and reference tests artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "riscof-tests"
           path: |
@@ -143,7 +143,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get submodules HEAD hash
         run: |
@@ -162,7 +162,7 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install ".[dev]"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         name: Download full verilog core
         with:
           name: "verilog-full-core"
@@ -204,7 +204,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get submodules HEAD hash
         run: |
@@ -229,7 +229,7 @@ jobs:
 
       - if: ${{ steps.cache-regression.outputs.cache-hit != 'true' }}
         name: Checkout with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -238,7 +238,7 @@ jobs:
 
       - if: ${{ steps.cache-regression.outputs.cache-hit != 'true' }}
         name: Upload riscv-tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: test/external/riscv-tests
 
@@ -250,7 +250,7 @@ jobs:
     needs: [ build-regression-tests, build-core ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get submodules HEAD hash
         run: |
@@ -269,7 +269,7 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install ".[dev]"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         name: Download full verilog core
         with:
           name: "verilog-full-core"
@@ -307,7 +307,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -338,7 +338,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish_comment.yml
+++ b/.github/workflows/publish_comment.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}


### PR DESCRIPTION
because for some reason checking out repository requires node.js and 6 versions.


it is depracated because of node.js 20 -> 24 requirement now and will stop working in next months.
bump other versions too.