### PR TITLE
Double counter refactor

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -68,9 +68,9 @@ class Retirement(Elaboratable):
         self.instret_csr = DoubleCounterCSR(
             gen_params,
             CSRAddress.MINSTRET,
-            CSRAddress.MINSTRETH if gen_params.isa.xlen == 32 else None,
+            CSRAddress.MINSTRETH,
             CSRAddress.INSTRET,
-            CSRAddress.INSTRETH if gen_params.isa.xlen == 32 else None,
+            CSRAddress.INSTRETH,
             shadow_access_filter=counteren_access_filter(gen_params, CounterEnableFieldOffsets.IR),
         )
         self.perf_instr_ret = HwCounter("backend.retirement.retired_instr", "Number of retired instructions")

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -106,9 +106,9 @@ class MachineModeCSRRegisters(Elaboratable):
         self.mcycle = DoubleCounterCSR(
             gen_params,
             CSRAddress.MCYCLE,
-            CSRAddress.MCYCLEH if gen_params.isa.xlen == 32 else None,
+            CSRAddress.MCYCLEH,
             CSRAddress.CYCLE,
-            CSRAddress.CYCLEH if gen_params.isa.xlen == 32 else None,
+            CSRAddress.CYCLEH,
             shadow_access_filter=counteren_access_filter(gen_params, CounterEnableFieldOffsets.CY),
         )
 

--- a/coreblocks/priv/csr/csr_register.py
+++ b/coreblocks/priv/csr/csr_register.py
@@ -56,7 +56,7 @@ class CSRRegisterBase(ABC, Elaboratable):
             Address of this CSR Register.
             If `None` is given, CSR is virtual - not registerable to `CSRUnit`.
             Otherwise it's registered under provided address to `CSRUnit` using `CSRListKey`.
-        width: Optional[int]
+        width: int
             Bit width of CSR register.
         src_loc: SrcLoc
             CSR location in source code for error reporting.

--- a/coreblocks/priv/csr/double_counter.py
+++ b/coreblocks/priv/csr/double_counter.py
@@ -1,5 +1,7 @@
-from amaranth import *
+from collections.abc import Callable
 from typing import Optional
+from amaranth import *
+from amaranth_types import ValueLike
 
 from transactron.core import Method, TModule, def_method
 
@@ -27,7 +29,7 @@ class DoubleCounterCSR(Elaboratable):
         high_addr: Optional[CSRAddress] = None,
         shadow_low_addr: Optional[CSRAddress] = None,
         shadow_high_addr: Optional[CSRAddress] = None,
-        shadow_access_filter=None,
+        shadow_access_filter: Optional[Callable[[TModule, Value], ValueLike]] = None,
     ):
         """
         Parameters
@@ -45,6 +47,8 @@ class DoubleCounterCSR(Elaboratable):
             Address of the shadow CSR register for the higher part of the counter. If provided, shadow CSR is
             synthetised with read-only access to the counter value. If `shadow_low_addr` is provided,
             `shadow_high_addr` also should be provided.
+        shadow_access_filter: Callable, optional
+            Provides `access_filter` for additional shadow CSRs.
         """
         self.increment = Method()
         self.register = CSRRegister(None, gen_params, width=64)

--- a/coreblocks/priv/csr/double_counter.py
+++ b/coreblocks/priv/csr/double_counter.py
@@ -2,32 +2,29 @@ from amaranth import *
 from typing import Optional
 
 from transactron.core import Method, TModule, def_method
-from transactron.utils import get_src_loc
 
 from coreblocks.arch import CSRAddress
 from coreblocks.params.genparams import GenParams
 from coreblocks.priv.csr.csr_register import CSRRegister
-from coreblocks.priv.csr.shadow import ShadowCSR
+from coreblocks.priv.csr.double_shadow import DoubleShadowCSR
 
 __all__ = ["DoubleCounterCSR"]
 
 
 class DoubleCounterCSR(Elaboratable):
-    """DoubleCounterCSR
+    """Double counter CSR.
 
     A 64-bit CSR counter, visible on two CSR addresses on RV32.
-
-    Attributes
-    ----------
-    increment: Method
-        Increments the counter by 1. At overflow, counter value is set to 0.
     """
+
+    increment: Method
+    """Increments the counter by 1. At overflow, counter value is set to 0."""
 
     def __init__(
         self,
         gen_params: GenParams,
-        low_addr: CSRAddress,
-        high_addr: CSRAddress,
+        low_addr: Optional[CSRAddress] = None,
+        high_addr: Optional[CSRAddress] = None,
         shadow_low_addr: Optional[CSRAddress] = None,
         shadow_high_addr: Optional[CSRAddress] = None,
         shadow_access_filter=None,
@@ -49,58 +46,21 @@ class DoubleCounterCSR(Elaboratable):
             synthetised with read-only access to the counter value. If `shadow_low_addr` is provided,
             `shadow_high_addr` also should be provided.
         """
-        assert (shadow_low_addr is None) == (shadow_high_addr is None)
-
-        self.gen_params = gen_params
-
         self.increment = Method()
-
         self.register = CSRRegister(None, gen_params, width=64)
-
-        self.register_low = ShadowCSR(low_addr, gen_params, self.register, width=gen_params.isa.xlen)
-        self.register_high = (
-            ShadowCSR(high_addr, gen_params, self.register, width=gen_params.isa.xlen, offset=gen_params.isa.xlen)
-            if gen_params.isa.xlen == 32
-            else None
+        self.shadow = DoubleShadowCSR(
+            gen_params, self.register, low_addr, high_addr, shadow_low_addr, shadow_high_addr, shadow_access_filter
         )
-
-        self.shadow_low = self.shadow_high = None
-        if shadow_low_addr is not None:
-            self.shadow_low = ShadowCSR(
-                shadow_low_addr,
-                gen_params,
-                self.register_low,
-                write_mask=0,
-                access_filter=shadow_access_filter,
-                src_loc=get_src_loc(1),
-            )
-            if self.register_high is not None:
-                self.shadow_high = ShadowCSR(
-                    shadow_high_addr,
-                    gen_params,
-                    self.register_high,
-                    write_mask=0,
-                    access_filter=shadow_access_filter,
-                    src_loc=get_src_loc(1),
-                )
 
     def elaborate(self, platform):
         m = TModule()
 
         m.submodules.register = self.register
-        m.submodules.register_low = self.register_low
-        if self.register_high is not None:
-            m.submodules.register_high = self.register_high
+        m.submodules.shadow = self.shadow
 
         @def_method(m, self.increment)
         def _():
             register_read = self.register.read(m).data
             self.register.write(m, data=register_read + 1)
-
-        if self.shadow_low is not None:
-            m.submodules.shadow_low = self.shadow_low
-
-        if self.shadow_high is not None:
-            m.submodules.shadow_high = self.shadow_high
 
         return m

--- a/coreblocks/priv/csr/double_counter.py
+++ b/coreblocks/priv/csr/double_counter.py
@@ -14,7 +14,8 @@ __all__ = ["DoubleCounterCSR"]
 
 class DoubleCounterCSR(Elaboratable):
     """DoubleCounterCSR
-    Groups two `CSRRegisters` to form counter with double `isa.xlen` width.
+
+    A 64-bit CSR counter, visible on two CSR addresses on RV32.
 
     Attributes
     ----------
@@ -26,7 +27,7 @@ class DoubleCounterCSR(Elaboratable):
         self,
         gen_params: GenParams,
         low_addr: CSRAddress,
-        high_addr: Optional[CSRAddress] = None,
+        high_addr: CSRAddress,
         shadow_low_addr: Optional[CSRAddress] = None,
         shadow_high_addr: Optional[CSRAddress] = None,
         shadow_access_filter=None,
@@ -37,25 +38,31 @@ class DoubleCounterCSR(Elaboratable):
         gen_params: GenParams
             Core generation parameters.
         low_addr: CSRAddress
-            Address of the CSR register representing lower part of the counter (bits `[isa.xlen-1 : 0]`).
-        high_addr: CSRAddress or None, optional
-            Address of the CSR register representing higher part of the counter (bits `[2*isa.xlen-1 : isa.xlen]`).
-            If high_addr is None or not provided, then higher CSR is not synthetised and only the width of
-            low_addr CSR is available to the counter.
-        shadow_low_addr: CSRAddress or None, optional
+            Address of the CSR register representing lower part of the counter on RV32, or the entire counter on RV64.
+        high_addr: CSRAddress
+            Address of the CSR register representing higher part of the counter on RV32. Unused on RV64.
+        shadow_low_addr: CSRAddress, optional
             Address of the shadow CSR register for the lower part of the counter. If provided, shadow CSR is
             synthetised with read-only access to the counter value.
-        shadow_high_addr: CSRAddress or None, optional
+        shadow_high_addr: CSRAddress, optional
             Address of the shadow CSR register for the higher part of the counter. If provided, shadow CSR is
-            synthetised with read-only access to the counter value. If high_addr is None, providing shadow_high_addr
-            will raise an error.
+            synthetised with read-only access to the counter value. If `shadow_low_addr` is provided,
+            `shadow_high_addr` also should be provided.
         """
+        assert (shadow_low_addr is None) == (shadow_high_addr is None)
+
         self.gen_params = gen_params
 
         self.increment = Method()
 
-        self.register_low = CSRRegister(low_addr, gen_params)
-        self.register_high = CSRRegister(high_addr, gen_params) if high_addr is not None else None
+        self.register = CSRRegister(None, gen_params, width=64)
+
+        self.register_low = ShadowCSR(low_addr, gen_params, self.register, width=gen_params.isa.xlen)
+        self.register_high = (
+            ShadowCSR(high_addr, gen_params, self.register, width=gen_params.isa.xlen, offset=gen_params.isa.xlen)
+            if gen_params.isa.xlen == 32
+            else None
+        )
 
         self.shadow_low = self.shadow_high = None
         if shadow_low_addr is not None:
@@ -67,37 +74,28 @@ class DoubleCounterCSR(Elaboratable):
                 access_filter=shadow_access_filter,
                 src_loc=get_src_loc(1),
             )
-        if shadow_high_addr is not None:
-            if not self.register_high:
-                raise ValueError("shadow_high_addr provided but high_addr is None")
-
-            if not shadow_low_addr:
-                raise ValueError("shadow_high_addr provided but shadow_low_addr is None")
-
-            self.shadow_high = ShadowCSR(
-                shadow_high_addr,
-                gen_params,
-                self.register_high,
-                write_mask=0,
-                access_filter=shadow_access_filter,
-                src_loc=get_src_loc(1),
-            )
+            if self.register_high is not None:
+                self.shadow_high = ShadowCSR(
+                    shadow_high_addr,
+                    gen_params,
+                    self.register_high,
+                    write_mask=0,
+                    access_filter=shadow_access_filter,
+                    src_loc=get_src_loc(1),
+                )
 
     def elaborate(self, platform):
         m = TModule()
 
+        m.submodules.register = self.register
         m.submodules.register_low = self.register_low
         if self.register_high is not None:
             m.submodules.register_high = self.register_high
 
         @def_method(m, self.increment)
         def _():
-            register_read = self.register_low.read(m).data
-            self.register_low.write(m, data=register_read + 1)
-
-            if self.register_high is not None:
-                with m.If(register_read == (1 << self.gen_params.isa.xlen) - 1):
-                    self.register_high.write(m, data=self.register_high.read(m).data + 1)
+            register_read = self.register.read(m).data
+            self.register.write(m, data=register_read + 1)
 
         if self.shadow_low is not None:
             m.submodules.shadow_low = self.shadow_low

--- a/coreblocks/priv/csr/double_shadow.py
+++ b/coreblocks/priv/csr/double_shadow.py
@@ -1,0 +1,96 @@
+from amaranth import *
+from typing import Optional
+
+from transactron.core import Method, TModule
+from transactron.utils import get_src_loc
+
+from coreblocks.arch import CSRAddress
+from coreblocks.params.genparams import GenParams
+from coreblocks.priv.csr.csr_register import CSRRegisterBase
+from coreblocks.priv.csr.shadow import ShadowCSR
+
+__all__ = ["DoubleShadowCSR"]
+
+
+class DoubleShadowCSR(Elaboratable):
+    """Double shadow CSR.
+
+    Creates two 32-bit shadows of an 64-bit CSR on RV32, or a single 64-bit shadow on RV64.
+    Can also create an additional shadow pair, e.g. for S-mode registers.
+    """
+
+    def __init__(
+        self,
+        gen_params: GenParams,
+        shadowed: CSRRegisterBase,
+        low_addr: Optional[CSRAddress] = None,
+        high_addr: Optional[CSRAddress] = None,
+        shadow_low_addr: Optional[CSRAddress] = None,
+        shadow_high_addr: Optional[CSRAddress] = None,
+        shadow_access_filter=None,
+    ):
+        """
+        Parameters
+        ----------
+        gen_params: GenParams
+            Core generation parameters.
+        low_addr: CSRAddress, optional
+            Address of the CSR register representing lower part of the CSR on RV32, or the entire CSR on RV64.
+        high_addr: CSRAddress, optional
+            Address of the CSR register representing higher part of the CSR on RV32. Unused on RV64.
+        shadow_low_addr: CSRAddress, optional
+            Address of the shadow CSR register for the lower part of the CSR. If provided, shadow CSR is
+            synthetised with read-only access to the CSR value.
+        shadow_high_addr: CSRAddress, optional
+            Address of the shadow CSR register for the higher part of the CSR. If provided, shadow CSR is
+            synthetised with read-only access to the CSR value. If `shadow_low_addr` is provided,
+            `shadow_high_addr` also should be provided.
+        """
+        assert (low_addr is None) == (high_addr is None)
+        assert (shadow_low_addr is None) == (shadow_high_addr is None)
+
+        self.gen_params = gen_params
+
+        self.increment = Method()
+
+        self.register_low = ShadowCSR(low_addr, gen_params, shadowed, width=gen_params.isa.xlen)
+        self.register_high = (
+            ShadowCSR(high_addr, gen_params, shadowed, width=gen_params.isa.xlen, offset=gen_params.isa.xlen)
+            if gen_params.isa.xlen == 32
+            else None
+        )
+
+        self.shadow_low = self.shadow_high = None
+        if shadow_low_addr is not None:
+            self.shadow_low = ShadowCSR(
+                shadow_low_addr,
+                gen_params,
+                self.register_low,
+                write_mask=0,
+                access_filter=shadow_access_filter,
+                src_loc=get_src_loc(1),
+            )
+            if self.register_high is not None:
+                self.shadow_high = ShadowCSR(
+                    shadow_high_addr,
+                    gen_params,
+                    self.register_high,
+                    write_mask=0,
+                    access_filter=shadow_access_filter,
+                    src_loc=get_src_loc(1),
+                )
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        m.submodules.register_low = self.register_low
+        if self.register_high is not None:
+            m.submodules.register_high = self.register_high
+
+        if self.shadow_low is not None:
+            m.submodules.shadow_low = self.shadow_low
+
+        if self.shadow_high is not None:
+            m.submodules.shadow_high = self.shadow_high
+
+        return m

--- a/coreblocks/priv/csr/double_shadow.py
+++ b/coreblocks/priv/csr/double_shadow.py
@@ -1,5 +1,7 @@
-from amaranth import *
+from collections.abc import Callable
 from typing import Optional
+from amaranth import *
+from amaranth_types import ValueLike
 
 from transactron.core import Method, TModule
 from transactron.utils import get_src_loc
@@ -27,7 +29,7 @@ class DoubleShadowCSR(Elaboratable):
         high_addr: Optional[CSRAddress] = None,
         shadow_low_addr: Optional[CSRAddress] = None,
         shadow_high_addr: Optional[CSRAddress] = None,
-        shadow_access_filter=None,
+        shadow_access_filter: Optional[Callable[[TModule, Value], ValueLike]] = None,
     ):
         """
         Parameters
@@ -45,6 +47,8 @@ class DoubleShadowCSR(Elaboratable):
             Address of the shadow CSR register for the higher part of the CSR. If provided, shadow CSR is
             synthetised with read-only access to the CSR value. If `shadow_low_addr` is provided,
             `shadow_high_addr` also should be provided.
+        shadow_access_filter: Callable, optional
+            Provides `access_filter` for additional shadow CSRs.
         """
         assert (low_addr is None) == (high_addr is None)
         assert (shadow_low_addr is None) == (shadow_high_addr is None)

--- a/coreblocks/priv/csr/shadow.py
+++ b/coreblocks/priv/csr/shadow.py
@@ -101,7 +101,7 @@ class ShadowCSR(CSRRegisterBase):
         def _(data: Value):
             self.shadowed.write(
                 m,
-                data=(data & write_mask) | (self.shadowed.read(m).data & ~write_mask),
+                data=((data & write_mask) << self.offset) | (self.shadowed.read(m).data & ~(write_mask << self.offset)),
             )
 
         @def_method(m, self.read, nonexclusive=True)

--- a/coreblocks/priv/csr/shadow.py
+++ b/coreblocks/priv/csr/shadow.py
@@ -22,7 +22,7 @@ log = logging.HardwareLogger("priv.csr.shadow")
 class ShadowCSR(CSRRegisterBase):
     """CSR shadow register.
 
-    Exposes an instruction-visible CSR number that reads/writes another CSR.
+    Creates a CSR which is backed by another CSR - reads and writes are forwarded to it.
     Optional bit masks can restrict visible read bits and writable bits for both instruction-visible access and
     internal CSR logic.
     """
@@ -41,10 +41,22 @@ class ShadowCSR(CSRRegisterBase):
         access_filter: Optional[Callable[[TModule, Value], ValueLike]] = None,
         src_loc: int | SrcLoc = 0,
     ):
-        width = shadowed.width if width is None else width
         self.offset = offset = 0 if offset is None else offset
-        assert self.offset < shadowed.width, "Offset larger than shadowed CSR width"
-        assert self.offset + width <= shadowed.width, "Shadowed window outside of CSR"
+
+        if width is None:
+            if csr_number is not None:
+                width = gen_params.isa.xlen
+            elif self.offset == 0:
+                width = shadowed.width
+            else:
+                raise ValueError("width must be specified for non-public shadow CSR with offset")
+
+        if self.offset < 0 or self.offset >= shadowed.width:
+            raise ValueError(f"Invalid offset value {self.offset}")
+
+        if width < 0 or self.offset + width > shadowed.width:
+            raise ValueError(f"Invalid width value {self.value}")
+
         super().__init__(gen_params, csr_number, width=width, src_loc=get_src_loc(src_loc))
 
         if mask is not None:

--- a/coreblocks/priv/csr/shadow.py
+++ b/coreblocks/priv/csr/shadow.py
@@ -44,7 +44,7 @@ class ShadowCSR(CSRRegisterBase):
         width = shadowed.width if width is None else width
         self.offset = offset = 0 if offset is None else offset
         assert self.offset < shadowed.width, "Offset larger than shadowed CSR width"
-        assert self.offset + width <= shadowed.width, "Shadowed wihdow outside of CSR"
+        assert self.offset + width <= shadowed.width, "Shadowed window outside of CSR"
         super().__init__(gen_params, csr_number, width=width, src_loc=get_src_loc(src_loc))
 
         if mask is not None:

--- a/coreblocks/priv/csr/shadow.py
+++ b/coreblocks/priv/csr/shadow.py
@@ -33,13 +33,19 @@ class ShadowCSR(CSRRegisterBase):
         gen_params: GenParams,
         shadowed: CSRRegisterBase,
         *,
+        width: Optional[int] = None,
+        offset: Optional[int] = None,
         mask: Optional[ValueLike | Method] = None,
         read_mask: Optional[ValueLike | Method] = None,
         write_mask: Optional[ValueLike | Method] = None,
         access_filter: Optional[Callable[[TModule, Value], ValueLike]] = None,
         src_loc: int | SrcLoc = 0,
     ):
-        super().__init__(gen_params, csr_number, width=shadowed.width, src_loc=get_src_loc(src_loc))
+        width = shadowed.width if width is None else width
+        self.offset = offset = 0 if offset is None else offset
+        assert self.offset < shadowed.width, "Offset larger than shadowed CSR width"
+        assert self.offset + width <= shadowed.width, "Shadowed wihdow outside of CSR"
+        super().__init__(gen_params, csr_number, width=width, src_loc=get_src_loc(src_loc))
 
         if mask is not None:
             assert (
@@ -78,16 +84,18 @@ class ShadowCSR(CSRRegisterBase):
 
         @def_method(m, self._fu_write)
         def _(data: Value, op_type: Value):
-            shadow_data = Signal.like(data)
+            shadow_data = Signal.like(self.shadowed.value)
             with m.If(op_type == CSRRegisterLayouts.WriteOpType.CSR_WRITE):
-                m.d.av_comb += shadow_data.eq((data & write_mask) | (self.shadowed.read(m).data & ~write_mask))
+                m.d.av_comb += shadow_data.eq(
+                    ((data & write_mask) << self.offset) | (self.shadowed.read(m).data & ~(write_mask << self.offset))
+                )
             with m.Else():
-                m.d.av_comb += shadow_data.eq(data & write_mask)
+                m.d.av_comb += shadow_data.eq((data & write_mask) << self.offset)
             return self.shadowed._fu_write(m, data=shadow_data, op_type=op_type)
 
         @def_method(m, self._fu_read)
         def _() -> Value:
-            return self.shadowed._fu_read(m).data & read_mask
+            return (self.shadowed._fu_read(m).data >> self.offset) & read_mask
 
         @def_method(m, self.write)
         def _(data: Value):
@@ -100,7 +108,7 @@ class ShadowCSR(CSRRegisterBase):
         def _():
             result = self.shadowed.read(m)
             return {
-                "data": result.data & read_mask,
+                "data": (result.data >> self.offset) & read_mask,
                 "read": result.read,
                 "written": result.written,
             }
@@ -109,7 +117,7 @@ class ShadowCSR(CSRRegisterBase):
         def _():
             result = self.shadowed.read_comb(m)
             return {
-                "data": result.data & read_mask,
+                "data": (result.data >> self.offset) & read_mask,
                 "read": result.read,
                 "written": result.written,
             }


### PR DESCRIPTION
This PR refactors the double counter, by introducing the following changes:

- The `ShadowCSR` class now has `width` and `offset` arguments, allowing to create a shadow of a part of a larger CSR.
- The internal counter is now always 64-bit. In RISC-V, all REG/REGH pairs are such that the base register is 64-bit, and the high register exists only on RV32.
- The arch-dependent logic is now internal, so that it does not need to be repeated at each use site.
- The dual-shadows part is now separate from the counter-part, so that the same logic can be used if the base register needs a different logic than a simple counter.

Required for #956.