### PR TITLE
*ignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Package files
 *.egg-info/
+*.lock
 
 # Environments
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Package files
 *.egg-info/
+build/
 *.lock
 
 # Environments

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -19,7 +19,7 @@ sub_help(){
 sub_check_format_flake8() {
     python3 -m flake8 \
       --max-line-length=$MAX_LINE_LENGTH \
-      --exclude ".env,.venv,env,venv,ENV,env.bak,venv.bak,stubs,external" \
+      --exclude ".env,.venv,env,venv,ENV,env.bak,venv.bak,external,build" \
       --ignore-names "OneHotSwitch,OneHotSwitchDynamic,OneHotCase,setUp,tearDown" \
       --extend-ignore=F403,F405,E203 $@
 }
@@ -27,7 +27,7 @@ sub_check_format_flake8() {
 sub_check_format_black() {
     python3 -m black \
       --line-length $MAX_LINE_LENGTH \
-      --extend-exclude "stubs|external" $@ \
+      --extend-exclude "external|build" $@ \
       --check $@
 }
 


### PR DESCRIPTION
Higher level python package managers like pdm, uv, poetry use internal lockfiles in project root, adds option to ignore them to be nicer for devs (i started using uv).

If we want to use lockfiles (which i think we should) the newer common Python standard is `pylock.toml` that will not match this ignore pattern and could be commited.

Additionally exculdes build/ folder used in packaging for autoformatters (they are sad about that dir :( )