### PR TITLE
[MMU 3/3] Implement page table walker

### DIFF
--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -175,7 +175,7 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
                         m.d.sync += access_fault.eq(1)
                         m.next = "DONE"
                     with m.Else():
-                        self.bus.request_read(m, addr=(pte_addr >> offset_bits), sel=~0)
+                        self.bus.request_read(m, addr=pte_addr[offset_bits:], sel=~0)
                         m.next = "EVAL"
             with m.State("EVAL"):
                 with Transaction().body(m):

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -1,0 +1,266 @@
+"""Page Table Walker - Hardware implementation of RISC-V page table walking."""
+
+from amaranth import *
+from amaranth.lib.data import StructLayout, View
+from amaranth.utils import exact_log2
+
+from coreblocks.arch.isa_consts import PAGE_SIZE, SatpMode, PAGE_SIZE_LOG
+from coreblocks.params.genparams import GenParams
+from coreblocks.interface.layouts import AddressTranslationLayouts
+from coreblocks.interface.keys import CSRInstancesKey
+from coreblocks.peripherals.bus_adapter import BusMasterInterface
+from coreblocks.priv.pmp import PMPChecker, PMPOperationMode
+
+from transactron import *
+from transactron.utils import DependencyContext, HardwareLogger
+
+from coreblocks.priv.vmem.iface import TLBBackingDevice
+
+
+__all__ = ["PageTableWalker"]
+
+
+log = HardwareLogger("mmu.walker")
+
+
+class PTELayout(StructLayout):
+    """Page Table Entry layout for RISC-V."""
+
+    def __init__(self, gen_params: GenParams):
+        # We assume all supported modes have the same PTE format.
+        if not gen_params.vmem_params.supported_non_bare_schemes:
+            raise ValueError("PTE layout cannot be determined without supported virtual memory schemes")
+
+        assert SatpMode.SV64 not in gen_params.vmem_params.supported_schemes, "SV64 is not supported"
+
+        self.gen_params = gen_params
+
+        # there is only one vmem scheme for RV32, and all RV64 schemes share the same PTE format
+        if self.gen_params.isa.xlen == 32:
+            layout = {
+                "V": 1,
+                "R": 1,
+                "W": 1,
+                "X": 1,
+                "U": 1,
+                "G": 1,
+                "A": 1,
+                "D": 1,
+                "RSW": 2,
+                "ppn": 22,
+            }
+        else:
+            layout = {
+                "V": 1,
+                "R": 1,
+                "W": 1,
+                "X": 1,
+                "U": 1,
+                "G": 1,
+                "A": 1,
+                "D": 1,
+                "RSW": 2,
+                "ppn": 44,
+                "reserved": 7,
+                "PBMT": 2,
+                "N": 1,
+            }
+
+        super().__init__(layout)
+
+    def __call__(self, value):
+        return PTEView(self, value)
+
+
+class PTEView(View):
+    """View of a Page Table Entry with helper methods."""
+
+    def __init__(self, layout, value):
+        self.gen_params: GenParams = layout.gen_params
+        super().__init__(layout, value)
+
+    def is_leaf(self):
+        return self.R | self.X
+
+    def invalid(self):
+        is_bad = ~self.V
+
+        # W needs R
+        is_bad |= self.W & ~self.R
+
+        # RSW is reserved for software - ignored
+
+        if self.gen_params.isa.xlen == 64:
+            # Reserved bits must be zero
+            is_bad |= self.reserved.any()
+            is_bad |= self.PBMT.any()
+            is_bad |= self.N
+
+        # Non-leaf PTEs have A and D bits reserved
+        is_bad |= ~self.is_leaf() & (self.A | self.D)
+
+        return is_bad
+
+
+class PageTableWalker(TLBBackingDevice, Elaboratable):
+    """Hardware page table walker for RISC-V virtual memory translation.
+
+    This module implements a page table walker that translates virtual page numbers (VPN)
+    to physical page numbers (PPN) by walking through the page table hierarchy according
+    to the current SATP configuration.
+
+    Supported virtual memory modes:
+    - BARE: No translation (immediate page fault)
+    - SV32: 32-bit virtual addresses, 2-level page table
+    - SV39: 64-bit virtual addresses, 3-level page table
+    - SV48: 64-bit virtual addresses, 4-level page table
+    - SV57: 64-bit virtual addresses, 5-level page table
+
+    Implements Svade semantics (exception on missing A/D bits).
+    """
+
+    def __init__(self, gen_params: GenParams, bus: BusMasterInterface) -> None:
+        self.gen_params = gen_params
+        self.layout = gen_params.get(AddressTranslationLayouts)
+        self.request = Method(i=self.layout.tlb_request)
+        self.accept = Method(o=self.layout.tlb_accept)
+        self.dm = DependencyContext.get()
+        self.bus = bus
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        csr = self.dm.get_dependency(CSRInstancesKey())
+        m.submodules.pmp_checker = pmp_checker = PMPChecker(self.gen_params, mode=PMPOperationMode.MMU)
+
+        pte_layout = PTELayout(self.gen_params)
+        xlen = self.gen_params.isa.xlen
+        bits_per_level = SatpMode.bits_per_page_table_level(xlen)
+        pte_bytes = pte_layout.as_shape().width // 8
+
+        assert (pte_bytes << bits_per_level) == PAGE_SIZE
+        assert pte_layout.as_shape().width == self.gen_params.isa.xlen
+        offset_bits = exact_log2(pte_bytes)
+
+        max_levels = max(SatpMode.level_count(mode) for mode in self.gen_params.vmem_params.supported_non_bare_schemes)
+
+        walk_level = Signal(range(max_levels))
+        walk_vpn = Signal(self.gen_params.vmem_params.max_tlb_vpn_bits)
+        is_store = Signal()
+        pte_addr = Signal(self.gen_params.phys_addr_bits)
+        ppn = Signal(self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)
+        access_fault = Signal()
+        page_fault = Signal()
+
+        accessed = Signal()
+        permissions = Signal(self.layout.permissions)
+
+        vpn_index = Signal(bits_per_level)
+        m.d.comb += [
+            vpn_index.eq(walk_vpn.word_select(walk_level, bits_per_level)),
+            pte_addr.eq(Cat(C(0, offset_bits), vpn_index, ppn)),
+            pmp_checker.paddr.eq(value=pte_addr),
+        ]
+
+        with m.FSM() as fsm:
+            with m.State("IDLE"):
+                with m.If(self.request.run):
+                    m.next = "ISSUE"
+            with m.State("DONE"):
+                with m.If(self.accept.run):
+                    m.next = "IDLE"
+            with m.State("ISSUE"):
+                with Transaction().body(m):
+                    with m.If(~pmp_checker.result.r):
+                        m.d.sync += access_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Else():
+                        self.bus.request_read(m, addr=(pte_addr >> offset_bits), sel=~0)
+                        m.next = "EVAL"
+            with m.State("EVAL"):
+                with Transaction().body(m):
+                    fetched = self.bus.get_read_response(m)
+                    pte = Signal(pte_layout)
+                    m.d.av_comb += pte.eq(fetched.data)
+
+                    m.d.sync += [
+                        permissions.r.eq(pte.R),
+                        permissions.w.eq(pte.W),
+                        permissions.x.eq(pte.X),
+                        permissions.u.eq(pte.U),
+                        permissions.d.eq(pte.D),
+                        permissions.g.eq(pte.G),
+                        accessed.eq(pte.A),
+                    ]
+
+                    m.d.sync += ppn.eq(pte.ppn)
+
+                    max_ppn = (1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1
+                    with m.If(fetched.err):
+                        m.d.sync += access_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Elif(pte.invalid()):
+                        m.d.sync += page_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Elif(pte.ppn > max_ppn):
+                        m.d.sync += access_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Elif(pte.is_leaf()):
+                        m.next = "DONE"
+                    with m.Elif(walk_level == 0):
+                        m.d.sync += page_fault.eq(1)
+                        m.next = "DONE"
+                    with m.Else():
+                        m.d.sync += walk_level.eq(walk_level - 1)
+                        m.next = "ISSUE"
+
+        @def_method(m, self.request, ready=fsm.ongoing("IDLE"))
+        def _(arg):
+            m.d.sync += [
+                walk_vpn.eq(arg.vpn),
+                is_store.eq(arg.is_store),
+                access_fault.eq(0),
+                page_fault.eq(0),
+            ]
+
+            with m.Switch(csr.s_mode.satp_mode):
+                for mode in self.gen_params.vmem_params.supported_non_bare_schemes:
+                    with m.Case(mode):
+                        m.d.sync += walk_level.eq(SatpMode.level_count(mode) - 1)
+                with m.Default():
+                    log.error(m, 1, "Unsupported SATP mode in page table walker")
+                    m.d.sync += walk_level.eq(0)
+
+            m.d.sync += ppn.eq(csr.s_mode.satp_ppn)
+
+        @def_method(m, self.accept, ready=fsm.ongoing("DONE"))
+        def _():
+            result = Signal(AddressTranslationLayouts.TLBResult, init=AddressTranslationLayouts.TLBResult.HIT)
+
+            ppn_misaligned = Signal()
+            with m.Switch(walk_level):
+                for level in range(max_levels):
+                    with m.Case(level):
+                        level_vpn_bits = bits_per_level * level
+                        m.d.comb += ppn_misaligned.eq(ppn[:level_vpn_bits].any())
+
+            with m.If(access_fault):
+                m.d.av_comb += result.eq(AddressTranslationLayouts.TLBResult.ACCESS_FAULT)
+            with m.Elif(page_fault | ppn_misaligned):
+                m.d.av_comb += result.eq(AddressTranslationLayouts.TLBResult.PAGE_FAULT)
+            with m.Elif(~accessed | (is_store & ~permissions.d)):
+                # Svade semantics: if A/D bits are not properly set, treat it as a page fault
+                m.d.av_comb += result.eq(AddressTranslationLayouts.TLBResult.PAGE_FAULT)
+                # TODO: implement non Svade once LSU gets real atomic support
+                #  -> just a CAS on last PTE with A/D bits set, and if it fails, restart the walk
+            with m.Else():
+                m.d.av_comb += result.eq(AddressTranslationLayouts.TLBResult.HIT)
+
+            return {
+                "result": result,
+                "ppn": ppn,
+                "permissions": permissions,
+                "size_class": walk_level,
+            }
+
+        return m

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -1,5 +1,3 @@
-"""Page Table Walker - Hardware implementation of RISC-V page table walking."""
-
 from amaranth import *
 from amaranth.lib.data import StructLayout, View
 from amaranth.utils import exact_log2
@@ -165,6 +163,7 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
         with m.FSM() as fsm:
             with m.State("IDLE"):
                 with m.If(self.request.run):
+                    log.info(m, 1, "Starting page table walk for VPN {:x}", self.request.data_in.vpn)
                     m.next = "ISSUE"
             with m.State("DONE"):
                 with m.If(self.accept.run):
@@ -172,9 +171,11 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
             with m.State("ISSUE"):
                 with Transaction().body(m):
                     with m.If(~pmp_checker.result.r):
+                        log.debug(m, 1, "PMP check failed for PTE address {:x}", pte_addr)
                         m.d.sync += access_fault.eq(1)
                         m.next = "DONE"
                     with m.Else():
+                        log.debug(m, 1, "Issuing bus request for PTE at address {:x}", pte_addr)
                         self.bus.request_read(m, addr=pte_addr[offset_bits:], sel=~0)
                         m.next = "EVAL"
             with m.State("EVAL"):
@@ -197,20 +198,26 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
 
                     max_ppn = (1 << (self.gen_params.phys_addr_bits - PAGE_SIZE_LOG)) - 1
                     with m.If(fetched.err):
+                        log.debug(m, 1, "Bus error while fetching PTE at address {:x}", pte_addr)
                         m.d.sync += access_fault.eq(1)
                         m.next = "DONE"
                     with m.Elif(pte.invalid()):
+                        log.debug(m, 1, "Invalid PTE for VPN {:x}", walk_vpn)
                         m.d.sync += page_fault.eq(1)
                         m.next = "DONE"
                     with m.Elif(pte.ppn > max_ppn):
+                        log.debug(m, 1, "PTE PPN {:x} exceeds maximum {:x}", pte.ppn, max_ppn)
                         m.d.sync += access_fault.eq(1)
                         m.next = "DONE"
                     with m.Elif(pte.is_leaf()):
+                        log.debug(m, 1, "Leaf PTE found for VPN {:x}, PPN {:x}", walk_vpn, pte.ppn)
                         m.next = "DONE"
                     with m.Elif(walk_level == 0):
+                        log.debug(m, 1, "Non-leaf PTE at lowest level for VPN {:x}", walk_vpn)
                         m.d.sync += page_fault.eq(1)
                         m.next = "DONE"
                     with m.Else():
+                        log.debug(m, 1, "Non-leaf PTE for VPN {:x}, descending to next level", walk_vpn)
                         m.d.sync += walk_level.eq(walk_level - 1)
                         m.next = "ISSUE"
 

--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -137,10 +137,10 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
         pte_bytes = pte_layout.as_shape().width // 8
 
         assert (pte_bytes << bits_per_level) == PAGE_SIZE
-        assert pte_layout.as_shape().width == self.gen_params.isa.xlen
+        assert pte_layout.as_shape().width == self.bus.params.data_width
         offset_bits = exact_log2(pte_bytes)
 
-        max_levels = max(SatpMode.level_count(mode) for mode in self.gen_params.vmem_params.supported_non_bare_schemes)
+        max_levels = max(mode.level_count() for mode in self.gen_params.vmem_params.supported_non_bare_schemes)
 
         walk_level = Signal(range(max_levels))
         walk_vpn = Signal(self.gen_params.vmem_params.max_tlb_vpn_bits)
@@ -233,7 +233,7 @@ class PageTableWalker(TLBBackingDevice, Elaboratable):
             with m.Switch(csr.s_mode.satp_mode):
                 for mode in self.gen_params.vmem_params.supported_non_bare_schemes:
                     with m.Case(mode):
-                        m.d.sync += walk_level.eq(SatpMode.level_count(mode) - 1)
+                        m.d.sync += walk_level.eq(mode.level_count() - 1)
                 with m.Default():
                     log.error(m, 1, "Unsupported SATP mode in page table walker")
                     m.d.sync += walk_level.eq(0)

--- a/test/priv/vmem/test_walker.py
+++ b/test/priv/vmem/test_walker.py
@@ -66,7 +66,7 @@ class TestPageTableWalker(TestCaseWithSimulator):
 
         translation_path = []
 
-        vpn_len = self.gen_params.vmem_params.vpn_bits_for_mode(self.gen_params.isa.xlen, mode)
+        vpn_len = mode.vpn_bits()
         vpn = random.randint(0, (1 << vpn_len) - 1)
         is_write = random.random() < 0.5
 

--- a/test/priv/vmem/test_walker.py
+++ b/test/priv/vmem/test_walker.py
@@ -46,8 +46,9 @@ class TestPageTableWalker(TestCaseWithSimulator):
         self.csr_instances = CSRInstances(self.gen_params)
         DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
 
+        offset_bits = exact_log2(self.gen_params.isa.xlen // 8)
         self.bus = MockMasterAdapter(
-            BusMockParameters(data_width=self.gen_params.isa.xlen, addr_width=self.gen_params.phys_addr_bits)
+            BusMockParameters(data_width=self.gen_params.isa.xlen, addr_width=self.gen_params.phys_addr_bits - offset_bits)
         )
         self.dut = SimpleTestCircuit(PageTableWalker(self.gen_params, self.bus))
         self.m = ModuleConnector(dut=self.dut, bus=self.bus, csrs=self.csr_instances)

--- a/test/priv/vmem/test_walker.py
+++ b/test/priv/vmem/test_walker.py
@@ -1,0 +1,309 @@
+import random
+from dataclasses import dataclass
+from typing import Optional
+import pytest
+
+from amaranth.utils import exact_log2
+
+from transactron.testing import TestCaseWithSimulator, TestbenchContext, SimpleTestCircuit, def_method_mock, MethodMock
+from transactron.utils import DependencyContext, ModuleConnector
+
+from coreblocks.arch.isa_consts import PAGE_SIZE, PAGE_SIZE_LOG, SatpMode
+from coreblocks.interface.keys import CSRInstancesKey
+from coreblocks.interface.layouts import AddressTranslationLayouts
+from coreblocks.params import GenParams, configurations
+from coreblocks.priv.csr.csr_instances import CSRInstances
+from coreblocks.priv.vmem.walker import PageTableWalker, PTELayout
+from test.peripherals.bus_mock import BusMockParameters, MockMasterAdapter
+
+
+@dataclass
+class TranslationInfo:
+    satp_ppn: int
+    satp_mode: SatpMode
+    vpn: int
+    is_write: bool
+    path: list[tuple[int, Optional[int]]]  # list of (PTE address, PTE value) pairs representing the translation path
+    result: AddressTranslationLayouts.TLBResult
+    ppn: Optional[int] = None
+    permissions: Optional[int] = None
+    # expected size class is determined by the length of the path
+    pmp_failing: Optional[int] = None  # address to cause a PMP violation, if any
+
+
+class TestPageTableWalker(TestCaseWithSimulator):
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        self.gen_params = GenParams(
+            configurations.test.replace(
+                supervisor_mode=True,
+                asidlen=4,
+                supported_vm_schemes=(SatpMode.BARE, SatpMode.SV32),
+                pmp_register_count=16,
+            )
+        )
+        self.layouts = self.gen_params.get(AddressTranslationLayouts)
+        self.csr_instances = CSRInstances(self.gen_params)
+        DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
+
+        self.bus = MockMasterAdapter(
+            BusMockParameters(data_width=self.gen_params.isa.xlen, addr_width=self.gen_params.phys_addr_bits)
+        )
+        self.dut = SimpleTestCircuit(PageTableWalker(self.gen_params, self.bus))
+        self.m = ModuleConnector(dut=self.dut, bus=self.bus, csrs=self.csr_instances)
+
+        self.mem_ready = False
+        self.mem_results = []
+        self.mem_expected = []
+
+    def gen_random_translation_path(self, mode: SatpMode) -> TranslationInfo:
+        """
+        Implementation of 'Virtual Address Translation Process' from RISC-V Privileged Spec.
+        """
+
+        translation_path = []
+
+        vpn_len = self.gen_params.vmem_params.vpn_bits_for_mode(self.gen_params.isa.xlen, mode)
+        vpn = random.randint(0, (1 << vpn_len) - 1)
+        is_write = random.random() < 0.5
+
+        def get_vpn_index(vpn, level):
+            bits_per_level = SatpMode.bits_per_page_table_level(self.gen_params.isa.xlen)
+            return (vpn >> (bits_per_level * level)) & ((1 << bits_per_level) - 1)
+
+        pte_layout = PTELayout(self.gen_params)
+        pte_size = pte_layout.as_shape().width // 8
+
+        def encode_pte(fields_dict):
+            return pte_layout.const(fields_dict).as_bits()
+
+        max_ppn = ((1 << self.gen_params.phys_addr_bits) >> PAGE_SIZE_LOG) - 1
+        root_ppn = random.randint(0, max_ppn)
+
+        common = {
+            "satp_ppn": root_ppn,
+            "satp_mode": mode,
+            "vpn": vpn,
+            "is_write": is_write,
+        }
+
+        """1. Let a be satp.ppn×PAGESIZE, and let i=LEVELS-1."""
+        a = root_ppn * PAGE_SIZE
+
+        leaf_pte = None
+        leaf_i = None
+        for i in reversed(range(SatpMode.level_count(mode))):
+            """2. Let pte be the value of the PTE at address a+va.vpn[i]×PTESIZE. (For Sv32, PTESIZE=4.)
+            If accessing pte violates a PMA or PMP check, raise an access-fault exception corresponding
+            to the original access type.
+            """
+            pte = a + (get_vpn_index(vpn, i) * pte_size)
+
+            if random.random() < 0.05:  # 5% chance of PMP violation
+                return TranslationInfo(
+                    **common,
+                    path=translation_path,
+                    result=AddressTranslationLayouts.TLBResult.ACCESS_FAULT,
+                    pmp_failing=pte,
+                )
+
+            if random.random() < 0.05:  # 5% chance of bus error
+                return TranslationInfo(
+                    **common,
+                    path=translation_path + [(pte, None)],
+                    result=AddressTranslationLayouts.TLBResult.ACCESS_FAULT,
+                )
+
+            """3. If pte.v=0, or if pte.r=0 and pte.w=1, or if any bits or encodings that are
+            reserved for future standard use are set within pte, stop and raise a page-fault
+            exception corresponding to the original access type.
+            """
+
+            # generate pte value
+            if random.random() < 0.1:
+                # generate any invalid PTE encoding
+                bad_encodings = []
+                bad_encodings.append({"V": 0})
+                bad_encodings.append({"V": 1, "R": 0, "W": 1})
+                for v in ("A", "D"):
+                    bad_encodings.append({"V": 1, v: 1})  # non-leaf with A/D is reserved
+                if self.gen_params.isa.xlen == 64:
+                    bad_encodings.append({"V": 1, "reserved": random.randint(1, 0x7F)})
+                    bad_encodings.append({"V": 1, "PBMT": random.randint(1, 3)})
+                    bad_encodings.append({"V": 1, "N": 1})
+
+                pte_dict = random.choice(bad_encodings)
+                pte_dict["ppn"] = random.randint(0, max_ppn)
+
+                translation_path.append((pte, encode_pte(pte_dict)))
+                return TranslationInfo(
+                    **common,
+                    path=translation_path,
+                    result=AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+                )
+
+            """4. Otherwise, the PTE is valid. If pte.r=1 or pte.x=1, go to step 5.
+            Otherwise, this PTE is a pointer to the next level of the page table.
+            Let i=i-1. If i<0, stop and raise a page-fault exception corresponding to the original access type.
+            Otherwise, let a=pte.ppn×PAGESIZE and go to step 2.
+            """
+            if random.random() < 0.5:
+                leaf_pte = pte
+                leaf_i = i
+                break
+
+            # non-leaf PTE
+            ppn = random.randint(0, max_ppn)
+            translation_path.append((pte, encode_pte({"V": 1, "ppn": ppn})))
+            if i == 0:
+                return TranslationInfo(
+                    **common,
+                    path=translation_path,
+                    result=AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+                )
+            a = ppn * PAGE_SIZE
+
+        # leaf PTE
+        assert leaf_pte is not None
+        assert leaf_i is not None
+
+        rw = random.randint(0, 2)
+
+        pte_dict = {
+            "V": 1,
+            "R": rw >= 1,
+            "W": rw == 2,
+            "X": rw == 0 or (random.random() < 0.3),
+            "U": random.random() < 0.5,
+            "A": random.random() < 0.9,
+            "D": random.random() < 0.5,
+            "G": random.random() < 0.5,
+            "RSW": random.randint(0, 3),
+        }
+
+        level_bits = SatpMode.bits_per_page_table_level(self.gen_params.isa.xlen) * leaf_i
+        upper_ppn = random.randint(0, max_ppn >> level_bits)
+
+        """5. A leaf PTE has been reached. If i>0 and pte.ppn[i-1:0] ≠ 0, this is a misaligned superpage;
+        stop and raise a page-fault exception corresponding to the original access type.
+        """
+        if leaf_i > 0 and random.random() < 0.1:  # 10% chance of misaligned superpage
+            lower_ppn = random.randint(1, (1 << level_bits) - 1)  # ensure misalignment
+            ppn = (upper_ppn << level_bits) | lower_ppn
+            translation_path.append((leaf_pte, encode_pte({**pte_dict, "ppn": ppn})))
+            return TranslationInfo(
+                **common,
+                path=translation_path,
+                result=AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+            )
+
+        pte_dict["ppn"] = upper_ppn << level_bits
+        translation_path.append((leaf_pte, encode_pte(pte_dict)))
+
+        if pte_dict["A"] == 0 or (is_write and pte_dict["D"] == 0):
+            # if A=0 or if it's a store and D=0, Svade treats it as a page fault
+            return TranslationInfo(
+                **common,
+                path=translation_path,
+                result=AddressTranslationLayouts.TLBResult.PAGE_FAULT,
+            )
+
+        permissions = {
+            "r": pte_dict["R"],
+            "w": pte_dict["W"],
+            "x": pte_dict["X"],
+            "u": pte_dict["U"],
+            "d": pte_dict["D"],
+            "g": pte_dict["G"],
+        }
+
+        return TranslationInfo(
+            **common,
+            path=translation_path,
+            result=AddressTranslationLayouts.TLBResult.HIT,
+            ppn=pte_dict["ppn"],
+            permissions=self.layouts.permissions.const(permissions).as_bits(),  # type: ignore
+        )
+
+    @def_method_mock(lambda self: self.bus.request_read_mock, enable=lambda self: not self.mem_ready)
+    def bus_read_req_proc(self, addr, sel):
+        @MethodMock.effect
+        def _():
+            assert len(self.mem_expected) > 0
+
+            expected_addr, data = self.mem_expected.pop(0)
+            off_bits = exact_log2(self.gen_params.isa.xlen // 8)
+
+            b_addr = addr << off_bits
+
+            assert sel == 0xFF if self.gen_params.isa.xlen == 64 else 0xF
+            assert b_addr == expected_addr
+            if data is None:
+                self.mem_results.append(
+                    {
+                        "data": 0,
+                        "err": 1,
+                    }
+                )
+            else:
+                self.mem_results.append(
+                    {
+                        "data": data,
+                        "err": 0,
+                    }
+                )
+            self.mem_ready = True
+
+    @def_method_mock(lambda self: self.bus.get_read_response_mock, enable=lambda self: self.mem_ready)
+    def bus_read_resp_proc(self):
+        @MethodMock.effect
+        def _():
+            self.mem_ready = False
+
+        if self.mem_results:
+            return self.mem_results[-1]
+
+    async def random_translations_process(self, sim: TestbenchContext):
+        # allow PMP for S-mode
+        sim.set(self.csr_instances.m_mode.pmpxcfg[6].value, 0b00001001)  # R=1, A=TOR
+        sim.set(self.csr_instances.m_mode.pmpaddrx[5].value, 0)
+        sim.set(self.csr_instances.m_mode.pmpaddrx[6].value, ~0)
+
+        for _ in range(128):
+            mode = random.choice([*self.gen_params.vmem_params.supported_non_bare_schemes])
+            translation_info = self.gen_random_translation_path(mode)
+
+            sim.set(self.csr_instances.s_mode.satp_mode, translation_info.satp_mode)
+            sim.set(self.csr_instances.s_mode.satp_ppn, translation_info.satp_ppn)
+
+            # clean PPM
+            if translation_info.pmp_failing is not None:
+                sim.set(self.csr_instances.m_mode.pmpxcfg[1].value, 0b00001000)  # RWX=0, A=TOR
+                pmp_addr = translation_info.pmp_failing >> 2
+                pnp_top = (translation_info.pmp_failing + self.gen_params.pmp_grain_bytes) >> 2
+
+                sim.set(self.csr_instances.m_mode.pmpaddrx[0].value, pmp_addr)
+                sim.set(self.csr_instances.m_mode.pmpaddrx[1].value, pnp_top)
+            else:
+                sim.set(self.csr_instances.m_mode.pmpxcfg[0].value, 0)
+
+            self.mem_expected = translation_info.path.copy()
+            self.mem_results = []
+            self.mem_ready = False
+
+            await sim.tick()
+            await self.dut.request.call(sim, vpn=translation_info.vpn, is_store=translation_info.is_write)
+            ret = await self.dut.accept.call(sim)
+            assert not self.mem_expected
+
+            assert ret.result == translation_info.result
+            if translation_info.result == AddressTranslationLayouts.TLBResult.HIT:
+                assert ret.ppn == translation_info.ppn
+                assert ret.permissions.as_bits() == translation_info.permissions
+                assert ret.size_class == SatpMode.level_count(translation_info.satp_mode) - len(translation_info.path)
+
+    def test_random_translations(self):
+        with self.run_simulation(self.m) as sim:
+            self.add_mock(sim, self.bus_read_req_proc())  # type: ignore
+            self.add_mock(sim, self.bus_read_resp_proc())  # type: ignore
+            sim.add_testbench(self.random_translations_process)

--- a/test/priv/vmem/test_walker.py
+++ b/test/priv/vmem/test_walker.py
@@ -48,7 +48,9 @@ class TestPageTableWalker(TestCaseWithSimulator):
 
         offset_bits = exact_log2(self.gen_params.isa.xlen // 8)
         self.bus = MockMasterAdapter(
-            BusMockParameters(data_width=self.gen_params.isa.xlen, addr_width=self.gen_params.phys_addr_bits - offset_bits)
+            BusMockParameters(
+                data_width=self.gen_params.isa.xlen, addr_width=self.gen_params.phys_addr_bits - offset_bits
+            )
         )
         self.dut = SimpleTestCircuit(PageTableWalker(self.gen_params, self.bus))
         self.m = ModuleConnector(dut=self.dut, bus=self.bus, csrs=self.csr_instances)

--- a/test/priv/vmem/test_walker.py
+++ b/test/priv/vmem/test_walker.py
@@ -307,6 +307,6 @@ class TestPageTableWalker(TestCaseWithSimulator):
 
     def test_random_translations(self):
         with self.run_simulation(self.m) as sim:
-            self.add_mock(sim, self.bus_read_req_proc())  # type: ignore
-            self.add_mock(sim, self.bus_read_resp_proc())  # type: ignore
+            sim.add_mock(self.bus_read_req_proc())
+            sim.add_mock(self.bus_read_resp_proc())
             sim.add_testbench(self.random_translations_process)


### PR DESCRIPTION
Continuation of #942.
This PR implements page table walker. It also implements randomized testing.
Even if this is called part 3 it can be merged independent of #947.

What will be left after this is just integrate the MMU into the core.