### PR TITLE
Transactron 0.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
   run-regression-tests:
     name: Run regression tests (riscv-tests)
     runs-on: ubuntu-22.04  # older version for compatibility with Docker image
-    timeout-minutes: 45
+    timeout-minutes: 60
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
     needs: [ build-regression-tests, build-core ]
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "amaranth-stubs~=0.5.0.0",
     "amaranth-yosys==0.40.0.0.post100",
     "dataclasses-json==0.6.3",
-    "transactron~=0.8.0",
+    "transactron @ git+https://github.com/kuznia-rdzeni/transactron.git",
 ]
 license = "BSD-3-Clause"
 license-files = [ "LICENSE" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "amaranth-stubs~=0.5.0.0",
     "amaranth-yosys==0.40.0.0.post100",
     "dataclasses-json==0.6.3",
-    "transactron @ git+https://github.com/kuznia-rdzeni/transactron.git",
+    "transactron==0.9.0",
 ]
 license = "BSD-3-Clause"
 license-files = [ "LICENSE" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "amaranth-stubs~=0.5.0.0",
     "amaranth-yosys==0.40.0.0.post100",
     "dataclasses-json==0.6.3",
-    "transactron==0.9.0",
+    "transactron~=0.9.0",
 ]
 license = "BSD-3-Clause"
 license-files = [ "LICENSE" ]


### PR DESCRIPTION
This PR will update Transactron to 0.9, after its release. For now, it's to verify if CI passes after Transactron changes.