### PR TITLE
Add instruction pipeline visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ venv.bak/
 
 # Tests outputs
 test/__traces__
+test/__evlogs__
 test/__profiles__/*.json
 pytestdebug.log
 _coreblocks_regression.lock

--- a/coreblocks/backend/announcement.py
+++ b/coreblocks/backend/announcement.py
@@ -2,9 +2,14 @@ from amaranth import *
 
 from coreblocks.params import GenParams
 from coreblocks.interface.layouts import FuncUnitLayouts, RFLayouts, ROBLayouts, RSLayouts
+from coreblocks.telemetry import ExecComplete
 from transactron import Method, Provided, Required, TModule, def_method
+from transactron.evlog import EventSource
 
 __all__ = ["ResultAnnouncement"]
+
+
+evlog = EventSource("backend.announcement")
 
 
 class ResultAnnouncement(Elaboratable):
@@ -53,6 +58,8 @@ class ResultAnnouncement(Elaboratable):
         @def_method(m, self.push_result)
         def _(result, rob_id, rp_dst, exception):
             self.rob_mark_done(m, rob_id=rob_id, exception=exception)
+
+            evlog.emit(m, ExecComplete.hw(rob_id=rob_id))
 
             self.rf_write_val(m, reg_id=rp_dst, reg_val=result)
             with m.If(rp_dst != 0):

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -13,8 +13,11 @@ from coreblocks.interface.layouts import (
 )
 
 from transactron.core import Method, Methods, Transaction, TModule, def_method
+from transactron.evlog import EventSource
 from transactron.utils.dependencies import DependencyContext
 from transactron.lib.metrics import *
+
+from coreblocks.telemetry import RobFlush, RobRetire
 
 from coreblocks.params.genparams import GenParams
 from coreblocks.arch import ExceptionCause, PrivilegeLevel
@@ -32,6 +35,9 @@ from coreblocks.arch.isa_consts import TrapVectorMode
 
 
 __all__ = ["Retirement"]
+
+
+evlog = EventSource("backend.retirement")
 
 
 class Retirement(Elaboratable):
@@ -124,9 +130,13 @@ class Retirement(Elaboratable):
             # free old rp_dst from overwritten R-RAT mapping
             free_phys_reg(i, rat_out.old_rp_dst)
 
+            evlog.emit(m, RobRetire.hw(rob_id=rob_entry.rob_id))
+
             self.perf_instr_ret.incr[i](m)
 
         def flush_instr(i: int, rob_entry: View):
+            evlog.emit(m, RobFlush.hw(rob_id=rob_entry.rob_id))
+
             # free the "new" instruction rp_dst - result is flushed
             free_phys_reg(i, rob_entry.rob_data.rp_dst)
 

--- a/coreblocks/core.py
+++ b/coreblocks/core.py
@@ -33,6 +33,7 @@ from coreblocks.peripherals.wishbone import WishboneMaster, WishboneInterface
 from coreblocks.priv.vmem.tlb import FullyAssociativeTLB, SetAssociativeTLB
 from coreblocks.priv.vmem.walker import PageTableWalker
 from transactron.lib.metrics import HwMetricsEnabledKey, TaggedCounter
+from transactron.evlog import EvLogEnabledKey
 
 __all__ = ["Core"]
 
@@ -56,6 +57,7 @@ class Core(Component):
         self.dm = DependencyContext.get()
         if self.gen_params.debug_signals_enabled:
             self.dm.add_dependency(HwMetricsEnabledKey(), True)
+            self.dm.add_dependency(EvLogEnabledKey(), True)
 
         self.wb_master_instr = WishboneMaster(self.gen_params.wb_params, "instr")
         self.wb_master_data = WishboneMaster(self.gen_params.wb_params, "data")

--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -3,13 +3,17 @@ from typing import Any
 from amaranth import *
 
 from coreblocks.arch import *
+from transactron.evlog import EventSource
 from transactron.lib.metrics import *
 from transactron import Method, Provided, Transaction, TModule, def_method
 from coreblocks.interface.layouts import DecodeLayouts, FetchLayouts, JumpBranchLayouts
 from transactron.utils.transactron_helpers import from_method_layout
 from coreblocks.params import GenParams
+from coreblocks.telemetry import InstrDecoded
 from .instr_decoder import InstrDecoder
 from coreblocks.params import *
+
+evlog = EventSource("frontend.decode")
 
 
 class Decode(Elaboratable):
@@ -31,7 +35,7 @@ class Decode(Elaboratable):
         m = TModule()
 
         @def_method(m, self.decode)
-        def _(instr, pc, rvc, predicted_taken, access_fault, cfi_type, ftq_ptr):
+        def _(instr, pc, rvc, predicted_taken, access_fault, cfi_type, ftq_ptr, ftq_offset):
             m.submodules.instr_decoder = instr_decoder = InstrDecoder(self.gen_params)
             m.d.top_comb += instr_decoder.instr.eq(instr)
 
@@ -94,6 +98,7 @@ class Decode(Elaboratable):
                 "csr": instr_decoder.csr,
                 "pc": pc,
                 "ftq_ptr": ftq_ptr,
+                "ftq_offset": ftq_offset,
             }
 
         return m
@@ -143,6 +148,14 @@ class DecodeStage(Elaboratable):
 
         with Transaction().body(m):
             instrs = self.get_raw(m)
+
+            for i in range(self.gen_params.frontend_superscalarity):
+                evlog.emit(
+                    m,
+                    InstrDecoded.hw(ftq_ptr=instrs.data[i].ftq_ptr, ftq_offset=instrs.data[i].ftq_offset),
+                    when=i < instrs.count,
+                )
+
             self.push_decoded(
                 m,
                 {

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -8,6 +8,7 @@ from transactron.utils import count_trailing_zeros, popcount, assign, StableSele
 from transactron.utils.transactron_helpers import make_layout
 from transactron.utils.amaranth_ext.coding import PriorityEncoder
 from transactron import *
+from transactron.evlog import EventSource
 
 from coreblocks.cache.iface import CacheInterface
 from coreblocks.frontend.decoder.rvc import InstrDecompress, is_instr_compressed
@@ -18,8 +19,10 @@ from coreblocks.params import *
 from coreblocks.interface.layouts import *
 from coreblocks.frontend import FrontendParams
 from coreblocks.priv.vmem.translation import AddressTranslator, AddressTranslatorMode
+from coreblocks.telemetry import InstrFetched
 
 log = logging.HardwareLogger("frontend.fetch")
+evlog = EventSource("frontend.fetch")
 
 
 class FetchUnit(Elaboratable):
@@ -416,6 +419,7 @@ class FetchUnit(Elaboratable):
                     raw_instrs[i].access_fault.eq(s1_data.access_fault),
                     raw_instrs[i].cfi_type.eq(predecoded_instr[i].cfi_type),
                     raw_instrs[i].ftq_ptr.eq(ftq_ptr),
+                    raw_instrs[i].ftq_offset.eq(i),
                 ]
 
             if Extension.ZCA in self.gen_params.isa.extensions:
@@ -443,6 +447,18 @@ class FetchUnit(Elaboratable):
                         flush()
 
                     self.perf_fetch_utilization.incr(m, popcount(fetch_mask))
+
+                    for i in range(fetch_width):
+                        evlog.emit(
+                            m,
+                            InstrFetched.hw(
+                                ftq_ptr=ftq_ptr,
+                                pc=raw_instrs[i].pc,
+                                instr=raw_instrs[i].instr,
+                                ftq_offset=i,
+                            ),
+                            when=fetch_mask[i],
+                        )
 
                     # Make sure this is called only once to avoid a huge mux on arguments
                     m.d.av_comb += [aligner.valids.eq(fetch_mask), aligner.inputs.eq(raw_instrs)]

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -2,6 +2,7 @@ from amaranth import *
 from amaranth.lib.data import Layout
 import amaranth.lib.memory as memory
 from transactron import *
+from transactron.evlog import EventSource
 from transactron.utils import make_layout, DependencyContext
 from transactron.utils import logging
 from transactron.lib.metrics import *
@@ -18,9 +19,11 @@ from coreblocks.interface.layouts import (
 )
 from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey, FTQCommitKey
 from coreblocks.frontend.fetch_addr_unit import FetchAddressUnit
+from coreblocks.telemetry import FetchRequest, FTQAlloc, FTQCommit, FTQRollback
 
 
 log = logging.HardwareLogger("frontend.ftq")
+evlog = EventSource("frontend.ftq")
 
 
 class FTQMemoryWrapper(Elaboratable):
@@ -156,6 +159,8 @@ class FetchTargetQueue(Elaboratable):
             self.bpu_request(m, pc=ret.pc, ftq_ptr=alloc_ptr)
             pc_mem.write(m, ftq_ptr=alloc_ptr, data=ret.pc)
 
+            evlog.emit(m, FTQAlloc.hw(ftq_ptr=alloc_ptr, pc=ret.pc))
+
             m.d.av_comb += alloc_fetch_bypass.eq(ret)
             m.d.sync += alloc_ptr.eq(alloc_ptr + 1)
 
@@ -172,6 +177,7 @@ class FetchTargetQueue(Elaboratable):
             m.d.av_comb += fetch_pc.eq(Mux(early_fetch, alloc_fetch_bypass, pc_mem.read_data))
 
             self.ifu_request(m, ftq_ptr=fetch_ptr, pc=fetch_pc)
+            evlog.emit(m, FetchRequest.hw(ftq_ptr=fetch_ptr, pc=fetch_pc))
             m.d.comb += fetch_ptr_next.eq(fetch_ptr + 1)
 
         ftq_alloc_transaction.schedule_before(send_fetch_req_transaction)
@@ -191,6 +197,8 @@ class FetchTargetQueue(Elaboratable):
 
             self.bpu_flush(m)
 
+            evlog.emit(m, FTQRollback.hw(ftq_ptr=ftq_ptr_plus_one, cause="ifu_writeback"))
+
             m.d.sync += alloc_ptr.eq(ftq_ptr_plus_one)
             m.d.comb += fetch_ptr_next.eq(ftq_ptr_plus_one)
 
@@ -208,6 +216,8 @@ class FetchTargetQueue(Elaboratable):
                 "FTQ entry was retired out-of-order",
             )
 
+            evlog.emit(m, FTQCommit.hw(ftq_ptr=ftq_ptr))
+
             m.d.sync += commit_ptr.eq(ftq_ptr)
 
         @def_method(m, self.backend_redirect)
@@ -224,6 +234,7 @@ class FetchTargetQueue(Elaboratable):
             # For an exception/backend redirect the whole pipeline is squashed, so we restart
             # allocation right after the last committed entry.
             with m.If(~from_unsafe):
+                evlog.emit(m, FTQRollback.hw(ftq_ptr=commit_ptr_plus_one, cause="backend_redirect"))
                 m.d.sync += alloc_ptr.eq(commit_ptr_plus_one)
                 m.d.sync += fetch_ptr.eq(commit_ptr_plus_one)
 

--- a/coreblocks/func_blocks/fu/common/rs_func_block.py
+++ b/coreblocks/func_blocks/fu/common/rs_func_block.py
@@ -9,6 +9,7 @@ from coreblocks.func_blocks.interface.func_protocols import FuncUnit, FuncBlock
 from transactron.lib import FIFO, Collector, Connect
 from coreblocks.arch import OpType
 from coreblocks.interface.layouts import RSInterfaceLayouts, RSLayouts, FuncUnitLayouts
+from coreblocks.telemetry import func_unit_kind
 
 __all__ = ["RSFuncBlock", "RSBlockComponent"]
 
@@ -83,6 +84,7 @@ class RSFuncBlock(FuncBlock, Elaboratable):
             wakeup_select = WakeupSelect(
                 gen_params=self.gen_params,
                 rs_entries=self.rs_entries,
+                fu_kind=func_unit_kind(func_unit),
             )
             wakeup_select.get_ready.provide(self.rs.get_ready_list[n])
             wakeup_select.take_row.provide(self.rs.take)

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -88,6 +88,9 @@ class CommonLayoutFields:
         self.ftq_ptr: LayoutListField = ("ftq_ptr", FTQPtrLayout(gen_params))
         """A pointer into the Fetch Target Queue"""
 
+        self.ftq_offset: LayoutListField = ("ftq_offset", gen_params.fetch_width_log)
+        """Offset of an instruction (counted in number of instructions) within its FTQ entry (fetch block)"""
+
         self.fb_addr: LayoutListField = ("fb_addr", gen_params.isa.xlen - gen_params.fetch_block_bytes_log)
         """Address of a fetch block"""
 
@@ -267,6 +270,7 @@ class SchedulerLayouts:
             fields.rollback_tag_v,
             fields.commit_checkpoint,
             fields.ftq_ptr,
+            fields.ftq_offset,
         )
 
         self.reg_alloc_in = self.scheduler_in = make_layout(
@@ -285,6 +289,7 @@ class SchedulerLayouts:
             fields.rollback_tag_v,
             fields.commit_checkpoint,
             fields.ftq_ptr,
+            fields.ftq_offset,
         )
 
         self.reg_alloc_out = self.instr_tag_in = make_layout(
@@ -303,6 +308,7 @@ class SchedulerLayouts:
             fields.tag_increment,
             fields.commit_checkpoint,
             fields.ftq_ptr,
+            fields.ftq_offset,
         )
 
         self.renaming_in = self.instr_tag_out = make_layout(
@@ -320,6 +326,7 @@ class SchedulerLayouts:
             fields.tag,
             fields.tag_increment,
             fields.ftq_ptr,
+            fields.ftq_offset,
         )
 
         self.renaming_out = self.rob_allocate_in = make_layout(
@@ -687,6 +694,7 @@ class FetchLayouts:
             fields.predicted_taken,
             fields.cfi_type,
             fields.ftq_ptr,
+            fields.ftq_offset,
         )
 
         self.fetch_result = make_layout(
@@ -735,6 +743,7 @@ class DecodeLayouts:
             fields.csr,
             fields.pc,
             fields.ftq_ptr,
+            fields.ftq_offset,
         )
 
         self.decode_result = make_layout(
@@ -753,6 +762,7 @@ class DecodeLayouts:
             fields.rollback_tag_v,
             fields.commit_checkpoint,
             fields.ftq_ptr,
+            fields.ftq_offset,
         )
 
         self.tagged_decode_result = make_layout(

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -9,15 +9,19 @@ from transactron.lib.metrics import TaggedCounter
 from transactron.utils import OneHotMux, logging, assign, AssignType
 from transactron.utils.dependencies import DependencyContext
 
+from transactron.evlog import EventSource
+
 from coreblocks.interface.layouts import RATLayouts, RFLayouts, ROBLayouts, RSFullDataLayout, SchedulerLayouts
 from coreblocks.params import GenParams
 from coreblocks.arch.optypes import OpType, impure_optypes
 from coreblocks.interface.keys import CoreStateKey
+from coreblocks.telemetry import RobAllocate, SchedulerEnter
 
 __all__ = ["Scheduler"]
 
 
 log = logging.HardwareLogger("frontend.scheduler")
+evlog = EventSource("backend.scheduler")
 
 
 class RegAllocation(Elaboratable):
@@ -54,6 +58,12 @@ class RegAllocation(Elaboratable):
             m.d.av_comb += assign(data_out, instrs)
 
             for i in range(self.gen_params.frontend_superscalarity):
+                evlog.emit(
+                    m,
+                    SchedulerEnter.hw(ftq_ptr=instrs.data[i].ftq_ptr, ftq_offset=instrs.data[i].ftq_offset),
+                    when=i < instrs.count,
+                )
+
                 with m.If((i < instrs.count) & (instrs.data[i].regs_l.rl_dst != 0)):
                     m.d.av_comb += data_out.data[i].regs_p.rp_dst.eq(self.get_free_reg[i](m).ident)
 
@@ -173,7 +183,9 @@ class Renaming(Elaboratable):
                     )
 
                 m.d.av_comb += assign(
-                    instr_out, instr, fields={"exec_fn", "imm", "csr", "pc", "tag", "tag_increment", "ftq_ptr"}
+                    instr_out,
+                    instr,
+                    fields={"exec_fn", "imm", "csr", "pc", "tag", "tag_increment", "ftq_ptr", "ftq_offset"},
                 )
                 m.d.av_comb += assign(instr_out.regs_l, instr.regs_l, fields=AssignType.COMMON)
                 m.d.av_comb += instr_out.regs_p.rp_dst.eq(instr.regs_p.rp_dst)
@@ -236,6 +248,16 @@ class ROBAllocation(Elaboratable):
             m.d.av_comb += assign(data_out, instrs, fields=AssignType.COMMON)
             for i in range(self.gen_params.frontend_superscalarity):
                 m.d.av_comb += data_out.data[i].rob_id.eq(rob_ids.entries[i].rob_id)
+
+                evlog.emit(
+                    m,
+                    RobAllocate.hw(
+                        ftq_ptr=instrs.data[i].ftq_ptr,
+                        ftq_offset=instrs.data[i].ftq_offset,
+                        rob_id=rob_ids.entries[i].rob_id,
+                    ),
+                    when=i < instrs.count,
+                )
 
             self.push_instrs(m, data_out)
 

--- a/coreblocks/scheduler/wakeup_select.py
+++ b/coreblocks/scheduler/wakeup_select.py
@@ -1,11 +1,18 @@
+from typing import Optional
+
 from amaranth import *
 
 from coreblocks.params import GenParams
 from coreblocks.interface.layouts import FuncUnitLayouts, RSLayouts
+from coreblocks.telemetry import FuIssue
+from transactron.evlog import EventSource
 from transactron.utils import PriorityEncoder, assign, AssignType
 from transactron.core import *
 
 __all__ = ["WakeupSelect"]
+
+
+evlog = EventSource("backend.wakeup_select")
 
 
 class WakeupSelect(Elaboratable):
@@ -31,7 +38,7 @@ class WakeupSelect(Elaboratable):
     take_row: Required[Method]
     issue: Required[Method]
 
-    def __init__(self, *, gen_params: GenParams, rs_entries: int):
+    def __init__(self, *, gen_params: GenParams, rs_entries: int, fu_kind: Optional[str] = None):
         """
         Parameters
         ----------
@@ -39,8 +46,12 @@ class WakeupSelect(Elaboratable):
             Instance of GenParams with parameters describing the core.
         rs_entries : int
             Number of entries of the RS connected to this instance of WakeupSelect.
+        fu_kind : str, optional
+            Name of the functional unit fed by this instance, reported in the
+            event log on every issue.
         """
         self.gen_params = gen_params
+        self.fu_kind = fu_kind
         rs_layouts = gen_params.get(RSLayouts, rs_entries=rs_entries)
         self.get_ready = Method(o=rs_layouts.get_ready_list_out)  # assumption: ready only if nonzero result
         self.take_row = Method(i=rs_layouts.take_in, o=rs_layouts.take_out)
@@ -58,5 +69,8 @@ class WakeupSelect(Elaboratable):
             issue_rec = Signal(self.gen_params.get(FuncUnitLayouts).issue)
             m.d.av_comb += assign(issue_rec, row, fields=AssignType.ALL)
             self.issue(m, issue_rec)
+
+            if self.fu_kind is not None:
+                evlog.emit(m, FuIssue.hw(rob_id=issue_rec.rob_id, unit=self.fu_kind))
 
         return m

--- a/coreblocks/telemetry/__init__.py
+++ b/coreblocks/telemetry/__init__.py
@@ -1,0 +1,1 @@
+from .events import *  # noqa: F401

--- a/coreblocks/telemetry/events.py
+++ b/coreblocks/telemetry/events.py
@@ -1,0 +1,133 @@
+import re
+
+from transactron.evlog import Event, Static, event
+
+__all__ = [
+    "FTQAlloc",
+    "FetchRequest",
+    "InstrFetched",
+    "InstrDecoded",
+    "FTQRollback",
+    "FTQCommit",
+    "SchedulerEnter",
+    "RobAllocate",
+    "RobRetire",
+    "RobFlush",
+    "FuIssue",
+    "ExecComplete",
+    "func_unit_kind",
+]
+
+
+def func_unit_kind(func_unit) -> str:
+    """A short name for a functional unit instance, derived from its class
+    name: ``JumpBranchFuncUnit`` -> ``jump_branch``."""
+    name = type(func_unit).__name__.removesuffix("FuncUnit").removesuffix("Unit")
+    # insert '_' at camelCase word boundaries, keeping acronym runs (e.g. LSU) together
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", "_", name).lower()
+
+
+@event("frontend.ftq_alloc")
+class FTQAlloc(Event):
+    """An FTQ entry was allocated for the fetch block at `pc`."""
+
+    ftq_ptr: int
+    pc: int
+
+
+@event("frontend.fetch_request")
+class FetchRequest(Event):
+    """The FTQ issued a request to the instruction fetch unit for the fetch
+    block owned by the FTQ entry."""
+
+    ftq_ptr: int
+    pc: int
+
+
+@event("frontend.instr_fetched")
+class InstrFetched(Event):
+    """The fetch unit produced a single instruction and sent it towards
+    the decode stage. `ftq_offset` is the instruction's slot index within
+    its fetch block."""
+
+    ftq_ptr: int
+    pc: int
+    instr: int
+    ftq_offset: Static[int]
+
+
+@event("frontend.instr_decoded")
+class InstrDecoded(Event):
+    """An instruction landed in the decode stage. The instruction is
+    identified by its FTQ entry and the slot index within it."""
+
+    ftq_ptr: int
+    ftq_offset: int
+
+
+@event("frontend.ftq_rollback")
+class FTQRollback(Event):
+    """FTQ allocation was rolled back: `ftq_ptr` is the new allocation
+    pointer, so all entries from `ftq_ptr` onward are squashed."""
+
+    ftq_ptr: int
+    cause: Static[str]
+
+
+@event("frontend.ftq_commit")
+class FTQCommit(Event):
+    """The FTQ commit pointer advanced to `ftq_ptr`: this entry is now the
+    oldest live one, and all entries strictly before it are fully retired
+    and freed. Emitted per retired instruction, so an entry with several
+    instructions produces multiple commits of the same pointer."""
+
+    ftq_ptr: int
+
+
+@event("backend.scheduler_enter")
+class SchedulerEnter(Event):
+    """The instruction entered the scheduler."""
+
+    ftq_ptr: int
+    ftq_offset: int
+
+
+@event("backend.rob_allocate")
+class RobAllocate(Event):
+    """A ROB entry was allocated for the instruction; from this point on
+    the instruction is identified by its `rob_id`."""
+
+    ftq_ptr: int
+    ftq_offset: int
+    rob_id: int
+
+
+@event("backend.rob_retire")
+class RobRetire(Event):
+    """The instruction retired."""
+
+    rob_id: int
+
+
+@event("backend.rob_flush")
+class RobFlush(Event):
+    """The instruction was squashed from the ROB without retiring."""
+
+    rob_id: int
+
+
+@event("backend.fu_issue")
+class FuIssue(Event):
+    """The instruction was issued from a reservation station to a
+    functional unit."""
+
+    rob_id: int
+    unit: Static[str]
+
+
+@event("backend.exec_complete")
+class ExecComplete(Event):
+    """The instruction finished executing: its result was announced and the
+    ROB entry was marked done."""
+
+    rob_id: int

--- a/coreblocks/telemetry/konata.py
+++ b/coreblocks/telemetry/konata.py
@@ -1,0 +1,283 @@
+"""Converter from captured event logs to the Kanata pipeline-visualization
+format (https://github.com/shioyadan/Konata).
+
+Since Kanata files are append-only with monotonically increasing time, and
+the concrete instructions of a fetch block are only known when they leave
+the fetch unit, the converter buffers everything: event handlers build
+per-instruction stage timelines, and the log is written out at the end,
+sorted by cycle. This allows backdating an instruction's fetch stages to
+the times its fetch block was allocated and requested.
+"""
+
+import argparse
+import signal
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Optional, TextIO
+import capstone
+
+from transactron.evlog import DecodedEvent, EventConsumer, EventLogReader, handles
+
+from .events import (
+    ExecComplete,
+    FetchRequest,
+    FTQAlloc,
+    FTQCommit,
+    FTQRollback,
+    FuIssue,
+    InstrDecoded,
+    InstrFetched,
+    RobAllocate,
+    RobFlush,
+    RobRetire,
+    SchedulerEnter,
+)
+
+
+__all__ = ["KonataParser"]
+
+
+@dataclass
+class _Block:
+    """A fetch block owned by a live FTQ entry, buffered until its concrete
+    instructions are known."""
+
+    pc: int
+    fetch_cycle: Optional[int] = None
+    instr_ids: dict[int, int] = field(default_factory=dict)
+    """Kanata instruction ids, keyed by the FTQ offset."""
+
+
+class KonataParser(EventConsumer):
+    """Converts instruction lifetime events into a Kanata log.
+
+    An instruction's lifetime starts at the fetch request for its fetch
+    block. Stages:
+     - "F" from the fetch request until the instruction leaves
+       the fetch unit,
+     - "Q" while it waits in the frontend instruction queue,
+     - "D" from landing in the decode stage,
+     - "Rn" (rename) from entering the scheduler,
+     - "Ds" (dispatch) from ROB allocation (which is where the
+        instruction becomes identified by its ROB id),
+     - "Is" (issue) from being issued to a functional unit,
+     - "Cm" once execution completes.
+
+    The instruction terminates by retiring (`RobRetire`) or being squashed.
+    Instructions still in flight when the event log ends are left unterminated.
+    """
+
+    def __init__(self, out: TextIO):
+        self.out = out
+        # Live FTQ entries, keyed by the raw FTQ pointer (with the parity
+        # bit, which makes keys unique among live entries); insertion order
+        # is allocation order.
+        self.blocks: dict[int, _Block] = {}
+        # Kanata instruction ids of live ROB entries, keyed by the ROB id.
+        self.rob: dict[int, int] = {}
+        # Kanata instruction ids with a terminal (retire/flush) record.
+        self.terminated: set[int] = set()
+        # (cycle, sequence number, line) command timeline; the sequence
+        # number keeps the append order among commands of the same cycle.
+        self.timeline: list[tuple[int, int, str]] = []
+        self.next_id = 0
+        self.next_retire_id = 0
+        self.disassembler = None
+
+        # The fetch unit expands compressed instructions, so plain RV32
+        # is enough to disassemble the (expanded) instruction words.
+        self.disassembler = capstone.Cs(capstone.CS_ARCH_RISCV, capstone.CS_MODE_RISCV32)
+
+    def _format_instr(self, pc: int, instr: int) -> str:
+        if self.disassembler is not None:
+            for disasm in self.disassembler.disasm(instr.to_bytes(4, "little"), pc):
+                return f"{disasm.mnemonic} {disasm.op_str}".strip()
+        return f"{instr:08x}"
+
+    def run(self, records: Iterable[DecodedEvent]):
+        super().run(records)
+        self._write()
+
+    def _command(self, cycle: int, *columns) -> None:
+        self.timeline.append((cycle, len(self.timeline), "\t".join(str(col) for col in columns)))
+
+    @handles(FTQAlloc)
+    def on_alloc(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, FTQAlloc)
+        # The allocation itself is not visualized (the FTQ entry's lifetime
+        # differs from the instructions'), but the entry must be tracked so
+        # that commits and rollbacks cover it.
+        self.blocks[ev.ftq_ptr] = _Block(pc=ev.pc)
+
+    @handles(FetchRequest)
+    def on_fetch_request(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, FetchRequest)
+        block = self.blocks.setdefault(ev.ftq_ptr, _Block(pc=ev.pc))
+        block.fetch_cycle = rec.cycle
+
+    @handles(InstrFetched)
+    def on_instr_fetched(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, InstrFetched)
+        block = self.blocks.setdefault(ev.ftq_ptr, _Block(pc=ev.pc))
+
+        insn_id = self.next_id
+        self.next_id += 1
+        block.instr_ids[ev.ftq_offset] = insn_id
+
+        start = block.fetch_cycle if block.fetch_cycle is not None else rec.cycle
+
+        self._command(start, "I", insn_id, insn_id, 0)
+        self._command(start, "L", insn_id, 0, f"{ev.pc:08x}: {self._format_instr(ev.pc, ev.instr)}")
+        self._command(start, "L", insn_id, 1, f"instr={ev.instr:08x} ftq_ptr={ev.ftq_ptr} ftq_offset={ev.ftq_offset}")
+        self._command(start, "S", insn_id, 0, "F")
+        self._command(rec.cycle, "S", insn_id, 0, "Q")
+
+    @handles(InstrDecoded)
+    def on_instr_decoded(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, InstrDecoded)
+        block = self.blocks.get(ev.ftq_ptr)
+        if block is None or ev.ftq_offset not in block.instr_ids:
+            return
+        self._command(rec.cycle, "S", block.instr_ids[ev.ftq_offset], 0, "D")
+
+    @handles(SchedulerEnter)
+    def on_scheduler_enter(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, SchedulerEnter)
+        block = self.blocks.get(ev.ftq_ptr)
+        if block is None or ev.ftq_offset not in block.instr_ids:
+            return
+        self._command(rec.cycle, "S", block.instr_ids[ev.ftq_offset], 0, "Rn")
+
+    @handles(RobAllocate)
+    def on_rob_allocate(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, RobAllocate)
+        block = self.blocks.get(ev.ftq_ptr)
+        if block is None or ev.ftq_offset not in block.instr_ids:
+            return
+        insn_id = block.instr_ids[ev.ftq_offset]
+        self.rob[ev.rob_id] = insn_id
+        self._command(rec.cycle, "S", insn_id, 0, "Ds")
+        self._command(rec.cycle, "L", insn_id, 1, f" rob_id={ev.rob_id}")
+
+    @handles(FuIssue)
+    def on_fu_issue(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, FuIssue)
+        insn_id = self.rob.get(ev.rob_id)
+        if insn_id is None or insn_id in self.terminated:
+            return
+        self._command(rec.cycle, "S", insn_id, 0, "Is")
+        self._command(rec.cycle, "L", insn_id, 1, f" fu={ev.unit}")
+
+    @handles(ExecComplete)
+    def on_exec_complete(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, ExecComplete)
+        insn_id = self.rob.get(ev.rob_id)
+        if insn_id is None or insn_id in self.terminated:
+            return
+        self._command(rec.cycle, "S", insn_id, 0, "Cm")
+
+    @handles(RobRetire)
+    def on_rob_retire(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, RobRetire)
+        insn_id = self.rob.pop(ev.rob_id, None)
+        if insn_id is None or insn_id in self.terminated:
+            return
+        self._command(rec.cycle, "R", insn_id, self.next_retire_id, 0)
+        self.next_retire_id += 1
+        self.terminated.add(insn_id)
+
+    @handles(RobFlush)
+    def on_rob_flush(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, RobFlush)
+        insn_id = self.rob.pop(ev.rob_id, None)
+        if insn_id is None or insn_id in self.terminated:
+            return
+        self._command(rec.cycle, "R", insn_id, 0, 1)
+        self.terminated.add(insn_id)
+
+    @handles(FTQCommit)
+    def on_commit(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, FTQCommit)
+        # The commit pointer is the oldest live FTQ entry, so all entries
+        # strictly before it are fully retired (each instruction got its own
+        # `RobRetire`); they only need to be dropped from the bookkeeping.
+        for key in self._entries_before(ev.ftq_ptr):
+            del self.blocks[key]
+
+    @handles(FTQRollback)
+    def on_rollback(self, rec: DecodedEvent):
+        ev = rec.event
+        assert isinstance(ev, FTQRollback)
+        # `ftq_ptr` is the new allocation pointer: it and everything
+        # allocated after it is squashed. Instructions already flushed from
+        # the ROB (via `RobFlush`) are skipped; blocks squashed before
+        # producing any instructions simply disappear from the log.
+        flushed: set[int] = set()
+        for key in self._entries_from(ev.ftq_ptr):
+            for insn_id in self.blocks.pop(key).instr_ids.values():
+                flushed.add(insn_id)
+                if insn_id in self.terminated:
+                    continue
+                self._command(rec.cycle, "R", insn_id, 0, 1)
+                self.terminated.add(insn_id)
+        self.rob = {rob_id: insn_id for rob_id, insn_id in self.rob.items() if insn_id not in flushed}
+
+    def _entries_before(self, ftq_ptr: int) -> list[int]:
+        """Returns the live entries allocated strictly before `ftq_ptr`."""
+        keys = list(self.blocks)
+        if ftq_ptr not in keys:
+            return []
+        return keys[: keys.index(ftq_ptr)]
+
+    def _entries_from(self, ftq_ptr: int) -> list[int]:
+        """Returns the live entries from `ftq_ptr` through the newest."""
+        keys = list(self.blocks)
+        if ftq_ptr not in keys:
+            return []
+        return keys[keys.index(ftq_ptr) :]
+
+    def _write(self):
+        self.out.write("Kanata\t0004\n")
+        self.timeline.sort(key=lambda command: command[:2])
+
+        current_cycle = self.timeline[0][0] if self.timeline else 0
+        self.out.write(f"C=\t{current_cycle}\n")
+        for cycle, _, line in self.timeline:
+            if cycle != current_cycle:
+                self.out.write(f"C\t{cycle - current_cycle}\n")
+                current_cycle = cycle
+            self.out.write(line + "\n")
+
+
+def main(argv: Optional[list[str]] = None):
+    # Die silently when the output is piped to e.g. `head`.
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    parser = argparse.ArgumentParser(description="Convert a captured event log to the Kanata format.")
+    parser.add_argument("path", help="The event log file (JSON lines)")
+    parser.add_argument("-o", "--output", help="Output file (default: standard output)")
+    args = parser.parse_args(argv)
+
+    reader = EventLogReader(args.path)
+    if args.output is not None:
+        with open(args.output, "w") as out:
+            KonataParser(out).run(reader)
+    else:
+        KonataParser(sys.stdout).run(reader)
+
+
+if __name__ == "__main__":
+    main()

--- a/coreblocks/telemetry/konata.py
+++ b/coreblocks/telemetry/konata.py
@@ -54,15 +54,15 @@ class KonataParser(EventConsumer):
 
     An instruction's lifetime starts at the fetch request for its fetch
     block. Stages:
-     - "F" from the fetch request until the instruction leaves
-       the fetch unit,
-     - "Q" while it waits in the frontend instruction queue,
-     - "D" from landing in the decode stage,
-     - "Rn" (rename) from entering the scheduler,
-     - "Ds" (dispatch) from ROB allocation (which is where the
-        instruction becomes identified by its ROB id),
-     - "Is" (issue) from being issued to a functional unit,
-     - "Cm" once execution completes.
+
+    - "F" from the fetch request until the instruction leaves the fetch unit,
+    - "Q" while it waits in the frontend instruction queue,
+    - "D" from landing in the decode stage,
+    - "Rn" (rename) from entering the scheduler,
+    - "Ds" (dispatch) from ROB allocation (which is where the
+      instruction becomes identified by its ROB id),
+    - "Is" (issue) from being issued to a functional unit,
+    - "Cm" once execution completes.
 
     The instruction terminates by retiring (`RobRetire`) or being squashed.
     Instructions still in flight when the event log ends are left unterminated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "amaranth-stubs~=0.5.0.0",
     "amaranth-yosys==0.40.0.0.post100",
     "dataclasses-json==0.6.3",
-    "transactron~=0.9.0",
+    "transactron~=0.10.0",
 ]
 license = "BSD-3-Clause"
 license-files = [ "LICENSE" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pyelftools==0.29",
     "tabulate==0.9.0",
     "filelock==3.13.1",
+    "capstone==5.0.9",
 ]
 
 [project.scripts]

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -147,6 +147,7 @@ def main():
     parser.add_argument("--log-level", default="WARNING", action="store", help="Level of messages to display.")
     parser.add_argument("--log-filter", default=".*", action="store", help="Regexp used to filter out logs.")
     parser.add_argument("-p", "--profile", action="store_true", help="Write execution profiles")
+    parser.add_argument("--evlog", action="store_true", help="Write captured event logs")
     parser.add_argument("-b", "--backend", default="cocotb", choices=["cocotb", "pysim"], help="Simulation backend")
     parser.add_argument(
         "-o",
@@ -179,6 +180,9 @@ def main():
 
     if args.profile:
         os.environ["__TRANSACTRON_PROFILE"] = "1"
+
+    if args.evlog:
+        os.environ["__TRANSACTRON_EVLOG"] = "1"
 
     success = run_benchmarks(benchmarks, args.backend, args.trace)
     if not success:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,7 @@ def pytest_addoption(parser: pytest.Parser):
     )
     group.addoption("--coreblocks-traces", action="store_true", help="Generate traces from regression tests")
     group.addoption("--coreblocks-profile", action="store_true", help="Write execution profiles")
+    group.addoption("--coreblocks-evlog", action="store_true", help="Write captured event logs")
     group.addoption("--coreblocks-list", action="store_true", help="List all tests in flatten format.")
     group.addoption(
         "--coreblocks-test-name",
@@ -107,6 +108,9 @@ def pytest_runtest_setup(item: pytest.Item):
 
     if item.config.getoption("--coreblocks-profile", False):  # type: ignore
         os.environ["__TRANSACTRON_PROFILE"] = "1"
+
+    if item.config.getoption("--coreblocks-evlog", False):  # type: ignore
+        os.environ["__TRANSACTRON_EVLOG"] = "1"
 
     log_filter = item.config.getoption("--coreblocks-log-filter")
     os.environ["__TRANSACTRON_LOG_FILTER"] = ".*" if not isinstance(log_filter, str) else log_filter

--- a/test/regression/benchmark.py
+++ b/test/regression/benchmark.py
@@ -12,6 +12,7 @@ test_dir = Path(__file__).parent.parent
 embench_dir = test_dir.joinpath("external/embench/build/src")
 results_dir = test_dir.joinpath("regression/benchmark_results")
 profile_dir = test_dir.joinpath("__profiles__")
+evlog_dir = test_dir.joinpath("__evlogs__")
 
 
 @dataclass_json
@@ -91,6 +92,10 @@ async def run_benchmark(sim_backend: SimulationBackend, benchmark_name: str):
     if result.profile is not None:
         os.makedirs(profile_dir, exist_ok=True)
         result.profile.encode(f"{profile_dir}/benchmark.{benchmark_name}.json")
+
+    if result.evlog is not None:
+        os.makedirs(evlog_dir, exist_ok=True)
+        result.evlog.save(f"{evlog_dir}/benchmark.{benchmark_name}.jsonl")
 
     if not result.success:
         raise RuntimeError("Simulation timed out")

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -16,6 +16,7 @@ from cocotb.result import SimTimeoutError
 from .memory import *
 from .common import SimulationBackend, SimulationExecutionResult
 
+from transactron.evlog import EventLog, GeneratedEvLogSampler, SignalHandle, SignalReader
 from transactron.profiler import CycleProfile, MethodSamples, Profile, ProfileSamples, TransactionSamples
 from transactron.utils.gen import GenerationInfo
 
@@ -186,6 +187,25 @@ class CocotbSimulation(SimulationBackend):
 
             await clock_edge_event  # type: ignore
 
+    async def evlog_handler(self, clock, evlog: EventLog):
+        generated = self.gen_info.evlog
+        if not generated.schema.sites:
+            return
+
+        def resolve(location: SignalHandle) -> SignalReader:
+            handle = self.get_cocotb_handle(location)
+            return lambda: int(handle.value)
+
+        sampler = GeneratedEvLogSampler(generated, resolve)
+
+        clock_edge_event = FallingEdge(clock)
+        cycle = 0
+
+        while True:
+            sampler.sample(cycle, evlog)
+            cycle += 1
+            await clock_edge_event  # type: ignore
+
     async def logging_handler(self, clock):
         clock_edge_event = FallingEdge(clock)
 
@@ -257,6 +277,11 @@ class CocotbSimulation(SimulationBackend):
             profile.transactions_and_methods = self.gen_info.profile_data.transactions_and_methods
             cocotb.start_soon(self.profile_handler(self.dut.clk, profile))
 
+        evlog = None
+        if "__TRANSACTRON_EVLOG" in os.environ and self.gen_info.evlog.schema.sites:
+            evlog = EventLog(self.gen_info.evlog.schema)
+            cocotb.start_soon(self.evlog_handler(self.dut.clk, evlog))
+
         cocotb.start_soon(self.logging_handler(self.dut.clk))
 
         success = True
@@ -268,6 +293,7 @@ class CocotbSimulation(SimulationBackend):
         result = SimulationExecutionResult(success)
 
         result.profile = profile
+        result.evlog = evlog
 
         for metric_name, metric_loc in self.gen_info.metrics_location.items():
             result.metric_values[metric_name] = {}

--- a/test/regression/common.py
+++ b/test/regression/common.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional
 from .memory import CoreMemoryModel
+from transactron.evlog import EventLog
 from transactron.profiler import Profile
 
 
@@ -21,6 +22,7 @@ class SimulationExecutionResult:
     success: bool
     metric_values: dict[str, dict[str, int]] = field(default_factory=dict)
     profile: Optional[Profile] = None
+    evlog: Optional[EventLog] = None
 
 
 class SimulationBackend(ABC):

--- a/test/regression/conftest.py
+++ b/test/regression/conftest.py
@@ -7,6 +7,7 @@ test_dir = Path(__file__).parent.parent
 riscv_tests_dir = test_dir.joinpath("external/riscv-tests")
 arch_tests_dir = test_dir.joinpath("external/riscv-arch-test/elfs")
 profile_dir = test_dir.joinpath("__profiles__")
+evlog_dir = test_dir.joinpath("__evlogs__")
 
 
 def get_all_test_names():

--- a/test/regression/pysim.py
+++ b/test/regression/pysim.py
@@ -20,6 +20,7 @@ from transactron.testing import (
     TestbenchContext,
     ProcessContext,
 )
+from transactron.testing.evlog import capture_evlog
 from transactron.utils.dependencies import DependencyContext, DependencyManager
 from transactron.lib.metrics import HardwareMetricsManager
 from ..peripherals.test_wishbone import WishboneInterfaceWrapper
@@ -179,6 +180,14 @@ class PySimulation(SimulationBackend):
                 profile = Profile()
                 sim.add_process(profiler_process(transaction_manager, profile))
 
+            evlog = None
+            if "__TRANSACTRON_EVLOG" in os.environ:
+                evlog, evlog_process = capture_evlog()
+                if evlog.schema.sites:
+                    sim.add_process(evlog_process)
+                else:  # the design was elaborated without the event log enabled
+                    evlog = None
+
             metric_values: dict[str, dict[str, int]] = {}
 
             def on_sim_finish(sim: TestbenchContext):
@@ -197,7 +206,7 @@ class PySimulation(SimulationBackend):
 
             self.pretty_dump_metrics(metric_values)
 
-            return SimulationExecutionResult(success, metric_values, profile)
+            return SimulationExecutionResult(success, metric_values, profile, evlog)
 
     def stop(self):
         self.running = False

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -1,6 +1,6 @@
 from .memory import *
 from .common import SimulationBackend
-from .conftest import riscv_tests_dir, profile_dir
+from .conftest import riscv_tests_dir, profile_dir, evlog_dir
 from test.regression.pysim import PySimulation
 import xml.etree.ElementTree as eT
 import asyncio
@@ -55,6 +55,10 @@ async def run_test(sim_backend: SimulationBackend, test_name: str):
     if result.profile is not None:
         os.makedirs(profile_dir, exist_ok=True)
         result.profile.encode(f"{profile_dir}/test.regression.{test_name}.json")
+
+    if result.evlog is not None:
+        os.makedirs(evlog_dir, exist_ok=True)
+        result.evlog.save(f"{evlog_dir}/test.regression.{test_name}.jsonl")
 
     if not result.success:
         raise RuntimeError("Simulation timed out")

--- a/test/telemetry/test_konata.py
+++ b/test/telemetry/test_konata.py
@@ -1,0 +1,195 @@
+from io import StringIO
+from textwrap import dedent
+
+from transactron.evlog import DecodedEvent, Event, EventSiteSchema
+
+from coreblocks.telemetry import (
+    ExecComplete,
+    FetchRequest,
+    FTQAlloc,
+    FTQCommit,
+    FTQRollback,
+    FuIssue,
+    InstrDecoded,
+    InstrFetched,
+    RobAllocate,
+    RobFlush,
+    RobRetire,
+    SchedulerEnter,
+)
+from coreblocks.telemetry.konata import KonataParser
+
+DUMMY_SITE = EventSiteSchema(source_name="frontend", event_name="dummy", location=("x.py", 1), fields=[], statics={})
+
+
+def dec(cycle: int, event: Event) -> DecodedEvent:
+    return DecodedEvent(cycle=cycle, site=DUMMY_SITE, event=event)
+
+
+class TestKonataParser:
+    def test_convert(self):
+        # Two fetch blocks: block 0 produces two instructions which go all
+        # the way through the backend and retire, block 1 produces one
+        # instruction which is flushed before reaching the ROB.
+        records = [
+            dec(0, FTQAlloc(ftq_ptr=0, pc=0x100)),
+            dec(1, FetchRequest(ftq_ptr=0, pc=0x100)),
+            dec(1, FTQAlloc(ftq_ptr=1, pc=0x108)),
+            dec(2, FetchRequest(ftq_ptr=1, pc=0x108)),
+            dec(3, InstrFetched(ftq_ptr=0, pc=0x100, instr=0x13, ftq_offset=0)),
+            dec(3, InstrFetched(ftq_ptr=0, pc=0x104, instr=0x93, ftq_offset=1)),
+            dec(4, InstrFetched(ftq_ptr=1, pc=0x108, instr=0x33, ftq_offset=0)),
+            dec(5, InstrDecoded(ftq_ptr=0, ftq_offset=0)),
+            dec(5, InstrDecoded(ftq_ptr=0, ftq_offset=1)),
+            dec(6, SchedulerEnter(ftq_ptr=0, ftq_offset=0)),
+            dec(6, SchedulerEnter(ftq_ptr=0, ftq_offset=1)),
+            dec(7, RobAllocate(ftq_ptr=0, ftq_offset=0, rob_id=0)),
+            dec(7, RobAllocate(ftq_ptr=0, ftq_offset=1, rob_id=1)),
+            dec(8, FuIssue(rob_id=0, unit="alu")),
+            dec(8, FuIssue(rob_id=1, unit="alu")),
+            dec(9, ExecComplete(rob_id=0)),
+            dec(9, ExecComplete(rob_id=1)),
+            dec(11, RobRetire(rob_id=0)),
+            dec(11, RobRetire(rob_id=1)),
+            dec(11, FTQCommit(ftq_ptr=0)),
+            dec(12, FTQRollback(ftq_ptr=1, cause="backend_redirect")),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        assert out.getvalue() == dedent(
+            """\
+            Kanata\t0004
+            C=\t1
+            I\t0\t0\t0
+            L\t0\t0\t00000100: nop
+            L\t0\t1\tinstr=00000013 ftq_ptr=0 ftq_offset=0
+            S\t0\t0\tF
+            I\t1\t1\t0
+            L\t1\t0\t00000104: mv ra, zero
+            L\t1\t1\tinstr=00000093 ftq_ptr=0 ftq_offset=1
+            S\t1\t0\tF
+            C\t1
+            I\t2\t2\t0
+            L\t2\t0\t00000108: add zero, zero, zero
+            L\t2\t1\tinstr=00000033 ftq_ptr=1 ftq_offset=0
+            S\t2\t0\tF
+            C\t1
+            S\t0\t0\tQ
+            S\t1\t0\tQ
+            C\t1
+            S\t2\t0\tQ
+            C\t1
+            S\t0\t0\tD
+            S\t1\t0\tD
+            C\t1
+            S\t0\t0\tRn
+            S\t1\t0\tRn
+            C\t1
+            S\t0\t0\tDs
+            L\t0\t1\t rob_id=0
+            S\t1\t0\tDs
+            L\t1\t1\t rob_id=1
+            C\t1
+            S\t0\t0\tIs
+            L\t0\t1\t fu=alu
+            S\t1\t0\tIs
+            L\t1\t1\t fu=alu
+            C\t1
+            S\t0\t0\tCm
+            S\t1\t0\tCm
+            C\t2
+            R\t0\t0\t0
+            R\t1\t1\t0
+            C\t1
+            R\t2\t0\t1
+            """
+        )
+
+    def test_rollback_without_instructions(self):
+        # A block squashed before any instruction was fetched leaves no
+        # trace in the log.
+        records = [
+            dec(0, FTQAlloc(ftq_ptr=0, pc=0x100)),
+            dec(1, FetchRequest(ftq_ptr=0, pc=0x100)),
+            dec(2, FTQRollback(ftq_ptr=0, cause="ifu_writeback")),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        assert out.getvalue() == "Kanata\t0004\nC=\t0\n"
+
+    def test_commit_does_not_terminate_instructions(self):
+        # The FTQ commit pointer names the *oldest live* entry: it is emitted
+        # per retired instruction and must not terminate anything by itself.
+        records = [
+            dec(0, FTQAlloc(ftq_ptr=0, pc=0x100)),
+            dec(1, InstrFetched(ftq_ptr=0, pc=0x100, instr=0x13, ftq_offset=0)),
+            dec(2, FTQAlloc(ftq_ptr=1, pc=0x108)),
+            dec(3, RobAllocate(ftq_ptr=0, ftq_offset=0, rob_id=5)),
+            dec(4, FTQCommit(ftq_ptr=0)),
+            dec(5, FTQCommit(ftq_ptr=1)),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        assert not any(line.startswith("R") for line in out.getvalue().splitlines())
+
+    def test_rob_flush_then_rollback_terminates_once(self):
+        # An instruction flushed from the ROB whose FTQ entry is later rolled
+        # back gets exactly one terminal record.
+        records = [
+            dec(0, FTQAlloc(ftq_ptr=0, pc=0x100)),
+            dec(1, InstrFetched(ftq_ptr=0, pc=0x100, instr=0x13, ftq_offset=0)),
+            dec(2, RobAllocate(ftq_ptr=0, ftq_offset=0, rob_id=3)),
+            dec(3, RobFlush(rob_id=3)),
+            dec(4, FTQRollback(ftq_ptr=0, cause="backend_redirect")),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        retires = [line for line in out.getvalue().splitlines() if line.startswith("R")]
+        assert retires == ["R\t0\t0\t1"]
+
+    def test_unterminated_instructions(self):
+        # Instructions still in flight when the log ends stay unterminated.
+        records = [
+            dec(0, FTQAlloc(ftq_ptr=0, pc=0x100)),
+            dec(2, InstrFetched(ftq_ptr=0, pc=0x100, instr=0x13, ftq_offset=0)),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        assert not any(line.startswith("R") for line in out.getvalue().splitlines())
+
+    def test_undisassemblable_instruction_falls_back_to_hex(self):
+        records = [
+            dec(0, FetchRequest(ftq_ptr=0, pc=0x100)),
+            dec(1, InstrFetched(ftq_ptr=0, pc=0x100, instr=0xFFFFFFFF, ftq_offset=0)),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        assert "L\t0\t0\t00000100: ffffffff" in out.getvalue().splitlines()
+
+    def test_decode_of_squashed_instruction_is_ignored(self):
+        # A decode event arriving after its FTQ entry was squashed (or for an
+        # unknown entry) leaves no trace.
+        records = [
+            dec(0, FTQAlloc(ftq_ptr=0, pc=0x100)),
+            dec(1, InstrFetched(ftq_ptr=0, pc=0x100, instr=0x13, ftq_offset=0)),
+            dec(2, FTQRollback(ftq_ptr=0, cause="backend_redirect")),
+            dec(3, InstrDecoded(ftq_ptr=0, ftq_offset=0)),
+            dec(3, InstrDecoded(ftq_ptr=7, ftq_offset=0)),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        assert not any("\tD" in line for line in out.getvalue().splitlines() if line.startswith("S"))


### PR DESCRIPTION
A few changes were required to achieve this:
- `ftq_offset` is now part of the instruction payload up to ROB allocation, so we can trace them
- new `coreblocks.telemetry` package with events tracing instructions through the whole pipeline
- a converter from captured event logs to the Kanata format, for viewing pipeline traces in Konata (https://github.com/shioyadan/Konata). The UI of the viewer is a bit wonky, but this is the best I could find and I think should be good enough for now. 

Depends on https://github.com/kuznia-rdzeni/transactron/pull/189

Usage:
1. run your favorite test (this _should_ also work on benchmarks, but haven't tested it yet - bechmark run times grew significantly in the past year hehe) 
```
$ pytest --coreblocks-backend=pysim --coreblocks-regression --coreblocks-evlog -k "rv32uc-rvc"
```
2. manually inspect events
```
$ python -m transactron.cmd.evlog test/__evlogs__/test.regression.rv32uc-rvc.jsonl | rg "rob_id=56"
 412 backend.scheduler     backend.rob_allocate     ftq_ptr=18 ftq_offset=2 rob_id=56
 415 backend.wakeup_select backend.fu_issue         rob_id=56 unit=alu
 416 backend.announcement  backend.exec_complete    rob_id=56
 417 backend.retirement    backend.rob_retire       rob_id=56
```
3. generate logs in Konata format
```
$ python -m coreblocks.telemetry.konata test/__evlogs__/test.regression.rv32uc-rvc.jsonl > /tmp/coreblocks.log
```
4. profit

Pics:
<img width="1783" height="365" alt="image" src="https://github.com/user-attachments/assets/117e9c79-2f62-457f-b87a-b5fbe4b5a7fd" />
why there are two cycles between retiring instructions (7, 8) and (9, 10)? (this could be a bug in tracing)

This also shows that icache misses hurt (the big purple block).


<img width="1717" height="99" alt="image" src="https://github.com/user-attachments/assets/8c373b92-a100-4024-acff-2ff76b45e6c1" />
Sequential execution of SYSTEM instructions.


<img width="1427" height="202" alt="image" src="https://github.com/user-attachments/assets/8bf44b6d-87cc-48b9-9ecd-c68291227499" />
misprediction + pipeline flush!

I think this fixes #763  