### PR TITLE
IFU: robust flushing 

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -53,6 +53,11 @@ class FetchUnit(Elaboratable):
     stall_unsafe: Required[Method]
     """Called when an unsafe instruction is fetched."""
 
+    check_stale: Required[Methods]
+    """
+    Asks the FTQ whether a fetch request is stale. One instance per stage (1 and 2).
+    """
+
     def __init__(self, gen_params: GenParams, icache: CacheInterface) -> None:
         """
         Parameters
@@ -72,6 +77,7 @@ class FetchUnit(Elaboratable):
         self.cont = Method(i=self.layouts.fetch_result)
         self.fetch_request = Method(i=self.layouts.fetch_request)
         self.fetch_writeback = Method(i=self.layouts.fetch_writeback)
+        self.check_stale = Methods(2, i=self.layouts.check_stale_req, o=self.layouts.check_stale_resp)
 
         self.flush = Method()
 
@@ -124,20 +130,16 @@ class FetchUnit(Elaboratable):
             self.cont(m, result)
 
         m.submodules.fetch_requests = fetch_requests = BasicFifo(
-            make_layout(fields.pc, ("access_fault", 1), ("page_fault", 1), fields.ftq_ptr),
+            make_layout(fields.pc, ("access_fault", 1), ("page_fault", 1), fields.ftq_ptr, fields.fetch_gen),
             depth=2,
         )
 
         # This limits number of fetch blocks the fetch unit can process
         # at a time. We start counting when sending a request to the cache and
         # stop when pushing a fetch packet out of the fetch unit.
-        m.submodules.req_counter = req_counter = Semaphore(4)
-        flushing_counter = Signal.like(req_counter.count)
-
-        flush_now = Signal()
-
-        def flush():
-            m.d.comb += flush_now.eq(1)
+        max_inflight_requests = 4
+        assert max_inflight_requests <= 2 ** make_layout(fields.fetch_gen).size
+        m.submodules.req_counter = req_counter = Semaphore(max_inflight_requests)
 
         #
         # Fetch - stage 0
@@ -156,19 +158,19 @@ class FetchUnit(Elaboratable):
         )
         m.submodules += ConnectTrans.create(self.addr_translator.accept, addr_translator_accept_pipe.write)
 
-        m.submodules.ftq_ptr_pipe = ftq_ptr_pipe = Pipe(make_layout(fields.ftq_ptr))
+        m.submodules.ftq_ptr_pipe = ftq_ptr_pipe = Pipe(make_layout(fields.ftq_ptr, fields.fetch_gen))
 
         @def_method(m, self.fetch_request)
-        def _(pc, ftq_ptr):
+        def _(pc, ftq_ptr, fetch_gen):
             log.info(m, True, "[IFU] request pc=0x{:x}", pc)
             req_counter.acquire(m)
 
             self.addr_translator.request(m, addr=pc, is_store=0)
-            ftq_ptr_pipe.write(m, ftq_ptr=ftq_ptr)
+            ftq_ptr_pipe.write(m, ftq_ptr=ftq_ptr, fetch_gen=fetch_gen)
 
         with Transaction().body(m):
             translated = addr_translator_accept_pipe.read(m)
-            ftq_ptr = ftq_ptr_pipe.read(m).ftq_ptr
+            request_id = ftq_ptr_pipe.read(m)
             access_fault = Signal()
 
             m.d.av_comb += pmp_checker.paddr.eq(translated.paddr)
@@ -182,7 +184,8 @@ class FetchUnit(Elaboratable):
                 pc=translated.vaddr,
                 access_fault=access_fault,
                 page_fault=translated.page_fault,
-                ftq_ptr=ftq_ptr,
+                ftq_ptr=request_id.ftq_ptr,
+                fetch_gen=request_id.fetch_gen,
             )
 
         #
@@ -192,11 +195,14 @@ class FetchUnit(Elaboratable):
             [
                 fields.fb_addr,
                 fields.ftq_ptr,
+                fields.fetch_gen,
                 ("instr_valid", fetch_width),
                 ("access_fault", FetchLayouts.FaultFlag),
                 ("rvc", fetch_width),
                 ("instrs", ArrayLayout(self.gen_params.isa.ilen, fetch_width)),
-                ("instr_block_cross", 1),
+                ("starts_mid_instr", 1),
+                ("ends_mid_instr", 1),
+                ("last_half", 16),
             ]
         )
 
@@ -220,6 +226,8 @@ class FetchUnit(Elaboratable):
         prev_half_v = Signal()
         with Transaction(name="Fetch_Stage1").body(m):
             fetch_request = fetch_requests.read(m)
+
+            s1_stale = self.check_stale[0](m, ftq_ptr=fetch_request.ftq_ptr, fetch_gen=fetch_request.fetch_gen).stale
 
             # The address of the fetch block.
             fetch_block_addr = params.fb_addr(fetch_request.pc)
@@ -247,15 +255,15 @@ class FetchUnit(Elaboratable):
 
             # Whether in this cycle we have a fetch block that contains
             # an instruction that crosses a fetch boundary
-            instr_block_cross = Signal()
-            m.d.av_comb += instr_block_cross.eq(prev_half_v & ((prev_half_addr + 1) == fetch_block_addr))
+            starts_mid_instr = Signal()
+            m.d.av_comb += starts_mid_instr.eq(prev_half_v & ((prev_half_addr + 1) == fetch_block_addr))
 
             for i in range(fetch_width):
                 if Extension.ZCA in self.gen_params.isa.extensions:
                     full_instr = Signal(self.gen_params.isa.ilen)
                     if i == 0:
                         # If we have a half of an instruction from the previous block - we need to use it now.
-                        with m.If(instr_block_cross):
+                        with m.If(starts_mid_instr):
                             m.d.av_comb += full_instr.eq(Cat(prev_half, cache_resp.fetch_block[0:16]))
                         with m.Else():
                             m.d.av_comb += full_instr.eq(cache_resp.fetch_block[:32])
@@ -279,7 +287,7 @@ class FetchUnit(Elaboratable):
                         m.d.av_comb += instr_start[i].eq(fetch_block_offset == 0)
                     elif i == 1:
                         m.d.av_comb += instr_start[i].eq(
-                            (fetch_block_offset <= i) & (~instr_start[0] | is_rvc[0] | instr_block_cross)
+                            (fetch_block_offset <= i) & (~instr_start[0] | is_rvc[0] | starts_mid_instr)
                         )
                     else:
                         m.d.av_comb += instr_start[i].eq(
@@ -288,14 +296,18 @@ class FetchUnit(Elaboratable):
                 else:
                     m.d.av_comb += instr_start[i].eq(fetch_block_offset <= i)
 
+            ends_mid_instr = Signal()
+
             if Extension.ZCA in self.gen_params.isa.extensions:
                 instr_position_mask = Cat(instr_start[:-1], instr_start[-1] & is_rvc[-1])
 
-                m.d.sync += prev_half_v.eq(
-                    (flushing_counter <= 1) & ~access_fault.any() & ~is_rvc[-1] & instr_start[-1]
-                )
-                m.d.sync += prev_half.eq(cache_resp.fetch_block[-16:])
-                m.d.sync += prev_half_addr.eq(fetch_block_addr)
+                m.d.av_comb += ends_mid_instr.eq(~access_fault.any() & ~is_rvc[-1] & instr_start[-1])
+
+                # Only a live block may update the cross-fetch carry
+                with m.If(~s1_stale):
+                    m.d.sync += prev_half_v.eq(ends_mid_instr)
+                    m.d.sync += prev_half.eq(cache_resp.fetch_block[-16:])
+                    m.d.sync += prev_half_addr.eq(fetch_block_addr)
             else:
                 instr_position_mask = Cat(instr_start)
 
@@ -309,13 +321,12 @@ class FetchUnit(Elaboratable):
                 access_fault=access_fault,
                 rvc=is_rvc,
                 ftq_ptr=fetch_request.ftq_ptr,
+                fetch_gen=fetch_request.fetch_gen,
                 instrs=expanded_instr,
-                instr_block_cross=instr_block_cross,
+                starts_mid_instr=starts_mid_instr,
+                ends_mid_instr=ends_mid_instr,
+                last_half=cache_resp.fetch_block[-16:],
             )
-
-        # Make sure to clean the state
-        with m.If(flush_now):
-            m.d.sync += prev_half_v.eq(0)
 
         #
         # Fetch - stage 2
@@ -351,13 +362,15 @@ class FetchUnit(Elaboratable):
             # No prediction for now
             prediction = Signal(self.layouts.bpu_prediction)
 
+            s2_stale = self.check_stale[1](m, ftq_ptr=ftq_ptr, fetch_gen=s1_data.fetch_gen).stale
+
             # The method is guarded by the If to make sure that the metrics
-            # are updated only if not flushing.
-            with m.If(flushing_counter == 0):
+            # are updated only for live blocks.
+            with m.If(~s2_stale):
                 predcheck_res = prediction_checker.check(
                     m,
                     fb_addr=fetch_block_addr,
-                    instr_block_cross=s1_data.instr_block_cross,
+                    starts_mid_instr=s1_data.starts_mid_instr,
                     instr_valid=instr_valid,
                     predecoded=predecoded_instr,
                     prediction=prediction,
@@ -425,59 +438,65 @@ class FetchUnit(Elaboratable):
                 ]
 
             if Extension.ZCA in self.gen_params.isa.extensions:
-                with m.If(s1_data.instr_block_cross):
+                with m.If(s1_data.starts_mid_instr):
                     m.d.av_comb += raw_instrs[0].pc.eq(params.pc_from_fb(fetch_block_addr, 0) - 2)
                     with m.If(s1_data.access_fault):
                         # Mark that access/page fault happened only at second (current) half.
-                        # If fault happened on the first half `instr_block_cross` would be false
+                        # If fault happened on the first half `starts_mid_instr` would be false
                         m.d.av_comb += raw_instrs[0].access_fault.eq(
                             s1_data.access_fault | FetchLayouts.FaultFlag.EXCEPTION_ON_SECOND_HALF
                         )
 
-            with condition(m) as branch:
-                with branch(flushing_counter == 0):
-                    with m.If(fault_any | unsafe_stall):
-                        self.stall_unsafe(m)
+            with m.If(~s2_stale):
+                with m.If(fault_any | unsafe_stall):
+                    self.stall_unsafe(m)
 
-                    with m.If(fault_any | unsafe_stall | redirect):
-                        flush()
+                self.fetch_writeback(
+                    m,
+                    ftq_ptr=ftq_ptr,
+                    redirect=redirect,
+                    stall=fault_any | unsafe_stall,
+                    cfi_idx=predcheck_res.cfi_idx,
+                    cfi_type=predcheck_res.cfi_type,
+                    cfi_target=predcheck_res.cfi_target,
+                )
 
-                    self.fetch_writeback(
+                # The cross-fetch carry is dropped whenever this block breaks the
+                # sequential fetch stream (redirect/fault/stall), with one exception: a
+                # fall-through resteer (a predicted CFI decoded as a non-CFI; cfi_type is
+                # INVALID) steers to the next sequential block, so this whole block is on-path
+                # and the carry must be re-established instead.
+                if Extension.ZCA in self.gen_params.isa.extensions:
+                    with m.If(redirect & s1_data.ends_mid_instr & ~CfiType.valid(predcheck_res.cfi_type)):
+                        m.d.sync += [
+                            prev_half_v.eq(1),
+                            prev_half.eq(s1_data.last_half),
+                            prev_half_addr.eq(fetch_block_addr),
+                        ]
+                    with m.Elif(fault_any | unsafe_stall | redirect):
+                        m.d.sync += prev_half_v.eq(0)
+
+                self.perf_fetch_utilization.incr(m, popcount(fetch_mask))
+
+                for i in range(fetch_width):
+                    evlog.emit(
                         m,
-                        ftq_ptr=ftq_ptr,
-                        redirect=redirect,
-                        stall=fault_any | unsafe_stall,
-                        cfi_idx=predcheck_res.cfi_idx,
-                        cfi_type=predcheck_res.cfi_type,
-                        cfi_target=predcheck_res.cfi_target,
+                        InstrFetched.hw(
+                            ftq_ptr=ftq_ptr,
+                            pc=raw_instrs[i].pc,
+                            instr=raw_instrs[i].instr,
+                            ftq_offset=i,
+                        ),
+                        when=fetch_mask[i],
                     )
 
-                    self.perf_fetch_utilization.incr(m, popcount(fetch_mask))
-
-                    for i in range(fetch_width):
-                        evlog.emit(
-                            m,
-                            InstrFetched.hw(
-                                ftq_ptr=ftq_ptr,
-                                pc=raw_instrs[i].pc,
-                                instr=raw_instrs[i].instr,
-                                ftq_offset=i,
-                            ),
-                            when=fetch_mask[i],
-                        )
-
-                    # Make sure this is called only once to avoid a huge mux on arguments
-                    m.d.av_comb += [aligner.valids.eq(fetch_mask), aligner.inputs.eq(raw_instrs)]
-                    serializer.write(m, data=aligner.outputs, count=aligner.output_cnt)
-                with branch():
-                    m.d.sync += flushing_counter.eq(flushing_counter - 1)
-
-        with m.If(flush_now):
-            m.d.sync += flushing_counter.eq(req_counter.count_next)
+                # Make sure this is called only once to avoid a huge mux on arguments
+                m.d.av_comb += [aligner.valids.eq(fetch_mask), aligner.inputs.eq(raw_instrs)]
+                serializer.write(m, data=aligner.outputs, count=aligner.output_cnt)
 
         @def_method(m, self.flush)
         def _():
-            flush()
+            m.d.sync += prev_half_v.eq(0)
             serializer.clear(m)
 
         return m
@@ -611,7 +630,7 @@ class PredictionChecker(Elaboratable):
         ]
 
         @def_method(m, self.check)
-        def _(fb_addr, instr_block_cross, instr_valid, predecoded, prediction):
+        def _(fb_addr, starts_mid_instr, instr_valid, predecoded, prediction):
             decoded_cfi_types = Array([predecoded[i].cfi_type for i in range(self.gen_params.fetch_width)])
             decoded_cfi_offsets = Array([predecoded[i].cfi_offset for i in range(self.gen_params.fetch_width)])
 
@@ -642,7 +661,7 @@ class PredictionChecker(Elaboratable):
             def get_decoded_target_for(idx: Value) -> Value:
                 base = params.pc_from_fb(fb_addr, idx) + decoded_cfi_offsets[idx]
                 if Extension.ZCA in self.gen_params.isa.extensions:
-                    return base - Mux(instr_block_cross & (idx == 0), 2, 0)
+                    return base - Mux(starts_mid_instr & (idx == 0), 2, 0)
                 return base
 
             # Target of a CFI that would redirect the frontend according to the prediction

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -144,6 +144,7 @@ class CoreFrontend(Elaboratable):
 
         self.ftq.ifu_request.provide(self.fetch.fetch_request)
         self.fetch.fetch_writeback.provide(self.ftq.ifu_writeback)
+        self.fetch.check_stale.provide(self.ftq.check_stale)
         self.stall_ctrl.redirect_frontend.provide(self.ftq.backend_redirect)
 
         m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -83,6 +83,11 @@ class FetchTargetQueue(Elaboratable):
     Handle an IFU-detected misprediction/unsafe instruction: flush the BPU and optionally
     redirect fetch to a new PC.
     """
+    check_stale: Provided[Methods]
+    """
+    Tell whether a fetch request (identified by its FTQ pointer and generation) is stale, i.e.
+    was invalidated by a redirect after it was issued.
+    """
     bpu_response: Provided[Method]
     """Accept a branch prediction result and supply the predicted next PC to the FAU."""
     jump_target_req: Provided[Method]
@@ -114,6 +119,7 @@ class FetchTargetQueue(Elaboratable):
         self.bpu_request = Method(i=bpu_layouts.request)
         self.bpu_response = Method(i=bpu_layouts.write_prediction)
         self.bpu_flush = Method()
+        self.check_stale = Methods(2, i=ifu_layouts.check_stale_req, o=ifu_layouts.check_stale_resp)
 
         jb_layouts = self.gen_params.get(JumpBranchLayouts)
         self.jump_target_req = Method(i=jb_layouts.predicted_jump_target_req)
@@ -144,6 +150,10 @@ class FetchTargetQueue(Elaboratable):
         alloc_ptr = FTQPtr(gen_params=self.gen_params)
         fetch_ptr = FTQPtr(gen_params=self.gen_params)
         commit_ptr = FTQPtr(gen_params=self.gen_params)
+
+        entry_gen = Array(
+            Signal(make_layout(fields.fetch_gen).size, name=f"entry_gen_{i}") for i in range(self.gen_params.ftq_size)
+        )
 
         fetch_ptr_next = FTQPtr(gen_params=self.gen_params)
         m.d.sync += fetch_ptr.eq(fetch_ptr_next)
@@ -180,15 +190,29 @@ class FetchTargetQueue(Elaboratable):
             fetch_pc = Signal(self.gen_params.isa.xlen)
             m.d.av_comb += fetch_pc.eq(Mux(early_fetch, alloc_fetch_bypass, pc_mem.read_data))
 
-            self.ifu_request(m, ftq_ptr=fetch_ptr, pc=fetch_pc)
-            evlog.emit(m, FetchRequest.hw(ftq_ptr=fetch_ptr, pc=fetch_pc))
+            new_gen = entry_gen[fetch_ptr.ptr] + 1
+            m.d.sync += entry_gen[fetch_ptr.ptr].eq(new_gen)
+
+            self.ifu_request(m, ftq_ptr=fetch_ptr, pc=fetch_pc, fetch_gen=new_gen)
             m.d.comb += fetch_ptr_next.eq(fetch_ptr + 1)
+
+            evlog.emit(m, FetchRequest.hw(ftq_ptr=fetch_ptr, pc=fetch_pc))
 
         ftq_alloc_transaction.schedule_before(send_fetch_req_transaction)
 
         @def_method(m, self.bpu_response)
         def _(pc, ftq_ptr):
             fetch_address_unit.write(m, pc=pc)
+
+        # A request is stale iff any of:
+        #  - its entry was re-issued since (generation mismatch),
+        #  - its entry sits at or past the fetch pointer: a redirect rewound fetch over it and
+        #    it was not re-issued yet,
+        #  - the FTQ is stalled (pointers not rewound until the backend resumes).
+        @def_methods(m, self.check_stale)
+        def _(_, ftq_ptr, fetch_gen):
+            p = FTQPtr(ftq_ptr, gen_params=self.gen_params)
+            return {"stale": (entry_gen[p.ptr] != fetch_gen) | (p >= fetch_ptr) | (~self.stall_guard.ready)}
 
         @def_method(m, self.ifu_writeback)
         def _(

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -91,6 +91,11 @@ class CommonLayoutFields:
         self.ftq_offset: LayoutListField = ("ftq_offset", gen_params.fetch_width_log)
         """Offset of an instruction (counted in number of instructions) within its FTQ entry (fetch block)"""
 
+        self.fetch_gen: LayoutListField = ("fetch_gen", 2)
+        """Generation counter of a fetch request, bumped each time its FTQ entry is (re)issued
+        to the IFU. 2 bits suffice: we assume (and assert) that IFU admits at most 4 blocks, so
+        at most 4 generations of one entry can coexist."""
+
         self.fb_addr: LayoutListField = ("fb_addr", gen_params.isa.xlen - gen_params.fetch_block_bytes_log)
         """Address of a fetch block"""
 
@@ -708,7 +713,7 @@ class FetchLayouts:
             ("data", ArrayLayout(self.raw_instr, gen_params.frontend_superscalarity)),
         )
 
-        self.fetch_request = make_layout(fields.pc, fields.ftq_ptr)
+        self.fetch_request = make_layout(fields.pc, fields.ftq_ptr, fields.fetch_gen)
         self.fetch_writeback = make_layout(
             fields.ftq_ptr, ("redirect", 1), ("stall", 1), fields.cfi_idx, fields.cfi_type, fields.cfi_target
         )
@@ -726,9 +731,15 @@ class FetchLayouts:
             fields.branch_mask, fields.cfi_idx, fields.cfi_type, fields.cfi_target, ("cfi_target_valid", 1)
         )
 
+        self.check_stale_req = make_layout(fields.ftq_ptr, fields.fetch_gen)
+        """Ask whether the fetch request identified by (ftq_ptr, fetch_gen) is stale."""
+
+        self.check_stale_resp = make_layout(("stale", 1))
+        """A stale fetch block must be dropped without side effects."""
+
         self.pred_checker_i = make_layout(
             fields.fb_addr,
-            ("instr_block_cross", 1),
+            ("starts_mid_instr", 1),
             ("instr_valid", gen_params.fetch_width),
             ("predecoded", ArrayLayout(self.predecoded_instr, gen_params.fetch_width)),
             ("prediction", self.bpu_prediction),

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -93,6 +93,15 @@ class TestFetchUnit(TestCaseWithSimulator):
         self.last_redirect = None
         self.backend_redirect = deque()
 
+        # Every fetch request is identified by (ftq_ptr, fetch_gen) and gets a monotone sequence number,
+        # so the testbench can answer `check_stale` queries the way the FTQ would
+        self.req_seq = 0
+        self.entry_gen = [0] * self.gen_params.ftq_size
+        self.issued_seq: dict[tuple[int, int, int], int] = {}
+        self.seq_of_ptr: dict[tuple[int, int], int] = {}
+        self.stale_ids: set[tuple[int, int, int]] = set()
+        self.redirect_origin_seq = 0
+
         random.seed(41)
 
     def add_instr(
@@ -210,9 +219,29 @@ class TestFetchUnit(TestCaseWithSimulator):
         @MethodMock.effect
         def eff():
             if redirect:
+                # A redirect rewinds the fetch pointer: every block issued after the
+                # redirecting one is dead
+                origin_seq = self.seq_of_ptr[(ftq_ptr["ptr"], ftq_ptr["parity"])]
+                for fetch_id, seq in self.issued_seq.items():
+                    if seq > origin_seq:
+                        self.stale_ids.add(fetch_id)
+                self.redirect_origin_seq = origin_seq
+
                 self.last_redirect = cfi_target
             elif stall:
                 self.stalled = True
+
+    def is_stale(self, ftq_ptr, fetch_gen) -> bool:
+        fetch_id = (ftq_ptr["ptr"], ftq_ptr["parity"], fetch_gen)
+        return self.stalled or fetch_id in self.stale_ids
+
+    @def_method_mock(lambda self: self.fetch.check_stale[0])
+    def check_stale_s1_mock(self, ftq_ptr, fetch_gen):
+        return {"stale": self.is_stale(ftq_ptr, fetch_gen)}
+
+    @def_method_mock(lambda self: self.fetch.check_stale[1])
+    def check_stale_s2_mock(self, ftq_ptr, fetch_gen):
+        return {"stale": self.is_stale(ftq_ptr, fetch_gen)}
 
     async def fetch_out_check(self, sim: TestbenchContext):
         async def check_instr(instr, v):
@@ -272,21 +301,47 @@ class TestFetchUnit(TestCaseWithSimulator):
     async def requester(self, sim: ProcessContext):
         while True:
             ret = None
+            issued_seq = None
+            slot = 0
+            parity = 0
+            gen = 0
+
             if self.stalled:
                 await sim.tick()
             else:
-                ret = await self.fetch.fetch_request.call_try(sim, pc=self.next_fetch_request)
+                seq = self.req_seq
+                slot = seq % self.gen_params.ftq_size
+                parity = (seq // self.gen_params.ftq_size) % 2
+                gen = (self.entry_gen[slot] + 1) % 4
+                ret = await self.fetch.fetch_request.call_try(
+                    sim, pc=self.next_fetch_request, ftq_ptr={"ptr": slot, "parity": parity}, fetch_gen=gen
+                )
+                if ret is not None:
+                    # The request fired - commit the FTQ-side bookkeeping
+                    fetch_id = (slot, parity, gen)
+                    self.entry_gen[slot] = gen
+                    self.issued_seq[fetch_id] = seq
+                    self.seq_of_ptr[(slot, parity)] = seq
+                    self.stale_ids.discard(fetch_id)
+                    self.req_seq = seq + 1
+                    issued_seq = seq
 
             await sim.delay(0)
             if self.stalled:
                 while not self.backend_redirect:
                     await self.tick(sim)
 
+                # A backend redirect rewinds the whole frontend: every block issued
+                # so far is dead
+                self.stale_ids.update(self.issued_seq.keys())
                 self.stalled = False
                 self.next_fetch_request = self.backend_redirect[0]
                 self.backend_redirect.popleft()
 
             elif self.last_redirect is not None:
+                if issued_seq is not None and issued_seq > self.redirect_origin_seq:
+                    self.stale_ids.add((slot, parity, gen))
+                self.req_seq = self.redirect_origin_seq + 1
                 self.next_fetch_request = self.last_redirect
             elif ret is not None:
                 self.next_fetch_request = (
@@ -561,7 +616,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
         res = await self.m.check.call(
             sim,
             fb_addr=pc >> self.gen_params.fetch_block_bytes_log,
-            instr_block_cross=block_cross,
+            starts_mid_instr=block_cross,
             instr_valid=instr_valid,
             predecoded=predecoded_raw,
             prediction=prediction,

--- a/test/frontend/test_ftq.py
+++ b/test/frontend/test_ftq.py
@@ -43,7 +43,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             self.bpu_requests.append(pc)
 
     @def_method_mock(lambda self: self.ftq.ifu_request)
-    def ifu_request_mock(self, pc, ftq_ptr):
+    def ifu_request_mock(self, pc, ftq_ptr, fetch_gen):
         @MethodMock.effect
         def eff():
             self.ifu_requests.append({"pc": pc, "ftq_ptr": ftq_ptr["ptr"]})
@@ -160,7 +160,7 @@ class TestFetchTargetQueueFull(TestCaseWithSimulator):
             self.bpu_requests.append(pc)
 
     @def_method_mock(lambda self: self.ftq.ifu_request)
-    def ifu_request_mock(self, pc, ftq_ptr):
+    def ifu_request_mock(self, pc, ftq_ptr, fetch_gen):
         @MethodMock.effect
         def eff():
             self.ifu_requests.append(pc)

--- a/test/frontend/test_ftq.py
+++ b/test/frontend/test_ftq.py
@@ -46,7 +46,15 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
     def ifu_request_mock(self, pc, ftq_ptr, fetch_gen):
         @MethodMock.effect
         def eff():
-            self.ifu_requests.append({"pc": pc, "ftq_ptr": ftq_ptr["ptr"]})
+            self.ifu_requests.append(
+                {"pc": pc, "ftq_ptr": ftq_ptr["ptr"], "parity": ftq_ptr["parity"], "fetch_gen": fetch_gen}
+            )
+
+    async def check_stale(self, sim: TestbenchContext, req: dict) -> int:
+        res = await self.ftq.check_stale[0].call(
+            sim, ftq_ptr={"ptr": req["ftq_ptr"], "parity": req["parity"]}, fetch_gen=req["fetch_gen"]
+        )
+        return res["stale"]
 
     async def auto_bpu_process(self, sim: ProcessContext):
         """Responds to each BPU request by predicting PC+4 as the next PC."""
@@ -131,6 +139,106 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             assert redirect_pc in [req["pc"] for req in self.ifu_requests]
 
         with self.run_simulation(self.ftq) as sim:
+            sim.add_testbench(proc)
+
+    def test_fetch_gen_starts_at_one_and_is_unique_per_entry(self):
+        # Each entry is issued exactly once as fetch advances, so every request carries
+        # generation 1
+        n_allocs = 4
+
+        async def proc(sim: TestbenchContext):
+            for _ in range(20):
+                await sim.tick()
+            assert len(self.ifu_requests) >= n_allocs
+            for i in range(n_allocs):
+                assert self.ifu_requests[i]["ftq_ptr"] == i
+                assert self.ifu_requests[i]["fetch_gen"] == 1
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
+            sim.add_testbench(proc)
+
+    def test_check_stale_false_for_inflight_request(self):
+        async def proc(sim: TestbenchContext):
+            for _ in range(10):
+                await sim.tick()
+            assert len(self.ifu_requests) >= 3
+            assert await self.check_stale(sim, self.ifu_requests[0]) == 0
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
+            sim.add_testbench(proc)
+
+    def test_check_stale_true_on_generation_mismatch(self):
+        # Querying a real entry with a generation it was never issued with is stale
+        async def proc(sim: TestbenchContext):
+            for _ in range(10):
+                await sim.tick()
+            assert len(self.ifu_requests) >= 3
+            req = dict(self.ifu_requests[0])
+            req["fetch_gen"] = 0
+            assert await self.check_stale(sim, req) == 1
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
+            sim.add_testbench(proc)
+
+    def test_check_stale_true_for_not_yet_fetched_entry(self):
+        async def proc(sim: TestbenchContext):
+            for _ in range(10):
+                await sim.tick()
+            future = {"ftq_ptr": self.gen_params.ftq_size - 1, "parity": 0, "fetch_gen": 1}
+            assert await self.check_stale(sim, future) == 1
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
+            sim.add_testbench(proc)
+
+    def test_ifu_redirect_makes_squashed_requests_stale(self):
+        redirect_pc = 0x500
+
+        async def proc(sim: TestbenchContext):
+            for _ in range(15):
+                await sim.tick()
+            assert len(self.ifu_requests) >= 4
+            before = self.ifu_requests[0]
+            squashed = self.ifu_requests[3]
+            assert before["ftq_ptr"] == 0
+            assert squashed["ftq_ptr"] == 3
+
+            # Both requests are valid before the redirect.
+            assert await self.check_stale(sim, before) == 0
+            assert await self.check_stale(sim, squashed) == 0
+
+            n_before_redirect = len(self.ifu_requests)
+
+            await self.ftq.ifu_writeback.call(
+                sim,
+                ftq_ptr={"ptr": 1, "parity": 0},
+                redirect=1,
+                stall=0,
+                cfi_idx=0,
+                cfi_type=0,
+                cfi_target=redirect_pc,
+            )
+
+            # The squashed request is now stale; the one before the redirect point is untouched.
+            assert await self.check_stale(sim, squashed) == 1
+            assert await self.check_stale(sim, before) == 0
+
+            # Fetch resumes from the redirect target and re-issues the squashed entry with a
+            # bumped generation. The old (stale) request stays stale
+            for _ in range(15):
+                await sim.tick()
+            new_requests = list(self.ifu_requests)[n_before_redirect:]
+            reissued = [req for req in new_requests if req["ftq_ptr"] == squashed["ftq_ptr"]]
+            assert reissued, "the squashed entry should have been re-fetched"
+            assert reissued[0]["fetch_gen"] != squashed["fetch_gen"]
+            assert await self.check_stale(sim, reissued[0]) == 0
+            assert await self.check_stale(sim, squashed) == 1
+
+        with self.run_simulation(self.ftq) as sim:
+            sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
 


### PR DESCRIPTION
Previously, staleness was tracked with a global `flushing_counter` that counted how many in-flight fetch blocks had to be drained after a redirect. This worked only because our branch predictor always predicted the fall-through address. Also, the `flushing_counter` approach can't handle overriding predictors: we predict address X for a given FTQ entry and send it to the IFU, but then in the next cycle we override the previous prediction and want to fetch Y instead. We need to tell the IFU that the fetch request for X is invalid and should be discarded.

Instead, staleness is now decided per request: every fetch request carries its FTQ pointer plus a small per-entry generation counter, and the IFU asks the FTQ whether the block is still live before letting it have any side effects.

Depends on #1008 