### PR TITLE
BPU: add micro-BTB predictor

### DIFF
--- a/coreblocks/cache/plru.py
+++ b/coreblocks/cache/plru.py
@@ -1,0 +1,83 @@
+from amaranth import *
+
+from transactron import Method, Methods, TModule, def_method, def_methods
+from transactron.utils.transactron_helpers import make_layout
+
+__all__ = ["TreePLRU"]
+
+
+class TreePLRU(Elaboratable):
+    """Tree-based pseudo-LRU replacement state over a power-of-two number of ways.
+
+    Tree-PLRU keeps one bit per internal node of a balanced binary tree. For a cache
+    with N ways, it requires exactly N - 1 bits. Each internal node indicates which
+    side was accessed less recently (0 - the left side).
+
+    To find the least recently used item, we traverse down the tree from the root node,
+    following the directions indicated by each bit.
+
+    When accessing an item, the bits along its specific path are flipped to point in
+    the opposite direction, so it is not selected for subsequent evictions.
+
+    Methods
+    -------
+    get_victim: Method (nonexclusive)
+        Returns the way to replace.
+    touch: Methods
+        Each method marks its `way` argument as most-recently-used. Touches are applied
+        in port order, so a higher-indexed port wins.
+    """
+
+    def __init__(self, ways: int, touch_ports: int = 1):
+        assert ways >= 2 and ways & (ways - 1) == 0, "TreePLRU ways must be a power of two"
+
+        self.ways = ways
+        self.ways_log = (ways - 1).bit_length()
+
+        way_layout = make_layout(("way", range(ways)))
+        self.get_victim = Method(o=way_layout)
+        self.touch = Methods(touch_ports, i=way_layout)
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        tree = Signal(self.ways - 1)
+
+        def victim_of(node: int, level: int) -> Value:
+            if level == self.ways_log:
+                return C(0, 0)
+            bit = tree[node]
+            left = victim_of(2 * node + 1, level + 1)
+            right = victim_of(2 * node + 2, level + 1)
+            return Cat(Mux(bit, right, left), bit)
+
+        @def_method(m, self.get_victim, nonexclusive=True)
+        def _():
+            return {"way": victim_of(0, 0)}
+
+        @def_methods(m, self.touch)
+        def _(k: int, way: Value):
+            pass
+
+        def apply_touch(cur: dict[int, Value], valid: Value, way: Value) -> dict[int, Value]:
+            new = dict(cur)
+
+            def walk(node: int, level: int, on_path: Value):
+                if level == self.ways_log:
+                    return
+                direction = way[self.ways_log - 1 - level]
+                new[node] = Mux(valid & on_path, ~direction, cur[node])
+                walk(2 * node + 1, level + 1, on_path & ~direction)
+                walk(2 * node + 2, level + 1, on_path & direction)
+
+            walk(0, 0, C(1, 1))
+            return new
+
+        # Apply each touch in port order; a higher-indexed port wins on shared nodes
+        state = {node: tree[node] for node in range(self.ways - 1)}
+        for port in self.touch:
+            state = apply_touch(state, port.run, port.data_in.way)
+
+        m.d.sync += tree.eq(Cat(state[node] for node in range(self.ways - 1)))
+
+        return m

--- a/coreblocks/cache/plru.py
+++ b/coreblocks/cache/plru.py
@@ -59,14 +59,14 @@ class TreePLRU(Elaboratable):
         def _(k: int, way: Value):
             pass
 
-        def apply_touch(cur: dict[int, Value], valid: Value, way: Value) -> dict[int, Value]:
-            new = dict(cur)
+        def apply_touch(cur: Value, valid: Value, way: Value) -> Value:
+            new = Signal(self.ways - 1)
 
             def walk(node: int, level: int, on_path: Value):
                 if level == self.ways_log:
                     return
                 direction = way[self.ways_log - 1 - level]
-                new[node] = Mux(valid & on_path, ~direction, cur[node])
+                m.d.comb += new[node].eq(Mux(valid & on_path, ~direction, cur[node]))
                 walk(2 * node + 1, level + 1, on_path & ~direction)
                 walk(2 * node + 2, level + 1, on_path & direction)
 
@@ -74,10 +74,10 @@ class TreePLRU(Elaboratable):
             return new
 
         # Apply each touch in port order; a higher-indexed port wins on shared nodes
-        state = {node: tree[node] for node in range(self.ways - 1)}
+        new_state = tree
         for port in self.touch:
-            state = apply_touch(state, port.run, port.data_in.way)
+            new_state = apply_touch(new_state, port.run, port.data_in.way)
 
-        m.d.sync += tree.eq(Cat(state[node] for node in range(self.ways - 1)))
+        m.d.sync += tree.eq(new_state)
 
         return m

--- a/coreblocks/frontend/bpu/bpu.py
+++ b/coreblocks/frontend/bpu/bpu.py
@@ -6,7 +6,9 @@ from transactron.utils import logging
 from transactron.lib import Pipe
 
 from coreblocks.params import *
+from coreblocks.arch import CfiType
 from coreblocks.frontend import FrontendParams
+from coreblocks.frontend.bpu.micro_btb import MicroBTB
 from coreblocks.interface.layouts import CommonLayoutFields
 from coreblocks.interface.layouts import BranchPredictionLayouts
 from coreblocks.interface.layouts import FetchLayouts
@@ -36,22 +38,44 @@ class BranchPredictionUnit(Elaboratable):
         fields = self.gen_params.get(CommonLayoutFields)
         fetch_layouts = self.gen_params.get(FetchLayouts)
 
-        m.submodules.pipe = pipe = Pipe(layout=make_layout(fields.pc, fields.ftq_ptr))
+        m.submodules.micro_btb = micro_btb = MicroBTB(self.gen_params, self.gen_params.bpu_config.micro_btb)
+        m.submodules.pipe = pipe = Pipe(
+            layout=make_layout(fields.pc, fields.ftq_ptr, ("entry_idx", self.gen_params.fetch_width_log))
+        )
 
         @def_method(m, self.request)
         def _(pc, ftq_ptr):
-            pipe.write(m, pc=fparams.pc_from_fb(fparams.fb_addr(pc) + 1, 0), ftq_ptr=ftq_ptr)
+            micro_btb.request(m, pc=pc)
+            pipe.write(
+                m,
+                pc=fparams.pc_from_fb(fparams.fb_addr(pc) + 1, 0),
+                ftq_ptr=ftq_ptr,
+                entry_idx=fparams.fb_instr_idx(pc),
+            )
 
         with Transaction(name="BPU_Stage1").body(m):
+            prediction = micro_btb.predict(m)
             stage = pipe.read(m)
 
-            # There are no sub-predictors yet - always predict a fall-through.
+            hit = Signal()
+            m.d.av_comb += hit.eq(prediction.hit & (prediction.cfi_idx >= stage.entry_idx))
+
+            # On a hit, redirect fetch to the predicted target; otherwise fall through
+            next_pc = Mux(hit, prediction.cfi_target, stage.pc)
+
             pred = Signal(fetch_layouts.bpu_prediction)
-            self.write_prediction(m, pc=stage.pc, ftq_ptr=stage.ftq_ptr, prediction=pred)
+            m.d.av_comb += [
+                pred.cfi_target.eq(prediction.cfi_target),
+                pred.cfi_target_valid.eq(hit),
+                pred.cfi_idx.eq(Mux(hit, prediction.cfi_idx, 0)),
+                pred.cfi_type.eq(Mux(hit, prediction.cfi_type, CfiType.INVALID)),
+                pred.branch_mask.eq(Mux(hit & CfiType.is_branch(prediction.cfi_type), 1 << prediction.cfi_idx, 0)),
+            ]
+            self.write_prediction(m, pc=next_pc, ftq_ptr=stage.ftq_ptr, prediction=pred)
 
         @def_method(m, self.update)
-        def _(pc, cfi_target, cfi_idx, cfi_type, taken, mispredict):
-            pass
+        def _(arg):
+            micro_btb.update(m, arg)
 
         @def_method(m, self.flush, nonexclusive=True)
         def _():

--- a/coreblocks/frontend/bpu/micro_btb.py
+++ b/coreblocks/frontend/bpu/micro_btb.py
@@ -1,0 +1,168 @@
+from amaranth import *
+
+from transactron import *
+from transactron.lib.metrics import *
+from transactron.utils import OneHotMux, popcount, logging
+from transactron.utils.transactron_helpers import make_layout
+from transactron.utils.amaranth_ext.coding import PriorityEncoder
+
+from coreblocks.params import GenParams, MicroBTBConfig
+from coreblocks.arch import CfiType
+from coreblocks.interface.layouts import BranchPredictionLayouts
+from coreblocks.frontend import FrontendParams
+from coreblocks.cache.plru import TreePLRU
+
+__all__ = ["MicroBTB"]
+
+log = logging.HardwareLogger("frontend.bpu.btb")
+
+
+class MicroBTB(Elaboratable):
+    """A small, fully-associative, single-cycle branch target buffer (micro-BTB).
+
+    The micro-BTB maps a fetch block address to a predicted next-fetch PC and
+    follows an "always-taken on hit" policy: a hit means the block is predicted to
+    redirect fetch to the stored target. The lookup is fully associative and
+    combinational over a registered request, so a prediction requested in one cycle
+    is available in the next cycle.
+
+    Each entry carries a saturating usefulness counter: an entry is valid while
+    its counter is non-zero. A correct, taken hit increases the counter; a not-taken
+    hit or a hit with a different target decreases it. When the counter reaches zero
+    the entry stops matching and becomes a replacement candidate. Replacement prefers
+    any such not-useful entry, otherwise it falls back to tree-pseudo-LRU over
+    the touched entries.
+    """
+
+    def __init__(self, gen_params: GenParams, config: MicroBTBConfig):
+        self.gen_params = gen_params
+
+        self.num_entries = 2**config.entries_log
+        self.useful_cnt_width = config.useful_cnt_width
+
+        xlen = gen_params.isa.xlen
+        # The tag is the full fetch-block address - aliasing is impossible
+        # TODO: maybe some aliasing is fine?
+        self.tag_width = xlen - gen_params.fetch_block_bytes_log
+
+        self.layouts = gen_params.get(BranchPredictionLayouts)
+
+        self.request = Method(i=self.layouts.predictor_request)
+        self.predict = Method(o=self.layouts.predictor_predict)
+        self.update = Method(i=self.layouts.update)
+
+        self.perf_lookups = HwCounter("frontend.bpu.ubtb.lookups", "Number of prediction requests to the micro-BTB")
+        self.perf_hits = TaggedCounter(
+            "frontend.bpu.ubtb.hits", "Number of micro-BTB hits, split by the CFI type of the entry", tags=CfiType
+        )
+        self.perf_alloc_free = HwCounter("frontend.bpu.ubtb.alloc_free", "Allocations that claimed a not-useful entry")
+        self.perf_alloc_evict = HwCounter(
+            "frontend.bpu.ubtb.alloc_evict", "Allocations that evicted a still-useful entry"
+        )
+
+    def elaborate(self, platform):
+        m = TModule()
+
+        fparams = self.gen_params.get(FrontendParams)
+        xlen = self.gen_params.isa.xlen
+        useful_max = (1 << self.useful_cnt_width) - 1
+
+        entry_layout = make_layout(
+            ("tag", self.tag_width),
+            ("target", xlen),
+            ("cfi_idx", self.gen_params.fetch_width_log),
+            ("cfi_type", CfiType),
+            ("useful", self.useful_cnt_width),
+        )
+        entries = [Signal(entry_layout, name=f"entry_{i}") for i in range(self.num_entries)]
+
+        m.submodules.plru = plru = TreePLRU(self.num_entries, touch_ports=2)
+
+        m.submodules += [self.perf_lookups, self.perf_hits, self.perf_alloc_free, self.perf_alloc_evict]
+
+        req_fb = Signal(self.tag_width)
+        req_valid = Signal()
+        m.d.sync += req_valid.eq(self.request.run)
+
+        def match_vec(fb: Value) -> list[Value]:
+            return [(entry.useful != 0) & (entry.tag == fb) for entry in entries]
+
+        def select_entry(matches: list[Value]):
+            entry = OneHotMux.create(m, list(zip(matches, entries)))
+            idx = OneHotMux.create(m, [(matches[i], C(i, range(self.num_entries))) for i in range(self.num_entries)])
+            return entry, idx
+
+        # A not-useful entries are preferred over the PLRU victim when allocating
+        not_useful = Cat(entry.useful == 0 for entry in entries)
+        m.submodules.not_useful_enc = not_useful_enc = PriorityEncoder(self.num_entries)
+        m.d.comb += not_useful_enc.i.eq(not_useful)
+
+        @def_method(m, self.request)
+        def _(pc):
+            m.d.sync += req_fb.eq(fparams.fb_addr(pc))
+
+        @def_method(m, self.predict, ready=req_valid)
+        def _():
+            req_matches = match_vec(req_fb)
+            req_entry, req_hit_idx = select_entry(req_matches)
+
+            hits = Cat(req_matches)
+            log.assertion(m, popcount(hits) <= 1, "micro-BTB hit vector must be one-hot")
+
+            # Touch the hit entry so the PLRU keeps frequently-predicted blocks
+            with m.If(hits.any()):
+                plru.touch[0](m, way=req_hit_idx)
+
+            self.perf_lookups.incr(m)
+            self.perf_hits.incr(m, tag=req_entry.cfi_type, enable_call=hits.any())
+
+            return {
+                "hit": hits.any(),
+                "cfi_target": req_entry.target,
+                "cfi_idx": req_entry.cfi_idx,
+                "cfi_type": req_entry.cfi_type,
+            }
+
+        @def_method(m, self.update)
+        def _(pc, cfi_target, cfi_idx, cfi_type, taken, mispredict):
+            fb = Signal(self.tag_width)
+            m.d.av_comb += fb.eq(fparams.fb_addr(pc))
+
+            matches = match_vec(fb)
+            hit = Cat(matches).any()
+            log.assertion(m, popcount(Cat(matches)) <= 1, "micro-BTB match vector must be one-hot")
+
+            _, hit_idx = select_entry(matches)
+
+            # Replacement victim: a not-useful entry first, else the PLRU way
+            victim_pick = plru.get_victim(m)
+            victim = Signal(range(self.num_entries))
+            m.d.av_comb += victim.eq(Mux(~not_useful_enc.n, not_useful_enc.o, victim_pick.way))
+
+            # Touch the updated entry: the hit entry, or the victim on a taken miss
+            with m.If(hit | taken):
+                plru.touch[1](m, way=Mux(hit, hit_idx, victim))
+
+            # An allocation with no not-useful entry available evicts a live entry
+            allocating = ~hit & taken
+            self.perf_alloc_free.incr(m, enable_call=allocating & ~not_useful_enc.n)
+            self.perf_alloc_evict.incr(m, enable_call=allocating & not_useful_enc.n)
+
+            for i, entry in enumerate(entries):
+                increased = Mux(entry.useful == useful_max, useful_max, entry.useful + 1)
+                decreased = Mux(entry.useful == 0, 0, entry.useful - 1)
+                pred_same = (entry.target == cfi_target) & (entry.cfi_idx == cfi_idx) & (entry.cfi_type == cfi_type)
+
+                with m.If(matches[i]):
+                    # Reinforce a correct taken hit
+                    m.d.sync += entry.useful.eq(Mux(taken & pred_same, increased, decreased))
+                with m.Elif(~hit & taken & (victim == i)):
+                    m.d.sync += [
+                        entry.tag.eq(fb),
+                        entry.target.eq(cfi_target),
+                        entry.cfi_idx.eq(cfi_idx),
+                        entry.cfi_type.eq(cfi_type),
+                        entry.useful.eq(useful_max),
+                    ]
+
+        return m

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -123,6 +123,7 @@ class FetchUnit(Elaboratable):
             depth=serializer_depth,
             read_width=self.gen_params.frontend_superscalarity,
             write_width=fetch_width,
+            write_max_count=True,
         )
 
         with Transaction(name="cont").body(m):
@@ -552,7 +553,7 @@ class FetchUnit(Elaboratable):
 
                 # Make sure this is called only once to avoid a huge mux on arguments
                 m.d.av_comb += [aligner.valids.eq(fetch_mask), aligner.inputs.eq(raw_instrs)]
-                serializer.write(m, data=aligner.outputs, count=aligner.output_cnt)
+                serializer.write(m, data=aligner.outputs, count=aligner.output_cnt, max_count=popcount(instr_valid))
 
         @def_method(m, self.flush)
         def _():

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -666,6 +666,9 @@ class BranchPredictionLayouts:
             fields.pc, fields.cfi_target, fields.cfi_idx, fields.cfi_type, ("taken", 1), ("mispredict", 1)
         )
 
+        self.predictor_request = make_layout(fields.pc)
+        self.predictor_predict = make_layout(("hit", 1), fields.cfi_target, fields.cfi_idx, fields.cfi_type)
+
 
 class FetchTargetQueueLayouts:
     def __init__(self, gen_params: GenParams):

--- a/coreblocks/params/__init__.py
+++ b/coreblocks/params/__init__.py
@@ -3,3 +3,4 @@ from .fu_params import *  # noqa: F401
 from .icache_params import *  # noqa: F401
 from .instr import *  # noqa: F401
 from .vmem_params import *  # noqa: F401
+from .bpu_params import *  # noqa: F401

--- a/coreblocks/params/bpu_params.py
+++ b/coreblocks/params/bpu_params.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+__all__ = [
+    "BranchPredictionConfig",
+    "MicroBTBConfig",
+]
+
+
+@dataclass(frozen=True)
+class MicroBTBConfig:
+    """Configuration of the micro-BTB."""
+
+    entries_log: int = 3
+    """Log of the number of entries."""
+
+    useful_cnt_width: int = 2
+    """Width of the per-entry saturating usefulness counter that drives replacement."""
+
+    def validate(self):
+        if self.entries_log < 1:
+            raise ValueError("Micro-BTB must have at least 2 entries")
+        if self.useful_cnt_width < 1:
+            raise ValueError("Micro-BTB usefulness counter must be at least 1 bit wide")
+
+
+@dataclass(frozen=True)
+class BranchPredictionConfig:
+    """Configuration of the branch prediction unit and all of its sub-predictors."""
+
+    micro_btb: MicroBTBConfig = MicroBTBConfig()
+
+    def validate(self):
+        self.micro_btb.validate()

--- a/coreblocks/params/configurations.py
+++ b/coreblocks/params/configurations.py
@@ -1,4 +1,5 @@
 from coreblocks.arch.isa import Extension
+from coreblocks.params.bpu_params import BranchPredictionConfig, MicroBTBConfig
 from coreblocks.params.core_configuration import CoreConfiguration
 from coreblocks.arch.isa_consts import SatpMode
 
@@ -119,6 +120,7 @@ full = CoreConfiguration(
     retirement_superscalarity=2,
     interrupt_custom_count=15,
     hpm_counters_count=2,
+    bpu_config=BranchPredictionConfig(micro_btb=MicroBTBConfig(entries_log=5)),
 )
 
 # Core configuration used in internal testbenches

--- a/coreblocks/params/core_configuration.py
+++ b/coreblocks/params/core_configuration.py
@@ -25,6 +25,7 @@ from coreblocks.func_blocks.fu.lsu.pma import PMARegion
 from coreblocks.func_blocks.csr.csr_unit import CSRBlockComponent
 from coreblocks.arch.isa_consts import SatpMode
 from coreblocks.params.vmem_params import TLBCacheConfiguration
+from coreblocks.params.bpu_params import BranchPredictionConfig
 
 __all__ = [
     "CoreConfiguration",
@@ -103,6 +104,8 @@ class _CoreConfigurationDataClass:
         Log of the size of the fetch block (in bytes).
     ftq_size_log: int
         Log of the number of entries in the Fetch Target Queue
+    bpu_config: BranchPredictionConfig
+        Configuration of the branch prediction unit and its sub-predictors (e.g. their sizes).
     instr_buffer_size: int
         Size of the instruction buffer.
     interrupt_custom_count: int
@@ -186,6 +189,8 @@ class _CoreConfigurationDataClass:
 
     fetch_block_bytes_log: int = 2
     ftq_size_log: int = 4
+
+    bpu_config: BranchPredictionConfig = BranchPredictionConfig()
 
     instr_buffer_size: int = 4
 

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -98,6 +98,9 @@ class GenParams(DependentCache):
         self.ftq_size_log = cfg.ftq_size_log
         self.ftq_size = 2**cfg.ftq_size_log
 
+        self.bpu_config = cfg.bpu_config
+        self.bpu_config.validate()
+
         self.frontend_superscalarity = cfg.frontend_superscalarity
         self.announcement_superscalarity = cfg.announcement_superscalarity
         self.retirement_superscalarity = cfg.retirement_superscalarity

--- a/test/cache/test_plru.py
+++ b/test/cache/test_plru.py
@@ -1,0 +1,86 @@
+import pytest
+
+from transactron.testing import (
+    TestCaseWithSimulator,
+    SimpleTestCircuit,
+    TestbenchContext,
+)
+
+from coreblocks.cache.plru import TreePLRU
+
+
+class TestTreePLRU(TestCaseWithSimulator):
+    def test_initial_victim_is_first_way(self):
+        dut = SimpleTestCircuit(TreePLRU(4))
+
+        async def proc(sim: TestbenchContext):
+            assert (await dut.get_victim.call(sim))["way"] == 0
+
+        with self.run_simulation(dut) as sim:
+            sim.add_testbench(proc)
+
+    @pytest.mark.parametrize("ways", [2, 4, 8])
+    def test_touched_way_is_not_the_victim(self, ways):
+        dut = SimpleTestCircuit(TreePLRU(ways))
+
+        async def proc(sim: TestbenchContext):
+            # Whatever the accumulated state, touching a way must steer the victim
+            # descent away from it, so it is never the immediate next victim
+            for way in range(ways):
+                await dut.touch[0].call(sim, way=way)
+                assert (await dut.get_victim.call(sim))["way"] != way
+
+        with self.run_simulation(dut) as sim:
+            sim.add_testbench(proc)
+
+    @pytest.mark.parametrize("ways", [2, 4, 8])
+    def test_touching_the_victim_cycles_all_ways(self, ways):
+        dut = SimpleTestCircuit(TreePLRU(ways))
+
+        async def proc(sim: TestbenchContext):
+            # Repeatedly evicting and touching the victim must
+            # visit every way exactly once before any way repeats
+            seen = []
+            for _ in range(ways):
+                victim = (await dut.get_victim.call(sim))["way"]
+                seen.append(victim)
+                await dut.touch[0].call(sim, way=victim)
+
+            assert sorted(seen) == list(range(ways))
+
+            # After a full sweep the order repeats from the start
+            assert (await dut.get_victim.call(sim))["way"] == seen[0]
+
+        with self.run_simulation(dut) as sim:
+            sim.add_testbench(proc)
+
+    def test_lru_after_full_touch_sequence(self):
+        dut = SimpleTestCircuit(TreePLRU(4))
+
+        async def proc(sim: TestbenchContext):
+            # Touch every way in order; the first-touched way is the pseudo-LRU
+            for way in range(4):
+                await dut.touch[0].call(sim, way=way)
+            assert (await dut.get_victim.call(sim))["way"] == 0
+
+        with self.run_simulation(dut) as sim:
+            sim.add_testbench(proc)
+
+    def test_higher_touch_port_wins(self):
+        dut = SimpleTestCircuit(TreePLRU(2, touch_ports=2))
+
+        async def proc(sim: TestbenchContext):
+            # Both ports touch different ways in the same cycle. Port 1 (higher
+            # index) wins on the shared node, so it protects way 0 and the victim
+            # becomes way 1 - which is not what port 0 alone (touching way 1)
+            # would produce, and differs from the untouched initial victim (0)
+            dut.touch[0].call_init(sim, way=1)
+            dut.touch[1].call_init(sim, way=0)
+            await sim.tick()
+            dut.touch[0].disable(sim)
+            dut.touch[1].disable(sim)
+
+            assert (await dut.get_victim.call(sim))["way"] == 1
+
+        with self.run_simulation(dut) as sim:
+            sim.add_testbench(proc)

--- a/test/frontend/test_bpu.py
+++ b/test/frontend/test_bpu.py
@@ -1,0 +1,74 @@
+import pytest
+from collections import deque
+
+from transactron.testing import (
+    TestCaseWithSimulator,
+    SimpleTestCircuit,
+    TestbenchContext,
+    def_method_mock,
+)
+from transactron.testing.method_mock import MethodMock
+
+from coreblocks.arch import CfiType
+from coreblocks.frontend.bpu.bpu import BranchPredictionUnit
+from coreblocks.params import GenParams
+from coreblocks.params import configurations
+
+
+class TestBranchPredictionUnit(TestCaseWithSimulator):
+    @pytest.fixture(autouse=True)
+    def setup(self, fixture_initialize_testing_env):
+        # A multi-instruction fetch block, so in-block CFI indices are meaningful
+        self.gen_params = GenParams(configurations.test.replace(fetch_block_bytes_log=4))
+        self.fbl = self.gen_params.fetch_block_bytes_log
+        self.bpu = SimpleTestCircuit(BranchPredictionUnit(self.gen_params))
+        self.predictions: deque = deque()
+
+    def fall_through(self, pc: int) -> int:
+        return ((pc >> self.fbl) + 1) << self.fbl
+
+    @def_method_mock(lambda self: self.bpu.write_prediction)
+    def write_prediction_mock(self, pc, ftq_ptr, prediction):
+        @MethodMock.effect
+        def eff():
+            self.predictions.append(pc)
+
+    async def predict(self, sim: TestbenchContext, pc: int) -> int:
+        self.predictions.clear()
+        await self.bpu.request.call(sim, pc=pc, ftq_ptr={"ptr": 0, "parity": 0})
+        while not self.predictions:
+            await sim.tick()
+        return self.predictions[-1]
+
+    def test_unknown_block_falls_through(self):
+        pc = 0x100
+
+        async def proc(sim: TestbenchContext):
+            assert await self.predict(sim, pc) == self.fall_through(pc)
+
+        with self.run_simulation(self.bpu) as sim:
+            sim.add_testbench(proc)
+
+    def test_learned_taken_branch_redirects_to_target(self):
+        pc = 0x100
+        target = 0x2ABC
+
+        async def proc(sim: TestbenchContext):
+            assert await self.predict(sim, pc) == self.fall_through(pc)
+
+            await self.bpu.update.call(sim, pc=pc, cfi_target=target, cfi_idx=0, cfi_type=CfiType.BRANCH, taken=1)
+
+            assert await self.predict(sim, pc) == target
+
+        with self.run_simulation(self.bpu) as sim:
+            sim.add_testbench(proc)
+
+    def test_not_taken_update_does_not_redirect(self):
+        pc = 0x100
+
+        async def proc(sim: TestbenchContext):
+            await self.bpu.update.call(sim, pc=pc, cfi_target=0xDEAD, cfi_idx=0, cfi_type=CfiType.BRANCH, taken=0)
+            assert await self.predict(sim, pc) == self.fall_through(pc)
+
+        with self.run_simulation(self.bpu) as sim:
+            sim.add_testbench(proc)

--- a/test/frontend/test_micro_btb.py
+++ b/test/frontend/test_micro_btb.py
@@ -1,0 +1,152 @@
+import pytest
+
+from transactron.testing import (
+    TestCaseWithSimulator,
+    SimpleTestCircuit,
+    TestbenchContext,
+)
+
+from coreblocks.frontend.bpu.micro_btb import MicroBTB
+from coreblocks.arch import CfiType
+from coreblocks.params import BranchPredictionConfig, MicroBTBConfig, GenParams
+from coreblocks.params import configurations
+
+
+class TestMicroBTB(TestCaseWithSimulator):
+    @pytest.fixture(autouse=True)
+    def setup(self, fixture_initialize_testing_env):
+        # fetch_block_bytes_log=4 gives fetch_width > 1, so cfi_idx has real bits
+        self.config = MicroBTBConfig(entries_log=2)
+        self.gen_params = GenParams(
+            configurations.test.replace(
+                fetch_block_bytes_log=4, bpu_config=BranchPredictionConfig(micro_btb=self.config)
+            )
+        )
+        self.num_entries = 2**self.config.entries_log
+        self.useful_max = 2**self.config.useful_cnt_width - 1
+        self.btb = SimpleTestCircuit(MicroBTB(self.gen_params, self.config))
+
+    async def lookup(self, sim: TestbenchContext, pc: int):
+        """Issue a request and read back the prediction it produces next cycle"""
+        await self.btb.request.call(sim, pc=pc)
+        return await self.btb.predict.call(sim)
+
+    async def train(self, sim: TestbenchContext, pc, cfi_target, taken, cfi_idx=0, cfi_type=CfiType.BRANCH):
+        await self.btb.update.call(
+            sim, pc=pc, cfi_target=cfi_target, cfi_idx=cfi_idx, cfi_type=cfi_type, taken=taken, mispredict=0
+        )
+
+    def test_unknown_block_misses(self):
+        async def proc(sim: TestbenchContext):
+            res = await self.lookup(sim, 0x1000)
+            assert res["hit"] == 0
+
+        with self.run_simulation(self.btb) as sim:
+            sim.add_testbench(proc)
+
+    def test_taken_branch_is_learned(self):
+        pc = 0x1000
+        target = 0x2ABC
+
+        async def proc(sim: TestbenchContext):
+            assert (await self.lookup(sim, pc))["hit"] == 0
+
+            await self.train(sim, pc, target, taken=1)
+
+            res = await self.lookup(sim, pc)
+            assert res["hit"] == 1
+            assert res["cfi_target"] == target
+
+        with self.run_simulation(self.btb) as sim:
+            sim.add_testbench(proc)
+
+    def test_prediction_carries_position_and_type(self):
+        pc = 0x1000
+
+        async def proc(sim: TestbenchContext):
+            await self.train(sim, pc, cfi_target=0x2000, taken=1, cfi_idx=2, cfi_type=CfiType.JAL)
+
+            res = await self.lookup(sim, pc)
+            assert res["hit"] == 1
+            assert res["cfi_target"] == 0x2000
+            assert res["cfi_idx"] == 2
+            assert res["cfi_type"] == CfiType.JAL
+
+        with self.run_simulation(self.btb) as sim:
+            sim.add_testbench(proc)
+
+    def test_useful_counter_hysteresis(self):
+        pc = 0x1000
+        target = 0x2ABC
+
+        async def proc(sim: TestbenchContext):
+            await self.train(sim, pc, target, taken=1)
+            assert (await self.lookup(sim, pc))["hit"] == 1
+
+            # The usefulness counter starts saturated, so a single not-taken
+            # resolution weakens the entry but keeps it valid
+            for _ in range(self.useful_max - 1):
+                await self.train(sim, pc, cfi_target=0, taken=0)
+                assert (await self.lookup(sim, pc))["hit"] == 1
+
+            # One more not-taken drives the counter to zero and invalidates it
+            await self.train(sim, pc, cfi_target=0, taken=0)
+            assert (await self.lookup(sim, pc))["hit"] == 0
+
+        with self.run_simulation(self.btb) as sim:
+            sim.add_testbench(proc)
+
+    def test_not_useful_entry_is_reused(self):
+        blocks = [(0x1000 * (i + 1), 0x20000 + 0x1000 * i) for i in range(self.num_entries)]
+
+        async def proc(sim: TestbenchContext):
+            for pc, target in blocks:
+                await self.train(sim, pc, target, taken=1)
+
+            # Decay the first block until its counter reaches zero (not useful)
+            for _ in range(self.useful_max):
+                await self.train(sim, blocks[0][0], cfi_target=0, taken=0)
+
+            # A new block must reuse the decayed slot, leaving the others intact
+            new_pc, new_target = 0x90000, 0x99000
+            await self.train(sim, new_pc, new_target, taken=1)
+
+            assert (await self.lookup(sim, blocks[0][0]))["hit"] == 0
+
+            res = await self.lookup(sim, new_pc)
+            assert res["hit"] == 1
+            assert res["cfi_target"] == new_target
+
+            for pc, target in blocks[1:]:
+                res = await self.lookup(sim, pc)
+                assert res["hit"] == 1
+                assert res["cfi_target"] == target
+
+        with self.run_simulation(self.btb) as sim:
+            sim.add_testbench(proc)
+
+    def test_full_table_evicts_one_entry(self):
+        # One more block than there are entries, so the last one must evict
+        blocks = [(0x1000 * (i + 1), 0x20000 + 0x1000 * i) for i in range(self.num_entries + 1)]
+
+        async def proc(sim: TestbenchContext):
+            for pc, target in blocks:
+                await self.train(sim, pc, target, taken=1)
+
+            results = {pc: await self.lookup(sim, pc) for pc, _ in blocks}
+
+            # The table holds num_entries blocks, so exactly one of the num_entries+1
+            # must have been evicted - which one is up to the replacement policy
+            resident = [pc for pc, res in results.items() if res["hit"]]
+            assert len(resident) == self.num_entries
+
+            # The just-installed block survives; the evicted one is an older block
+            assert results[blocks[-1][0]]["hit"] == 1
+
+            # Every resident block still predicts its own target
+            targets = dict(blocks)
+            for pc in resident:
+                assert results[pc]["cfi_target"] == targets[pc]
+
+        with self.run_simulation(self.btb) as sim:
+            sim.add_testbench(proc)


### PR DESCRIPTION
Coreblocks' first branch predictor!

The micro-BTB (branch target buffer) maps a fetch block address to a predicted next-fetch PC. The lookup is fully associative and combinational over a request, so a prediction requested in one cycle is available in the next cycle.

It's "micro" because of its relatively small size - regular BTBs are on the order of thousands of entries and use SRAM.

Note that this predictor is currently hard-wired into the BPU - this is temporary, for simplicity. The end goal is to have the BPU configurable in the same way as our FUs.

Depends on #1025