### PR TITLE
Radix 4 Division by digit recurrence

### DIFF
--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -1,0 +1,82 @@
+from amaranth import *
+from transactron import TModule, Method, def_method
+from coreblocks.func_blocks.fu.fpu.otfc import *
+from coreblocks.func_blocks.fu.fpu.qsf_tables import *
+from coreblocks.func_blocks.fu.fpu.fpu_qsf import *
+
+
+class DrDivParams:
+    """Division by digit recurrence parameters
+
+    Parameters
+    ----------
+    iterations: int
+        Number of iterations of digit recurrence
+    op_width: int
+        width of operands
+    result_width: int
+        width of result
+    """
+
+    def __init__(self, *, iterations: int, op_width: int, result_width: int):
+        self.iterations = iterations
+        self.op_width = op_width
+        self.result_width = result_width
+
+
+class DrDivMethodLayout:
+    """Division by digit recurrence module metohds layouts
+
+    Parameters
+    ----------
+    dr_div_params: DrDivParams
+        Parameters of division
+    """
+
+    def __init__(self, *, dr_div_params: DrDivisionParams):
+        """
+        d - divisor
+        x - dividend
+        result - result of operation
+        zero_rem - flag indicating if remainder is zero
+        """
+
+        self.division_init_in_layout = [
+            ("d", dr_div_params.op_width),
+            ("x", dr_div_params.op_width),
+        ]
+        self.division_run_out_layout = [
+            ("result", dr_div_params.result_width),
+            ("zero_rem", 1),
+        ]
+
+
+class DrDivModule(Elaboratable):
+    """Module for performing division by digit recurrence
+
+    Parameters
+    ----------
+    div_params: DrDivParams
+        Params for division
+
+    Attributes
+    ----------
+    div_init: Method
+        Transactional method for initiating division
+        Takes 'division_init_in_layout' as argument
+    div_run: Method
+        Performs division operation
+        Returns 'division_run_out_layout' as argument
+    """
+
+    def __init__(self, *, div_params: DrDivParams):
+        self.div_params  = div_params
+        self.otfc_params = OTFCParams(result_width=self.div_params.result_width) 
+        self.method_layouts = DrDivMethodLayout(dr_div_params=div_params)
+        self.div_init = Method(i=self.method_layouts.division_init_in_layout)
+        self.div_run = Method(o=self.method_layouts.division_run_out_layout)
+
+    def elaborate(self, platform):
+        m = Tmodule()
+        m.submodule.otfc = otfc = OTFCModule(otfc_params=self.otfc_params)
+        m.submodule.

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -1,5 +1,6 @@
 from amaranth import *
 from transactron import TModule, Method, def_method
+from transactron.utils import from_method_layout
 from coreblocks.func_blocks.fu.fpu.otfc import *
 from coreblocks.func_blocks.fu.fpu.qsf_tables import *
 from coreblocks.func_blocks.fu.fpu.fpu_qsf import *
@@ -69,9 +70,10 @@ class DrDivModule(Elaboratable):
         Returns 'division_run_out_layout' as argument
     """
 
-    def __init__(self, *, div_params: DrDivParams):
-        self.div_params  = div_params
-        self.otfc_params = OTFCParams(result_width=self.div_params.result_width) 
+    def __init__(self, *, div_params: DrDivParams, qsf_params: QSFParams):
+        self.div_params = div_params
+        self.qsf_params = qsf_params
+        self.otfc_params = OTFCParams(result_width=self.div_params.result_width)
         self.method_layouts = DrDivMethodLayout(dr_div_params=div_params)
         self.div_init = Method(i=self.method_layouts.division_init_in_layout)
         self.div_run = Method(o=self.method_layouts.division_run_out_layout)
@@ -79,4 +81,18 @@ class DrDivModule(Elaboratable):
     def elaborate(self, platform):
         m = Tmodule()
         m.submodule.otfc = otfc = OTFCModule(otfc_params=self.otfc_params)
-        m.submodule.
+        m.submodule.qsf = qsf = QSFModule(qsf_params=self.qsf_params)
+
+        additional_iterations = 2
+        max_divisor = 2 ** (self.div_params.op_width) - 1
+
+        counter = Signal(
+            range(0, self.div_params.iterations + additional_iterations + 1)
+        )
+        residual = Signal(3 + self.div_params.op_width)
+        adjusted_divisor = Signal(self.div_params.op_width + 1)
+
+        two_p = Signal(range(0, (2 * max_divisor) + 1))
+        one_p = Signal(range(0, max_divisor + 1))
+        m_one_p = Signal(range(-max_divisor, 1))
+        m_two_p = Signal(range(-2 * max_divisor, 1))

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -172,7 +172,7 @@ class DrDivModule(Elaboratable):
                 m.d.comb += otfc_response.eq(resp)
             m.d.sync += Print("RESULT: ", otfc_response["result"])
             with m.If(residual_negative):
-                m.d.comb += adjusted_result.eq((otfc_response["result"] - 2) << 2)
+                m.d.comb += adjusted_result.eq((otfc_response["result"] - 1) << 2)
             with m.Else():
                 m.d.comb += adjusted_result.eq(otfc_response["result"] << 2)
             return {"result": adjusted_result, "zero_rem": zero_rem}

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -47,7 +47,10 @@ class DrDivMethodLayout:
             ("x", dr_div_params.op_width),
         ]
         self.division_run_out_layout = [
-            ("result", dr_div_params.result_width),
+            (
+                "result",
+                dr_div_params.result_width - 2,
+            ),  # TODO change to another parameter
             ("zero_rem", 1),
         ]
 
@@ -73,7 +76,7 @@ class DrDivModule(Elaboratable):
     def __init__(self, *, div_params: DrDivParams, qsf_params: QSFParams):
         self.div_params = div_params
         self.qsf_params = qsf_params
-        self.otfc_params = OTFCParams(result_width=self.div_params.result_width)
+        self.otfc_params = OTFCParams(result_width=self.div_params.result_width - 1)
         self.method_layouts = DrDivMethodLayout(dr_div_params=div_params)
         self.div_init = Method(i=self.method_layouts.division_init_in_layout)
         self.div_result = Method(o=self.method_layouts.division_run_out_layout)
@@ -100,7 +103,9 @@ class DrDivModule(Elaboratable):
         result_ready = Signal()
         residual_negative = Signal()
 
-        otfc_response = Signal(from_method_layout(otfc.method_layouts.otfc_result_out_layout))
+        otfc_response = Signal(
+            from_method_layout(otfc.method_layouts.otfc_result_out_layout)
+        )
         qsf_response = Signal(from_method_layout(qsf.method_layouts.qsf_out_layout))
 
         @def_method(m, self.div_init)
@@ -115,24 +120,28 @@ class DrDivModule(Elaboratable):
             m.d.sync += one_p.eq(d)
             m.d.sync += m_one_p.eq(-1 * d)
             m.d.sync += m_two_p.eq(-2 * d)
-            m.d.sync += counter.eq(1)
+            m.d.sync += counter.eq(0)
             m.d.sync += result_ready.eq(0)
             m.d.sync += init_ready.eq(1)
-            m.d.sync += Print("INIT: ", x, " ", d)
+
+            m.d.sync += Print("INIT: ", x, " ", d, " ", counter, " ", counter_max)
             m.d.sync += Print("1d: ", one_p)
 
-        with m.If((counter < (self.div_params.iterations + additional_iterations)) & init_ready):
+        with m.If((counter < (counter_max)) & init_ready):
             m.d.sync += Print("COUNTER: ", counter, " r: ", residual, " d: ", divisor)
             new_residual = Signal(self.div_params.op_width + 1)
 
             with Transaction().body(m):
                 m.d.sync += Print(
-                    "qsf res: ",
-                    residual[-7:].as_signed(),
-                    " divisor: ",
-                    (divisor[-5:] << 0),
+                    Format(
+                        "qsf res: {:07b}, divisor: {:05b} ",
+                        residual[-7:].as_signed(),
+                        (divisor[-5:] << 0),
+                    )
                 )
-                resp_qsf = qsf.qsf_request(m, residual=residual[-7:].as_signed(), divisor=(divisor[-5:] << 0))
+                resp_qsf = qsf.qsf_request(
+                    m, residual=residual[-7:].as_signed(), divisor=(divisor[-5:] << 0)
+                )
                 m.d.comb += qsf_response.eq(resp_qsf)
                 otfc.otfc_add_digit(m, sign=qsf_response["sign"], q=qsf_response["q"])
             m.d.sync += counter.eq(counter + 1)
@@ -142,7 +151,9 @@ class DrDivModule(Elaboratable):
             # The residual is extended by two integer bits for the purpose of shift by 2 (4*R[j])
             # but only one integer bit is used in recurrence
             # so we use additional signal to cut off those two bits
-            m.d.sync += Print("qsf resp = ", qsf_response["q"], " sign: ", qsf_response["sign"])
+            m.d.sync += Print(
+                "qsf resp = ", qsf_response["q"], " sign: ", qsf_response["sign"]
+            )
             with m.Switch(qsf_response["q"]):
                 with m.Case(2):
                     with m.If(qsf_response["sign"] == 1):
@@ -156,7 +167,7 @@ class DrDivModule(Elaboratable):
                         m.d.comb += new_residual.eq(residual - one_p)
                 with m.Case(0):
                     m.d.comb += new_residual.eq(residual)
-            m.d.sync += Print("new residual: ", new_residual)
+            m.d.sync += Print(Format("new residual: {:014b}", new_residual))
             m.d.sync += residual.eq(new_residual << 2)  # R[j + 1] = 4*R[j]
         with m.Elif(counter == (counter_max)):
             m.d.sync += result_ready.eq(1)
@@ -165,16 +176,19 @@ class DrDivModule(Elaboratable):
         @def_method(m, self.div_result, ready=result_ready)
         def _():
             zero_rem = Signal()
-            adjusted_result = Signal(self.div_params.result_width)
+            adjusted_result = Signal(
+                self.div_params.result_width - 2
+            )  # TODO add another field to params for quotient bits and output bits
             m.d.comb += zero_rem.eq(~residual.any())
+            m.d.sync += counter.eq(0)
             with Transaction().body(m):
                 resp = otfc.otfc_result(m, shift=0)
                 m.d.comb += otfc_response.eq(resp)
-            m.d.sync += Print("RESULT: ", otfc_response["result"])
+            m.d.sync += Print(Format("RESULT: {:015b}", otfc_response["result"]))
             with m.If(residual_negative):
-                m.d.comb += adjusted_result.eq((otfc_response["result"] - 1) << 2)
+                m.d.comb += adjusted_result.eq((otfc_response["result"] - 1))
             with m.Else():
-                m.d.comb += adjusted_result.eq(otfc_response["result"] << 2)
+                m.d.comb += adjusted_result.eq(otfc_response["result"])
             return {"result": adjusted_result, "zero_rem": zero_rem}
 
         return m

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from transactron import TModule, Method, def_method
+from transactron import TModule, Method, def_method, Transaction
 from transactron.utils import from_method_layout
 from coreblocks.func_blocks.fu.fpu.otfc import *
 from coreblocks.func_blocks.fu.fpu.qsf_tables import *
@@ -34,7 +34,7 @@ class DrDivMethodLayout:
         Parameters of division
     """
 
-    def __init__(self, *, dr_div_params: DrDivisionParams):
+    def __init__(self, *, dr_div_params: DrDivParams):
         """
         d - divisor
         x - dividend
@@ -76,23 +76,105 @@ class DrDivModule(Elaboratable):
         self.otfc_params = OTFCParams(result_width=self.div_params.result_width)
         self.method_layouts = DrDivMethodLayout(dr_div_params=div_params)
         self.div_init = Method(i=self.method_layouts.division_init_in_layout)
-        self.div_run = Method(o=self.method_layouts.division_run_out_layout)
+        self.div_result = Method(o=self.method_layouts.division_run_out_layout)
 
     def elaborate(self, platform):
-        m = Tmodule()
-        m.submodule.otfc = otfc = OTFCModule(otfc_params=self.otfc_params)
-        m.submodule.qsf = qsf = QSFModule(qsf_params=self.qsf_params)
+        m = TModule()
+        m.submodules.otfc = otfc = OTFCModule(otfc_params=self.otfc_params)
+        m.submodules.qsf = qsf = QSFModule(qsf_params=self.qsf_params)
 
         additional_iterations = 2
-        max_divisor = 2 ** (self.div_params.op_width) - 1
+        integer_bits = 3
+        counter_max = self.div_params.iterations + additional_iterations
 
-        counter = Signal(
-            range(0, self.div_params.iterations + additional_iterations + 1)
-        )
-        residual = Signal(3 + self.div_params.op_width)
-        adjusted_divisor = Signal(self.div_params.op_width + 1)
+        counter = Signal(range(0, counter_max + 1))
+        residual = Signal(signed(integer_bits + self.div_params.op_width))
+        divisor = Signal(1 + self.div_params.op_width)
 
-        two_p = Signal(range(0, (2 * max_divisor) + 1))
-        one_p = Signal(range(0, max_divisor + 1))
-        m_one_p = Signal(range(-max_divisor, 1))
-        m_two_p = Signal(range(-2 * max_divisor, 1))
+        two_p = Signal(signed(2 + self.div_params.op_width))
+        one_p = Signal(signed(2 + self.div_params.op_width))
+        m_one_p = Signal(signed(2 + self.div_params.op_width))
+        m_two_p = Signal(signed(2 + self.div_params.op_width))
+
+        init_ready = Signal()
+        result_ready = Signal()
+        residual_negative = Signal()
+
+        otfc_response = Signal(from_method_layout(otfc.method_layouts.otfc_result_out_layout))
+        qsf_response = Signal(from_method_layout(qsf.method_layouts.qsf_out_layout))
+
+        @def_method(m, self.div_init)
+        def _(x, d):
+            m.d.sync
+            m.d.sync += divisor.eq(d)
+            m.d.sync += residual.eq(x)
+            m.d.sync += residual_negative.eq(0)
+            # Divisor does not change through the entirety of the division
+            # so we precompute all the possible value of q*d
+            m.d.sync += two_p.eq(2 * d)
+            m.d.sync += one_p.eq(d)
+            m.d.sync += m_one_p.eq(-1 * d)
+            m.d.sync += m_two_p.eq(-2 * d)
+            m.d.sync += counter.eq(1)
+            m.d.sync += result_ready.eq(0)
+            m.d.sync += init_ready.eq(1)
+            m.d.sync += Print("INIT: ", x, " ", d)
+            m.d.sync += Print("1d: ", one_p)
+
+        with m.If((counter < (self.div_params.iterations + additional_iterations)) & init_ready):
+            m.d.sync += Print("COUNTER: ", counter, " r: ", residual, " d: ", divisor)
+            new_residual = Signal(self.div_params.op_width + 1)
+
+            with Transaction().body(m):
+                m.d.sync += Print(
+                    "qsf res: ",
+                    residual[-7:].as_signed(),
+                    " divisor: ",
+                    (divisor[-5:] << 0),
+                )
+                resp_qsf = qsf.qsf_request(m, residual=residual[-7:].as_signed(), divisor=(divisor[-5:] << 0))
+                m.d.comb += qsf_response.eq(resp_qsf)
+                otfc.otfc_add_digit(m, sign=qsf_response["sign"], q=qsf_response["q"])
+            m.d.sync += counter.eq(counter + 1)
+            # To check if the last residual is zero we keep this
+            # information in a separate flag before we compute new residual
+            m.d.sync += residual_negative.eq(residual < 0)
+            # The residual is extended by two integer bits for the purpose of shift by 2 (4*R[j])
+            # but only one integer bit is used in recurrence
+            # so we use additional signal to cut off those two bits
+            m.d.sync += Print("qsf resp = ", qsf_response["q"], " sign: ", qsf_response["sign"])
+            with m.Switch(qsf_response["q"]):
+                with m.Case(2):
+                    with m.If(qsf_response["sign"] == 1):
+                        m.d.comb += new_residual.eq(residual - m_two_p)
+                    with m.Else():
+                        m.d.comb += new_residual.eq(residual - two_p)
+                with m.Case(1):
+                    with m.If(qsf_response["sign"] == 1):
+                        m.d.comb += new_residual.eq(residual - m_one_p)
+                    with m.Else():
+                        m.d.comb += new_residual.eq(residual - one_p)
+                with m.Case(0):
+                    m.d.comb += new_residual.eq(residual)
+            m.d.sync += Print("new residual: ", new_residual)
+            m.d.sync += residual.eq(new_residual << 2)  # R[j + 1] = 4*R[j]
+        with m.Elif(counter == (counter_max)):
+            m.d.sync += result_ready.eq(1)
+            m.d.sync += init_ready.eq(0)
+
+        @def_method(m, self.div_result, ready=result_ready)
+        def _():
+            zero_rem = Signal()
+            adjusted_result = Signal(self.div_params.result_width)
+            m.d.comb += zero_rem.eq(~residual.any())
+            with Transaction().body(m):
+                resp = otfc.otfc_result(m, shift=0)
+                m.d.comb += otfc_response.eq(resp)
+            m.d.sync += Print("RESULT: ", otfc_response["result"])
+            with m.If(residual_negative):
+                m.d.comb += adjusted_result.eq((otfc_response["result"] - 2) << 2)
+            with m.Else():
+                m.d.comb += adjusted_result.eq(otfc_response["result"] << 2)
+            return {"result": adjusted_result, "zero_rem": zero_rem}
+
+        return m

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -83,7 +83,9 @@ class DrDivModule(Elaboratable):
     def __init__(self, *, div_params: DrDivParams, qsf_params: QSFParams):
         self.div_params = div_params
         self.qsf_params = qsf_params
-        self.otfc_params = OTFCParams(result_width=self.div_params.result_fractional_bits)
+        self.otfc_params = OTFCParams(
+            result_width=self.div_params.result_fractional_bits
+        )
         self.method_layouts = DrDivMethodLayout(dr_div_params=div_params)
         self.div_init = Method(i=self.method_layouts.division_init_in_layout)
         self.div_result = Method(o=self.method_layouts.division_run_out_layout)
@@ -111,11 +113,14 @@ class DrDivModule(Elaboratable):
         residual_negative = Signal()
         residual_is_zero = Signal()
         residual_is_minus_d = Signal()
-        otfc_response = Signal(from_method_layout(otfc.method_layouts.otfc_result_out_layout))
+        otfc_response = Signal(
+            from_method_layout(otfc.method_layouts.otfc_result_out_layout)
+        )
         qsf_response = Signal(from_method_layout(qsf.method_layouts.qsf_out_layout))
 
         with m.FSM(init="Idle") as fsm:
             with m.State("Idle"):
+
                 @def_method(m, self.div_init, ready=fsm.ongoing("Idle"))
                 def _(x, d):
                     m.d.sync += divisor.eq(d)
@@ -133,69 +138,66 @@ class DrDivModule(Elaboratable):
                     m.d.sync += counter.eq(0)
                     m.d.sync += result_ready.eq(0)
                     m.next = "Loop"
-            with m.State("Loop"):
-                with m.If((counter < (counter_max))):
-                    # The residual for the next iteration. This Signal could have the same shape
-                    # as residual, but those two MSB bits would be shifted out anyway.
-                    new_residual = Signal(self.div_params.fractional_bits + 1)
 
-                    with Transaction().body(m):
-                        resp_qsf = qsf.qsf_request(
+            with m.State("Loop"):
+                # The residual for the next iteration. This Signal could have the same shape
+                # as residual, but those two MSB bits would be shifted out anyway.
+                new_residual = Signal(self.div_params.fractional_bits + 1)
+
+                with Transaction().always_body(m):
+                    m.d.av_comb += qsf_response.eq(
+                        qsf.qsf_request(
                             m,
                             residual=residual[-7:].as_signed(),
                             divisor=(divisor[-5:] << 0),
                         )
-                        m.d.comb += qsf_response.eq(resp_qsf)
-                        otfc.otfc_add_digit(m, sign=qsf_response["sign"], q=qsf_response["q"])
-                    m.d.sync += counter.eq(counter + 1)
-                    # To check if the last residual is zero we keep this
-                    # information in a separate flag before we compute new residual
-                    # This applies to the other flags as well
-                    m.d.sync += residual_negative.eq(residual < 0)
-                    m.d.sync += residual_is_minus_d.eq(residual == m_one_p)
-                    m.d.sync += residual_is_zero.eq(~(residual.any()))
-                    # The residual is extended by two integer bits for the purpose of shift by 2 (4*R[j])
-                    # but only one integer bit is used in recurrence
-                    # so we use additional signal to cut off those two bits
-                    with m.Switch(qsf_response["q"]):
-                        with m.Case(2):
-                            with m.If(qsf_response["sign"] == 1):
-                                m.d.comb += new_residual.eq(residual - m_two_p)
-                            with m.Else():
-                                m.d.comb += new_residual.eq(residual - two_p)
-                        with m.Case(1):
-                            with m.If(qsf_response["sign"] == 1):
-                                m.d.comb += new_residual.eq(residual - m_one_p)
-                            with m.Else():
-                                m.d.comb += new_residual.eq(residual - one_p)
-                        with m.Case(0):
-                            m.d.comb += new_residual.eq(residual)
-                    m.d.sync += residual.eq(new_residual << 2)  # R[j + 1] = 4*R[j]
-                with m.Elif(counter == (counter_max)):
-                    m.next = "Result"
-                    m.d.sync += result_ready.eq(1)
+                    )
+                    otfc.otfc_add_digit(
+                        m, sign=qsf_response["sign"], q=qsf_response["q"]
+                    )
+                m.d.sync += counter.eq(counter + 1)
+                # To check if the last residual is zero we keep this
+                # information in a separate flag before we compute new residual
+                # This applies to the other flags as well
+                m.d.sync += residual_negative.eq(residual < 0)
+                m.d.sync += residual_is_zero.eq(residual == 0)
+                # The residual is extended by two integer bits
+                # for the purpose of shift by 2 (4*R[j])
+                # but only one integer bit is used in recurrence
+                # so we use additional signal to cut off those two bits
+                with m.Switch(qsf_response["q"]):
+                    with m.Case(2):
+                        with m.If(qsf_response["sign"] == 1):
+                            m.d.comb += new_residual.eq(residual - m_two_p)
+                        with m.Else():
+                            m.d.comb += new_residual.eq(residual - two_p)
+                    with m.Case(1):
+                        with m.If(qsf_response["sign"] == 1):
+                            m.d.comb += new_residual.eq(residual - m_one_p)
+                        with m.Else():
+                            m.d.comb += new_residual.eq(residual - one_p)
+                    with m.Case(0):
+                        m.d.comb += new_residual.eq(residual)
+                m.d.sync += residual.eq(new_residual << 2)  # R[j + 1] = 4*R[j]
+            with m.If(counter == (counter_max)):
+                m.next = "Result"
+                m.d.sync += result_ready.eq(1)
             with m.State("Result"):
+
                 @def_method(m, self.div_result, ready=fsm.ongoing("Result"))
                 def _():
                     zero_rem = Signal()
                     adjusted_result = Signal(self.div_params.result_fractional_bits)
-                    # This is note for the future. We are chcecking if the residual
-                    # is not equal -d beacuse in this case of subtracting 1 from the result
-                    # to correct the negative final residual, our residual would be zero
-                    # However the books doesn't mention that something like that is needed
-                    # It just checks if the last residual is zero, so maybe this is redundant
                     m.d.sync += counter.eq(0)
-                    with Transaction().body(m):
-                        resp = otfc.otfc_result(m, shift=0)
-                        m.d.comb += otfc_response.eq(resp)
+                    m.d.av_comb += otfc_response.eq(otfc.otfc_result(m, shift=0))
                     # The initialization condition requires that we shift result left by 2.
                     # We can also do this by setting correct signal shape
                     with m.If(residual_negative):
-                        m.d.comb += zero_rem.eq(residual_is_minus_d)
-                        m.d.comb += adjusted_result.eq((otfc_response["result"] - 1))
+                        m.d.av_comb += zero_rem.eq(residual_is_minus_d)
+                        m.d.av_comb += adjusted_result.eq((otfc_response["result"] - 1))
                     with m.Else():
-                        m.d.comb += zero_rem.eq(residual_is_zero)
-                        m.d.comb += adjusted_result.eq(otfc_response["result"])
+                        m.d.av_comb += zero_rem.eq(residual_is_zero)
+                        m.d.av_comb += adjusted_result.eq(otfc_response["result"])
                     m.next = "Idle"
                     return {"result": adjusted_result, "zero_rem": zero_rem}
 

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -83,9 +83,7 @@ class DrDivModule(Elaboratable):
     def __init__(self, *, div_params: DrDivParams, qsf_params: QSFParams):
         self.div_params = div_params
         self.qsf_params = qsf_params
-        self.otfc_params = OTFCParams(
-            result_width=self.div_params.result_fractional_bits
-        )
+        self.otfc_params = OTFCParams(result_width=self.div_params.result_fractional_bits)
         self.method_layouts = DrDivMethodLayout(dr_div_params=div_params)
         self.div_init = Method(i=self.method_layouts.division_init_in_layout)
         self.div_result = Method(o=self.method_layouts.division_run_out_layout)
@@ -108,14 +106,10 @@ class DrDivModule(Elaboratable):
         m_one_p = Signal(signed(2 + self.div_params.fractional_bits))
         m_two_p = Signal(signed(2 + self.div_params.fractional_bits))
 
-        init_ready = Signal(init=1)
-        result_ready = Signal()
         residual_negative = Signal()
         residual_is_zero = Signal()
         residual_is_minus_d = Signal()
-        otfc_response = Signal(
-            from_method_layout(otfc.method_layouts.otfc_result_out_layout)
-        )
+        otfc_response = Signal(from_method_layout(otfc.method_layouts.otfc_result_out_layout))
         qsf_response = Signal(from_method_layout(qsf.method_layouts.qsf_out_layout))
 
         with m.FSM(init="Idle") as fsm:
@@ -136,7 +130,6 @@ class DrDivModule(Elaboratable):
                     m.d.sync += m_one_p.eq(-1 * d)
                     m.d.sync += m_two_p.eq(-2 * d)
                     m.d.sync += counter.eq(0)
-                    m.d.sync += result_ready.eq(0)
                     m.next = "Loop"
 
             with m.State("Loop"):
@@ -152,9 +145,7 @@ class DrDivModule(Elaboratable):
                             divisor=(divisor[-5:] << 0),
                         )
                     )
-                    otfc.otfc_add_digit(
-                        m, sign=qsf_response["sign"], q=qsf_response["q"]
-                    )
+                    otfc.otfc_add_digit(m, sign=qsf_response["sign"], q=qsf_response["q"])
                 m.d.sync += counter.eq(counter + 1)
                 # To check if the last residual is zero we keep this
                 # information in a separate flag before we compute new residual
@@ -179,9 +170,9 @@ class DrDivModule(Elaboratable):
                     with m.Case(0):
                         m.d.comb += new_residual.eq(residual)
                 m.d.sync += residual.eq(new_residual << 2)  # R[j + 1] = 4*R[j]
-            with m.If(counter == (counter_max)):
-                m.next = "Result"
-                m.d.sync += result_ready.eq(1)
+                next_counter = counter + 1
+                with m.If(next_counter == counter_max):
+                    m.next = "Result"
             with m.State("Result"):
 
                 @def_method(m, self.div_result, ready=fsm.ongoing("Result"))

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -13,16 +13,22 @@ class DrDivParams:
     ----------
     iterations: int
         Number of iterations of digit recurrence
-    op_width: int
-        width of operands
-    result_width: int
-        width of result
+    fractional_bits: int
+        width of the fractional part of the float
+    result_fractional_bits: int
+        Fractional bits of the result we want to compute. The integer bits are always zero before shift
     """
 
-    def __init__(self, *, iterations: int, op_width: int, result_width: int):
+    def __init__(
+        self,
+        *,
+        iterations: int,
+        fractional_bits: int,
+        result_fractional_bits: int,
+    ):
         self.iterations = iterations
-        self.op_width = op_width
-        self.result_width = result_width
+        self.fractional_bits = fractional_bits
+        self.result_fractional_bits = result_fractional_bits
 
 
 class DrDivMethodLayout:
@@ -41,16 +47,17 @@ class DrDivMethodLayout:
         result - result of operation
         zero_rem - flag indicating if remainder is zero
         """
-
+        # This algorithm uses fp number with range [1/2;1),
+        # so we only get number of fractional bits
         self.division_init_in_layout = [
-            ("d", dr_div_params.op_width),
-            ("x", dr_div_params.op_width),
+            ("d", dr_div_params.fractional_bits),
+            ("x", dr_div_params.fractional_bits),
         ]
         self.division_run_out_layout = [
             (
                 "result",
-                dr_div_params.result_width - 2,
-            ),  # TODO change to another parameter
+                dr_div_params.result_fractional_bits,
+            ),
             ("zero_rem", 1),
         ]
 
@@ -76,7 +83,7 @@ class DrDivModule(Elaboratable):
     def __init__(self, *, div_params: DrDivParams, qsf_params: QSFParams):
         self.div_params = div_params
         self.qsf_params = qsf_params
-        self.otfc_params = OTFCParams(result_width=self.div_params.result_width - 1)
+        self.otfc_params = OTFCParams(result_width=self.div_params.result_fractional_bits)
         self.method_layouts = DrDivMethodLayout(dr_div_params=div_params)
         self.div_init = Method(i=self.method_layouts.division_init_in_layout)
         self.div_result = Method(o=self.method_layouts.division_run_out_layout)
@@ -86,34 +93,36 @@ class DrDivModule(Elaboratable):
         m.submodules.otfc = otfc = OTFCModule(otfc_params=self.otfc_params)
         m.submodules.qsf = qsf = QSFModule(qsf_params=self.qsf_params)
 
-        additional_iterations = 2
+        # Integer bits needed for residual computation
         integer_bits = 3
-        counter_max = self.div_params.iterations + additional_iterations
+        counter_max = self.div_params.iterations
 
         counter = Signal(range(0, counter_max + 1))
-        residual = Signal(signed(integer_bits + self.div_params.op_width))
-        divisor = Signal(1 + self.div_params.op_width)
+        residual = Signal(signed(integer_bits + self.div_params.fractional_bits))
+        divisor = Signal(1 + self.div_params.fractional_bits)
 
-        two_p = Signal(signed(2 + self.div_params.op_width))
-        one_p = Signal(signed(2 + self.div_params.op_width))
-        m_one_p = Signal(signed(2 + self.div_params.op_width))
-        m_two_p = Signal(signed(2 + self.div_params.op_width))
+        two_p = Signal(signed(2 + self.div_params.fractional_bits))
+        one_p = Signal(signed(2 + self.div_params.fractional_bits))
+        m_one_p = Signal(signed(2 + self.div_params.fractional_bits))
+        m_two_p = Signal(signed(2 + self.div_params.fractional_bits))
 
-        init_ready = Signal()
+        init_ready = Signal(init=1)
         result_ready = Signal()
         residual_negative = Signal()
-
-        otfc_response = Signal(
-            from_method_layout(otfc.method_layouts.otfc_result_out_layout)
-        )
+        residual_is_zero = Signal()
+        residual_is_minus_d = Signal()
+        otfc_response = Signal(from_method_layout(otfc.method_layouts.otfc_result_out_layout))
         qsf_response = Signal(from_method_layout(qsf.method_layouts.qsf_out_layout))
 
-        @def_method(m, self.div_init)
+        @def_method(m, self.div_init, ready=init_ready)
         def _(x, d):
             m.d.sync
             m.d.sync += divisor.eq(d)
             m.d.sync += residual.eq(x)
             m.d.sync += residual_negative.eq(0)
+            m.d.sync += residual_is_minus_d.eq(0)
+            # We assume that divisor is not zero
+            m.d.sync += residual_is_zero.eq(0)
             # Divisor does not change through the entirety of the division
             # so we precompute all the possible value of q*d
             m.d.sync += two_p.eq(2 * d)
@@ -122,72 +131,79 @@ class DrDivModule(Elaboratable):
             m.d.sync += m_two_p.eq(-2 * d)
             m.d.sync += counter.eq(0)
             m.d.sync += result_ready.eq(0)
-            m.d.sync += init_ready.eq(1)
 
-            m.d.sync += Print("INIT: ", x, " ", d, " ", counter, " ", counter_max)
-            m.d.sync += Print("1d: ", one_p)
+        with m.FSM(init="Idle"):
+            with m.State("Idle"):
+                with m.If(self.div_init.run):
+                    m.next = "Loop"
+                    m.d.sync += init_ready.eq(0)
+            with m.State("Loop"):
+                with m.If((counter < (counter_max))):
+                    # The residual for the next iteration. This Signal could have the same shape
+                    # as residual, but those two MSB bits would be shifted out anyway.
+                    new_residual = Signal(self.div_params.fractional_bits + 1)
 
-        with m.If((counter < (counter_max)) & init_ready):
-            m.d.sync += Print("COUNTER: ", counter, " r: ", residual, " d: ", divisor)
-            new_residual = Signal(self.div_params.op_width + 1)
-
-            with Transaction().body(m):
-                m.d.sync += Print(
-                    Format(
-                        "qsf res: {:07b}, divisor: {:05b} ",
-                        residual[-7:].as_signed(),
-                        (divisor[-5:] << 0),
-                    )
-                )
-                resp_qsf = qsf.qsf_request(
-                    m, residual=residual[-7:].as_signed(), divisor=(divisor[-5:] << 0)
-                )
-                m.d.comb += qsf_response.eq(resp_qsf)
-                otfc.otfc_add_digit(m, sign=qsf_response["sign"], q=qsf_response["q"])
-            m.d.sync += counter.eq(counter + 1)
-            # To check if the last residual is zero we keep this
-            # information in a separate flag before we compute new residual
-            m.d.sync += residual_negative.eq(residual < 0)
-            # The residual is extended by two integer bits for the purpose of shift by 2 (4*R[j])
-            # but only one integer bit is used in recurrence
-            # so we use additional signal to cut off those two bits
-            m.d.sync += Print(
-                "qsf resp = ", qsf_response["q"], " sign: ", qsf_response["sign"]
-            )
-            with m.Switch(qsf_response["q"]):
-                with m.Case(2):
-                    with m.If(qsf_response["sign"] == 1):
-                        m.d.comb += new_residual.eq(residual - m_two_p)
-                    with m.Else():
-                        m.d.comb += new_residual.eq(residual - two_p)
-                with m.Case(1):
-                    with m.If(qsf_response["sign"] == 1):
-                        m.d.comb += new_residual.eq(residual - m_one_p)
-                    with m.Else():
-                        m.d.comb += new_residual.eq(residual - one_p)
-                with m.Case(0):
-                    m.d.comb += new_residual.eq(residual)
-            m.d.sync += Print(Format("new residual: {:014b}", new_residual))
-            m.d.sync += residual.eq(new_residual << 2)  # R[j + 1] = 4*R[j]
-        with m.Elif(counter == (counter_max)):
-            m.d.sync += result_ready.eq(1)
-            m.d.sync += init_ready.eq(0)
+                    with Transaction().body(m):
+                        resp_qsf = qsf.qsf_request(
+                            m,
+                            residual=residual[-7:].as_signed(),
+                            divisor=(divisor[-5:] << 0),
+                        )
+                        m.d.comb += qsf_response.eq(resp_qsf)
+                        otfc.otfc_add_digit(m, sign=qsf_response["sign"], q=qsf_response["q"])
+                    m.d.sync += counter.eq(counter + 1)
+                    # To check if the last residual is zero we keep this
+                    # information in a separate flag before we compute new residual
+                    # This applies to the other flags as well
+                    m.d.sync += residual_negative.eq(residual < 0)
+                    m.d.sync += residual_is_minus_d.eq(residual == m_one_p)
+                    m.d.sync += residual_is_zero.eq(~(residual.any()))
+                    # The residual is extended by two integer bits for the purpose of shift by 2 (4*R[j])
+                    # but only one integer bit is used in recurrence
+                    # so we use additional signal to cut off those two bits
+                    with m.Switch(qsf_response["q"]):
+                        with m.Case(2):
+                            with m.If(qsf_response["sign"] == 1):
+                                m.d.comb += new_residual.eq(residual - m_two_p)
+                            with m.Else():
+                                m.d.comb += new_residual.eq(residual - two_p)
+                        with m.Case(1):
+                            with m.If(qsf_response["sign"] == 1):
+                                m.d.comb += new_residual.eq(residual - m_one_p)
+                            with m.Else():
+                                m.d.comb += new_residual.eq(residual - one_p)
+                        with m.Case(0):
+                            m.d.comb += new_residual.eq(residual)
+                    m.d.sync += residual.eq(new_residual << 2)  # R[j + 1] = 4*R[j]
+                with m.Elif(counter == (counter_max)):
+                    m.next = "Result"
+                    m.d.sync += result_ready.eq(1)
+            with m.State("Result"):
+                with m.If(self.div_result.run):
+                    m.d.sync += result_ready.eq(0)
+                    m.d.sync += init_ready.eq(1)
+                    m.next = "Idle"
 
         @def_method(m, self.div_result, ready=result_ready)
         def _():
             zero_rem = Signal()
-            adjusted_result = Signal(
-                self.div_params.result_width - 2
-            )  # TODO add another field to params for quotient bits and output bits
-            m.d.comb += zero_rem.eq(~residual.any())
+            adjusted_result = Signal(self.div_params.result_fractional_bits)
+            # This is note for the future. We are chcecking if the residual
+            # is not equal -d beacuse in this case of subtracting 1 from the result
+            # to correct the negative final residual, our residual would be zero
+            # However the books doesn't mention that something like that is needed
+            # It just checks if the last residual is zero, so maybe this is redundant
             m.d.sync += counter.eq(0)
             with Transaction().body(m):
                 resp = otfc.otfc_result(m, shift=0)
                 m.d.comb += otfc_response.eq(resp)
-            m.d.sync += Print(Format("RESULT: {:015b}", otfc_response["result"]))
+            # The initialization condition requires that we shift result left by 2.
+            # We can also do this by setting correct signal shape
             with m.If(residual_negative):
+                m.d.comb += zero_rem.eq(residual_is_minus_d)
                 m.d.comb += adjusted_result.eq((otfc_response["result"] - 1))
             with m.Else():
+                m.d.comb += zero_rem.eq(residual_is_zero)
                 m.d.comb += adjusted_result.eq(otfc_response["result"])
             return {"result": adjusted_result, "zero_rem": zero_rem}
 

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -114,29 +114,25 @@ class DrDivModule(Elaboratable):
         otfc_response = Signal(from_method_layout(otfc.method_layouts.otfc_result_out_layout))
         qsf_response = Signal(from_method_layout(qsf.method_layouts.qsf_out_layout))
 
-        @def_method(m, self.div_init, ready=init_ready)
-        def _(x, d):
-            m.d.sync
-            m.d.sync += divisor.eq(d)
-            m.d.sync += residual.eq(x)
-            m.d.sync += residual_negative.eq(0)
-            m.d.sync += residual_is_minus_d.eq(0)
-            # We assume that divisor is not zero
-            m.d.sync += residual_is_zero.eq(0)
-            # Divisor does not change through the entirety of the division
-            # so we precompute all the possible value of q*d
-            m.d.sync += two_p.eq(2 * d)
-            m.d.sync += one_p.eq(d)
-            m.d.sync += m_one_p.eq(-1 * d)
-            m.d.sync += m_two_p.eq(-2 * d)
-            m.d.sync += counter.eq(0)
-            m.d.sync += result_ready.eq(0)
-
-        with m.FSM(init="Idle"):
+        with m.FSM(init="Idle") as fsm:
             with m.State("Idle"):
-                with m.If(self.div_init.run):
+                @def_method(m, self.div_init, ready=fsm.ongoing("Idle"))
+                def _(x, d):
+                    m.d.sync += divisor.eq(d)
+                    m.d.sync += residual.eq(x)
+                    m.d.sync += residual_negative.eq(0)
+                    m.d.sync += residual_is_minus_d.eq(0)
+                    # We assume that divisor is not zero
+                    m.d.sync += residual_is_zero.eq(0)
+                    # Divisor does not change through the entirety of the division
+                    # so we precompute all the possible value of q*d
+                    m.d.sync += two_p.eq(2 * d)
+                    m.d.sync += one_p.eq(d)
+                    m.d.sync += m_one_p.eq(-1 * d)
+                    m.d.sync += m_two_p.eq(-2 * d)
+                    m.d.sync += counter.eq(0)
+                    m.d.sync += result_ready.eq(0)
                     m.next = "Loop"
-                    m.d.sync += init_ready.eq(0)
             with m.State("Loop"):
                 with m.If((counter < (counter_max))):
                     # The residual for the next iteration. This Signal could have the same shape
@@ -179,32 +175,28 @@ class DrDivModule(Elaboratable):
                     m.next = "Result"
                     m.d.sync += result_ready.eq(1)
             with m.State("Result"):
-                with m.If(self.div_result.run):
-                    m.d.sync += result_ready.eq(0)
-                    m.d.sync += init_ready.eq(1)
+                @def_method(m, self.div_result, ready=fsm.ongoing("Result"))
+                def _():
+                    zero_rem = Signal()
+                    adjusted_result = Signal(self.div_params.result_fractional_bits)
+                    # This is note for the future. We are chcecking if the residual
+                    # is not equal -d beacuse in this case of subtracting 1 from the result
+                    # to correct the negative final residual, our residual would be zero
+                    # However the books doesn't mention that something like that is needed
+                    # It just checks if the last residual is zero, so maybe this is redundant
+                    m.d.sync += counter.eq(0)
+                    with Transaction().body(m):
+                        resp = otfc.otfc_result(m, shift=0)
+                        m.d.comb += otfc_response.eq(resp)
+                    # The initialization condition requires that we shift result left by 2.
+                    # We can also do this by setting correct signal shape
+                    with m.If(residual_negative):
+                        m.d.comb += zero_rem.eq(residual_is_minus_d)
+                        m.d.comb += adjusted_result.eq((otfc_response["result"] - 1))
+                    with m.Else():
+                        m.d.comb += zero_rem.eq(residual_is_zero)
+                        m.d.comb += adjusted_result.eq(otfc_response["result"])
                     m.next = "Idle"
-
-        @def_method(m, self.div_result, ready=result_ready)
-        def _():
-            zero_rem = Signal()
-            adjusted_result = Signal(self.div_params.result_fractional_bits)
-            # This is note for the future. We are chcecking if the residual
-            # is not equal -d beacuse in this case of subtracting 1 from the result
-            # to correct the negative final residual, our residual would be zero
-            # However the books doesn't mention that something like that is needed
-            # It just checks if the last residual is zero, so maybe this is redundant
-            m.d.sync += counter.eq(0)
-            with Transaction().body(m):
-                resp = otfc.otfc_result(m, shift=0)
-                m.d.comb += otfc_response.eq(resp)
-            # The initialization condition requires that we shift result left by 2.
-            # We can also do this by setting correct signal shape
-            with m.If(residual_negative):
-                m.d.comb += zero_rem.eq(residual_is_minus_d)
-                m.d.comb += adjusted_result.eq((otfc_response["result"] - 1))
-            with m.Else():
-                m.d.comb += zero_rem.eq(residual_is_zero)
-                m.d.comb += adjusted_result.eq(otfc_response["result"])
-            return {"result": adjusted_result, "zero_rem": zero_rem}
+                    return {"result": adjusted_result, "zero_rem": zero_rem}
 
         return m

--- a/coreblocks/func_blocks/fu/fpu/dr_division.py
+++ b/coreblocks/func_blocks/fu/fpu/dr_division.py
@@ -112,10 +112,10 @@ class DrDivModule(Elaboratable):
         otfc_response = Signal(from_method_layout(otfc.method_layouts.otfc_result_out_layout))
         qsf_response = Signal(from_method_layout(qsf.method_layouts.qsf_out_layout))
 
-        with m.FSM(init="Idle") as fsm:
+        with m.FSM(init="Idle"):
             with m.State("Idle"):
 
-                @def_method(m, self.div_init, ready=fsm.ongoing("Idle"))
+                @def_method(m, self.div_init)
                 def _(x, d):
                     m.d.sync += divisor.eq(d)
                     m.d.sync += residual.eq(x)
@@ -175,7 +175,7 @@ class DrDivModule(Elaboratable):
                     m.next = "Result"
             with m.State("Result"):
 
-                @def_method(m, self.div_result, ready=fsm.ongoing("Result"))
+                @def_method(m, self.div_result)
                 def _():
                     zero_rem = Signal()
                     adjusted_result = Signal(self.div_params.result_fractional_bits)

--- a/test/func_blocks/fu/fpu/test_dr_division.py
+++ b/test/func_blocks/fu/fpu/test_dr_division.py
@@ -1,0 +1,31 @@
+from coreblocks.func_blocks.fu.fpu.dr_division import *
+from coreblocks.func_blocks.fu.fpu.qsf_tables import R4A2RED_PARAMS
+from transactron.testing import *
+from amaranth import *
+
+
+# x = int("1011010011", 2)
+# d = int("1110110011", 2)
+
+
+class TestDRDivision(TestCaseWithSimulator):
+    def test_manual(self):
+        params = DrDivParams(iterations=5, op_width=10, result_width=14)
+        drd = SimpleTestCircuit(DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS))
+
+        async def tests(sim: TestbenchContext):
+            input_dict = {}
+            input_dict["x"] = 2**9
+            input_dict["d"] = 2**9
+            print(input_dict["x"])
+            print(input_dict["d"])
+            await drd.div_init.call(sim, input_dict)
+            resp = await drd.div_result.call(sim)
+            assert resp["result"] == (2 ** (10 + 2))
+            assert resp["zero_rem"] == 1
+
+        async def test_process(sim: TestbenchContext):
+            await tests(sim)
+
+        with self.run_simulation(drd) as sim:
+            sim.add_testbench(test_process)

--- a/test/func_blocks/fu/fpu/test_dr_division.py
+++ b/test/func_blocks/fu/fpu/test_dr_division.py
@@ -15,31 +15,40 @@ class TCase:
 
 class TestDRDivision(TestCaseWithSimulator):
     def test_manual(self):
-        params = DrDivParams(iterations=5, op_width=10, result_width=14)
-        drd = SimpleTestCircuit(DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS))
+        params = DrDivParams(
+            iterations=5, op_width=10, result_width=14 + 1
+        )  # fractional + one integer bit
+        drd = SimpleTestCircuit(
+            DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS)
+        )
 
         async def tests(sim: TestbenchContext):
             input_dict = {}
             test_cases = [
-                TCase(2**9, 2**9, 2**12, 1),
+                TCase(2**9, 2**9, int("1000000000000", 2), 1),
                 TCase(
                     int("1001011010", 2),
                     int("1101011101", 2),
                     int("101100101111", 2),
                     0,
                 ),
-                TCase(int("1011010011"), int("1110110011", 2), int("110000110110", 2), 0),
+                TCase(
+                    int("1011010011", 2),
+                    int("1110110011", 2),
+                    int("110000110110", 2),
+                    0,
+                ),
             ]
             for tc in test_cases:
-                input_dict["x"] = tc["x"]
-                input_dict["d"] = tc["d"]
+                input_dict["x"] = tc.x
+                input_dict["d"] = tc.d
                 print("TC")
                 print(input_dict["x"])
                 print(input_dict["d"])
                 await drd.div_init.call(sim, input_dict)
                 resp = await drd.div_result.call(sim)
-                assert resp["result"] == tc["result"]
-                assert resp["zero_rem"] == tc["zero_rem"]
+                assert resp["result"] == tc.result
+                assert resp["zero_rem"] == tc.zero_rem
 
         async def test_process(sim: TestbenchContext):
             await tests(sim)

--- a/test/func_blocks/fu/fpu/test_dr_division.py
+++ b/test/func_blocks/fu/fpu/test_dr_division.py
@@ -2,10 +2,15 @@ from coreblocks.func_blocks.fu.fpu.dr_division import *
 from coreblocks.func_blocks.fu.fpu.qsf_tables import R4A2RED_PARAMS
 from transactron.testing import *
 from amaranth import *
+from dataclasses import dataclass
 
 
-# x = int("1011010011", 2)
-# d = int("1110110011", 2)
+@dataclass
+class TCase:
+    x: int
+    d: int
+    result: int
+    zero_rem: int
 
 
 class TestDRDivision(TestCaseWithSimulator):
@@ -15,14 +20,26 @@ class TestDRDivision(TestCaseWithSimulator):
 
         async def tests(sim: TestbenchContext):
             input_dict = {}
-            input_dict["x"] = 2**9
-            input_dict["d"] = 2**9
-            print(input_dict["x"])
-            print(input_dict["d"])
-            await drd.div_init.call(sim, input_dict)
-            resp = await drd.div_result.call(sim)
-            assert resp["result"] == (2 ** (10 + 2))
-            assert resp["zero_rem"] == 1
+            test_cases = [
+                TCase(2**9, 2**9, 2**12, 1),
+                TCase(
+                    int("1001011010", 2),
+                    int("1101011101", 2),
+                    int("101100101111", 2),
+                    0,
+                ),
+                TCase(int("1011010011"), int("1110110011", 2), int("110000110110", 2), 0),
+            ]
+            for tc in test_cases:
+                input_dict["x"] = tc["x"]
+                input_dict["d"] = tc["d"]
+                print("TC")
+                print(input_dict["x"])
+                print(input_dict["d"])
+                await drd.div_init.call(sim, input_dict)
+                resp = await drd.div_result.call(sim)
+                assert resp["result"] == tc["result"]
+                assert resp["zero_rem"] == tc["zero_rem"]
 
         async def test_process(sim: TestbenchContext):
             await tests(sim)

--- a/test/func_blocks/fu/fpu/test_dr_division.py
+++ b/test/func_blocks/fu/fpu/test_dr_division.py
@@ -16,11 +16,11 @@ class TCase:
 class TestDRDivision(TestCaseWithSimulator):
     def test_manual(self):
         params = DrDivParams(
-            iterations=5, op_width=10, result_width=14 + 1
-        )  # fractional + one integer bit
-        drd = SimpleTestCircuit(
-            DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS)
+            iterations=7,
+            fractional_bits=10,
+            result_fractional_bits=14,
         )
+        drd = SimpleTestCircuit(DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS))
 
         async def tests(sim: TestbenchContext):
             input_dict = {}
@@ -42,9 +42,6 @@ class TestDRDivision(TestCaseWithSimulator):
             for tc in test_cases:
                 input_dict["x"] = tc.x
                 input_dict["d"] = tc.d
-                print("TC")
-                print(input_dict["x"])
-                print(input_dict["d"])
                 await drd.div_init.call(sim, input_dict)
                 resp = await drd.div_result.call(sim)
                 assert resp["result"] == tc.result

--- a/test/func_blocks/fu/fpu/test_dr_division.py
+++ b/test/func_blocks/fu/fpu/test_dr_division.py
@@ -20,9 +20,7 @@ class TestDRDivision(TestCaseWithSimulator):
             fractional_bits=10,
             result_fractional_bits=14,
         )
-        drd = SimpleTestCircuit(
-            DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS)
-        )
+        drd = SimpleTestCircuit(DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS))
 
         async def tests(sim: TestbenchContext):
             input_dict = {}

--- a/test/func_blocks/fu/fpu/test_dr_division.py
+++ b/test/func_blocks/fu/fpu/test_dr_division.py
@@ -20,22 +20,24 @@ class TestDRDivision(TestCaseWithSimulator):
             fractional_bits=10,
             result_fractional_bits=14,
         )
-        drd = SimpleTestCircuit(DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS))
+        drd = SimpleTestCircuit(
+            DrDivModule(div_params=params, qsf_params=R4A2RED_PARAMS)
+        )
 
         async def tests(sim: TestbenchContext):
             input_dict = {}
             test_cases = [
-                TCase(2**9, 2**9, int("1000000000000", 2), 1),
+                TCase(0b1000000000, 0b1000000000, 0b1000000000000, 1),
                 TCase(
-                    int("1001011010", 2),
-                    int("1101011101", 2),
-                    int("101100101111", 2),
+                    0b1001011010,
+                    0b1101011101,
+                    0b101100101111,
                     0,
                 ),
                 TCase(
-                    int("1011010011", 2),
-                    int("1110110011", 2),
-                    int("110000110110", 2),
+                    0b1011010011,
+                    0b1110110011,
+                    0b110000110110,
                     0,
                 ),
             ]


### PR DESCRIPTION
Radix-4 division by digit-recurrence algorithm (precisely its SRT variant). This algorithm works on floating-point numbers that are greater than or equal to `1/2` and less than `1` (basically, the normalization bit is at $2^{−1}$ rather than at $2^0$, as is the case for IEEE floats). 

The implementation is based on `Digital Arithmetic` by `Miloš D. Ercegovac` and `Tomás Lang`.

TODO:

- [x]  Add more comments to explain the algorithm
- [x] Add more tests from the book
- [x] Add test that gonna result in negative residual to test the quotient correction
- [x] Refactor parts of code
- [x] Change the body of division to FSM