### PR TITLE
fetch unit: restructure fetch around the block exit point

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -58,6 +58,9 @@ class FetchUnit(Elaboratable):
     Asks the FTQ whether a fetch request is stale. One instance per stage (1 and 2).
     """
 
+    read_prediction: Required[Method]
+    """Return the branch prediction stored for a given FTQ entry. """
+
     def __init__(self, gen_params: GenParams, icache: CacheInterface) -> None:
         """
         Parameters
@@ -78,6 +81,7 @@ class FetchUnit(Elaboratable):
         self.fetch_request = Method(i=self.layouts.fetch_request)
         self.fetch_writeback = Method(i=self.layouts.fetch_writeback)
         self.check_stale = Methods(2, i=self.layouts.check_stale_req, o=self.layouts.check_stale_resp)
+        self.read_prediction = Method(i=self.layouts.read_prediction_req, o=self.layouts.bpu_prediction)
 
         self.flush = Method()
 
@@ -359,14 +363,11 @@ class FetchUnit(Elaboratable):
             # Predecode instructions
             predecoded_instr = [predecoders[i].predecode(m, instrs[i]) for i in range(fetch_width)]
 
-            # No prediction for now
-            prediction = Signal(self.layouts.bpu_prediction)
-
             s2_stale = self.check_stale[1](m, ftq_ptr=ftq_ptr, fetch_gen=s1_data.fetch_gen).stale
 
-            # The method is guarded by the If to make sure that the metrics
-            # are updated only for live blocks.
             with m.If(~s2_stale):
+                prediction = self.read_prediction(m, ftq_ptr=ftq_ptr)
+
                 predcheck_res = prediction_checker.check(
                     m,
                     fb_addr=fetch_block_addr,
@@ -389,40 +390,52 @@ class FetchUnit(Elaboratable):
             has_unsafe = Signal()
             m.d.av_comb += has_unsafe.eq(~unsafe_prio_encoder.n)
 
-            redirect_before_unsafe = Signal()
-            m.d.av_comb += redirect_before_unsafe.eq(predcheck_res.cfi_idx < unsafe_idx)
+            # Is there any control flow instruction that we should follow?
+            cfi_followed = Signal()
+            m.d.av_comb += cfi_followed.eq(CfiType.valid(predcheck_res.cfi_type))
 
+            # The point where control leaves the block (its "exit")
+            # If we didn't follow any CFI, then our exit point is the last instruction
+            exit_idx = Signal(range(fetch_width))
+            exit_target = Signal(self.gen_params.isa.xlen)
+            m.d.av_comb += [
+                exit_idx.eq(Mux(cfi_followed, predcheck_res.cfi_idx, fetch_width - 1)),
+                exit_target.eq(Mux(cfi_followed, predcheck_res.cfi_target, params.pc_from_fb(fetch_block_addr + 1, 0))),
+            ]
+
+            # The exit is always reached, unless an unsafe instruction comes before it
+            exit_reached = Signal()
+            m.d.av_comb += exit_reached.eq(~has_unsafe | (exit_idx < unsafe_idx))
+
+            # A JALR's target cannot be computed from predecode, so a mispredicted JALR
+            # can't redirect - we stall until the backend executes it instead
+            eff_cfi_valid = Signal()
+            eff_redirect_target = Signal(self.gen_params.isa.xlen)
+            m.d.av_comb += eff_cfi_valid.eq(~CfiType.is_jalr(predcheck_res.cfi_type))
+            m.d.av_comb += eff_redirect_target.eq(exit_target)
+
+            mispredict = Signal()
+            m.d.av_comb += mispredict.eq(predcheck_res.mispredicted)
+
+            # Stall either on an unsafe instruction cutting the block (~exit_reached), or on
+            # an exit through a mispredicted JALR whose target we don't know (~eff_cfi_valid)
             redirect = Signal()
-            unsafe_stall = Signal()
-            redirect_or_unsafe_idx = Signal(range(fetch_width))
+            stall_core = Signal()
+            m.d.av_comb += redirect.eq(exit_reached & mispredict & eff_cfi_valid)
+            m.d.av_comb += stall_core.eq(~exit_reached | (mispredict & ~eff_cfi_valid))
 
-            with m.If(predcheck_res.mispredicted & (~has_unsafe | redirect_before_unsafe)):
-                # A JALR's target cannot be computed from predecode, so instead of redirecting
-                # we stall until the backend executes it. Any other mispredict (including a
-                # fall-through resteer, where cfi_type is INVALID) has a known target
-                m.d.av_comb += [
-                    redirect.eq(~CfiType.is_jalr(predcheck_res.cfi_type)),
-                    unsafe_stall.eq(CfiType.is_jalr(predcheck_res.cfi_type)),
-                    redirect_or_unsafe_idx.eq(predcheck_res.cfi_idx),
-                ]
-            with m.Elif(has_unsafe):
-                m.d.av_comb += [
-                    unsafe_stall.eq(1),
-                    redirect_or_unsafe_idx.eq(unsafe_idx),
-                ]
+            # Index of the last instruction of the block: the exit, or the unsafe instruction
+            # that cut the block before it
+            block_end_idx = Signal(range(fetch_width))
+            m.d.av_comb += block_end_idx.eq(Mux(exit_reached, exit_idx, unsafe_idx))
 
-            # This mask denotes what prefix of instructions we should enqueue.
-            valid_instr_prefix = Signal(fetch_width)
-            with m.If(redirect | unsafe_stall):
-                # If there is an instruction that redirects or stalls the frontend, enqueue
-                # instructions only up to that instruction.
-                m.d.av_comb += valid_instr_prefix.eq((1 << (redirect_or_unsafe_idx + 1)) - 1)
-            with m.Else():
-                m.d.av_comb += valid_instr_prefix.eq(C(1).replicate(fetch_width))
+            # The mask that denotes what prefix of instructions we should enqueue
+            block_prefix_mask = Signal(fetch_width)
+            m.d.av_comb += block_prefix_mask.eq((1 << (block_end_idx + 1)) - 1)
 
-            # The ultimate mask that tells which instructions should be sent to the backend.
+            # The ultimate mask that tells which instructions should be sent to the backend
             fetch_mask = Signal(fetch_width)
-            m.d.av_comb += fetch_mask.eq(instr_valid & valid_instr_prefix)
+            m.d.av_comb += fetch_mask.eq(instr_valid & block_prefix_mask)
 
             # Aggregate all signals that will be sent out of the fetch unit.
             raw_instrs = Signal(ArrayLayout(self.layouts.raw_instr, fetch_width))
@@ -448,17 +461,17 @@ class FetchUnit(Elaboratable):
                         )
 
             with m.If(~s2_stale):
-                with m.If(fault_any | unsafe_stall):
+                with m.If(fault_any | stall_core):
                     self.stall_unsafe(m)
 
                 self.fetch_writeback(
                     m,
                     ftq_ptr=ftq_ptr,
                     redirect=redirect,
-                    stall=fault_any | unsafe_stall,
-                    cfi_idx=predcheck_res.cfi_idx,
+                    stall=fault_any | stall_core,
+                    cfi_idx=exit_idx,
                     cfi_type=predcheck_res.cfi_type,
-                    cfi_target=predcheck_res.cfi_target,
+                    cfi_target=eff_redirect_target,
                 )
 
                 # The cross-fetch carry is dropped whenever this block breaks the
@@ -473,7 +486,7 @@ class FetchUnit(Elaboratable):
                             prev_half.eq(s1_data.last_half),
                             prev_half_addr.eq(fetch_block_addr),
                         ]
-                    with m.Elif(fault_any | unsafe_stall | redirect):
+                    with m.Elif(fault_any | stall_core | redirect):
                         m.d.sync += prev_half_v.eq(0)
 
                 self.perf_fetch_utilization.incr(m, popcount(fetch_mask))
@@ -677,8 +690,14 @@ class PredictionChecker(Elaboratable):
                 | ~CfiType.valid(prediction.cfi_type)
             )
 
+            decoded_cfi_type_at_pred = Mux(
+                instr_valid.bit_select(prediction.cfi_idx, 1),
+                decoded_cfi_types[prediction.cfi_idx],
+                CfiType.INVALID,
+            )
+
             mispredicted_cfi_type = CfiType.valid(prediction.cfi_type) & (
-                prediction.cfi_type != decoded_cfi_types[prediction.cfi_idx]
+                prediction.cfi_type != decoded_cfi_type_at_pred
             )
 
             mispredicted_cfi_target = (CfiType.is_branch(prediction.cfi_type) | CfiType.is_jal(prediction.cfi_type)) & (
@@ -700,14 +719,16 @@ class PredictionChecker(Elaboratable):
                 )
             with m.Elif(mispredicted_cfi_type):
                 self.perf_mispredicted_cfi_type.incr(m, prediction.cfi_type)
-                fallthrough_addr = params.pc_from_fb(fb_addr + 1, 0)
+                # If no decoded instruction redirects (pd_redirection_enc.n), this is a
+                # fall-through resteer: cfi_type is INVALID and cfi_idx/cfi_target are
+                # meaningless.
                 m.d.av_comb += assign(
                     ret,
                     {
                         "mispredicted": 1,
-                        "cfi_idx": Mux(pd_redirection_enc.n, self.gen_params.fetch_width - 1, pd_redirect_idx),
+                        "cfi_idx": pd_redirect_idx,
                         "cfi_type": Mux(pd_redirection_enc.n, CfiType.INVALID, decoded_cfi_types[pd_redirect_idx]),
-                        "cfi_target": Mux(pd_redirection_enc.n, fallthrough_addr, decoded_target_for_decoded_cfi),
+                        "cfi_target": decoded_target_for_decoded_cfi,
                     },
                 )
             with m.Elif(mispredicted_cfi_target):

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -145,6 +145,7 @@ class CoreFrontend(Elaboratable):
         self.ftq.ifu_request.provide(self.fetch.fetch_request)
         self.fetch.fetch_writeback.provide(self.ftq.ifu_writeback)
         self.fetch.check_stale.provide(self.ftq.check_stale)
+        self.fetch.read_prediction.provide(self.ftq.read_prediction)
         self.stall_ctrl.redirect_frontend.provide(self.ftq.backend_redirect)
 
         m.submodules.decode = decode = DecodeStage(gen_params=self.gen_params)

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -90,6 +90,8 @@ class FetchTargetQueue(Elaboratable):
     """
     bpu_response: Provided[Method]
     """Accept a branch prediction result and supply the predicted next PC to the FAU."""
+    read_prediction: Provided[Method]
+    """Return the branch prediction stored for a given FTQ entry (read by the fetch unit)."""
     jump_target_req: Provided[Method]
     """Request the predicted jump target for a given FTQ entry (stub)."""
     jump_target_resp: Provided[Method]
@@ -120,6 +122,7 @@ class FetchTargetQueue(Elaboratable):
         self.bpu_response = Method(i=bpu_layouts.write_prediction)
         self.bpu_flush = Method()
         self.check_stale = Methods(2, i=ifu_layouts.check_stale_req, o=ifu_layouts.check_stale_resp)
+        self.read_prediction = Method(i=ifu_layouts.read_prediction_req, o=ifu_layouts.bpu_prediction)
 
         jb_layouts = self.gen_params.get(JumpBranchLayouts)
         self.jump_target_req = Method(i=jb_layouts.predicted_jump_target_req)
@@ -203,6 +206,11 @@ class FetchTargetQueue(Elaboratable):
         @def_method(m, self.bpu_response)
         def _(pc, ftq_ptr):
             fetch_address_unit.write(m, pc=pc)
+
+        @def_method(m, self.read_prediction)
+        def _(ftq_ptr):
+            # There is no BPU prediction storage yet
+            return Signal(self.gen_params.get(FetchLayouts).bpu_prediction)
 
         # A request is stale iff any of:
         #  - its entry was re-issued since (generation mismatch),

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -737,6 +737,8 @@ class FetchLayouts:
         self.check_stale_resp = make_layout(("stale", 1))
         """A stale fetch block must be dropped without side effects."""
 
+        self.read_prediction_req = make_layout(fields.ftq_ptr)
+
         self.pred_checker_i = make_layout(
             fields.fb_addr,
             ("starts_mid_instr", 1),
@@ -752,8 +754,8 @@ class FetchLayouts:
             fields.cfi_target,
         )
         """cfi_type - type of the CFI the frontend follows in this block (on a misprediction,
-        the one causing the redirect); CfiType.INVALID on a misprediction means a fall-through resteer
-        with no redirecting CFI, so cfi_target is the next sequential fetch block."""
+        the one causing the redirect). cfi_idx and cfi_target are meaningful only when cfi_type
+        is valid."""
 
 
 class DecodeLayouts:

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -102,6 +102,10 @@ class TestFetchUnit(TestCaseWithSimulator):
         self.stale_ids: set[tuple[int, int, int]] = set()
         self.redirect_origin_seq = 0
 
+        # BPU predictions, keyed by fetch block address
+        self.predictions_by_block: dict[int, dict] = {}
+        self.pred_of_ptr: dict[tuple[int, int], Optional[dict]] = {}
+
         random.seed(41)
 
     def add_instr(
@@ -160,6 +164,39 @@ class TestFetchUnit(TestCaseWithSimulator):
 
         # Static prediction with no BPU: backward branches (negative offset) are predicted taken.
         return self.add_instr(data, True, jump_offset=offset, branch_taken=taken, predicted_taken=offset < 0)
+
+    def empty_prediction(self) -> dict:
+        return {"branch_mask": 0, "cfi_idx": 0, "cfi_type": CfiType.INVALID, "cfi_target": 0, "cfi_target_valid": 0}
+
+    def predict_block(self, instr_pc: int, cfi_type: CfiType, target: int, branch: bool = False):
+        block_addr = instr_pc & ~(self.gen_params.fetch_block_bytes - 1)
+        cfi_idx = (instr_pc & (self.gen_params.fetch_block_bytes - 1)) >> self.gen_params.min_instr_width_bytes_log
+        self.predictions_by_block[block_addr] = {
+            "branch_mask": (1 << cfi_idx) if branch else 0,
+            "cfi_idx": cfi_idx,
+            "cfi_type": cfi_type,
+            "cfi_target": target,
+            "cfi_target_valid": 1,
+        }
+
+    def gen_predicted_branch(self, offset: int) -> int:
+        assert offset > 0
+        data = BTypeInstr(opcode=Opcode.BRANCH, imm=offset, funct3=Funct3.BEQ, rs1=0, rs2=0).encode()
+        pc = self.add_instr(data, True, jump_offset=offset, branch_taken=True, predicted_taken=True)
+        self.predict_block(pc, CfiType.BRANCH, pc + offset, branch=True)
+        return pc
+
+    def gen_predicted_jal(self, offset: int) -> int:
+        data = JTypeInstr(opcode=Opcode.JAL, rd=0, imm=offset).encode()
+        pc = self.add_instr(data, True, jump_offset=offset, branch_taken=True, predicted_taken=True)
+        self.predict_block(pc, CfiType.JAL, pc + offset)
+        return pc
+
+    def gen_predicted_jalr(self, target_offset: int) -> int:
+        data = ITypeInstr(opcode=Opcode.JALR, rd=0, funct3=Funct3.JALR, rs1=0, imm=0).encode()
+        pc = self.add_instr(data, True, jump_offset=target_offset, branch_taken=True, predicted_taken=True)
+        self.predict_block(pc, CfiType.JALR, pc + target_offset)
+        return pc
 
     async def cache_process(self, sim: ProcessContext):
         while True:
@@ -243,6 +280,10 @@ class TestFetchUnit(TestCaseWithSimulator):
     def check_stale_s2_mock(self, ftq_ptr, fetch_gen):
         return {"stale": self.is_stale(ftq_ptr, fetch_gen)}
 
+    @def_method_mock(lambda self: self.fetch.read_prediction)
+    def read_prediction_mock(self, ftq_ptr):
+        return self.pred_of_ptr.get((ftq_ptr["ptr"], ftq_ptr["parity"])) or self.empty_prediction()
+
     async def fetch_out_check(self, sim: TestbenchContext):
         async def check_instr(instr, v):
             access_fault = FetchLayouts.FaultFlag.ACCESS_FAULT if instr["pc"] in self.memerr else 0
@@ -302,6 +343,7 @@ class TestFetchUnit(TestCaseWithSimulator):
         while True:
             ret = None
             issued_seq = None
+            issued_pred = None
             slot = 0
             parity = 0
             gen = 0
@@ -326,6 +368,12 @@ class TestFetchUnit(TestCaseWithSimulator):
                     self.req_seq = seq + 1
                     issued_seq = seq
 
+                    # Record the BPU prediction for this block (if any), to be served
+                    # to the fetch unit via `read_prediction`
+                    block_addr = self.next_fetch_request & ~(self.gen_params.fetch_block_bytes - 1)
+                    issued_pred = self.predictions_by_block.get(block_addr)
+                    self.pred_of_ptr[(slot, parity)] = issued_pred
+
             await sim.delay(0)
             if self.stalled:
                 while not self.backend_redirect:
@@ -344,9 +392,13 @@ class TestFetchUnit(TestCaseWithSimulator):
                 self.req_seq = self.redirect_origin_seq + 1
                 self.next_fetch_request = self.last_redirect
             elif ret is not None:
-                self.next_fetch_request = (
-                    1 + (self.next_fetch_request // self.gen_params.fetch_block_bytes)
-                ) * self.gen_params.fetch_block_bytes
+                if issued_pred is not None:
+                    # Follow the prediction, like the FTQ would
+                    self.next_fetch_request = issued_pred["cfi_target"]
+                else:
+                    self.next_fetch_request = (
+                        1 + (self.next_fetch_request // self.gen_params.fetch_block_bytes)
+                    ) * self.gen_params.fetch_block_bytes
 
             self.last_redirect = None
 
@@ -489,6 +541,64 @@ class TestFetchUnit(TestCaseWithSimulator):
             self.gen_branch(offset=1028, taken=(i % 2 == 0))
 
         self.gen_non_branch_instr(rvc=False)
+
+        self.run_sim()
+
+    def test_correct_predictions(self):
+        # A predicted-taken forward branch. Statically it would be predicted not-taken,
+        # so any redirect would mean the BPU prediction was ignored
+        self.gen_predicted_branch(self.gen_params.fetch_block_bytes)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        # A correctly predicted JAL
+        self.gen_predicted_jal(2 * self.gen_params.fetch_block_bytes)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        # A predicted JALR: its target is only known from the prediction. Without one,
+        # fetch would have to stall until the backend resolves it
+        self.gen_predicted_jalr(3 * self.gen_params.fetch_block_bytes)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        # A predicted branch that is not the first instruction of its block - the
+        # instructions before it must still be delivered, the ones after it dropped
+        if self.gen_params.fetch_width >= 2:
+            self.gen_non_branch_instr(rvc=False)
+            self.gen_predicted_branch(self.gen_params.fetch_block_bytes)
+            for _ in range(self.gen_params.fetch_width):
+                self.gen_non_branch_instr(rvc=False)
+
+        self.run_sim()
+
+    def test_bogus_prediction_resteer(self):
+        # A few blocks of plain instructions
+        for _ in range(2 * self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        # The predictor claims there is a taken JAL in a block that has no CFI at all
+        pc = self.gen_non_branch_instr(rvc=False)
+        self.predict_block(pc, CfiType.JAL, pc + 0x1000)
+        for _ in range(2 * self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        self.run_sim()
+
+    def test_mistargeted_prediction_redirect(self):
+        # A JAL predicted with a wrong target: the prediction checker must redirect
+        # to the decoded target
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        offset = 2 * self.gen_params.fetch_block_bytes
+        data = JTypeInstr(opcode=Opcode.JAL, rd=0, imm=offset).encode()
+        # The frontend corrects the bad target itself
+        pc = self.add_instr(data, True, jump_offset=offset, branch_taken=True, predicted_taken=True)
+        self.predict_block(pc, CfiType.JAL, pc + 0x1000)
+
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
 
         self.run_sim()
 
@@ -914,14 +1024,12 @@ class TestPredictionChecker(TestCaseWithSimulator):
     def test_mispredicted_cfi_type(self):
         instr_width = self.gen_params.min_instr_width_bytes
         fetch_width = self.gen_params.fetch_width
-        fb_bytes = self.gen_params.fetch_block_bytes
 
         async def proc(sim: TestbenchContext):
-            # We predicted a JAL, but in fact there is a non-CFI instruction
+            # We predicted a JAL, but in fact there is a non-CFI instruction.
+            # cfi_type is INVALID and cfi_idx/cfi_target are meaningless
             ret = await self.check(sim, 0x100, False, [(CfiType.INVALID, 0)], 0, 0, CfiType.JAL, 100)
-            self.assert_resp(
-                ret, mispredicted=True, cfi_type=CfiType.INVALID, cfi_idx=fetch_width - 1, cfi_target=0x100 + fb_bytes
-            )
+            self.assert_resp(ret, mispredicted=True, cfi_type=CfiType.INVALID)
 
             # We predicted a JAL, but in fact there is a branch
             ret = await self.check(sim, 0x100, False, [(CfiType.BRANCH, -100)], 0, 0, CfiType.JAL, 100)
@@ -942,9 +1050,7 @@ class TestPredictionChecker(TestCaseWithSimulator):
             ret = await self.check(
                 sim, 0x100, False, [(CfiType.BRANCH, -100), (CfiType.INVALID, 0)], 0b11, 1, CfiType.BRANCH, 100
             )
-            self.assert_resp(
-                ret, mispredicted=True, cfi_type=CfiType.INVALID, cfi_idx=fetch_width - 1, cfi_target=0x100 + fb_bytes
-            )
+            self.assert_resp(ret, mispredicted=True, cfi_type=CfiType.INVALID)
 
             # The same as above, but we start from the second instruction
             ret = await self.check(
@@ -957,8 +1063,48 @@ class TestPredictionChecker(TestCaseWithSimulator):
                 CfiType.BRANCH,
                 100,
             )
+            self.assert_resp(ret, mispredicted=True, cfi_type=CfiType.INVALID)
+
+        with self.run_simulation(self.m) as sim:
+            sim.add_testbench(proc)
+
+    def test_prediction_at_invalid_slot(self):
+        instr_width = self.gen_params.min_instr_width_bytes
+        fetch_width = self.gen_params.fetch_width
+
+        async def proc(sim: TestbenchContext):
+            if fetch_width < 2:
+                return
+
+            # The prediction points at a slot before the entry point of the block. Even
+            # though the slot holds a JAL matching the prediction, it is not on the
+            # fetch path and must be treated as if there was no CFI there at all
+            ret = await self.check(
+                sim,
+                0x100 + instr_width,
+                False,
+                [(CfiType.JAL, 100), (CfiType.INVALID, 0)],
+                0,
+                0,
+                CfiType.JAL,
+                0x100 + 100,
+            )
+            self.assert_resp(ret, mispredicted=True, cfi_type=CfiType.INVALID)
+
+            # Same, but a real JAL sits at a later, valid slot - the checker must
+            # redirect to that one instead
+            ret = await self.check(
+                sim,
+                0x100 + instr_width,
+                False,
+                [(CfiType.JAL, 100), (CfiType.JAL, 100)],
+                0,
+                0,
+                CfiType.JAL,
+                0x100 + 100,
+            )
             self.assert_resp(
-                ret, mispredicted=True, cfi_type=CfiType.INVALID, cfi_idx=fetch_width - 1, cfi_target=0x100 + fb_bytes
+                ret, mispredicted=True, cfi_type=CfiType.JAL, cfi_idx=1, cfi_target=0x100 + instr_width + 100
             )
 
         with self.run_simulation(self.m) as sim:


### PR DESCRIPTION
The fetch unit now reads the block's prediction from the FTQ (an empty fall-through prediction for now). I also cleaned up the logic how the fetch unit computes the exit point per fetch block, from which redirect/stall decisions and the instruction mask are derived. 

Additionally, I fixed a bug in the prediction checker when a prediction is pointing at an invalid instruction slot (see the added test). It remained uncovered because currently we simply don't produce predictions.
