### PR TITLE
frontend: rename prediction-checker output fields, expose cfi_type

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -377,7 +377,7 @@ class FetchUnit(Elaboratable):
             m.d.av_comb += has_unsafe.eq(~unsafe_prio_encoder.n)
 
             redirect_before_unsafe = Signal()
-            m.d.av_comb += redirect_before_unsafe.eq(predcheck_res.fb_instr_idx < unsafe_idx)
+            m.d.av_comb += redirect_before_unsafe.eq(predcheck_res.cfi_idx < unsafe_idx)
 
             redirect = Signal()
             unsafe_stall = Signal()
@@ -385,9 +385,9 @@ class FetchUnit(Elaboratable):
 
             with m.If(predcheck_res.mispredicted & (~has_unsafe | redirect_before_unsafe)):
                 m.d.av_comb += [
-                    redirect.eq(~predcheck_res.stall),
-                    unsafe_stall.eq(predcheck_res.stall),
-                    redirect_or_unsafe_idx.eq(predcheck_res.fb_instr_idx),
+                    redirect.eq(predcheck_res.cfi_valid),
+                    unsafe_stall.eq(~predcheck_res.cfi_valid),
+                    redirect_or_unsafe_idx.eq(predcheck_res.cfi_idx),
                 ]
             with m.Elif(has_unsafe):
                 m.d.av_comb += [
@@ -415,7 +415,7 @@ class FetchUnit(Elaboratable):
                     raw_instrs[i].instr.eq(instrs[i]),
                     raw_instrs[i].pc.eq(params.pc_from_fb(fetch_block_addr, i)),
                     raw_instrs[i].rvc.eq(s1_data.rvc[i]),
-                    raw_instrs[i].predicted_taken.eq(redirect & (predcheck_res.fb_instr_idx == i)),
+                    raw_instrs[i].predicted_taken.eq(redirect & (predcheck_res.cfi_idx == i)),
                     raw_instrs[i].access_fault.eq(s1_data.access_fault),
                     raw_instrs[i].cfi_type.eq(predecoded_instr[i].cfi_type),
                     raw_instrs[i].ftq_ptr.eq(ftq_ptr),
@@ -442,7 +442,7 @@ class FetchUnit(Elaboratable):
                             m,
                             ftq_ptr=ftq_ptr,
                             redirect=redirect,
-                            redirect_target=predcheck_res.redirect_target,
+                            cfi_target=predcheck_res.cfi_target,
                         )
                         flush()
 
@@ -668,9 +668,10 @@ class PredictionChecker(Elaboratable):
                     ret,
                     {
                         "mispredicted": 1,
-                        "stall": CfiType.is_jalr(decoded_cfi_types[pd_redirect_idx]),
-                        "fb_instr_idx": pd_redirect_idx,
-                        "redirect_target": decoded_target_for_decoded_cfi,
+                        "cfi_valid": ~CfiType.is_jalr(decoded_cfi_types[pd_redirect_idx]),
+                        "cfi_idx": pd_redirect_idx,
+                        "cfi_type": decoded_cfi_types[pd_redirect_idx],
+                        "cfi_target": decoded_target_for_decoded_cfi,
                     },
                 )
             with m.Elif(mispredicted_cfi_type):
@@ -680,9 +681,10 @@ class PredictionChecker(Elaboratable):
                     ret,
                     {
                         "mispredicted": 1,
-                        "stall": CfiType.is_jalr(decoded_cfi_types[pd_redirect_idx]),
-                        "fb_instr_idx": Mux(pd_redirection_enc.n, self.gen_params.fetch_width - 1, pd_redirect_idx),
-                        "redirect_target": Mux(pd_redirection_enc.n, fallthrough_addr, decoded_target_for_decoded_cfi),
+                        "cfi_valid": ~CfiType.is_jalr(decoded_cfi_types[pd_redirect_idx]),
+                        "cfi_idx": Mux(pd_redirection_enc.n, self.gen_params.fetch_width - 1, pd_redirect_idx),
+                        "cfi_type": Mux(pd_redirection_enc.n, CfiType.INVALID, decoded_cfi_types[pd_redirect_idx]),
+                        "cfi_target": Mux(pd_redirection_enc.n, fallthrough_addr, decoded_target_for_decoded_cfi),
                     },
                 )
             with m.Elif(mispredicted_cfi_target):
@@ -691,8 +693,21 @@ class PredictionChecker(Elaboratable):
                     ret,
                     {
                         "mispredicted": 1,
-                        "fb_instr_idx": prediction.cfi_idx,
-                        "redirect_target": decoded_target_for_predicted_cfi,
+                        "cfi_valid": 1,
+                        "cfi_idx": prediction.cfi_idx,
+                        "cfi_type": decoded_cfi_types[prediction.cfi_idx],
+                        "cfi_target": decoded_target_for_predicted_cfi,
+                    },
+                )
+            with m.Else():
+                m.d.av_comb += assign(
+                    ret,
+                    {
+                        "mispredicted": 0,
+                        "cfi_valid": prediction.cfi_target_valid,
+                        "cfi_idx": prediction.cfi_idx,
+                        "cfi_type": prediction.cfi_type,
+                        "cfi_target": prediction.cfi_target,
                     },
                 )
 

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -190,7 +190,7 @@ class FetchTargetQueue(Elaboratable):
         def _(
             ftq_ptr,
             redirect,
-            redirect_target,
+            cfi_target,
         ):
             ftq_ptr_plus_one = FTQPtr(gen_params=self.gen_params)
             m.d.av_comb += ftq_ptr_plus_one.eq(FTQPtr(ftq_ptr, gen_params=self.gen_params) + 1)
@@ -203,7 +203,7 @@ class FetchTargetQueue(Elaboratable):
             m.d.comb += fetch_ptr_next.eq(ftq_ptr_plus_one)
 
             with m.If(redirect):
-                fetch_address_unit.ifu_redirect(m, pc=redirect_target)
+                fetch_address_unit.ifu_redirect(m, pc=cfi_target)
 
         @def_method(m, self.commit)
         def _(ftq_ptr):

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -708,7 +708,7 @@ class FetchLayouts:
         )
 
         self.fetch_request = make_layout(fields.pc, fields.ftq_ptr)
-        self.fetch_writeback = make_layout(fields.ftq_ptr, ("redirect", 1), ("redirect_target", gen_params.isa.xlen))
+        self.fetch_writeback = make_layout(fields.ftq_ptr, ("redirect", 1), fields.cfi_target)
         self.redirect = make_layout(fields.pc)
 
         # The ftq_ptr points to an FTQ entry such that no newer entries contain instructions that will be
@@ -731,9 +731,10 @@ class FetchLayouts:
 
         self.pred_checker_o = make_layout(
             ("mispredicted", 1),
-            ("stall", 1),
-            fields.fb_instr_idx,
-            ("redirect_target", gen_params.isa.xlen),
+            ("cfi_valid", 1),
+            fields.cfi_idx,
+            fields.cfi_type,
+            fields.cfi_target,
         )
 
 

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -194,11 +194,11 @@ class TestFetchUnit(TestCaseWithSimulator):
         pass
 
     @def_method_mock(lambda self: self.fetch.fetch_writeback)
-    def fetch_writeback_mock(self, ftq_ptr, redirect, redirect_target):
+    def fetch_writeback_mock(self, ftq_ptr, redirect, cfi_target):
         @MethodMock.effect
         def eff():
             if redirect:
-                self.last_redirect = redirect_target
+                self.last_redirect = cfi_target
             else:
                 self.stalled = True
 
@@ -484,9 +484,10 @@ class TestFetchUnit(TestCaseWithSimulator):
 @dataclass(frozen=True)
 class CheckerResult:
     mispredicted: bool
-    stall: bool
-    fb_instr_idx: int
-    redirect_target: int
+    cfi_valid: bool
+    cfi_idx: int
+    cfi_type: CfiType
+    cfi_target: int
 
 
 @parameterized_class(
@@ -519,7 +520,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
         block_cross: bool,
         predecoded: list[tuple[CfiType, int]],
         branch_mask: int,
-        cfi_idx: int,
+        cfi_offset: int,
         cfi_type: CfiType,
         cfi_target: Optional[int],
         valid_mask: int = -1,
@@ -534,7 +535,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
 
         prediction = {
             "branch_mask": branch_mask,
-            "cfi_idx": cfi_idx,
+            "cfi_idx": cfi_offset,
             "cfi_type": cfi_type,
             "cfi_target": cfi_target or 0,
             "cfi_target_valid": 1 if cfi_target is not None else 0,
@@ -557,27 +558,31 @@ class TestPredictionChecker(TestCaseWithSimulator):
 
         return CheckerResult(
             mispredicted=bool(res["mispredicted"]),
-            stall=bool(res["stall"]),
-            fb_instr_idx=res["fb_instr_idx"],
-            redirect_target=res["redirect_target"],
+            cfi_valid=bool(res["cfi_valid"]),
+            cfi_idx=res["cfi_idx"],
+            cfi_type=CfiType(res["cfi_type"]),
+            cfi_target=res["cfi_target"],
         )
 
     def assert_resp(
         self,
         res: CheckerResult,
         mispredicted: Optional[bool] = None,
-        stall: Optional[bool] = None,
-        fb_instr_idx: Optional[int] = None,
-        redirect_target: Optional[int] = None,
+        cfi_valid: Optional[bool] = None,
+        cfi_idx: Optional[int] = None,
+        cfi_type: Optional[CfiType] = None,
+        cfi_target: Optional[int] = None,
     ):
         if mispredicted is not None:
             assert res.mispredicted == mispredicted
-        if stall is not None:
-            assert res.stall == stall
-        if fb_instr_idx is not None:
-            assert res.fb_instr_idx == fb_instr_idx
-        if redirect_target is not None:
-            assert res.redirect_target == redirect_target
+        if cfi_valid is not None:
+            assert res.cfi_valid == cfi_valid
+        if cfi_idx is not None:
+            assert res.cfi_idx == cfi_idx
+        if cfi_type is not None:
+            assert res.cfi_type == cfi_type
+        if cfi_target is not None:
+            assert res.cfi_target == cfi_target
 
     def test_no_misprediction(self):
         instr_width = self.gen_params.min_instr_width_bytes
@@ -748,16 +753,16 @@ class TestPredictionChecker(TestCaseWithSimulator):
         async def proc(sim: TestbenchContext):
             # No prediction was made, but there is a JAL at the beginning
             ret = await self.check(sim, 0x100, False, [(CfiType.JAL, 0x20)], 0, 0, CfiType.INVALID, None)
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 + 0x20)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 + 0x20)
 
             # The same, but the jump is between two fetch blocks
             if self.with_rvc:
                 ret = await self.check(sim, 0x100, True, [(CfiType.JAL, 0x20)], 0, 0, CfiType.INVALID, None)
-                self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 + 0x20 - 2)
+                self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 + 0x20 - 2)
 
             # Not predicted backward branch
             ret = await self.check(sim, 0x100, False, [(CfiType.BRANCH, -100)], 0b0, 0, CfiType.INVALID, 0)
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 - 100)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 - 100)
 
             # Now tests for fetch blocks with multiple instructions
             if fetch_width < 2:
@@ -774,7 +779,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
                 CfiType.BRANCH,
                 0x100 + instr_width + 100,
             )
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 - 100)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 - 100)
 
             # We predicted the branch on the second instruction, but there's a JALR on the first one.
             ret = await self.check(
@@ -787,7 +792,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
                 CfiType.BRANCH,
                 0x100 + instr_width + 100,
             )
-            self.assert_resp(ret, mispredicted=True, stall=True, fb_instr_idx=0)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=False, cfi_idx=0)
 
             # We predicted the branch on the second instruction, but there's a backward on the first one.
             ret = await self.check(
@@ -800,29 +805,25 @@ class TestPredictionChecker(TestCaseWithSimulator):
                 CfiType.BRANCH,
                 0x100 + instr_width + 100,
             )
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 - 100)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 - 100)
 
             # Unpredicted backward branch as the second instruction
             ret = await self.check(
                 sim, 0x100, False, [(CfiType.INVALID, 0), (CfiType.BRANCH, -100)], 0b00, 0, CfiType.INVALID, 0
             )
-            self.assert_resp(
-                ret, mispredicted=True, stall=False, fb_instr_idx=1, redirect_target=0x100 + instr_width - 100
-            )
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=1, cfi_target=0x100 + instr_width - 100)
 
             # Unpredicted JAL as the second instruction
             ret = await self.check(
                 sim, 0x100, False, [(CfiType.INVALID, 0), (CfiType.JAL, 100)], 0b00, 0, CfiType.INVALID, 0
             )
-            self.assert_resp(
-                ret, mispredicted=True, stall=False, fb_instr_idx=1, redirect_target=0x100 + instr_width + 100
-            )
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=1, cfi_target=0x100 + instr_width + 100)
 
             # Unpredicted JALR as the second instruction
             ret = await self.check(
                 sim, 0x100, False, [(CfiType.INVALID, 0), (CfiType.JALR, 100)], 0b00, 0, CfiType.INVALID, 0
             )
-            self.assert_resp(ret, mispredicted=True, stall=True, fb_instr_idx=1)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=False, cfi_idx=1)
 
             if fetch_width < 3:
                 return
@@ -838,7 +839,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
                 None,
             )
             self.assert_resp(
-                ret, mispredicted=True, stall=False, fb_instr_idx=2, redirect_target=0x100 + 2 * instr_width + 100
+                ret, mispredicted=True, cfi_valid=True, cfi_idx=2, cfi_target=0x100 + 2 * instr_width + 100
             )
 
         with self.run_simulation(self.m) as sim:
@@ -853,20 +854,20 @@ class TestPredictionChecker(TestCaseWithSimulator):
             # We predicted a JAL, but in fact there is a non-CFI instruction
             ret = await self.check(sim, 0x100, False, [(CfiType.INVALID, 0)], 0, 0, CfiType.JAL, 100)
             self.assert_resp(
-                ret, mispredicted=True, stall=False, fb_instr_idx=fetch_width - 1, redirect_target=0x100 + fb_bytes
+                ret, mispredicted=True, cfi_valid=True, cfi_idx=fetch_width - 1, cfi_target=0x100 + fb_bytes
             )
 
             # We predicted a JAL, but in fact there is a branch
             ret = await self.check(sim, 0x100, False, [(CfiType.BRANCH, -100)], 0, 0, CfiType.JAL, 100)
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 - 100)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 - 100)
 
             # We predicted a JAL, but in fact there is a JALR instruction
             ret = await self.check(sim, 0x100, False, [(CfiType.JALR, -100)], 0, 0, CfiType.JAL, 100)
-            self.assert_resp(ret, mispredicted=True, stall=True, fb_instr_idx=0)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=False, cfi_idx=0)
 
             # We predicted a branch, but in fact there is a JAL
             ret = await self.check(sim, 0x100, False, [(CfiType.JAL, -100)], 0b1, 0, CfiType.BRANCH, 100)
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 - 100)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 - 100)
 
             if fetch_width < 2:
                 return
@@ -876,7 +877,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
                 sim, 0x100, False, [(CfiType.BRANCH, -100), (CfiType.INVALID, 0)], 0b11, 1, CfiType.BRANCH, 100
             )
             self.assert_resp(
-                ret, mispredicted=True, stall=False, fb_instr_idx=fetch_width - 1, redirect_target=0x100 + fb_bytes
+                ret, mispredicted=True, cfi_valid=True, cfi_idx=fetch_width - 1, cfi_target=0x100 + fb_bytes
             )
 
             # The same as above, but we start from the second instruction
@@ -891,7 +892,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
                 100,
             )
             self.assert_resp(
-                ret, mispredicted=True, stall=False, fb_instr_idx=fetch_width - 1, redirect_target=0x100 + fb_bytes
+                ret, mispredicted=True, cfi_valid=True, cfi_idx=fetch_width - 1, cfi_target=0x100 + fb_bytes
             )
 
         with self.run_simulation(self.m) as sim:
@@ -904,20 +905,20 @@ class TestPredictionChecker(TestCaseWithSimulator):
         async def proc(sim: TestbenchContext):
             # We predicted a wrong JAL target
             ret = await self.check(sim, 0x100, False, [(CfiType.JAL, 100)], 0, 0, CfiType.JAL, 200)
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 + 100)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 + 100)
 
             # We predicted a wrong branch target
             ret = await self.check(sim, 0x100, False, [(CfiType.BRANCH, 100)], 0b1, 0, CfiType.BRANCH, 200)
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 + 100)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 + 100)
 
             # We didn't provide the branch target
             ret = await self.check(sim, 0x100, False, [(CfiType.BRANCH, 100)], 0b1, 0, CfiType.BRANCH, None)
-            self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 + 100)
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 + 100)
 
             # We predicted a wrong JAL target that is between two fetch blocks
             if self.with_rvc:
                 ret = await self.check(sim, 0x100, True, [(CfiType.JAL, 100)], 0, 0, CfiType.JAL, 300)
-                self.assert_resp(ret, mispredicted=True, stall=False, fb_instr_idx=0, redirect_target=0x100 + 100 - 2)
+                self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=0, cfi_target=0x100 + 100 - 2)
 
             if fetch_width < 2:
                 return
@@ -926,17 +927,13 @@ class TestPredictionChecker(TestCaseWithSimulator):
             ret = await self.check(
                 sim, 0x100, False, [(CfiType.INVALID, 0), (CfiType.BRANCH, 100)], 0b10, 1, CfiType.BRANCH, None
             )
-            self.assert_resp(
-                ret, mispredicted=True, stall=False, fb_instr_idx=1, redirect_target=0x100 + instr_width + 100
-            )
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=1, cfi_target=0x100 + instr_width + 100)
 
             # The second instruction is a JAL with a wrong target
             ret = await self.check(
                 sim, 0x100, False, [(CfiType.INVALID, 0), (CfiType.JAL, 100)], 0b10, 1, CfiType.JAL, 200
             )
-            self.assert_resp(
-                ret, mispredicted=True, stall=False, fb_instr_idx=1, redirect_target=0x100 + instr_width + 100
-            )
+            self.assert_resp(ret, mispredicted=True, cfi_valid=True, cfi_idx=1, cfi_target=0x100 + instr_width + 100)
 
         with self.run_simulation(self.m) as sim:
             sim.add_testbench(proc)

--- a/test/frontend/test_ftq.py
+++ b/test/frontend/test_ftq.py
@@ -89,7 +89,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             for _ in range(5):
                 await sim.tick()
             flush_count_before = self.bpu_flush_count
-            await self.ftq.ifu_writeback.call(sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, redirect_target=0x200)
+            await self.ftq.ifu_writeback.call(sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, cfi_target=0x200)
             assert self.bpu_flush_count > flush_count_before
 
         with self.run_simulation(self.ftq) as sim:
@@ -102,9 +102,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
         redirect_pc = 0x200
 
         async def proc(sim: TestbenchContext):
-            await self.ftq.ifu_writeback.call(
-                sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, redirect_target=redirect_pc
-            )
+            await self.ftq.ifu_writeback.call(sim, ftq_ptr={"ptr": 0, "parity": 0}, redirect=1, cfi_target=redirect_pc)
             for _ in range(5):
                 await sim.tick()
             assert redirect_pc in [req["pc"] for req in self.ifu_requests]


### PR DESCRIPTION
This is mostly to unify it with other modules that use `cfi_`-like naming. No functional changes expected.