### PR TITLE
Store FTQ pointers in RS and use them when redirecting the frontend

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -10,6 +10,7 @@ from coreblocks.interface.layouts import (
     RFLayouts,
     ROBLayouts,
     RetirementLayouts,
+    FTQPtr,
 )
 
 from transactron.core import Method, Methods, Transaction, TModule, def_method
@@ -55,7 +56,7 @@ class Retirement(Elaboratable):
         self.exception_cause_get = Method(o=gen_params.get(ExceptionRegisterLayouts).get)
         self.exception_cause_clear = Method()
         self.c_rat_restore = Method(i=gen_params.get(RATLayouts).crat_flush_restore_in)
-        self.fetch_continue = Method(i=self.gen_params.get(FetchLayouts).resume)
+        self.fetch_continue = Method(i=self.gen_params.get(FetchLayouts).backend_redirect)
         self.instr_decrement = Method(
             i=gen_params.get(CoreInstructionCounterLayouts).decrement_in,
             o=gen_params.get(CoreInstructionCounterLayouts).decrement_out,
@@ -136,6 +137,7 @@ class Retirement(Elaboratable):
         continue_pc = Signal(self.gen_params.isa.xlen)
         core_flushing = Signal()
         trap_target_priv = Signal(PrivilegeLevel, init=PrivilegeLevel.MACHINE)
+        ftq_commit_ptr = FTQPtr(gen_params=self.gen_params)
 
         retire_count = Signal(range(self.gen_params.retirement_superscalarity + 1))
         no_trap_count = Signal.like(retire_count)
@@ -261,6 +263,7 @@ class Retirement(Elaboratable):
                     # Commit the FTQ entry for the last retired instruction this cycle.
                     with m.If(no_trap_count.bool() | commit_trapping):
                         ftq_commit(m, ftq_ptr=last_commit_ftq_ptr)
+                        m.d.sync += ftq_commit_ptr.eq(last_commit_ftq_ptr)
 
             with m.State("TRAP_FLUSH"):
                 with Transaction(name="Retirement_FLUSH").body(m):
@@ -316,7 +319,7 @@ class Retirement(Elaboratable):
                     resume_pc = Mux(continue_pc_override, continue_pc, handler_pc)
                     m.d.sync += continue_pc_override.eq(0)
 
-                    self.fetch_continue(m, pc=resume_pc)
+                    self.fetch_continue(m, ftq_ptr=ftq_commit_ptr, pc=resume_pc)
 
                     # Release pending trap state - allow accepting new reports
                     self.exception_cause_clear(m)

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -119,7 +119,7 @@ class FetchTargetQueue(Elaboratable):
         ftq_layouts = self.gen_params.get(FetchTargetQueueLayouts)
         self.commit = Method(i=ftq_layouts.commit)
         self.resolve = Method(i=ftq_layouts.branch_resolve)
-        self.backend_redirect = Method(i=ifu_layouts.frontend_redirect)
+        self.backend_redirect = Method(i=ifu_layouts.backend_redirect)
 
         self.dep_manager.add_dependency(BranchResolveKey(), self.resolve)
         self.dep_manager.add_dependency(FTQCommitKey(), self.commit)
@@ -211,21 +211,14 @@ class FetchTargetQueue(Elaboratable):
             m.d.sync += commit_ptr.eq(ftq_ptr)
 
         @def_method(m, self.backend_redirect)
-        def _(pc, from_unsafe):
-            commit_ptr_plus_one = FTQPtr(gen_params=self.gen_params)
-            m.d.av_comb += commit_ptr_plus_one.eq(FTQPtr(commit_ptr, gen_params=self.gen_params) + 1)
+        def _(ftq_ptr, pc):
+            ftq_ptr_plus_one = FTQPtr(gen_params=self.gen_params)
+            m.d.av_comb += ftq_ptr_plus_one.eq(FTQPtr(ftq_ptr, gen_params=self.gen_params) + 1)
 
             fetch_address_unit.backend_redirect(m, pc=pc)
 
-            # An unsafe instruction (e.g. a CSR access) is not squashed - it keeps its FTQ entry
-            # and is committed normally. Its resume is signalled before it retires, so `commit_ptr`
-            # is stale here and must not be used. The alloc/fetch pointers were already rewound to
-            # just past the unsafe instruction when the fetch unit wrote it back (`ifu_writeback`).
-            # For an exception/backend redirect the whole pipeline is squashed, so we restart
-            # allocation right after the last committed entry.
-            with m.If(~from_unsafe):
-                m.d.sync += alloc_ptr.eq(commit_ptr_plus_one)
-                m.d.sync += fetch_ptr.eq(commit_ptr_plus_one)
+            m.d.sync += alloc_ptr.eq(ftq_ptr)
+            m.d.sync += fetch_ptr.eq(ftq_ptr)
 
         @def_method(m, self.jump_target_req)
         def _():

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -217,8 +217,8 @@ class FetchTargetQueue(Elaboratable):
 
             fetch_address_unit.backend_redirect(m, pc=pc)
 
-            m.d.sync += alloc_ptr.eq(ftq_ptr)
-            m.d.sync += fetch_ptr.eq(ftq_ptr)
+            m.d.sync += alloc_ptr.eq(ftq_ptr_plus_one)
+            m.d.sync += fetch_ptr.eq(ftq_ptr_plus_one)
 
         @def_method(m, self.jump_target_req)
         def _():

--- a/coreblocks/frontend/stall_controller.py
+++ b/coreblocks/frontend/stall_controller.py
@@ -75,7 +75,7 @@ class StallController(Elaboratable):
             # Make sure that there is at most one caller - there can be only one unsafe instruction
             log.assertion(m, popcount(runs) <= 1)
             m.submodules.resume_prio_encoder = resume_prio_encoder = PriorityEncoder(len(args))
-            m.d.top_comb += resume_prio_encoder.i.eq(runs)
+            m.d.comb += resume_prio_encoder.i.eq(runs)
             return Array(args)[resume_prio_encoder.o]
 
         @def_method(m, self._resume_from_unsafe, nonexclusive=True, combiner=resume_combiner)

--- a/coreblocks/frontend/stall_controller.py
+++ b/coreblocks/frontend/stall_controller.py
@@ -1,6 +1,4 @@
 from typing import Sequence
-import operator
-from functools import reduce
 
 from amaranth import *
 
@@ -10,6 +8,7 @@ from transactron.lib.metrics import *
 from transactron.lib.simultaneous import condition
 from transactron.utils import popcount, DependencyContext, MethodStruct
 from transactron.utils.assign import AssignArg
+from transactron.utils.amaranth_ext.coding import PriorityEncoder
 from transactron import *
 
 from coreblocks.params import *
@@ -52,10 +51,10 @@ class StallController(Elaboratable):
         self.stall_unsafe = Method()
         self.stall_exception = Method()
         self.stall_guard = Method()
-        self.resume_from_exception = Method(i=layouts.resume)
-        self._resume_from_unsafe = Method(i=layouts.resume)
+        self.resume_from_exception = Method(i=layouts.backend_redirect)
+        self._resume_from_unsafe = Method(i=layouts.backend_redirect)
 
-        self.redirect_frontend = Method(i=layouts.frontend_redirect)
+        self.redirect_frontend = Method(i=layouts.backend_redirect)
 
         DependencyContext.get().add_dependency(UnsafeInstructionResolvedKey(), self._resume_from_unsafe)
 
@@ -75,27 +74,27 @@ class StallController(Elaboratable):
         def resume_combiner(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
             # Make sure that there is at most one caller - there can be only one unsafe instruction
             log.assertion(m, popcount(runs) <= 1)
-            pcs = [Mux(runs[i], v.pc, 0) for i, v in enumerate(args)]
-
-            return {"pc": reduce(operator.or_, pcs, 0)}
+            m.submodules.resume_prio_encoder = resume_prio_encoder = PriorityEncoder(len(args))
+            m.d.top_comb += resume_prio_encoder.i.eq(runs)
+            return Array(args)[resume_prio_encoder.o]
 
         @def_method(m, self._resume_from_unsafe, nonexclusive=True, combiner=resume_combiner)
-        def _(pc):
+        def _(ftq_ptr, pc):
             log.assertion(m, stalled_unsafe)
             m.d.sync += stalled_unsafe.eq(0)
 
             with condition(m, nonblocking=True) as branch:
                 with branch(~stalled_exception):
                     log.info(m, True, "Resuming from unsafe instruction new_pc=0x{:x}", pc)
-                    self.redirect_frontend(m, pc=pc, from_unsafe=1)
+                    self.redirect_frontend(m, ftq_ptr=ftq_ptr, pc=pc)
 
         @def_method(m, self.resume_from_exception)
-        def _(pc):
+        def _(ftq_ptr, pc):
             m.d.sync += stalled_unsafe.eq(0)
             m.d.sync += stalled_exception.eq(0)
 
             log.info(m, True, "Resuming from exception new_pc=0x{:x}", pc)
-            self.redirect_frontend(m, pc=pc, from_unsafe=0)
+            self.redirect_frontend(m, ftq_ptr=ftq_ptr, pc=pc)
 
         @def_method(m, self.stall_unsafe)
         def _():

--- a/coreblocks/func_blocks/csr/csr_unit.py
+++ b/coreblocks/func_blocks/csr/csr_unit.py
@@ -254,7 +254,7 @@ class CSRUnit(FuncBlock, Elaboratable):
 
             with m.If(~core_state.flushing & ~exception & ~interrupt):
                 # CSR instructions are never compressed, PC+4 is always next instruction
-                resume_core(m, pc=instr.pc + self.gen_params.isa.ilen_bytes)
+                resume_core(m, ftq_ptr=instr.ftq_ptr, pc=instr.pc + self.gen_params.isa.ilen_bytes)
 
             return {
                 "rob_id": instr.rob_id,

--- a/coreblocks/func_blocks/fu/priv.py
+++ b/coreblocks/func_blocks/fu/priv.py
@@ -16,7 +16,7 @@ from transactron.utils import DependencyContext, OneHotSwitch
 from coreblocks.params import *
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, ExceptionCause
-from coreblocks.interface.layouts import PrivUnitLayouts
+from coreblocks.interface.layouts import PrivUnitLayouts, FTQPtr
 from coreblocks.interface.keys import (
     CoreStateKey,
     MretKey,
@@ -87,6 +87,7 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
         instr_rob = Signal(self.gen_params.rob_entries_bits)
         instr_pc = Signal(self.gen_params.isa.xlen)
         instr_fn = self.fn.get_function()
+        ftq_ptr = FTQPtr(gen_params=self.gen_params)
 
         instr_imm = Signal(self.gen_params.isa.xlen)
         instr_s1_val = Signal(self.gen_params.isa.xlen)
@@ -115,6 +116,7 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
                 instr_s1_val.eq(arg.s1_val),
                 instr_s2_val.eq(arg.s2_val),
                 instr_imm.eq(arg.imm),
+                ftq_ptr.eq(arg.ftq_ptr),
             ]
 
         with Transaction().body(m, ready=instr_valid & ~finished):
@@ -260,7 +262,7 @@ class PrivilegedFuncUnit(FuncUnitBase[PrivilegedFn]):
             with m.Elif(~core_state.flushing):
                 log.info(m, True, "Unstalling fetch from the priv unit new_pc=0x{:x}", ret_pc)
                 # Unstall the fetch
-                resume_core(m, pc=ret_pc)
+                resume_core(m, ftq_ptr=ftq_ptr, pc=ret_pc)
 
             self.push_result(
                 m,

--- a/coreblocks/func_blocks/fu/zbc.py
+++ b/coreblocks/func_blocks/fu/zbc.py
@@ -185,7 +185,7 @@ class ZbcUnit(FuncUnitBase[ZbcFn]):
             self.push_result(m, rob_id=params.rob_id, rp_dst=params.rp_dst, result=reversed_result, exception=0)
 
         @def_method(m, self.issue_decoded)
-        def _(exec_fn, decode_fn, imm, s1_val, s2_val, rob_id, rp_dst, pc, tag):
+        def _(exec_fn, decode_fn, imm, s1_val, s2_val, rob_id, rp_dst, pc, tag, ftq_ptr):
             i1 = s1_val
             i2 = Mux(imm, imm, s2_val)
 

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -335,6 +335,7 @@ class SchedulerLayouts:
             fields.csr,
             fields.pc,
             fields.tag,
+            fields.ftq_ptr,
         )
 
         self.rob_allocate_out = self.rs_select_in = make_layout(
@@ -352,6 +353,7 @@ class SchedulerLayouts:
             fields.csr,
             fields.pc,
             fields.tag,
+            fields.ftq_ptr,
         )
 
         self.rs_insert_in = self.rs_select_out = make_layout(
@@ -530,6 +532,7 @@ class RSFullDataLayout:
             fields.csr,
             fields.pc,
             fields.tag,
+            fields.ftq_ptr,
         )
 
 
@@ -581,6 +584,7 @@ class RSLayouts:
             "imm",
             "pc",
             "tag",
+            "ftq_ptr",
         }
 
         self.rs = gen_params.get(RSInterfaceLayouts, rs_entries=rs_entries, data_fields=data_fields)
@@ -602,6 +606,7 @@ class RSLayouts:
                 "imm",
                 "pc",
                 "tag",
+                "ftq_ptr",
             },
         )
 
@@ -697,8 +702,10 @@ class FetchLayouts:
         self.fetch_request = make_layout(fields.pc, fields.ftq_ptr)
         self.fetch_writeback = make_layout(fields.ftq_ptr, ("redirect", 1), ("redirect_target", gen_params.isa.xlen))
         self.redirect = make_layout(fields.pc)
-        self.frontend_redirect = make_layout(fields.pc, ("from_unsafe", 1))
-        self.resume = make_layout(fields.pc)
+
+        # The ftq_ptr points to an FTQ entry such that no newer entries contain instructions that will be
+        # (or have already been) committed before the instruction the core is being redirected to.
+        self.backend_redirect = make_layout(fields.ftq_ptr, fields.pc)
 
         self.predecoded_instr = make_layout(fields.cfi_type, ("cfi_offset", signed(21)), ("unsafe", 1))
 
@@ -779,6 +786,7 @@ class FuncUnitLayouts:
             fields.imm,
             fields.pc,
             fields.tag,
+            fields.ftq_ptr,
         )
 
         self.push_result = make_layout(
@@ -885,6 +893,7 @@ class CSRUnitLayouts:
             "csr",
             "pc",
             "tag",
+            "ftq_ptr",
         }
 
         self.rs = gen_params.get(RSInterfaceLayouts, rs_entries=self.rs_entries, data_fields=data_fields)

--- a/coreblocks/scheduler/scheduler.py
+++ b/coreblocks/scheduler/scheduler.py
@@ -425,6 +425,7 @@ class RSInsertion(Elaboratable):
                         "csr": instr.csr,
                         "pc": instr.pc,
                         "tag": instr.tag,
+                        "ftq_ptr": instr.ftq_ptr,
                     },
                 )
                 rs_datas.append(rs_data)

--- a/test/func_blocks/csr/test_csr.py
+++ b/test/func_blocks/csr/test_csr.py
@@ -57,7 +57,9 @@ class CSRUnitTestCircuit(Elaboratable):
         m.submodules.insert = self.insert = TestbenchIO(AdapterTrans.create(self.dut.insert))
         m.submodules.update = self.update = TestbenchIO(AdapterTrans.create(self.dut.update[0]))
         m.submodules.accept = self.accept = TestbenchIO(AdapterTrans.create(self.dut.get_result))
-        m.submodules.fetch_resume = self.fetch_resume = TestbenchIO(Adapter(i=self.gen_params.get(FetchLayouts).resume))
+        m.submodules.fetch_resume = self.fetch_resume = TestbenchIO(
+            Adapter(i=self.gen_params.get(FetchLayouts).backend_redirect)
+        )
         m.submodules.csr_instances = self.csr_instances = CSRInstances(self.gen_params)
         m.submodules.priv_io = self.priv_io = TestbenchIO(
             AdapterTrans.create(self.csr_instances.m_mode.priv_mode.write)

--- a/test/func_blocks/fu/common/test_rs.py
+++ b/test/func_blocks/fu/common/test_rs.py
@@ -43,6 +43,7 @@ def create_data_list(gen_params: GenParams, count: int, optypes: int = 1):
             "imm": k,
             "pc": k,
             "tag": 0,
+            "ftq_ptr": {"ptr": 0, "parity": 0},
         }
         for k in range(count)
     ]

--- a/test/scheduler/test_rs_selection.py
+++ b/test/scheduler/test_rs_selection.py
@@ -63,6 +63,10 @@ class TestRSSelect(TestCaseWithSimulator):
                 "csr": csr,
                 "pc": pc,
                 "tag": 0,
+                "ftq_ptr": {
+                    "ptr": random.randrange(2**self.gen_params.ftq_size_log),
+                    "parity": random.randrange(2),
+                },
             }
 
             self.input_instrs.append(instr)


### PR DESCRIPTION
- Made the `FTQ::backend_redirect` function take a ftq_ptr so we can redirect the fetch unit before all active instructions are commited (useful for checkpointing)
- Passed the FTQ pointer of an instruction all the way to RSes. I think it is useful for functional units to know it: jumpbranch for reading the predicted target, csr & priv for redirecting the fetch unit.