### PR TITLE
Remove condition from retirement

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -226,13 +226,10 @@ class Retirement(Elaboratable):
                         # Normally retire all non-trap instructions
                         m.d.av_comb += commit.eq(1)
 
-                    # Condition is used to avoid FRAT locking during normal operation
-                    with condition(m) as cond:
-                        with cond(commit):
-                            retire_instr(rob_entry)
-                        with cond():
-                            # Not using default condition, because we want to block if branch is not ready
-                            flush_instr(0, rob_entry)
+                    with m.If(commit):
+                        retire_instr(rob_entry)
+                    with m.Else():
+                        flush_instr(0, rob_entry)
 
                     validate_transaction.schedule_before(retire_transaction)
 

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -13,7 +13,6 @@ from coreblocks.interface.layouts import (
 )
 
 from transactron.core import Method, Methods, Transaction, TModule, def_method
-from transactron.lib.simultaneous import condition
 from transactron.utils.dependencies import DependencyContext
 from transactron.lib.metrics import *
 

--- a/coreblocks/core_structs/crat.py
+++ b/coreblocks/core_structs/crat.py
@@ -252,9 +252,6 @@ class CheckpointRAT(Elaboratable):
             with m.If(active_renames[k].valid):
                 m.d.sync += self.frat[active_renames[k].rl_dst].eq(active_renames[k].rp_dst)
 
-        for rename in self.rename:
-            for flush_restore in self.flush_restore:
-                flush_restore.add_conflict(rename, Priority.RIGHT)
         # FIXME: Commented due to Transactron #63. rollback is not currently used, fix later
         # self.rollback.add_conflict(self.flush_restore, Priority.RIGHT)
 

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -176,6 +176,10 @@ class TestRetirement(TestCaseWithSimulator):
     def mock_checkpoint_get_active_tags(self):
         return {"active_tags": -1}
 
+    @def_method_mock(lambda self: self.retc.mock_c_rat_restore)
+    def mock_c_rat_restore(self):
+        pass
+
     @def_method_mock(lambda self: self.retc.mock_checkpoint_tag_free)
     def mock_checkpoint_tag_free(self):
         pass


### PR DESCRIPTION
It turns out that during flushing, register renaming is not important anyway. The conflict on FRAT can be therefore safely removed, and with it - the use of `condition` in retirement.

In the future, further simplification of the flushing process needs to be considered.