### PR TITLE
change all FIFO to BasicFifo

### DIFF
--- a/coreblocks/func_blocks/fu/common/rs_func_block.py
+++ b/coreblocks/func_blocks/fu/common/rs_func_block.py
@@ -6,7 +6,7 @@ from .rs import RS, RSBase
 from coreblocks.scheduler.wakeup_select import WakeupSelect
 from transactron import Method, Methods, TModule
 from coreblocks.func_blocks.interface.func_protocols import FuncUnit, FuncBlock
-from transactron.lib import FIFO, Collector, Connect
+from transactron.lib import Collector, Connect, BasicFifo
 from coreblocks.arch import OpType
 from coreblocks.interface.layouts import RSInterfaceLayouts, RSLayouts, FuncUnitLayouts
 from coreblocks.telemetry import func_unit_kind
@@ -90,7 +90,7 @@ class RSFuncBlock(FuncBlock, Elaboratable):
             wakeup_select.take_row.provide(self.rs.take)
             wakeup_select.issue.provide(func_unit.issue)
             if result_fifo:
-                connector = FIFO(self.gen_params.get(FuncUnitLayouts).push_result, 2)
+                connector = BasicFifo(self.gen_params.get(FuncUnitLayouts).push_result, 2)
             else:
                 connector = Connect(self.gen_params.get(FuncUnitLayouts).push_result)
             m.submodules[f"func_unit_{n}"] = func_unit

--- a/coreblocks/func_blocks/fu/div_unit.py
+++ b/coreblocks/func_blocks/fu/div_unit.py
@@ -49,7 +49,7 @@ class DivUnit(FuncUnitBase[DivFn]):
     def elaborate(self, platform):
         m = super().elaborate(platform)
 
-        m.submodules.params_fifo = params_fifo = FIFO(
+        m.submodules.params_fifo = params_fifo = BasicFifo(
             [
                 ("rob_id", self.gen_params.rob_entries_bits),
                 ("rp_dst", self.gen_params.phys_regs_bits),

--- a/coreblocks/func_blocks/fu/lsu/dummyLsu.py
+++ b/coreblocks/func_blocks/fu/lsu/dummyLsu.py
@@ -2,10 +2,8 @@ from dataclasses import dataclass
 
 from amaranth import *
 from transactron import Method, TModule, Transaction, def_method
-from transactron.lib.connectors import FIFO, ConnectTrans, Pipe
-from transactron.utils import logging
-from transactron.lib.simultaneous import condition
-from transactron.utils import DependencyContext
+from transactron.lib import ConnectTrans, Pipe, BasicFifo, condition
+from transactron.utils import logging, DependencyContext
 
 from coreblocks.arch import OpType
 from coreblocks.arch.isa_consts import ExceptionCause
@@ -80,12 +78,12 @@ class LSUDummy(FuncUnit, Elaboratable):
         m.submodules.pmp_checker = pmp_checker = PMPChecker(self.gen_params, mode=PMPOperationMode.LSU)
         m.submodules.requester = requester = LSURequester(self.gen_params, self.bus)
 
-        m.submodules.requests = requests = FIFO(self.fu_layouts.issue, 2)
+        m.submodules.requests = requests = BasicFifo(self.fu_layouts.issue, 2)
         m.submodules.translator_in = translator_in = Pipe(self.translator_layouts.request)
-        m.submodules.translated = translated = FIFO(self.translator_layouts.accept, 2)
-        m.submodules.results_noop = results_noop = FIFO(self.lsu_layouts.accept, 2)
-        m.submodules.issued = issued = FIFO(self.fu_layouts.issue, 2)
-        m.submodules.issued_noop = issued_noop = FIFO(self.fu_layouts.issue, 2)
+        m.submodules.translated = translated = BasicFifo(self.translator_layouts.accept, 2)
+        m.submodules.results_noop = results_noop = BasicFifo(self.lsu_layouts.accept, 2)
+        m.submodules.issued = issued = BasicFifo(self.fu_layouts.issue, 2)
+        m.submodules.issued_noop = issued_noop = BasicFifo(self.fu_layouts.issue, 2)
 
         @def_method(m, self.issue)
         def _(arg):

--- a/coreblocks/func_blocks/fu/mul_unit.py
+++ b/coreblocks/func_blocks/fu/mul_unit.py
@@ -103,7 +103,7 @@ class MulUnit(FuncUnitBase[MulFn]):
     def elaborate(self, platform):
         m = super().elaborate(platform)
 
-        m.submodules.params_fifo = params_fifo = FIFO(
+        m.submodules.params_fifo = params_fifo = BasicFifo(
             [
                 ("rob_id", self.gen_params.rob_entries_bits),
                 ("rp_dst", self.gen_params.phys_regs_bits),

--- a/coreblocks/func_blocks/fu/unsigned_multiplication/fast_recursive.py
+++ b/coreblocks/func_blocks/fu/unsigned_multiplication/fast_recursive.py
@@ -4,10 +4,9 @@ from coreblocks.func_blocks.fu.unsigned_multiplication.common import MulBaseUnsi
 from coreblocks.params import GenParams
 from transactron import *
 from transactron.core import def_method
+from transactron.lib import BasicFifo
 
 __all__ = ["RecursiveUnsignedMul"]
-
-from transactron.lib import FIFO
 
 
 class FastRecursiveMul(Elaboratable):
@@ -117,7 +116,7 @@ class RecursiveUnsignedMul(MulBaseUnsigned):
 
     def elaborate(self, platform):
         m = TModule()
-        m.submodules.fifo = fifo = FIFO([("o", 2 * self.gen_params.isa.xlen)], 2)
+        m.submodules.fifo = fifo = BasicFifo([("o", 2 * self.gen_params.isa.xlen)], 2)
 
         m.submodules.mul = mul = FastRecursiveMul(self.gen_params.isa.xlen, self.dsp_width)
 

--- a/coreblocks/func_blocks/fu/zbc.py
+++ b/coreblocks/func_blocks/fu/zbc.py
@@ -9,7 +9,7 @@ from coreblocks.func_blocks.interface.func_protocols import FuncUnit
 from coreblocks.params import GenParams, FunctionalComponentParams
 from coreblocks.arch import OpType, Funct3
 from transactron import Transaction, def_method
-from transactron.lib import FIFO
+from transactron.lib import BasicFifo
 from transactron.utils import OneHotSwitch
 
 
@@ -160,7 +160,7 @@ class ZbcUnit(FuncUnitBase[ZbcFn]):
     def elaborate(self, platform):
         m = super().elaborate(platform)
 
-        m.submodules.params_fifo = params_fifo = FIFO(
+        m.submodules.params_fifo = params_fifo = BasicFifo(
             [
                 ("rob_id", self.gen_params.rob_entries_bits),
                 ("rp_dst", self.gen_params.phys_regs_bits),

--- a/test/backend/test_retirement.py
+++ b/test/backend/test_retirement.py
@@ -3,7 +3,7 @@ from coreblocks.arch.isa_consts import PrivilegeLevel
 from coreblocks.backend.retirement import *
 from coreblocks.priv.csr.csr_instances import CSRInstances
 
-from transactron.lib import FIFO, Adapter
+from transactron.lib import BasicFifo, Adapter
 from transactron.core import TModule
 from transactron.utils import DependencyContext
 from coreblocks.core_structs.rat import RRAT
@@ -26,7 +26,7 @@ class RetirementTestCircuit(Elaboratable):
         m = TModule()
 
         m.submodules.r_rat = self.rat = RRAT(gen_params=self.gen_params)
-        m.submodules.free_rf_list = self.free_rf = FIFO(
+        m.submodules.free_rf_list = self.free_rf = BasicFifo(
             [("ident", range(self.gen_params.phys_regs))], self.gen_params.phys_regs
         )
 

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -9,7 +9,7 @@ from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 from coreblocks.interface.keys import CoreStateKey, RollbackKey
 from coreblocks.interface.layouts import RSInterfaceLayouts, RetirementLayouts
 
-from transactron.lib import FIFO, AdapterTrans, Adapter
+from transactron.lib import BasicFifo, AdapterTrans, Adapter
 from transactron.testing.functions import MethodData, data_const_to_dict
 from transactron.testing.method_mock import MethodMock
 from transactron.utils.amaranth_ext.elaboratables import ModuleConnector
@@ -55,8 +55,8 @@ class SchedulerTestCircuit(Elaboratable):
         scheduler_layouts = self.gen_params.get(SchedulerLayouts)
 
         # data structures
-        m.submodules.instr_fifo = instr_fifo = FIFO(scheduler_layouts.scheduler_in, 16)
-        m.submodules.free_rf_fifo = free_rf_fifo = FIFO(
+        m.submodules.instr_fifo = instr_fifo = BasicFifo(scheduler_layouts.scheduler_in, 16)
+        m.submodules.free_rf_fifo = free_rf_fifo = BasicFifo(
             scheduler_layouts.free_rf_layout, 2**self.gen_params.phys_regs_bits
         )
         m.submodules.crat = self.crat = crat = CheckpointRAT(gen_params=self.gen_params)


### PR DESCRIPTION
removes all instances of `transactron.FIFO` in favor of `transactron.BasicFifo`.