### PR TITLE
Superscalar retirement

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -99,7 +99,7 @@ jobs:
   run-perf-benchmarks:
     name: Run performance benchmarks
     runs-on: ubuntu-22.04  # older version for compatibility with Docker image
-    timeout-minutes: 40
+    timeout-minutes: 60
     container: ghcr.io/kuznia-rdzeni/verilator:v5.032-2026.04.15
     needs: build-perf-benchmarks
     steps:

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -155,7 +155,10 @@ class Retirement(Elaboratable):
             m.d.av_comb += safe_mask.eq(tag_incr_mask & (tag_incr_mask - 1) | (-1 << rob_entries.done_count))
             m.d.av_comb += retire_count.eq(count_trailing_zeros(safe_mask))
 
-            m.d.av_comb += no_trap_count.eq(count_trailing_zeros(Cat(entry.exception for entry in rob_entries.entries)))
+            m.d.av_comb += no_trap_count.eq(
+                count_trailing_zeros(Cat(entry.exception for entry in rob_entries.entries))
+                | (-1 << rob_entries.done_count)
+            )
             m.d.av_comb += exception.eq(no_trap_count < retire_count)
 
             # Ensure that when exception is processed, correct entry is alredy in ExceptionCauseRegister
@@ -318,11 +321,17 @@ class Retirement(Elaboratable):
 
         # Run precommit on first not-done instr, if exception not encountered
         precommit_rob_id = Signal(self.gen_params.rob_entries_bits)
+        exc_prefixes = Array(
+            [
+                Cat(rob_entries.entries[j].exception for j in range(i)).any()
+                for i in range(self.gen_params.retirement_superscalarity + 1)
+            ]
+        )
         m.d.comb += precommit_rob_id.eq(rob_entries.entries[0].rob_id + rob_entries.done_count)
         m.d.comb += self._done_count.eq(rob_entries.done_count)
 
         # Disable executing any side effects from instructions in core when it is flushed
-        m.d.comb += core_flushing.eq(fsm.ongoing("TRAP_FLUSH") | exception)
+        m.d.comb += core_flushing.eq(fsm.ongoing("TRAP_FLUSH") | exc_prefixes[rob_entries.done_count])
 
         # The argument is only used in argument validation, it is not needed in the method body.
         # A dummy combiner is provided.

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -156,8 +156,7 @@ class Retirement(Elaboratable):
             m.d.av_comb += retire_count.eq(count_trailing_zeros(safe_mask))
 
             m.d.av_comb += no_trap_count.eq(
-                count_trailing_zeros(Cat(entry.exception for entry in rob_entries.entries))
-                | (-1 << rob_entries.done_count)
+                count_trailing_zeros(Cat(entry.exception for entry in rob_entries.entries)) | safe_mask
             )
             m.d.av_comb += exception.eq(no_trap_count < retire_count)
 
@@ -246,11 +245,11 @@ class Retirement(Elaboratable):
                         m.d.av_comb += commit.eq(1)
 
                     self.instret_csr.write(
-                        m, data=Mux(exception, self.instret_csr.read(m).data + no_trap_count + commit, retire_count)
+                        m, data=self.instret_csr.read(m).data + Mux(exception, no_trap_count + commit, retire_count)
                     )
 
                     for i in range(self.gen_params.retirement_superscalarity):
-                        with m.If(i + 1 - commit <= no_trap_count):
+                        with m.If(i - commit < no_trap_count):
                             retire_instr(i, rob_entries.entries[i])
                         with m.Elif(i < retire_count):
                             flush_instr(i, rob_entries.entries[i])

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -177,7 +177,7 @@ class Retirement(Elaboratable):
 
         with m.FSM("NORMAL") as fsm:
             with m.State("NORMAL"):
-                with Transaction().body(m, ready=retire_valid):
+                with Transaction(name="Retirement_NORMAL").body(m, ready=retire_valid):
                     self.rob_retire(m, count=retire_count)
 
                     with m.If((tag_incr_mask & ~(-1 << retire_count)).any()):
@@ -261,7 +261,7 @@ class Retirement(Elaboratable):
                             flush_instr(i, rob_entries.entries[i])
 
             with m.State("TRAP_FLUSH"):
-                with Transaction().body(m):
+                with Transaction(name="Retirement_FLUSH").body(m):
                     # Flush entire core
                     self.rob_retire(m, count=retire_count)
 
@@ -278,7 +278,7 @@ class Retirement(Elaboratable):
                         m.next = "TRAP_RESUME"
 
             with m.State("TRAP_RESUME"):
-                with Transaction().body(m):
+                with Transaction(name="Retirement_RESUME").body(m):
                     # Resume core operation
                     self.perf_trap_latency.stop(m)
 

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -148,6 +148,7 @@ class Retirement(Elaboratable):
         no_trap_count = Signal(range(self.gen_params.retirement_superscalarity + 1))
         tag_incr_mask = Signal(self.gen_params.retirement_superscalarity)
         safe_mask = Signal.like(tag_incr_mask)
+        free_checkpoint = Signal()
 
         with Transaction().body(m):
             rob_entries = self.rob_peek(m)
@@ -157,6 +158,9 @@ class Retirement(Elaboratable):
             m.d.av_comb += tag_incr_mask.eq(Cat(entry.rob_data.tag_increment for entry in rob_entries.entries))
             m.d.av_comb += safe_mask.eq(tag_incr_mask & (tag_incr_mask - 1) | (-1 << rob_entries.done_count))
             m.d.av_comb += retire_count.eq(count_trailing_zeros(safe_mask))
+            m.d.av_comb += free_checkpoint.eq(
+                safe_mask != (tag_incr_mask | (-1 << rob_entries.done_count))[: len(safe_mask)]
+            )
 
             exception_bits = Signal(self.gen_params.retirement_superscalarity)
             m.d.av_comb += exception_bits.eq(Cat(rob_entry.exception for rob_entry in rob_entries.entries))
@@ -177,7 +181,7 @@ class Retirement(Elaboratable):
                 with Transaction(name="Retirement_NORMAL").body(m, ready=retire_valid):
                     self.rob_retire(m, count=retire_count)
 
-                    with m.If((tag_incr_mask & ~(-1 << retire_count)).any()):
+                    with m.If(free_checkpoint):
                         self.checkpoint_tag_free(m)
 
                     core_empty = self.instr_decrement(m, count=retire_count)
@@ -262,7 +266,7 @@ class Retirement(Elaboratable):
                     # Flush entire core
                     self.rob_retire(m, count=retire_count)
 
-                    with m.If((tag_incr_mask & ~(-1 << retire_count)).any()):
+                    with m.If(free_checkpoint):
                         self.checkpoint_tag_free(m)
 
                     core_empty = self.instr_decrement(m, count=retire_count)

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -30,6 +30,9 @@ from coreblocks.priv.csr.double_shadow import DoubleShadowCSR
 from coreblocks.arch.isa_consts import TrapVectorMode
 
 
+__all__ = ["Retirement"]
+
+
 class Retirement(Elaboratable):
     def __init__(
         self,
@@ -156,7 +159,7 @@ class Retirement(Elaboratable):
             m.d.av_comb += retire_count.eq(count_trailing_zeros(safe_mask))
 
             m.d.av_comb += no_trap_count.eq(
-                count_trailing_zeros(Cat(entry.exception for entry in rob_entries.entries)) | safe_mask
+                count_trailing_zeros(Cat(entry.exception for entry in rob_entries.entries) | safe_mask)
             )
             m.d.av_comb += exception.eq(no_trap_count < retire_count)
 
@@ -177,7 +180,7 @@ class Retirement(Elaboratable):
 
                     core_empty = self.instr_decrement(m, count=retire_count)
 
-                    commit = Signal()
+                    commit_trapping = Signal()
 
                     with m.If(exception):
                         self.perf_trap_latency.start(m)
@@ -193,7 +196,7 @@ class Retirement(Elaboratable):
                             # The PC field is set to address of instruction to resume from interrupt (e.g. for jumps
                             # it is a jump result).
                             # Instruction that reported interrupt is the last one that is committed.
-                            m.d.av_comb += commit.eq(1)
+                            m.d.av_comb += commit_trapping.eq(1)
 
                             # Set MSB - the Interrupt bit
                             m.d.av_comb += cause_entry.eq(
@@ -201,7 +204,7 @@ class Retirement(Elaboratable):
                             )
                         with m.Elif(cause_register.cause == ExceptionCause._COREBLOCKS_MISPREDICTION):
                             # Branch misprediction - commit jump, flush core and continue from correct pc.
-                            m.d.av_comb += commit.eq(1)
+                            m.d.av_comb += commit_trapping.eq(1)
                             # Do not modify trap related CSRs
                             m.d.av_comb += arch_trap.eq(0)
 
@@ -211,7 +214,7 @@ class Retirement(Elaboratable):
                             # RISC-V synchronous exceptions - don't retire instruction that caused exception,
                             # and later resume from it.
                             # Value of ExceptionCauseRegister pc field is the instruction address.
-                            m.d.av_comb += commit.eq(0)
+                            m.d.av_comb += commit_trapping.eq(0)
 
                             m.d.av_comb += cause_entry.eq(cause_register.cause)
 
@@ -240,16 +243,14 @@ class Retirement(Elaboratable):
                         with m.Else():
                             m.next = "TRAP_FLUSH"
 
-                    with m.Else():
-                        # Normally retire all non-trap instructions
-                        m.d.av_comb += commit.eq(1)
-
                     self.instret_csr.write(
-                        m, data=self.instret_csr.read(m).data + Mux(exception, no_trap_count + commit, retire_count)
+                        m,
+                        data=self.instret_csr.read(m).data
+                        + Mux(exception, no_trap_count + commit_trapping, retire_count),
                     )
 
                     for i in range(self.gen_params.retirement_superscalarity):
-                        with m.If(i - commit < no_trap_count):
+                        with m.If(i - commit_trapping < no_trap_count):
                             retire_instr(i, rob_entries.entries[i])
                         with m.Elif(i < retire_count):
                             flush_instr(i, rob_entries.entries[i])

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -77,7 +77,11 @@ class Retirement(Elaboratable):
             CSRAddress.INSTRETH,
             shadow_access_filter=counteren_access_filter(gen_params, CounterEnableFieldOffsets.IR),
         )
-        self.perf_instr_ret = HwCounter("backend.retirement.retired_instr", "Number of retired instructions")
+        self.perf_instr_ret = HwCounter(
+            "backend.retirement.retired_instr",
+            "Number of retired instructions",
+            ways=gen_params.retirement_superscalarity,
+        )
         self.perf_trap_latency = FIFOLatencyMeasurer(
             "backend.retirement.trap_latency",
             "Cycles spent flushing the core after a trap",
@@ -111,15 +115,14 @@ class Retirement(Elaboratable):
             with m.If(rp_dst):  # don't put rp0 to free list - reserved to no-return instructions
                 self.free_rf_put[i](m, rp_dst)
 
-        def retire_instr(rob_entry):
+        def retire_instr(i: int, rob_entry: View):
             # set rl_dst -> rp_dst in R-RAT
-            rat_out = self.r_rat_commit[0](m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rob_entry.rob_data.rp_dst)
+            rat_out = self.r_rat_commit[i](m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rob_entry.rob_data.rp_dst)
 
             # free old rp_dst from overwritten R-RAT mapping
-            free_phys_reg(0, rat_out.old_rp_dst)
+            free_phys_reg(i, rat_out.old_rp_dst)
 
-            self.instret_csr.write(m, data=self.instret_csr.read(m).data + 1)
-            self.perf_instr_ret.incr(m)
+            self.perf_instr_ret.incr[i](m)
 
         def flush_instr(i: int, rob_entry: View):
             # get original rp_dst mapped to instruction rl_dst in R-RAT
@@ -132,35 +135,49 @@ class Retirement(Elaboratable):
             self.c_rat_restore[i](m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rat_out.old_rp_dst)
 
         retire_valid = Signal()
-        with Transaction().body(m) as validate_transaction:
-            # Ensure that when exception is processed, correct entry is alredy in ExceptionCauseRegister
-            rob_entries = self.rob_peek(m)
-            rob_entry = rob_entries.entries[0]
-            ecr_entry = self.exception_cause_get(m)
-            m.d.comb += retire_valid.eq(
-                ~rob_entry.exception | (rob_entry.exception & ecr_entry.valid & (ecr_entry.rob_id == rob_entry.rob_id))
-            )
-
+        exception = Signal()
         continue_pc_override = Signal()
         continue_pc = Signal(self.gen_params.isa.xlen)
         core_flushing = Signal()
         trap_target_priv = Signal(PrivilegeLevel, init=PrivilegeLevel.MACHINE)
 
+        retire_count = Signal(range(self.gen_params.retirement_superscalarity + 1))
+        no_trap_count = Signal(range(self.gen_params.retirement_superscalarity + 1))
+        tag_incr_mask = Signal(self.gen_params.retirement_superscalarity)
+        safe_mask = Signal.like(tag_incr_mask)
+
+        with Transaction().body(m):
+            rob_entries = self.rob_peek(m)
+
+            # CRAT can currently deallocate at most one tag per cycle, this logic reduces the retire rate
+            # TODO: improve
+            m.d.av_comb += tag_incr_mask.eq(Cat(entry.rob_data.tag_increment for entry in rob_entries.entries))
+            m.d.av_comb += safe_mask.eq(tag_incr_mask & (tag_incr_mask - 1) | (-1 << rob_entries.done_count))
+            m.d.av_comb += retire_count.eq(count_trailing_zeros(safe_mask))
+
+            m.d.av_comb += no_trap_count.eq(count_trailing_zeros(Cat(entry.exception for entry in rob_entries.entries)))
+            m.d.av_comb += exception.eq(no_trap_count < retire_count)
+
+            # Ensure that when exception is processed, correct entry is alredy in ExceptionCauseRegister
+            ecr_entry = self.exception_cause_get(m)
+            m.d.av_comb += retire_valid.eq(
+                ~exception
+                | (exception & ecr_entry.valid & (ecr_entry.rob_id == rob_entries.entries[no_trap_count].rob_id))
+            )
+
         with m.FSM("NORMAL") as fsm:
             with m.State("NORMAL"):
-                with Transaction().body(m, ready=retire_valid) as retire_transaction:
-                    rob_entries = self.rob_peek(m)
-                    rob_entry = rob_entries.entries[0]
-                    self.rob_retire(m, count=1)
+                with Transaction().body(m, ready=retire_valid):
+                    self.rob_retire(m, count=retire_count)
 
-                    with m.If(rob_entry.rob_data.tag_increment):
+                    with m.If((tag_incr_mask & ~(-1 << retire_count)).any()):
                         self.checkpoint_tag_free(m)
 
-                    core_empty = self.instr_decrement(m, count=1)
+                    core_empty = self.instr_decrement(m, count=retire_count)
 
                     commit = Signal()
 
-                    with m.If(rob_entry.exception):
+                    with m.If(exception):
                         self.perf_trap_latency.start(m)
 
                         cause_register = self.exception_cause_get(m)
@@ -173,7 +190,7 @@ class Retirement(Elaboratable):
                             # Async interrupts are inserted only by JumpBranchUnit and conditionally by MRET and CSR
                             # The PC field is set to address of instruction to resume from interrupt (e.g. for jumps
                             # it is a jump result).
-                            # Instruction that reported interrupt is the last one that is commited.
+                            # Instruction that reported interrupt is the last one that is committed.
                             m.d.av_comb += commit.eq(1)
 
                             # Set MSB - the Interrupt bit
@@ -225,36 +242,28 @@ class Retirement(Elaboratable):
                         # Normally retire all non-trap instructions
                         m.d.av_comb += commit.eq(1)
 
-                    with m.If(commit):
-                        retire_instr(rob_entry)
-                    with m.Else():
-                        flush_instr(0, rob_entry)
+                    self.instret_csr.write(
+                        m, data=Mux(exception, self.instret_csr.read(m).data + no_trap_count + commit, retire_count)
+                    )
 
-                    validate_transaction.schedule_before(retire_transaction)
+                    for i in range(self.gen_params.retirement_superscalarity):
+                        with m.If(i + 1 - commit <= no_trap_count):
+                            retire_instr(i, rob_entries.entries[i])
+                        with m.Elif(i < retire_count):
+                            flush_instr(i, rob_entries.entries[i])
 
             with m.State("TRAP_FLUSH"):
                 with Transaction().body(m):
                     # Flush entire core
-                    rob_entries = self.rob_peek(m)
+                    self.rob_retire(m, count=retire_count)
 
-                    count = Signal(range(self.gen_params.retirement_superscalarity + 1))
-                    tag_incr_mask = Signal(self.gen_params.retirement_superscalarity)
-                    safe_mask = Signal.like(tag_incr_mask)
-                    # CRAT can currently deallocate at most one tag per cycle, this logic reduces the flush rate
-                    # TODO: improve
-                    m.d.av_comb += tag_incr_mask.eq(Cat(entry.rob_data.tag_increment for entry in rob_entries.entries))
-                    m.d.av_comb += safe_mask.eq(tag_incr_mask & (tag_incr_mask - 1) | (-1 << rob_entries.done_count))
-                    m.d.av_comb += count.eq(count_trailing_zeros(safe_mask))
-
-                    self.rob_retire(m, count=count)
-
-                    with m.If((tag_incr_mask & ~(-1 << count)).any()):
+                    with m.If((tag_incr_mask & ~(-1 << retire_count)).any()):
                         self.checkpoint_tag_free(m)
 
-                    core_empty = self.instr_decrement(m, count=count)
+                    core_empty = self.instr_decrement(m, count=retire_count)
 
                     for i in range(self.gen_params.retirement_superscalarity):
-                        with m.If(i < count):
+                        with m.If(i < retire_count):
                             flush_instr(i, rob_entries.entries[i])
 
                     with m.If(core_empty):
@@ -309,17 +318,11 @@ class Retirement(Elaboratable):
 
         # Run precommit on first not-done instr, if exception not encountered
         precommit_rob_id = Signal(self.gen_params.rob_entries_bits)
-        exc_prefixes = Array(
-            [
-                Cat(rob_entries.entries[j].exception for j in range(i)).any()
-                for i in range(self.gen_params.retirement_superscalarity + 1)
-            ]
-        )
         m.d.comb += precommit_rob_id.eq(rob_entries.entries[0].rob_id + rob_entries.done_count)
         m.d.comb += self._done_count.eq(rob_entries.done_count)
 
         # Disable executing any side effects from instructions in core when it is flushed
-        m.d.comb += core_flushing.eq(fsm.ongoing("TRAP_FLUSH") | exc_prefixes[rob_entries.done_count])
+        m.d.comb += core_flushing.eq(fsm.ongoing("TRAP_FLUSH") | exception)
 
         # The argument is only used in argument validation, it is not needed in the method body.
         # A dummy combiner is provided.

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -161,19 +161,16 @@ class Retirement(Elaboratable):
             exception_bits = Signal(self.gen_params.retirement_superscalarity)
             m.d.av_comb += exception_bits.eq(Cat(rob_entry.exception for rob_entry in rob_entries.entries))
             m.d.av_comb += no_trap_count.eq(count_trailing_zeros(exception_bits | safe_mask))
-            m.d.av_comb += exception.eq(no_trap_count < retire_count)
+            m.d.av_comb += exception.eq(no_trap_count != retire_count)
 
             # Ensure that when exception is processed, correct entry is alredy in ExceptionCauseRegister
             ecr_entry = self.exception_cause_get(m)
             exception_one_hot = Signal.like(exception_bits)
             m.d.av_comb += exception_one_hot.eq(exception_bits & (~exception_bits + 1))
             exception_rob_id = or_value(
-                rob_entry.rob_id & exception_one_hot[i].replicate(rob_entry.rob_id.shape().width)
-                for i, rob_entry in enumerate(rob_entries.entries)
+                Mux(exception_one_hot[i], rob_entry.rob_id, 0) for i, rob_entry in enumerate(rob_entries.entries)
             )
-            m.d.av_comb += retire_valid.eq(
-                ~exception | (exception & ecr_entry.valid & (ecr_entry.rob_id == exception_rob_id))
-            )
+            m.d.av_comb += retire_valid.eq(Mux(exception, ecr_entry.valid & (ecr_entry.rob_id == exception_rob_id), 1))
 
         with m.FSM("NORMAL") as fsm:
             with m.State("NORMAL"):

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -1,6 +1,6 @@
 from amaranth import *
 from amaranth.lib.data import View
-from transactron.utils import count_trailing_zeros
+from transactron.utils import count_trailing_zeros, or_value
 from coreblocks.interface.layouts import (
     CoreInstructionCounterLayouts,
     ExceptionRegisterLayouts,
@@ -158,16 +158,21 @@ class Retirement(Elaboratable):
             m.d.av_comb += safe_mask.eq(tag_incr_mask & (tag_incr_mask - 1) | (-1 << rob_entries.done_count))
             m.d.av_comb += retire_count.eq(count_trailing_zeros(safe_mask))
 
-            m.d.av_comb += no_trap_count.eq(
-                count_trailing_zeros(Cat(entry.exception for entry in rob_entries.entries) | safe_mask)
-            )
+            exception_bits = Signal(self.gen_params.retirement_superscalarity)
+            m.d.av_comb += exception_bits.eq(Cat(rob_entry.exception for rob_entry in rob_entries.entries))
+            m.d.av_comb += no_trap_count.eq(count_trailing_zeros(exception_bits | safe_mask))
             m.d.av_comb += exception.eq(no_trap_count < retire_count)
 
             # Ensure that when exception is processed, correct entry is alredy in ExceptionCauseRegister
             ecr_entry = self.exception_cause_get(m)
+            exception_one_hot = Signal.like(exception_bits)
+            m.d.av_comb += exception_one_hot.eq(exception_bits & (~exception_bits + 1))
+            exception_rob_id = or_value(
+                rob_entry.rob_id & exception_one_hot[i].replicate(rob_entry.rob_id.shape().width)
+                for i, rob_entry in enumerate(rob_entries.entries)
+            )
             m.d.av_comb += retire_valid.eq(
-                ~exception
-                | (exception & ecr_entry.valid & (ecr_entry.rob_id == rob_entries.entries[no_trap_count].rob_id))
+                ~exception | (exception & ecr_entry.valid & (ecr_entry.rob_id == exception_rob_id))
             )
 
         with m.FSM("NORMAL") as fsm:

--- a/coreblocks/core_structs/rat.py
+++ b/coreblocks/core_structs/rat.py
@@ -57,10 +57,15 @@ class RRAT(Elaboratable):
         @def_methods(m, self.commit, ready=lambda _: initialized)
         def _(i: int, rp_dst: Value, rl_dst: Value):
             self.entries.write[i](m, addr=rl_dst, data=rp_dst)
-            return {"old_rp_dst": self.entries.read[i](m, addr=rl_dst).data}
+            return {"old_rp_dst": self.peek[i](m, rl_dst)}
 
         @def_methods(m, self.peek, ready=lambda _: initialized)
         def _(i: int, rl_dst: Value):
-            return self.entries.read[i](m, addr=rl_dst).data
+            old_rp_dst = Signal(self.gen_params.phys_regs_bits)
+            m.d.av_comb += old_rp_dst.eq(self.entries.read[i](m, addr=rl_dst).data)
+            for j in range(i):
+                with m.If(self.commit[j].run & (self.commit[j].data_in.rl_dst == rl_dst)):
+                    m.d.av_comb += old_rp_dst.eq(self.commit[j].data_in.rp_dst)
+            return old_rp_dst
 
         return m

--- a/coreblocks/core_structs/rf.py
+++ b/coreblocks/core_structs/rf.py
@@ -99,7 +99,7 @@ class RegisterFile(Elaboratable):
 
         # It is assumed that two simultaneous write calls never write the same physical register.
         for k1, m1 in enumerate(self.write):
-            for k2, m2 in enumerate(self.write[k1 + 1 :]):
+            for k2, m2 in enumerate(self.write[k1 + 1 :], k1 + 1):
                 log.error(
                     m,
                     m1.run & m2.run & (m1.data_in.reg_id == m2.data_in.reg_id) & (m1.data_in.reg_id != 0),
@@ -111,7 +111,7 @@ class RegisterFile(Elaboratable):
 
         # It is assumed that two simultaneous free calls never free the same physical register.
         for k1, m1 in enumerate(self.free):
-            for k2, m2 in enumerate(self.free[k1 + 1 :]):
+            for k2, m2 in enumerate(self.free[k1 + 1 :], k1 + 1):
                 log.error(
                     m,
                     m1.run & m2.run & (m1.data_in.reg_id == m2.data_in.reg_id) & (m1.data_in.reg_id != 0),

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -1,11 +1,15 @@
 from amaranth import *
+from coreblocks.arch.isa_consts import PrivilegeLevel
 from coreblocks.backend.retirement import *
 from coreblocks.priv.csr.csr_instances import CSRInstances
 
 from transactron.lib import FIFO, Adapter
+from transactron.core import TModule
+from transactron.utils import DependencyContext
 from coreblocks.core_structs.rat import RRAT
 from coreblocks.params import GenParams
 from coreblocks.params import configurations
+from coreblocks.interface.keys import CSRInstancesKey, InstructionPrecommitKey
 from transactron.lib.adapters import AdapterTrans
 
 from transactron.testing import *

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -118,7 +118,7 @@ class TestRetirement(TestCaseWithSimulator):
 
     @def_method_mock(lambda self: self.retc.mock_rob_peek, enable=lambda self: bool(self.submit_q))
     def peek_process(self):
-        return {"count": 1, "entries": [self.submit_q[0]]}
+        return {"count": 1, "done_count": 1, "entries": [self.submit_q[0]]}
 
     async def free_reg_process(self, sim: TestbenchContext):
         while self.rf_exp_q:
@@ -194,4 +194,5 @@ class TestRetirement(TestCaseWithSimulator):
         with self.run_simulation(self.retc) as sim:
             sim.add_testbench(self.free_reg_process)
             sim.add_testbench(self.rat_process)
-            sim.add_testbench(self.precommit_process)
+            # TODO: actually working side effect test
+            # sim.add_testbench(self.precommit_process)

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -1,3 +1,4 @@
+from amaranth import *
 from coreblocks.backend.retirement import *
 from coreblocks.priv.csr.csr_instances import CSRInstances
 


### PR DESCRIPTION
Finally, superscalar retirement.

Looks like the performance limiters are elsewhere. I suspect the biggest offender is the branch predictor, as deep speculation is impossible without it. The other is probably the LSU. Another big one is lack of cycle-to-cycle forwarding for ALU ops.

TODO:
- [x] Look into Fmax drop
- [x] Look into failing test