### PR TITLE
Use OneHotMux where appropriate

### DIFF
--- a/coreblocks/cache/icache.py
+++ b/coreblocks/cache/icache.py
@@ -10,9 +10,8 @@ from transactron.core import def_method, Priority, TModule
 from transactron import Method, Transaction
 from coreblocks.params import ICacheParameters
 from coreblocks.interface.layouts import ICacheLayouts
-from transactron.utils import assign, OneHotSwitchDynamic
+from transactron.utils import OneHotMux, assign, logging
 from transactron.lib import *
-from transactron.utils import logging
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
 
 from coreblocks.cache.iface import CacheInterface, CacheRefillerInterface
@@ -198,8 +197,7 @@ class ICache(Elaboratable, CacheInterface):
                 m.d.comb += forwarding_response_now.eq(1)
                 self.perf_hits.incr(m, enable_call=tag_hit_any)
                 mem_out = Signal(self.params.fetch_block_bytes * 8)
-                for i in OneHotSwitchDynamic(m, Cat(tag_hit)):
-                    m.d.av_comb += mem_out.eq(self.mem.data_rd_data[i])
+                m.d.av_comb += mem_out.eq(OneHotMux.create(m, zip(tag_hit, self.mem.data_rd_data)))
 
                 req_zipper.write_results(m, fetch_block=mem_out, error=refill_error_saved)
                 m.d.sync += refill_error_saved.eq(0)

--- a/coreblocks/peripherals/wishbone.py
+++ b/coreblocks/peripherals/wishbone.py
@@ -7,7 +7,7 @@ import operator
 from transactron import Method, def_method, TModule
 from transactron.core import Transaction
 from transactron.lib import AdapterTrans, BasicFifo
-from transactron.utils import OneHotSwitchDynamic, assign, RoundRobin
+from transactron.utils import OneHotMux, assign, RoundRobin
 from transactron.utils.amaranth_ext.component_interface import ComponentInterface, CIn, COut
 from transactron.lib.connectors import Forwarder
 from transactron.utils.transactron_helpers import make_layout
@@ -373,11 +373,12 @@ class WishboneMuxer(Component):
         m.d.comb += self.master_wb.ack.eq(reduce(operator.or_, [self.slaves[i].ack for i in range(len(self.slaves))]))
         m.d.comb += self.master_wb.err.eq(reduce(operator.or_, [self.slaves[i].err for i in range(len(self.slaves))]))
         m.d.comb += self.master_wb.rty.eq(reduce(operator.or_, [self.slaves[i].rty for i in range(len(self.slaves))]))
-        for i in OneHotSwitchDynamic(m, self.sselTGA):
-            # mux S->M data
-            # workaround for the lack of selective connecting in wiring
-            for n in ["dat_r", "stall"]:
-                m.d.comb += getattr(self.master_wb, n).eq(getattr(self.slaves[i], n))
+        # mux S->M data
+        # workaround for the lack of selective connecting in wiring
+        for n in ["dat_r", "stall"]:
+            m.d.comb += getattr(self.master_wb, n).eq(
+                OneHotMux.create(m, [(i, getattr(self.slaves[i], n)) for i in range(len(self.slaves))])
+            )
         return m
 
 

--- a/coreblocks/peripherals/wishbone.py
+++ b/coreblocks/peripherals/wishbone.py
@@ -377,7 +377,7 @@ class WishboneMuxer(Component):
         # workaround for the lack of selective connecting in wiring
         for n in ["dat_r", "stall"]:
             m.d.comb += getattr(self.master_wb, n).eq(
-                OneHotMux.create(m, [(i, getattr(self.slaves[i], n)) for i in range(len(self.slaves))])
+                OneHotMux.create(m, [(self.sselTGA[i], getattr(self.slaves[i], n)) for i in range(len(self.slaves))])
             )
         return m
 

--- a/coreblocks/priv/pmp.py
+++ b/coreblocks/priv/pmp.py
@@ -3,7 +3,7 @@ from amaranth.lib import data
 from amaranth.lib.enum import Enum, auto, unique
 from amaranth_types import HasElaborate
 from transactron.core import TModule
-from transactron.utils import DependencyContext, assign
+from transactron.utils import DependencyContext, OneHotMux, assign
 
 from coreblocks.arch.isa_consts import PMPAFlagEncoding, PMPCfgLayout, PrivilegeLevel
 from coreblocks.interface.keys import CSRInstancesKey
@@ -78,9 +78,9 @@ class PMPChecker(Elaboratable):
         with m.If(effective_priv_mode == PrivilegeLevel.MACHINE):
             m.d.comb += self.result.eq(PMPLayout().const({"r": 1, "w": 1, "x": 1}))
 
-        entry_matches = []
-        cfgs = []
-        addr_vals = []
+        entry_matches: list[Value] = []
+        cfgs: list[data.View] = []
+        addr_vals: list[Value] = []
 
         for i in range(n):
             cfg_val = data.View(PMPCfgLayout(), self.csr.pmpxcfg[i].value)
@@ -116,20 +116,9 @@ class PMPChecker(Elaboratable):
 
             entry_matches.append(entry_match)
 
-        matches = Cat(entry_matches)
-        one_hot = matches & (~matches + 1)
+        selected = OneHotMux.create(m, [(match, cfg) for match, cfg in zip(entry_matches, cfgs)], priority=True)
 
-        r_bits = Cat(cfg.R for cfg in cfgs)
-        w_bits = Cat(cfg.W for cfg in cfgs)
-        x_bits = Cat(cfg.X for cfg in cfgs)
-        l_bits = Cat(cfg.L for cfg in cfgs)
-
-        selected_r = (one_hot & r_bits).any()
-        selected_w = (one_hot & w_bits).any()
-        selected_x = (one_hot & x_bits).any()
-        selected_l = (one_hot & l_bits).any()
-
-        with m.If(matches.any() & ((effective_priv_mode != PrivilegeLevel.MACHINE) | selected_l)):
-            m.d.comb += assign(self.result, {"r": selected_r, "w": selected_w, "x": selected_x})
+        with m.If((effective_priv_mode != PrivilegeLevel.MACHINE) | selected.L):
+            m.d.comb += assign(self.result, {"r": selected.R, "w": selected.W, "x": selected.X})
 
         return m

--- a/coreblocks/priv/pmp.py
+++ b/coreblocks/priv/pmp.py
@@ -116,7 +116,7 @@ class PMPChecker(Elaboratable):
 
             entry_matches.append(entry_match)
 
-        selected = OneHotMux.create(m, [(match, cfg) for match, cfg in zip(entry_matches, cfgs)], priority=True)
+        selected = OneHotMux.create(m, zip(entry_matches, cfgs), priority=True)
 
         with m.If((effective_priv_mode != PrivilegeLevel.MACHINE) | selected.L):
             m.d.comb += assign(self.result, {"r": selected.R, "w": selected.W, "x": selected.X})

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -2,11 +2,11 @@ from collections.abc import Sequence
 
 from amaranth import *
 
+from amaranth.lib.data import View
 from transactron import Method, Methods, Required, Transaction, TModule
 from transactron.lib import Connect, Pipe, WideFifo
-from transactron.utils import logging
 from transactron.lib.metrics import TaggedCounter
-from transactron.utils import OneHotSwitchDynamic, assign, AssignType
+from transactron.utils import OneHotMux, logging, assign, AssignType
 from transactron.utils.dependencies import DependencyContext
 
 from coreblocks.interface.layouts import RATLayouts, RFLayouts, ROBLayouts, RSFullDataLayout, SchedulerLayouts
@@ -387,7 +387,7 @@ class RSInsertion(Elaboratable):
             active_tags = self.crat_active_tags(m)
             rs_entry_id: list[Value] = []
             rs_selected: list[Value] = []
-            rs_datas = []
+            rs_datas: list[View] = []
 
             for i in range(self.gen_params.frontend_superscalarity):
                 instr = instrs.data[i]
@@ -435,12 +435,14 @@ class RSInsertion(Elaboratable):
                     )
                 )
 
+                matched_rs_data = OneHotMux.create(m, [(matches[i], rs_datas[i]) for i in range(len(matches))])
+                matched_entry_id = OneHotMux.create(m, [(matches[i], rs_entry_id[i]) for i in range(len(matches))])
+
                 arg = Signal.like(rs_insert.data_in)
-                for i in OneHotSwitchDynamic(m, matches):
-                    # connect only matching fields
-                    m.d.av_comb += assign(arg.rs_data, rs_datas[i], fields=AssignType.COMMON)
-                    # this assignment truncates signal width from max rs_entry_bits to target RS specific width
-                    m.d.av_comb += arg.rs_entry_id.eq(rs_entry_id[i])
+                # connect only matching fields
+                m.d.av_comb += assign(arg.rs_data, matched_rs_data, fields=AssignType.COMMON)
+                # this assignment truncates signal width from max rs_entry_bits to target RS specific width
+                m.d.av_comb += arg.rs_entry_id.eq(matched_entry_id)
 
                 with m.If(matches.any()):
                     rs_insert(m, arg)


### PR DESCRIPTION
`OneHotMux` is currently more efficient than `OneHotSwitch*`, and it also implements nice FPGA-optimized priority muxing. This PR applies the new functionality where appropriate.