### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-Copyright (c) 2022-2024, University of Wroclaw
-All rights reserved.
+Copyright (c) 2022-2026, Coreforge Foundation and the Coreblocks project contributors
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -8,7 +7,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the University of Wroclaw nor the
+    * Neither the name of the Coreforge Foundation nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,4 @@ Coreblocks project is financially supported by [NGI0 Commons Fund](https://nlnet
 
 Contact us at [Coreforge Foundation](https://kuznia-rdzeni.org) if you want to support development of Coreforge projects!
 
-## License
-
-Copyright © 2022-2025, University of Wrocław.
-
-This project is [three-clause BSD](https://github.com/kuznia-rdzeni/coreblocks/blob/master/LICENSE) licensed.
+This project is [three-clause BSD licensed](https://github.com/kuznia-rdzeni/coreblocks/blob/master/LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
@@ -23,6 +22,8 @@ dependencies = [
     "dataclasses-json==0.6.3",
     "transactron~=0.8.0",
 ]
+license = "BSD-3-Clause"
+license-files = [ "LICENSE" ]
 
 [project.urls]
 Homepage = "https://kuznia-rdzeni.org"


### PR DESCRIPTION
as discussed with contributors internally

additionally changes pyproject license definition to PEP639 compatible https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files 