### PR TITLE
Add and use test exit CSR for asm tests

### DIFF
--- a/coreblocks/arch/csr_address.py
+++ b/coreblocks/arch/csr_address.py
@@ -444,6 +444,8 @@ class CSRAddress(IntEnum, shape=12):
 
     # CSR for custom communication with testbenches
     COREBLOCKS_TEST_CSR = 0x7FF
+    # CSR for signalling end of test in testbenches
+    COREBLOCKS_TEST_EXIT_CSR = 0x8FE
     # CSR providing writable current privilege mode (U-mode accesible)
     COREBLOCKS_TEST_PRIV_MODE = 0x8FF
 

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -544,6 +544,7 @@ class CSRInstances(Elaboratable):
 
         if gen_params._generate_test_hardware:
             self.csr_coreblocks_test = CSRRegister(CSRAddress.COREBLOCKS_TEST_CSR, gen_params)
+            self.csr_coreblocks_test_exit = CSRRegister(CSRAddress.COREBLOCKS_TEST_EXIT_CSR, gen_params)
 
         self.time = CSRRegister(
             CSRAddress.TIME,
@@ -566,6 +567,7 @@ class CSRInstances(Elaboratable):
 
         if self.gen_params._generate_test_hardware:
             m.submodules.csr_coreblocks_test = self.csr_coreblocks_test
+            m.submodules.csr_coreblocks_test_exit = self.csr_coreblocks_test_exit
 
         # TIME CSR is a R/O alias to Memory-Mapped `mtime` value (from clint). If `mtime` is not available,
         # then fallback to providing a cycle counter source.

--- a/test/asm/csr.asm
+++ b/test/asm/csr.asm
@@ -3,5 +3,7 @@ rdinstret x1
 nop
 nop
 rdinstret x2
-end:
-j end
+
+pass:
+csrw 0x8fe, 0x10
+j pass

--- a/test/asm/csr_mmode.asm
+++ b/test/asm/csr_mmode.asm
@@ -20,8 +20,9 @@ next:
     # test writable CSRs
     csrw mscratch, 4
     csrr x6, mscratch
-infloop:
-    j infloop
+pass:
+    csrw 0x8fe, 0x10
+    j pass
 
 exception_handler:
    addi x15, x15, -1 # count exceptions

--- a/test/asm/exception.asm
+++ b/test/asm/exception.asm
@@ -2,3 +2,7 @@ li x2, 2
 li x1, 1
 .4byte 0  /* should be unimp, but it would test nothing since unimp is system and stalls the fetcher >:( */
 li x2, 9
+
+pass:
+csrw 0x8fe, 0x10
+j pass

--- a/test/asm/exception_handler.asm
+++ b/test/asm/exception_handler.asm
@@ -37,8 +37,9 @@ rob_loop:
 
     li x11, 0xaaaa # verify exception return
 
-infloop:
-    j infloop
+pass:
+    csrw 0x8fe, 0x10
+    j pass
 
 exception_handler:
    mv x6, x2

--- a/test/asm/exception_mem.asm
+++ b/test/asm/exception_mem.asm
@@ -9,5 +9,9 @@ sw x2, 4(x0)
 sw x1, 4(x0)  /* TODO: actually check the side fx */
 li x2, 9
 
+pass:
+csrw 0x8fe, 0x10
+j pass
+
 .section .bss
 .skip 0x8

--- a/test/asm/fibonacci.asm
+++ b/test/asm/fibonacci.asm
@@ -5,5 +5,7 @@ loop:
     mv x1, x2
     mv x2, x3
     bne x2, x4, loop
-infloop:
-    j infloop
+
+pass:
+    csrw 0x8fe, 0x10
+    j pass

--- a/test/asm/interrupt.asm
+++ b/test/asm/interrupt.asm
@@ -23,8 +23,9 @@ loop:
     mv x1, x2
     mv x2, x3
     bne x2, x4, loop
-infloop:
-    j infloop
+pass:
+    csrwi 0x8fe, 0x10
+    j pass
 
 int_handler:
     # save main loop register state
@@ -94,6 +95,7 @@ skip:
 
 fail:
     csrwi 0x7ff, 2
+    csrwi 0x8fe, 0x12
     j fail
 
 

--- a/test/asm/interrupt_vectored.asm
+++ b/test/asm/interrupt_vectored.asm
@@ -33,8 +33,9 @@ loop:
     mv x1, x2
     mv x2, x3
     bne x2, x4, loop
-infloop:
-    j infloop
+pass:
+    csrwi 0x8fe, 0x10
+    j pass
 
 int0_handler:
     # save main loop register state
@@ -110,6 +111,7 @@ ecall_handler:
 
 fail:
     csrwi 0x7ff, 2
+    csrwi 0x8fe, 0x12
     j fail
 
 .org 0x200

--- a/test/asm/mtval.asm
+++ b/test/asm/mtval.asm
@@ -29,6 +29,7 @@ c9: # mtval=0 mcause=ENVIRONMENT_CALL_FROM_M
     ecall
 
 pass:
+    csrw 0x8fe, 0x10
     j pass
 
 
@@ -55,6 +56,7 @@ handler: # test each case. test case number = in x8>>2
     mret
 
 fail:
+    csrw 0x8fe, 0x12
     j fail
 
 # it is legal - C is enabled in core, but can't be enabled in toolchain to keep 4-byte nops

--- a/test/asm/plic.asm
+++ b/test/asm/plic.asm
@@ -213,8 +213,10 @@ bne x1, x0, fail  # no plic irqs pending
 
 pass:
 li x31, 0xcafe
+csrwi 0x8fe, 0x10
 1:
 j 1b
 
 fail:
+csrwi 0x8fe, 0x12
 j fail

--- a/test/asm/pmp_fetch.asm
+++ b/test/asm/pmp_fetch.asm
@@ -27,8 +27,10 @@ trap_handler:
     j pass
 
 fail:
+    csrw 0x8fe, 0x12
     j fail
 
 pass:
     li x1, 1
+    csrw 0x8fe, 0x10
     j pass

--- a/test/asm/pmp_lsu.asm
+++ b/test/asm/pmp_lsu.asm
@@ -29,8 +29,10 @@ trap_handler:
     j pass
 
 fail:
+    csrw 0x8fe, 0x12
     j fail
 
 pass:
     li x1, 1
+    csrw 0x8fe, 0x10
     j pass

--- a/test/asm/smode_interrupt.asm
+++ b/test/asm/smode_interrupt.asm
@@ -71,7 +71,9 @@ machine_trap:
     li x31, 0xae
 
 fail:
+    csrw 0x8fe, 0x12
     j fail
 
 pass:
+    csrw 0x8fe, 0x10
     j pass

--- a/test/asm/socks_clint.asm
+++ b/test/asm/socks_clint.asm
@@ -52,10 +52,12 @@ t2c:
 
 fail:
     sw x0, (x0)
+    csrw 0x8fe, 0x12
     j fail
 
 pass:
     li x8, 1
+    csrw 0x8fe, 0x10
     j pass
 
 trap_handler:

--- a/test/asm/user_mode.asm
+++ b/test/asm/user_mode.asm
@@ -51,9 +51,11 @@ user_code4:
     j fail
 
 fail:
+    csrwi 0x8fe, 0x12
     j fail
 
 pass:
+    csrwi 0x8fe, 0x10
     j pass
 
 set_mpp_umode:

--- a/test/asm/wfi_int.asm
+++ b/test/asm/wfi_int.asm
@@ -13,8 +13,10 @@ _start:
 loop:
     wfi
     beq x2, x3, loop
-infloop:
-    j infloop
+
+pass:
+    csrw 0x8fe, 0x10
+    j pass
 
 handler:
     addi x30, x30, 1

--- a/test/asm/wfi_no_mie.asm
+++ b/test/asm/wfi_no_mie.asm
@@ -17,10 +17,12 @@ _start:
     j pass
 
 fail:
+    csrwi 0x8fe, 0x12
     j fail
 
 pass:
     li x8, 8
+    csrwi 0x8fe, 0x10
     j pass
 
 trap_handler:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -26,6 +26,9 @@ from parameterized import parameterized_class
 
 from transactron.utils.dependencies import DependencyContext
 
+TEST_EXIT_SUCCESS = 0x10
+TEST_EXIT_FAILURE = 0x12
+
 
 class CoreTestElaboratable(Elaboratable):
     def __init__(
@@ -75,6 +78,9 @@ class TestCoreBase(TestCaseWithSimulator):
     gen_params: GenParams
     m: CoreTestElaboratable
 
+    def setup_method(self):
+        self.configuration = self.configuration.replace(_generate_test_hardware=True)
+
     def get_phys_reg_rrat(self, sim: TestbenchContext, reg_id):
         # TODO: abstract memories don't implement MemoryData, but standard lib.Memory used in tests
         return sim.get(self.m.core.RRAT.entries.mem.data[reg_id])  # type: ignore
@@ -85,6 +91,9 @@ class TestCoreBase(TestCaseWithSimulator):
 
 class TestCoreAsmSourceBase(TestCoreBase):
     base_dir: str = "test/asm/"
+    cycle_count: int
+    expected_regvals: dict[int, int]
+    exit_csr: bool = True
 
     def prepare_source(self, filename, *, c_extension=False):
         with (
@@ -143,39 +152,55 @@ class TestCoreAsmSourceBase(TestCoreBase):
 
             return {"text": load_section(".text"), "data": load_section(".data")}
 
+    async def wait_or_timeout(self, sim: TestbenchContext, cond: ValueLike, pred: Callable[[Any], bool]):
+        ticks = DependencyContext.get().get_dependency(TicksKey())
+
+        async for *_, value in sim.tick().sample(cond):
+            if pred(value):
+                return True
+            if sim.get(ticks) >= self.cycle_count:
+                return False
+
+        return False
+
+    async def run_and_check(self, sim: TestbenchContext):
+        success = await self.wait_or_timeout(
+            sim, self.m.core.csr_instances.csr_coreblocks_test_exit.value, lambda value: value != 0
+        )
+
+        if self.exit_csr:
+            assert (
+                sim.get(self.m.core.csr_instances.csr_coreblocks_test_exit.value) == TEST_EXIT_SUCCESS
+            ), f"Bad exit CSR, timeout:{not success}"
+
+        for reg_id, val in self.expected_regvals.items():
+            assert self.get_arch_reg_val(sim, reg_id) == val, "Bad register value"
+
 
 @parameterized_class(
-    ("name", "source_file", "cycle_count", "expected_regvals", "configuration"),
+    ("name", "source_file", "cycle_count", "expected_regvals", "exit_csr", "configuration"),
     [
-        ("fibonacci", "fibonacci.asm", 500, {2: 2971215073}, configurations.basic),
-        ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, configurations.basic),
-        ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, configurations.tiny),
-        ("csr", "csr.asm", 200, {1: 1, 2: 4}, configurations.full),
-        ("csr_mmode", "csr_mmode.asm", 1000, {1: 0, 2: 44, 3: 0, 4: 0, 5: 0, 6: 4, 15: 0}, configurations.full),
-        ("exception", "exception.asm", 200, {1: 1, 2: 2}, configurations.basic),
-        ("exception_mem", "exception_mem.asm", 200, {1: 1, 2: 2}, configurations.basic),
-        ("exception_handler", "exception_handler.asm", 2000, {2: 987, 11: 0xAAAA, 15: 16}, configurations.full),
-        ("wfi_no_int", "wfi_no_int.asm", 200, {1: 1}, configurations.full),
-        ("mtval", "mtval.asm", 2000, {8: 5 * 8}, configurations.full),
-        ("socks_clint", "socks_clint.asm", 1200, {2: 5, 8: 1}, configurations.basic),
-        ("socks_plic", "plic.asm", 1000, {31: 0xCAFE}, configurations.basic),
-        ("pmp_fetch", "pmp_fetch.asm", 1000, {1: 1}, configurations.full),
-        ("pmp_lsu", "pmp_lsu.asm", 1000, {1: 1}, configurations.full),
-        ("smode_exception", "smode_exception.asm", 800, {5: 1, 6: 1, 7: 1, 8: 1}, configurations.full),
+        ("fibonacci", "fibonacci.asm", 500, {2: 2971215073}, True, configurations.basic),
+        ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, False, configurations.basic),
+        ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, False, configurations.tiny),
+        ("csr", "csr.asm", 200, {1: 1, 2: 4}, True, configurations.full),
+        ("csr_mmode", "csr_mmode.asm", 1000, {1: 0, 2: 44, 3: 0, 4: 0, 5: 0, 6: 4, 15: 0}, True, configurations.full),
+        ("exception", "exception.asm", 200, {1: 1, 2: 2}, False, configurations.basic),
+        ("exception_mem", "exception_mem.asm", 200, {1: 1, 2: 2}, False, configurations.basic),
+        ("exception_handler", "exception_handler.asm", 2000, {2: 987, 11: 0xAAAA, 15: 16}, False, configurations.full),
+        ("wfi_no_int", "wfi_no_int.asm", 200, {1: 1}, False, configurations.full),
+        ("mtval", "mtval.asm", 2000, {8: 5 * 8}, True, configurations.full),
+        ("socks_clint", "socks_clint.asm", 1200, {2: 5, 8: 1}, True, configurations.basic),
+        ("socks_plic", "plic.asm", 1000, {31: 0xCAFE}, True, configurations.basic),
+        ("pmp_fetch", "pmp_fetch.asm", 1000, {1: 1}, True, configurations.full),
+        ("pmp_lsu", "pmp_lsu.asm", 1000, {1: 1}, True, configurations.full),
+        ("smode_exception", "smode_exception.asm", 800, {5: 1, 6: 1, 7: 1, 8: 1}, False, configurations.full),
     ],
 )
 class TestCoreBasicAsm(TestCoreAsmSourceBase):
     name: str
     source_file: str
-    cycle_count: int
-    expected_regvals: dict[int, int]
     configuration: CoreConfiguration
-
-    async def run_and_check(self, sim: TestbenchContext):
-        await self.tick(sim, self.cycle_count)
-
-        for reg_id, val in self.expected_regvals.items():
-            assert self.get_arch_reg_val(sim, reg_id) == val
 
     def test_asm_source(self):
         bin_src = self.prepare_source(self.source_file)
@@ -199,7 +224,7 @@ class TestCoreBasicAsm(TestCoreAsmSourceBase):
 # test interrupts with varying triggering frequency (parametrizable amount of cycles between
 # returning from an interrupt and triggering it again with 'lo' and 'hi' parameters)
 @parameterized_class(
-    ("source_file", "main_cycle_count", "start_regvals", "expected_regvals", "lo", "hi", "edge_only"),
+    ("source_file", "cycle_count", "start_regvals", "expected_regvals", "lo", "hi", "edge_only"),
     [
         (
             "interrupt.asm",
@@ -228,9 +253,7 @@ class TestCoreBasicAsm(TestCoreAsmSourceBase):
 )
 class TestCoreInterrupt(TestCoreAsmSourceBase):
     source_file: str
-    main_cycle_count: int
     start_regvals: dict[int, int]
-    expected_regvals: dict[int, int]
     lo: int
     hi: int
     edge_only: bool
@@ -278,7 +301,7 @@ class TestCoreInterrupt(TestCoreAsmSourceBase):
             return count
 
         early_interrupt = False
-        while main_cycles < self.main_cycle_count or early_interrupt:
+        while main_cycles < self.cycle_count or early_interrupt:
             if not early_interrupt:
                 # run main code for some semi-random amount of cycles
                 c = random.randrange(self.lo, self.hi)
@@ -310,8 +333,7 @@ class TestCoreInterrupt(TestCoreAsmSourceBase):
         assert self.get_arch_reg_val(sim, 30) == int_count
         assert self.get_arch_reg_val(sim, 27) == handler_count
 
-        for reg_id, val in self.expected_regvals.items():
-            assert self.get_arch_reg_val(sim, reg_id) == val
+        await self.run_and_check(sim)
 
     def test_interrupted_prog(self):
         bin_src = self.prepare_source(self.source_file)
@@ -332,8 +354,6 @@ class TestCoreInterrupt(TestCoreAsmSourceBase):
 )
 class TestCoreInterruptOnPrivMode(TestCoreAsmSourceBase):
     source_file: str
-    cycle_count: int
-    expected_regvals: dict[int, int]
     always_mmode: bool
 
     def setup_method(self):
@@ -347,12 +367,7 @@ class TestCoreInterruptOnPrivMode(TestCoreAsmSourceBase):
         ticks = DependencyContext.get().get_dependency(TicksKey())
 
         # wait for interrupt enable
-        async def wait_or_timeout(cond: ValueLike, pred: Callable[[Any], bool]):
-            async for *_, value in sim.tick().sample(cond):
-                if pred(value) or sim.get(ticks) >= self.cycle_count:
-                    break
-
-        await wait_or_timeout(self.m.core.interrupt_controller.mie.value, lambda value: value != 0)
+        await self.wait_or_timeout(sim, self.m.core.interrupt_controller.mie.value, lambda value: value != 0)
         await self.random_wait(sim, 5)
 
         while sim.get(ticks) < self.cycle_count:
@@ -363,21 +378,20 @@ class TestCoreInterruptOnPrivMode(TestCoreAsmSourceBase):
                 continue
 
             # wait for the interrupt to get registered
-            await wait_or_timeout(
-                self.m.core.csr_instances.m_mode.priv_mode.value, lambda value: value == PrivilegeLevel.MACHINE
+            await self.wait_or_timeout(
+                sim, self.m.core.csr_instances.m_mode.priv_mode.value, lambda value: value == PrivilegeLevel.MACHINE
             )
 
             sim.set(self.m.interrupt_level, 0)
 
             # wait until ISR returns
-            await wait_or_timeout(
-                self.m.core.csr_instances.m_mode.priv_mode.value, lambda value: value != PrivilegeLevel.MACHINE
+            await self.wait_or_timeout(
+                sim, self.m.core.csr_instances.m_mode.priv_mode.value, lambda value: value != PrivilegeLevel.MACHINE
             )
 
             await self.random_wait(sim, 5)
 
-        for reg_id, val in self.expected_regvals.items():
-            assert self.get_arch_reg_val(sim, reg_id) == val
+        await self.run_and_check(sim)
 
     def test_interrupted_prog(self):
         bin_src = self.prepare_source(self.source_file)
@@ -404,19 +418,13 @@ class TestCoreSModeInterruptDelegation(TestCoreAsmSourceBase):
         ticks = DependencyContext.get().get_dependency(TicksKey())
 
         # Wait until software transitions into supervisor mode and enables delegated interrupt source.
-        for _ in range(self.cycle_count):
-            if sim.get(self.m.core.csr_instances.m_mode.priv_mode.value) == PrivilegeLevel.SUPERVISOR:
-                break
-            await sim.tick()
-        else:
-            assert False, "Timed out waiting to enter supervisor mode"
+        success = await self.wait_or_timeout(
+            sim, self.m.core.csr_instances.m_mode.priv_mode.value, lambda value: value == PrivilegeLevel.SUPERVISOR
+        )
+        assert success, "Timed out waiting to enter supervisor mode"
 
-        for _ in range(self.cycle_count):
-            if sim.get(self.m.core.interrupt_controller.sie.value) != 0:
-                break
-            await sim.tick()
-        else:
-            assert False, "Timed out waiting for delegated supervisor interrupt enable"
+        success = await self.wait_or_timeout(sim, self.m.core.interrupt_controller.sie.value, lambda value: value != 0)
+        assert success, "Timed out waiting for delegated supervisor interrupt enable"
 
         sim.set(self.m.interrupt_level, 1)
 
@@ -428,11 +436,7 @@ class TestCoreSModeInterruptDelegation(TestCoreAsmSourceBase):
 
         sim.set(self.m.interrupt_level, 0)
 
-        while sim.get(ticks) < self.cycle_count:
-            await sim.tick()
-
-        for reg_id, val in self.expected_regvals.items():
-            assert self.get_arch_reg_val(sim, reg_id) == val
+        await self.run_and_check(sim)
 
     def test_smode_delegated_interrupt(self):
         bin_src = self.prepare_source(self.source_file)


### PR DESCRIPTION
This is intended to address #822 . Not sure it saves much actual execution time currently.

There's a bunch of refactoring in here to make these tests more homogenous, I'm sure there could be a bunch more later.

Some tests can't use CSR for various reasons: they effectively halt the CPU, tiny config doesn't have CSRs, and whatever is currently going on with the PMP.