### PR TITLE
RS: use OneHotMux

### DIFF
--- a/coreblocks/func_blocks/fu/common/rs.py
+++ b/coreblocks/func_blocks/fu/common/rs.py
@@ -154,12 +154,18 @@ class RSBase(Elaboratable):
         def _(rs_entry_id: Value) -> ReturnDict:
             actual_rs_entry_id = Signal.like(rs_entry_id)
             m.d.av_comb += actual_rs_entry_id.eq(self.order[rs_entry_id])
-            record = self.data[actual_rs_entry_id]
+
+            take_sel = Signal(self.rs_entries)
+            m.d.av_comb += take_sel.eq(Cat(actual_rs_entry_id == i for i in range(self.rs_entries)))
+            record = OneHotMux.create(m, [(take_sel[i], self.data[i].rs_data) for i in range(self.rs_entries)])
+
             free_idx(m, idx=rs_entry_id)
-            m.d.sync += record.rec_full.eq(0)
+            for i in range(self.rs_entries):
+                with m.If(take_sel[i]):
+                    m.d.sync += self.data[i].rec_full.eq(0)
             self.perf_rs_wait_time.stop(m, slot=actual_rs_entry_id)
             out = Signal(self.layouts.take_out)
-            m.d.av_comb += assign(out, record.rs_data, fields=AssignType.COMMON)
+            m.d.av_comb += assign(out, record, fields=AssignType.COMMON)
             self.log.debug(m, True, "taken entry {} at idx {}", actual_rs_entry_id, rs_entry_id)
             return out
 


### PR DESCRIPTION
Following @qbojj's suggestion, replacing the Array indexing with an explicit OneHotMux. Regression introduced by #1004 added 5 bits to the RS entry (from 174 to 179), which isn't much, but possibly was enough to create some unexpected routing.

The critical both before and after goes through the RS select path.

Before #1004: the critical path of the basic configuration was around 6.51 ns logic, 13.48 ns routing
After: 8.96 + 19.81