### PR TITLE
Towards fast flush - single cycle RAT overwrite

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -46,18 +46,14 @@ class Retirement(Elaboratable):
             i=gen_params.get(RATLayouts).rrat_commit_in,
             o=gen_params.get(RATLayouts).rrat_commit_out,
         )
-        self.r_rat_peek = Methods(
-            gen_params.retirement_superscalarity,
-            i=gen_params.get(RATLayouts).rrat_peek_in,
+        self.r_rat_peek = Method(
             o=gen_params.get(RATLayouts).rrat_peek_out,
         )
         self.free_rf_put = Methods(gen_params.retirement_superscalarity, i=[("ident", range(gen_params.phys_regs))])
         self.rf_free = Methods(gen_params.retirement_superscalarity, i=gen_params.get(RFLayouts).rf_free)
         self.exception_cause_get = Method(o=gen_params.get(ExceptionRegisterLayouts).get)
         self.exception_cause_clear = Method()
-        self.c_rat_restore = Methods(
-            gen_params.retirement_superscalarity, i=gen_params.get(RATLayouts).crat_flush_restore
-        )
+        self.c_rat_restore = Method(i=gen_params.get(RATLayouts).crat_flush_restore_in)
         self.fetch_continue = Method(i=self.gen_params.get(FetchLayouts).resume)
         self.instr_decrement = Method(
             i=gen_params.get(CoreInstructionCounterLayouts).decrement_in,
@@ -128,14 +124,8 @@ class Retirement(Elaboratable):
             self.perf_instr_ret.incr[i](m)
 
         def flush_instr(i: int, rob_entry: View):
-            # get original rp_dst mapped to instruction rl_dst in R-RAT
-            rat_out = self.r_rat_peek[i](m, rl_dst=rob_entry.rob_data.rl_dst)
-
             # free the "new" instruction rp_dst - result is flushed
             free_phys_reg(i, rob_entry.rob_data.rp_dst)
-
-            # restore original rl_dst->rp_dst mapping in F-RAT
-            self.c_rat_restore[i](m, rl_dst=rob_entry.rob_data.rl_dst, rp_dst=rat_out.old_rp_dst)
 
         retire_valid = Signal()
         exception = Signal()
@@ -283,6 +273,7 @@ class Retirement(Elaboratable):
             with m.State("TRAP_RESUME"):
                 with Transaction(name="Retirement_RESUME").body(m):
                     # Resume core operation
+                    self.c_rat_restore(m, entries=self.r_rat_peek(m).entries)
                     self.perf_trap_latency.stop(m)
 
                     handler_pc = Signal(self.gen_params.isa.xlen)

--- a/coreblocks/core_structs/crat.py
+++ b/coreblocks/core_structs/crat.py
@@ -69,10 +69,9 @@ class CheckpointRAT(Elaboratable):
         # Checkpoint count = 1 is not currently possible because of how retirement freeing works
         assert gen_params.checkpoint_count > 1
 
-        self.frat_layout = ArrayLayout(gen_params.phys_regs_bits, gen_params.isa.reg_cnt)
-        self.frat = Signal(self.frat_layout)
-
         layouts = gen_params.get(RATLayouts)
+        self.frat = Signal(layouts.rat_array)
+
         self.tag = Method(i=layouts.crat_tag_in, o=layouts.crat_tag_out)
         self.commit_checkpoint = Method(i=layouts.crat_commit_checkpoint_in)
         self.rename = Methods(gen_params.frontend_superscalarity, i=layouts.crat_rename_in, o=layouts.crat_rename_out)
@@ -104,7 +103,7 @@ class CheckpointRAT(Elaboratable):
         active_tags = Signal(2**self.gen_params.tag_bits, init=1)
         checkpointed_tags = Signal(2**self.gen_params.tag_bits, init=0)
 
-        storage = MemoryBank(shape=self.frat_layout, depth=self.gen_params.checkpoint_count)
+        storage = MemoryBank(shape=self.frat.shape(), depth=self.gen_params.checkpoint_count)
         tag_map = MemoryBank(
             shape=range(self.gen_params.checkpoint_count),
             depth=2**self.gen_params.tag_bits,

--- a/coreblocks/core_structs/crat.py
+++ b/coreblocks/core_structs/crat.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from amaranth.lib.data import ArrayLayout
+from amaranth.lib.data import ArrayLayout, View
 from amaranth.utils import ceil_log2
 
 from transactron.core import *
@@ -70,12 +70,12 @@ class CheckpointRAT(Elaboratable):
         assert gen_params.checkpoint_count > 1
 
         layouts = gen_params.get(RATLayouts)
-        self.frat = Signal(layouts.rat_array)
+        self.frat = Signal(layouts.entries_shape)
 
         self.tag = Method(i=layouts.crat_tag_in, o=layouts.crat_tag_out)
         self.commit_checkpoint = Method(i=layouts.crat_commit_checkpoint_in)
         self.rename = Methods(gen_params.frontend_superscalarity, i=layouts.crat_rename_in, o=layouts.crat_rename_out)
-        self.flush_restore = Methods(self.gen_params.retirement_superscalarity, i=layouts.crat_flush_restore)
+        self.flush_restore = Method(i=layouts.crat_flush_restore_in)
 
         self.rollback = Method(i=layouts.rollback_in)
         self.dm = DependencyContext.get()
@@ -239,13 +239,10 @@ class CheckpointRAT(Elaboratable):
             storage.write(m, addr=checkpoint, data=self.frat)
 
         # Block until last FRAT overwrite from Rollback is finished.
-        # Retirement restores entries on hard-flushes that were not covered by checkpoints one-by-one, don't overwrite.
-        @def_methods(m, self.flush_restore, ready=lambda _: last_rollback_finished)
-        def _(i: int, rl_dst: Value, rp_dst: Value):
-            with m.If(rl_dst != 0):  # Duplicated, because otherwise causes comb loop in rename condition
-                m.d.comb += active_renames[i].valid.eq(1)
-                m.d.comb += active_renames[i].rl_dst.eq(rl_dst)
-                m.d.comb += active_renames[i].rp_dst.eq(rp_dst)
+        # Retirement restores entries on hard-flushes that were not covered by checkpoints, don't overwrite.
+        @def_method(m, self.flush_restore, ready=last_rollback_finished)
+        def _(entries: View):
+            m.d.sync += self.frat.eq(entries)
 
         for k in range(len(active_renames)):
             with m.If(active_renames[k].valid):

--- a/coreblocks/core_structs/rat.py
+++ b/coreblocks/core_structs/rat.py
@@ -1,6 +1,5 @@
 from amaranth import *
-from transactron import Method, Methods, Transaction, def_method, TModule, def_methods
-from transactron.lib.storage import AsyncMemoryBank
+from transactron import Method, Methods, def_method, TModule, def_methods
 from coreblocks.interface.layouts import RATLayouts
 from coreblocks.params import GenParams
 
@@ -31,38 +30,24 @@ class RRAT(Elaboratable):
     def __init__(self, *, gen_params: GenParams):
         self.gen_params = gen_params
 
-        self.entries = AsyncMemoryBank(
-            shape=self.gen_params.phys_regs_bits,
-            depth=self.gen_params.isa.reg_cnt,
-            read_ports=gen_params.retirement_superscalarity,
-            write_ports=gen_params.retirement_superscalarity,
-        )
-
         layouts = gen_params.get(RATLayouts)
+        self.entries = Signal(layouts.rat_array)
+
         self.commit = Methods(gen_params.retirement_superscalarity, i=layouts.rrat_commit_in, o=layouts.rrat_commit_out)
         self.peek = Methods(gen_params.retirement_superscalarity, i=layouts.rrat_peek_in, o=layouts.rrat_peek_out)
 
     def elaborate(self, platform):
         m = TModule()
-        m.submodules.entries = self.entries
 
-        initialized = Signal()
-        rl_idx = Signal(range(self.gen_params.isa.reg_cnt))
-        with Transaction().body(m, ready=~initialized):
-            self.entries.write[0](m, addr=rl_idx, data=0)
-            m.d.sync += rl_idx.eq(rl_idx + 1)
-            with m.If(rl_idx == self.gen_params.isa.reg_cnt - 1):
-                m.d.sync += initialized.eq(1)
-
-        @def_methods(m, self.commit, ready=lambda _: initialized)
+        @def_methods(m, self.commit)
         def _(i: int, rp_dst: Value, rl_dst: Value):
-            self.entries.write[i](m, addr=rl_dst, data=rp_dst)
+            m.d.sync += self.entries[rl_dst].eq(rp_dst)
             return {"old_rp_dst": self.peek[i](m, rl_dst)}
 
-        @def_methods(m, self.peek, ready=lambda _: initialized)
+        @def_methods(m, self.peek)
         def _(i: int, rl_dst: Value):
             old_rp_dst = Signal(self.gen_params.phys_regs_bits)
-            m.d.av_comb += old_rp_dst.eq(self.entries.read[i](m, addr=rl_dst).data)
+            m.d.av_comb += old_rp_dst.eq(self.entries[rl_dst])
             for j in range(i):
                 with m.If(self.commit[j].run & (self.commit[j].data_in.rl_dst == rl_dst)):
                     m.d.av_comb += old_rp_dst.eq(self.commit[j].data_in.rp_dst)

--- a/coreblocks/core_structs/rat.py
+++ b/coreblocks/core_structs/rat.py
@@ -31,10 +31,10 @@ class RRAT(Elaboratable):
         self.gen_params = gen_params
 
         layouts = gen_params.get(RATLayouts)
-        self.entries = Signal(layouts.rat_array)
+        self.entries = Signal(layouts.entries_shape)
 
         self.commit = Methods(gen_params.retirement_superscalarity, i=layouts.rrat_commit_in, o=layouts.rrat_commit_out)
-        self.peek = Methods(gen_params.retirement_superscalarity, i=layouts.rrat_peek_in, o=layouts.rrat_peek_out)
+        self.peek = Method(o=layouts.rrat_peek_out)
 
     def elaborate(self, platform):
         m = TModule()
@@ -42,15 +42,16 @@ class RRAT(Elaboratable):
         @def_methods(m, self.commit)
         def _(i: int, rp_dst: Value, rl_dst: Value):
             m.d.sync += self.entries[rl_dst].eq(rp_dst)
-            return {"old_rp_dst": self.peek[i](m, rl_dst)}
 
-        @def_methods(m, self.peek)
-        def _(i: int, rl_dst: Value):
             old_rp_dst = Signal(self.gen_params.phys_regs_bits)
             m.d.av_comb += old_rp_dst.eq(self.entries[rl_dst])
             for j in range(i):
                 with m.If(self.commit[j].run & (self.commit[j].data_in.rl_dst == rl_dst)):
                     m.d.av_comb += old_rp_dst.eq(self.commit[j].data_in.rp_dst)
-            return old_rp_dst
+            return {"old_rp_dst": old_rp_dst}
+
+        @def_method(m, self.peek, nonexclusive=True)
+        def _():
+            return {"entries": self.entries}
 
         return m

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -363,6 +363,9 @@ class RATLayouts:
     def __init__(self, gen_params: GenParams):
         fields = gen_params.get(CommonLayoutFields)
 
+        self.rat_array = ArrayLayout(gen_params.phys_regs_bits, gen_params.isa.reg_cnt)
+        """The RAT array shape."""
+
         self.old_rp_dst: LayoutListField = ("old_rp_dst", gen_params.phys_regs_bits)
         """Physical register previously associated with the given logical register in RRAT."""
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -363,8 +363,11 @@ class RATLayouts:
     def __init__(self, gen_params: GenParams):
         fields = gen_params.get(CommonLayoutFields)
 
-        self.rat_array = ArrayLayout(gen_params.phys_regs_bits, gen_params.isa.reg_cnt)
+        self.entries_shape = ArrayLayout(gen_params.phys_regs_bits, gen_params.isa.reg_cnt)
         """The RAT array shape."""
+
+        self.entries: LayoutListField = ("entries", self.entries_shape)
+        """The RAT entries."""
 
         self.old_rp_dst: LayoutListField = ("old_rp_dst", gen_params.phys_regs_bits)
         """Physical register previously associated with the given logical register in RRAT."""
@@ -386,8 +389,7 @@ class RATLayouts:
         self.rrat_commit_in = make_layout(fields.rl_dst, fields.rp_dst)
         self.rrat_commit_out = make_layout(self.old_rp_dst)
 
-        self.rrat_peek_in = make_layout(fields.rl_dst)
-        self.rrat_peek_out = self.rrat_commit_out
+        self.rrat_peek_out = make_layout(self.entries)
 
         self.rollback_in = make_layout(fields.tag)
         self.get_active_tags_out = make_layout(self.active_tags_bitmask)
@@ -400,7 +402,7 @@ class RATLayouts:
         self.crat_tag_in = (fields.rollback_tag, fields.rollback_tag_v, fields.commit_checkpoint)
         self.crat_tag_out = make_layout(fields.tag, fields.tag_increment, fields.commit_checkpoint)
 
-        self.crat_flush_restore = make_layout(fields.rl_dst, fields.rp_dst)
+        self.crat_flush_restore_in = make_layout(self.entries)
 
 
 class ROBLayouts:

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -134,8 +134,7 @@ class TestRetirement(TestCaseWithSimulator):
             curr_map = self.rat_map_q.popleft()
             wait_cycles = 0
             # this test waits for next rat pair to be correctly set and will timeout if that assignment fails
-            # TODO: abstract memories don't implement MemoryData, but standard lib.Memory used in tests
-            while sim.get(self.retc.rat.entries.mem.data[curr_map["rl_dst"]]) != curr_map["rp_dst"]:  # type: ignore
+            while sim.get(self.retc.rat.entries[curr_map["rl_dst"]]) != curr_map["rp_dst"]:  # type: ignore
                 wait_cycles += 1
                 if wait_cycles >= self.cycles + 10:
                     assert False, "RAT entry was not updated"

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -67,7 +67,7 @@ class RetirementTestCircuit(Elaboratable):
             Adapter.create(self.retirement.checkpoint_get_active_tags)
         )
         m.submodules.mock_c_rat_restore = self.mock_c_rat_restore = TestbenchIO(
-            Adapter.create(self.retirement.c_rat_restore[0])
+            Adapter.create(self.retirement.c_rat_restore)
         )
 
         m.submodules.free_rf_fifo_adapter = self.free_rf_adapter = TestbenchIO(AdapterTrans.create(self.free_rf.read))

--- a/test/core_structs/test_rat.py
+++ b/test/core_structs/test_rat.py
@@ -55,6 +55,11 @@ class TestFrontendRegisterAliasTable(TestCaseWithSimulator):
 
 @pytest.mark.parametrize("ports", [1, 2, 4])
 class TestRetirementRegisterAliasTable(TestCaseWithSimulator):
+    async def copy_entries(self, sim: TestbenchContext):
+        while True:
+            await sim.tick()
+            self.expected_entries_copy = self.expected_entries[:]
+
     async def clear_chosen(self, sim: TestbenchContext):
         while True:
             self.chosen = set()
@@ -62,17 +67,14 @@ class TestRetirementRegisterAliasTable(TestCaseWithSimulator):
 
     def do_commit(self, i: int):
         async def tb(sim: TestbenchContext):
-            # wait until R-RAT clears itself after reset
-            await self.tick(sim, self.gen_params.isa.reg_cnt)
             for _ in range(self.test_steps):
-                await sim.delay(1e-12 * i)
                 rl = self.rand.choice(list(set(range(self.gen_params.isa.reg_cnt)) - self.chosen))
                 rp = self.rand.randrange(1, 2**self.gen_params.phys_regs_bits) if rl != 0 else 0
                 self.chosen.add(rl)
 
                 if self.rand.randrange(2):
-                    peek_res = await self.m.peek[i].call(sim, rl_dst=rl)
-                    assert peek_res.old_rp_dst == self.expected_entries[rl]
+                    peek_res = await self.m.peek.call(sim)
+                    assert list(peek_res.entries) == self.expected_entries_copy
                 else:
                     res = await self.m.commit[i].call(sim, rl_dst=rl, rp_dst=rp)
                     assert res.old_rp_dst == self.expected_entries[rl]
@@ -95,8 +97,10 @@ class TestRetirementRegisterAliasTable(TestCaseWithSimulator):
 
         self.to_execute_list = deque()
         self.expected_entries = [0 for _ in range(self.log_regs)]
+        self.chosen = set()
 
         with self.run_simulation(m) as sim:
+            sim.add_testbench(self.copy_entries, background=True)
             for i in range(ports):
                 sim.add_testbench(self.do_commit(i))
-                sim.add_testbench(self.clear_chosen, background=True)
+            sim.add_testbench(self.clear_chosen, background=True)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -82,10 +82,10 @@ class TestCoreBase(TestCaseWithSimulator):
         self.configuration = self.configuration.replace(_generate_test_hardware=True)
 
     def get_phys_reg_rrat(self, sim: TestbenchContext, reg_id):
-        # TODO: abstract memories don't implement MemoryData, but standard lib.Memory used in tests
-        return sim.get(self.m.core.RRAT.entries.mem.data[reg_id])  # type: ignore
+        return sim.get(self.m.core.RRAT.entries[reg_id])
 
     def get_arch_reg_val(self, sim: TestbenchContext, reg_id):
+        # TODO: abstract memories don't implement MemoryData, but standard lib.Memory used in tests
         return sim.get(self.m.core.RF.entries.mem.data[(self.get_phys_reg_rrat(sim, reg_id))])  # type: ignore
 
 


### PR DESCRIPTION
This PR is a work in progress towards #990. Implemented changes:

- RRAT using `ArrayLayout` instead of a memory.
- Single-cycle RRAT->FRAT overwrite.

Clearing the free regs in single cycle requires Transactron changes.