### PR TITLE
Efficient precommit

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -86,7 +86,7 @@ class Retirement(Elaboratable):
         self.core_state = Method(o=self.gen_params.get(RetirementLayouts).core_state)
         self.dependency_manager.add_dependency(CoreStateKey(), self.core_state)
 
-        self.precommit = Method(i=layouts.precommit_in, o=layouts.precommit_out)
+        self.precommit = Method(i=layouts.precommit_in)
         self.dependency_manager.add_dependency(InstructionPrecommitKey(), self.precommit)
 
     def elaborate(self, platform):
@@ -98,8 +98,6 @@ class Retirement(Elaboratable):
         m_csr = csr_instances.m_mode
         s_csr = csr_instances.s_mode if self.gen_params.supervisor_mode else None
         m.submodules.instret_csr = self.instret_csr
-
-        side_fx = Signal(init=1)
 
         def free_phys_reg(i: int, rp_dst: Value):
             # mark reg in Register File as free
@@ -318,7 +316,6 @@ class Retirement(Elaboratable):
         m.d.top_comb += precommit_rob_id.eq(rob_entries.entries[0].rob_id + rob_entries.done_count)
 
         # Disable executing any side effects from instructions in core when it is flushed
-        m.d.comb += side_fx.eq(~fsm.ongoing("TRAP_FLUSH"))
         m.d.comb += core_flushing.eq(fsm.ongoing("TRAP_FLUSH") | exc_prefixes[rob_entries.done_count])
 
         # The argument is only used in argument validation, it is not needed in the method body.
@@ -332,6 +329,6 @@ class Retirement(Elaboratable):
             combiner=lambda m, args, runs: 0,
         )
         def _(rob_id):
-            return {"side_fx": side_fx}
+            return
 
         return m

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -230,8 +230,6 @@ class Retirement(Elaboratable):
                             # Not using default condition, because we want to block if branch is not ready
                             flush_instr(0, rob_entry)
 
-                            m.d.comb += core_flushing.eq(1)
-
                     validate_transaction.schedule_before(retire_transaction)
 
             with m.State("TRAP_FLUSH"):
@@ -261,8 +259,6 @@ class Retirement(Elaboratable):
 
                     with m.If(core_empty):
                         m.next = "TRAP_RESUME"
-
-                m.d.comb += core_flushing.eq(1)
 
             with m.State("TRAP_RESUME"):
                 with Transaction().body(m):
@@ -307,26 +303,35 @@ class Retirement(Elaboratable):
 
                     m.next = "NORMAL"
 
-        # Disable executing any side effects from instructions in core when it is flushed
-        m.d.comb += side_fx.eq(~fsm.ongoing("TRAP_FLUSH"))
-
         @def_method(m, self.core_state, nonexclusive=True)
         def _():
             return {"flushing": core_flushing}
 
-        rob_id_val = Signal(self.gen_params.rob_entries_bits)
+        # Run precommit on first not-done instr, if exception not encountered
+        precommit_rob_id = Signal(self.gen_params.rob_entries_bits)
+        exc_prefixes = Array(
+            [
+                Cat(rob_entries.entries[j].exception for j in range(i)).any()
+                for i in range(self.gen_params.retirement_superscalarity + 1)
+            ]
+        )
+        m.d.top_comb += precommit_rob_id.eq(rob_entries.entries[0].rob_id + rob_entries.done_count)
+
+        # Disable executing any side effects from instructions in core when it is flushed
+        m.d.comb += side_fx.eq(~fsm.ongoing("TRAP_FLUSH"))
+        m.d.comb += core_flushing.eq(fsm.ongoing("TRAP_FLUSH") | exc_prefixes[rob_entries.done_count])
 
         # The argument is only used in argument validation, it is not needed in the method body.
         # A dummy combiner is provided.
         @def_method(
             m,
             self.precommit,
-            validate_arguments=lambda rob_id: rob_id == rob_id_val,
+            ready=~core_flushing,
+            validate_arguments=lambda rob_id: rob_id == precommit_rob_id,
             nonexclusive=True,
             combiner=lambda m, args, runs: 0,
         )
         def _(rob_id):
-            m.d.top_comb += rob_id_val.eq(self.rob_peek(m).entries[0].rob_id)
             return {"side_fx": side_fx}
 
         return m

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -25,7 +25,9 @@ from coreblocks.interface.keys import (
     CSRInstancesKey,
     InstructionPrecommitKey,
 )
-from coreblocks.priv.csr.csr_instances import CSRAddress, DoubleCounterCSR, counteren_access_filter
+from coreblocks.priv.csr.csr_instances import CSRAddress, counteren_access_filter
+from coreblocks.priv.csr.csr_register import CSRRegister
+from coreblocks.priv.csr.double_shadow import DoubleShadowCSR
 from coreblocks.arch.isa_consts import TrapVectorMode
 
 
@@ -65,8 +67,11 @@ class Retirement(Elaboratable):
         self.checkpoint_tag_free = Method()
         self.checkpoint_get_active_tags = Method(o=gen_params.get(RATLayouts).get_active_tags_out)
 
-        self.instret_csr = DoubleCounterCSR(
+        self._done_count = Signal(range(gen_params.retirement_superscalarity + 1))
+        self.instret_csr = CSRRegister(None, gen_params, width=64, fu_read_map=lambda _, v: v + self._done_count)
+        self.instret_shadow = DoubleShadowCSR(
             gen_params,
+            self.instret_csr,
             CSRAddress.MINSTRET,
             CSRAddress.MINSTRETH,
             CSRAddress.INSTRET,
@@ -98,6 +103,7 @@ class Retirement(Elaboratable):
         m_csr = csr_instances.m_mode
         s_csr = csr_instances.s_mode if self.gen_params.supervisor_mode else None
         m.submodules.instret_csr = self.instret_csr
+        m.submodules.instret_shadow = self.instret_shadow
 
         def free_phys_reg(i: int, rp_dst: Value):
             # mark reg in Register File as free
@@ -113,7 +119,7 @@ class Retirement(Elaboratable):
             # free old rp_dst from overwritten R-RAT mapping
             free_phys_reg(0, rat_out.old_rp_dst)
 
-            self.instret_csr.increment(m)
+            self.instret_csr.write(m, data=self.instret_csr.read(m).data + 1)
             self.perf_instr_ret.incr(m)
 
         def flush_instr(i: int, rob_entry: View):
@@ -313,7 +319,8 @@ class Retirement(Elaboratable):
                 for i in range(self.gen_params.retirement_superscalarity + 1)
             ]
         )
-        m.d.top_comb += precommit_rob_id.eq(rob_entries.entries[0].rob_id + rob_entries.done_count)
+        m.d.comb += precommit_rob_id.eq(rob_entries.entries[0].rob_id + rob_entries.done_count)
+        m.d.comb += self._done_count.eq(rob_entries.done_count)
 
         # Disable executing any side effects from instructions in core when it is flushed
         m.d.comb += core_flushing.eq(fsm.ongoing("TRAP_FLUSH") | exc_prefixes[rob_entries.done_count])

--- a/coreblocks/func_blocks/csr/csr_unit.py
+++ b/coreblocks/func_blocks/csr/csr_unit.py
@@ -17,6 +17,7 @@ from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 from coreblocks.interface.layouts import FuncUnitLayouts, CSRUnitLayouts, RSInterfaceLayouts, CSRRegisterLayouts
 from coreblocks.interface.keys import (
     CSRListKey,
+    CoreStateKey,
     UnsafeInstructionResolvedKey,
     CSRInstancesKey,
     InstructionPrecommitKey,
@@ -146,13 +147,10 @@ class CSRUnit(FuncBlock, Elaboratable):
             with m.Case(Funct3.CSRRC, Funct3.CSRRCI):
                 m.d.av_comb += write_type.eq(CSRRegisterLayouts.WriteOpType.CSR_CLEAR)
 
-        exe_side_fx = Signal()
-
         # Methods used within this Tranaction are CSRRegister internal _fu_(read|write) handlers which are always ready
         with Transaction().body(m, ready=(ready_to_process & ~done)):
             precommit = self.dependency_manager.get_dependency(InstructionPrecommitKey())
-            info = precommit(m, instr.rob_id)
-            m.d.top_comb += exe_side_fx.eq(info.side_fx)
+            precommit(m, instr.rob_id)
             csr_instances = self.dependency_manager.get_dependency(CSRInstancesKey())
             current_priv_mode = csr_instances.m_mode.priv_mode.read(m).data
 
@@ -190,9 +188,6 @@ class CSRUnit(FuncBlock, Elaboratable):
 
             m.d.sync += done.eq(1)
 
-        with Transaction().body(m, ready=(ready_to_process & ~exe_side_fx)):
-            m.d.sync += done.eq(1)
-
         @def_method(m, self.select, ~reserved)
         def _():
             m.d.sync += reserved.eq(1)
@@ -213,7 +208,10 @@ class CSRUnit(FuncBlock, Elaboratable):
                 m.d.sync += instr.s1_val.eq(reg_val)
                 m.d.sync += instr.rp_s1.eq(0)
 
-        @def_method(m, self.get_result, done)
+        with Transaction().body(m):
+            core_state = self.dependency_manager.get_dependency(CoreStateKey())(m)
+
+        @def_method(m, self.get_result, done | (ready_to_process & core_state.flushing))
         def _():
             m.d.sync += reserved.eq(0)
             m.d.sync += instr.valid.eq(0)
@@ -256,7 +254,7 @@ class CSRUnit(FuncBlock, Elaboratable):
 
             m.d.sync += exception.eq(0)
 
-            with m.If(exe_side_fx & ~exception & ~interrupt):
+            with m.If(~core_state.flushing & ~exception & ~interrupt):
                 # CSR instructions are never compressed, PC+4 is always next instruction
                 resume_core(m, pc=instr.pc + self.gen_params.isa.ilen_bytes)
 

--- a/coreblocks/func_blocks/csr/csr_unit.py
+++ b/coreblocks/func_blocks/csr/csr_unit.py
@@ -165,10 +165,8 @@ class CSRUnit(FuncBlock, Elaboratable):
                         m.d.av_comb += priv_valid.eq(priv_level_required <= current_priv_mode)
 
                         with m.If(priv_valid & csr_access_valid):
-                            read_val = Signal(self.gen_params.isa.xlen)
                             with m.If(should_read_csr & ~done):
-                                m.d.av_comb += read_val.eq(csr._fu_read(m))
-                                m.d.sync += current_result.eq(read_val)
+                                m.d.sync += current_result.eq(csr._fu_read(m))
 
                             if read_only:
                                 with m.If(should_write_csr):

--- a/coreblocks/func_blocks/csr/csr_unit.py
+++ b/coreblocks/func_blocks/csr/csr_unit.py
@@ -169,8 +169,7 @@ class CSRUnit(FuncBlock, Elaboratable):
                         with m.If(priv_valid & csr_access_valid):
                             read_val = Signal(self.gen_params.isa.xlen)
                             with m.If(should_read_csr & ~done):
-                                with m.If(exe_side_fx):
-                                    m.d.av_comb += read_val.eq(csr._fu_read(m))
+                                m.d.av_comb += read_val.eq(csr._fu_read(m))
                                 m.d.sync += current_result.eq(read_val)
 
                             if read_only:
@@ -179,8 +178,7 @@ class CSRUnit(FuncBlock, Elaboratable):
                                     m.d.sync += exception.eq(1)
                             else:
                                 with m.If(should_write_csr & ~done):
-                                    with m.If(exe_side_fx):
-                                        csr._fu_write(m, data=instr.s1_val, op_type=write_type)
+                                    csr._fu_write(m, data=instr.s1_val, op_type=write_type)
 
                         with m.Else():
                             # Missing privilege
@@ -190,6 +188,9 @@ class CSRUnit(FuncBlock, Elaboratable):
                     # Invalid CSR number
                     m.d.sync += exception.eq(1)
 
+            m.d.sync += done.eq(1)
+
+        with Transaction().body(m, ready=(ready_to_process & ~exe_side_fx)):
             m.d.sync += done.eq(1)
 
         @def_method(m, self.select, ~reserved)

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -18,6 +18,7 @@ from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, ExceptionCause
 from coreblocks.interface.layouts import PrivUnitLayouts
 from coreblocks.interface.keys import (
+    CoreStateKey,
     MretKey,
     SretKey,
     AsyncInterruptInsertSignalKey,
@@ -118,9 +119,9 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
 
         with Transaction().body(m, ready=instr_valid & ~finished):
             precommit = self.dm.get_dependency(InstructionPrecommitKey())
-            info = precommit(m, instr_rob)
+            precommit(m, instr_rob)
             m.d.sync += finished.eq(1)
-            self.perf_instr.incr(m, instr_fn, enable_call=info.side_fx)
+            self.perf_instr.incr(m, instr_fn)
 
             priv_data = priv_mode.read(m).data
 
@@ -148,15 +149,15 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
             )
 
             with condition(m, nonblocking=True) as branch:
-                with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.MRET) & ~illegal_mret):
+                with branch((instr_fn == PrivilegedFn.Fn.MRET) & ~illegal_mret):
                     mret(m)
                 if self.fn.supervisor_enable:
                     assert sret is not None
-                    with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.SRET) & ~illegal_sret):
+                    with branch((instr_fn == PrivilegedFn.Fn.SRET) & ~illegal_sret):
                         sret(m)
 
                     if self.gen_params.vmem_params.supported_non_bare_schemes and sfence_vma is not None:
-                        with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.SFENCEVMA) & ~illegal_sfencevma):
+                        with branch((instr_fn == PrivilegedFn.Fn.SFENCEVMA) & ~illegal_sfencevma):
                             imm_view = data.View(self.gen_params.get(PrivUnitLayouts).sfencevma_imm_layout, instr_imm)
 
                             sfence_vma[0](
@@ -167,16 +168,19 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
                                 all_asids=imm_view.rs2 == 0,
                             )
 
-                with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.FENCEI)):
+                with branch((instr_fn == PrivilegedFn.Fn.FENCEI)):
                     flush_icache(m)
-                with branch(info.side_fx & (instr_fn == PrivilegedFn.Fn.WFI) & ~illegal_wfi):
+                with branch((instr_fn == PrivilegedFn.Fn.WFI) & ~illegal_wfi):
                     # async_interrupt_active implies wfi_resume. WFI should continue normal execution
                     # when interrupt is enabled in xie, but disabled via global mstatus.xIE
                     m.d.sync += finished.eq(wfi_resume)
 
             m.d.sync += illegal_instruction.eq(illegal_wfi | illegal_mret | illegal_sret | illegal_sfencevma)
 
-        with Transaction().body(m, ready=instr_valid & finished):
+        with Transaction().body(m):
+            core_state = self.dm.get_dependency(CoreStateKey())(m)
+
+        with Transaction().body(m, ready=instr_valid & (finished | core_state.flushing)):
             m.d.sync += instr_valid.eq(0)
             m.d.sync += finished.eq(0)
 
@@ -242,7 +246,7 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
                 self.exception_report(
                     m, cause=ExceptionCause._COREBLOCKS_ASYNC_INTERRUPT, pc=ret_pc, rob_id=instr_rob, mtval=0
                 )
-            with m.Else():
+            with m.Elif(~core_state.flushing):
                 log.info(m, True, "Unstalling fetch from the priv unit new_pc=0x{:x}", ret_pc)
                 # Unstall the fetch
                 resume_core(m, pc=ret_pc)

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -126,9 +126,6 @@ class CommonLayoutFields:
         self.error: LayoutListField = ("error", 1)
         """Request ended with an error."""
 
-        self.side_fx: LayoutListField = ("side_fx", 1)
-        """Side effects are enabled."""
-
         self.rvc: LayoutListField = ("rvc", 1)
         """Instruction is a compressed (two-byte) one."""
 
@@ -527,8 +524,6 @@ class RetirementLayouts:
         fields = gen_params.get(CommonLayoutFields)
 
         self.precommit_in = make_layout(fields.rob_id)
-
-        self.precommit_out = make_layout(fields.side_fx)
 
         self.flushing = ("flushing", 1)
         """ Core is currently flushed """

--- a/test/asm/csr_mmode.asm
+++ b/test/asm/csr_mmode.asm
@@ -1,6 +1,10 @@
     li x15, 5 # this many instructions will raise an exception
     la x6, exception_handler
     csrw mtvec, x6 # set-up handler
+    # perform a forward jump to trigger flushing
+    j next
+    nop
+next:
     # test read-only CSRs
     csrw mvendorid, 1
     csrw marchid, 1

--- a/test/asm/csr_mmode.asm
+++ b/test/asm/csr_mmode.asm
@@ -2,7 +2,8 @@
     la x6, exception_handler
     csrw mtvec, x6 # set-up handler
     # perform a forward jump to trigger flushing
-    j next
+    mv x7, x6
+    beq x6, x7, next
     nop
 next:
     # test read-only CSRs

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -140,7 +140,6 @@ class TestRetirement(TestCaseWithSimulator):
         while self.precommit_q:
             info = await self.retc.precommit_adapter.call_try(sim, rob_id=self.precommit_q[0])
             assert info is not None
-            assert info["side_fx"]
             self.precommit_q.popleft()
 
     @def_method_mock(lambda self: self.retc.mock_rf_free)

--- a/test/func_blocks/csr/test_csr.py
+++ b/test/func_blocks/csr/test_csr.py
@@ -12,6 +12,7 @@ from coreblocks.params import configurations
 from coreblocks.interface.layouts import ExceptionRegisterLayouts, RetirementLayouts, FetchLayouts, CSRRegisterLayouts
 from coreblocks.interface.keys import (
     AsyncInterruptInsertSignalKey,
+    CoreStateKey,
     UnsafeInstructionResolvedKey,
     ExceptionReportKey,
     InstructionPrecommitKey,
@@ -36,16 +37,19 @@ class CSRUnitTestCircuit(Elaboratable):
         m.submodules.precommit = self.precommit = TestbenchIO(
             Adapter(
                 i=self.gen_params.get(RetirementLayouts).precommit_in,
-                o=self.gen_params.get(RetirementLayouts).precommit_out,
                 nonexclusive=True,
                 combiner=lambda m, args, runs: args[0],
             ).set(with_validate_arguments=True)
+        )
+        m.submodules.core_state = self.core_state = TestbenchIO(
+            Adapter(o=self.gen_params.get(RetirementLayouts).core_state)
         )
         m.submodules.exception_report = self.exception_report = TestbenchIO(
             Adapter(i=self.gen_params.get(ExceptionRegisterLayouts).report)
         )
         DependencyContext.get().add_dependency(InstructionPrecommitKey(), self.precommit.adapter.iface)
         DependencyContext.get().add_dependency(ExceptionReportKey(), lambda: self.exception_report.adapter.iface)
+        DependencyContext.get().add_dependency(CoreStateKey(), self.core_state.adapter.iface)
 
         m.submodules.dut = self.dut = CSRUnit(self.gen_params)
 
@@ -87,7 +91,15 @@ class CSRUnitTestCircuit(Elaboratable):
         return m
 
 
-class TestCSRUnit(TestCaseWithSimulator):
+class TestCSRUnitBase(TestCaseWithSimulator):
+    dut: CSRUnitTestCircuit
+
+    @def_method_mock(lambda self: self.dut.core_state)
+    def core_state_mock(self):
+        return {"flushing": 0}
+
+
+class TestCSRUnit(TestCSRUnitBase):
     def gen_expected_out(self, sim: TestbenchContext, op: Funct3, rd: int, rs1: int, operand_val: int, csr: int):
         exp_read = {"rp_dst": rd, "result": sim.get(self.dut.csr[csr].value)}
         rs1_val = {"rp_s1": rs1, "value": operand_val}
@@ -161,7 +173,7 @@ class TestCSRUnit(TestCaseWithSimulator):
             # TODO: this is a hack, a real method mock should be used
             for _, r in self.dut.precommit.adapter.validators:  # type: ignore
                 sim.set(r, 1)
-            self.dut.precommit.call_init(sim, side_fx=1)  # TODO: sensible precommit handling
+            self.dut.precommit.call_init(sim)  # TODO: sensible precommit handling
 
             await self.random_wait_geom(sim)
             res, resume_res = await CallTrigger(sim).call(self.dut.accept).sample(self.dut.fetch_resume).until_done()
@@ -255,7 +267,7 @@ class TestCSRUnit(TestCaseWithSimulator):
             # TODO: this is a hack, a real method mock should be used
             for _, r in self.dut.precommit.adapter.validators:  # type: ignore
                 sim.set(r, 1)
-            self.dut.precommit.call_init(sim, side_fx=1)
+            self.dut.precommit.call_init(sim)
 
             await self.random_wait_geom(sim)
             res, report = await CallTrigger(sim).call(self.dut.accept).sample(self.dut.exception_report).until_done()
@@ -311,7 +323,7 @@ class TestCSRUnit(TestCaseWithSimulator):
             await self.random_wait_geom(sim)
             for _, r in self.dut.precommit.adapter.validators:  # type: ignore
                 sim.set(r, 1)
-            self.dut.precommit.call_init(sim, side_fx=1)
+            self.dut.precommit.call_init(sim)
 
             await self.random_wait_geom(sim)
             res, report = await CallTrigger(sim).call(self.dut.accept).sample(self.dut.exception_report).until_done()

--- a/test/func_blocks/lsu/test_dummylsu.py
+++ b/test/func_blocks/lsu/test_dummylsu.py
@@ -83,7 +83,6 @@ class DummyLSUTestCircuit(Elaboratable):
         m.submodules.precommit = self.precommit = TestbenchIO(
             Adapter(
                 i=layouts.precommit_in,
-                o=layouts.precommit_out,
                 nonexclusive=True,
                 combiner=lambda m, args, runs: args[0],
             ).set(with_validate_arguments=True)
@@ -257,7 +256,7 @@ class TestDummyLSULoads(TestCaseWithSimulator):
 
         @def_method_mock(lambda: self.test_module.precommit, validate_arguments=lambda rob_id: True)
         def precommiter(rob_id):
-            return {"side_fx": 1}
+            return {}
 
         @def_method_mock(lambda: self.test_module.core_state)
         def core_state_process():
@@ -327,7 +326,7 @@ class TestDummyLSULoadsCycles(TestCaseWithSimulator):
 
         @def_method_mock(lambda: self.test_module.precommit, validate_arguments=lambda rob_id: True)
         def precommiter(rob_id):
-            return {"side_fx": 1}
+            return {}
 
         with self.run_simulation(self.test_module) as sim:
             sim.add_testbench(self.one_instr_test)
@@ -427,7 +426,7 @@ class TestDummyLSUStores(TestCaseWithSimulator):
 
     @def_method_mock(lambda self: self.test_module.precommit, validate_arguments=precommit_validate)
     def precommiter(self, rob_id):
-        return {"side_fx": 1}
+        return {}
 
     def test(self):
         @def_method_mock(lambda: self.test_module.exception_report)
@@ -473,7 +472,7 @@ class TestDummyLSUFence(TestCaseWithSimulator):
 
         @def_method_mock(lambda: self.test_module.precommit, validate_arguments=lambda rob_id: True)
         def precommiter(rob_id):
-            return {"side_fx": 1}
+            return {}
 
         pending_req = False
 

--- a/test/func_blocks/lsu/test_pma.py
+++ b/test/func_blocks/lsu/test_pma.py
@@ -63,7 +63,6 @@ class PMAIndirectTestCircuit(Elaboratable):
         m.submodules.precommit = self.precommit = TestbenchIO(
             Adapter(
                 i=layouts.precommit_in,
-                o=layouts.precommit_out,
                 nonexclusive=True,
                 combiner=lambda m, args, runs: args[0],
             ).set(with_validate_arguments=True)
@@ -141,7 +140,7 @@ class TestPMAIndirect(TestCaseWithSimulator):
             enable=lambda: self.precommit_enabled,
         )
         def precommiter(rob_id):
-            return {"side_fx": 1}
+            return {}
 
         @def_method_mock(lambda: self.test_module.core_state)
         def core_state_process():


### PR DESCRIPTION
There is no need to enable `precommit` just on the head of the ROB. When an instruction is preceded only by done, non-trapping insns, performing side effects early is safe.

Also, if any of the instructions in the done prefix is trapping, we already know that we will start flushing and no more side effects will need to be executed.

It also turns out that changing the semantics of `precommit` to only be enabled when not flushing (and therefore, side effects can be done) makes code simpler. Maybe the name should be changed to `can_side_fx` or something like that?

In the future, side effects could skip around instructions which are not done, but cannot trap nor perform side effects and are not dependent on side-effecting instructions (let's call them pure instructions?). CSRs would probably need to get special treatment as they can influence virtually freaking everything. <- ~this should get an issue~ #958

Unfortunately this patch breaks `rdinstret`. Fixing it requires working around the `DoubleCounterCSR` stuff: the length of the done prefix needs to be added to the counter value to get the proper `rdinstret` value.

This is a prerequisite for proper superscalar retirement.

Based on #957.

TODO:
- [x] Fix `rdinstret`
- [x] Fix tests