### PR TITLE
test: fix pytest hook order so count runs after -k/-m (#753)

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -90,6 +90,7 @@ def deselect_based_on_count(items: list[pytest.Item], config: pytest.Config) -> 
         items[:] = remaining
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Config) -> None:
     deselect_based_on_flatten_name(items, config)
     deselect_based_on_count(items, config)


### PR DESCRIPTION
conftest'spytest_collection_modifyitems was registered after pytest's built-in _pytest.mark plugin, so by LIFO it ran first. This made --coreblocks-test-count slice the first N items from the full collection before -k/-m keyword/marker deselection, selecting the wrong tests (or none).

Add @pytest.hookimpl(trylast=True) so the name/count deselection runs after marker filtering, operating on the already-filtered set.
