### PR TITLE
Fix wave tracing for cocotb

### DIFF
--- a/test/regression/cocotb/arch_test.Makefile
+++ b/test/regression/cocotb/arch_test.Makefile
@@ -1,25 +1,3 @@
-# Makefile for arch regression cocotb tests
-
-# defaults
-SIM ?= verilator
-TOPLEVEL_LANG ?= verilog
-SIM_BUILD ?= build/riscv-arch-test/$(SIM)
-
-# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
-TOPLEVEL = top
-
-# MODULE is the basename of the Python test file
 MODULE = arch_elf_entrypoint
-
-# Yosys/Amaranth borkedness workaround
-ifeq ($(SIM),verilator)
-  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN -Wno-UNOPTFLAT
-  BUILD_ARGS += -j`nproc`
-endif
-
-ifeq ($(TRACES),1)
-  EXTRA_ARGS += --trace --trace-fst --trace-structs
-endif
-
-# include cocotb's make rules to take care of the simulator setup
-include $(shell cocotb-config --makefiles)/Makefile.sim
+BUILD_NAME = riscv-arch-test
+include common.Makefile

--- a/test/regression/cocotb/arch_test.Makefile
+++ b/test/regression/cocotb/arch_test.Makefile
@@ -18,7 +18,7 @@ ifeq ($(SIM),verilator)
 endif
 
 ifeq ($(TRACES),1)
-  EXTRA_ARGS += --trace-fst --trace-structs
+  EXTRA_ARGS += --trace --trace-fst --trace-structs
 endif
 
 # include cocotb's make rules to take care of the simulator setup

--- a/test/regression/cocotb/benchmark.Makefile
+++ b/test/regression/cocotb/benchmark.Makefile
@@ -1,26 +1,3 @@
-# Makefile
-
-# defaults
-SIM ?= verilator
-TOPLEVEL_LANG ?= verilog
-
-# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
-TOPLEVEL = top
-
-# MODULE is the basename of the Python test file
 MODULE = benchmark_entrypoint
-
-SIM_BUILD = build/benchmark
-
-# Yosys/Amaranth borkedness workaround
-ifeq ($(SIM),verilator)
-  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN
-  BUILD_ARGS += -j`nproc`
-endif
-
-ifeq ($(TRACES),1)
-  EXTRA_ARGS += --trace --trace-fst --trace-structs
-endif
-
-# include cocotb's make rules to take care of the simulator setup
-include $(shell cocotb-config --makefiles)/Makefile.sim
+BUILD_NAME = benchmark
+include common.Makefile

--- a/test/regression/cocotb/benchmark.Makefile
+++ b/test/regression/cocotb/benchmark.Makefile
@@ -19,7 +19,7 @@ ifeq ($(SIM),verilator)
 endif
 
 ifeq ($(TRACES),1)
-  EXTRA_ARGS += --trace-fst --trace-structs
+  EXTRA_ARGS += --trace --trace-fst --trace-structs
 endif
 
 # include cocotb's make rules to take care of the simulator setup

--- a/test/regression/cocotb/common.Makefile
+++ b/test/regression/cocotb/common.Makefile
@@ -3,7 +3,11 @@
 # defaults
 SIM ?= verilator
 TOPLEVEL_LANG ?= verilog
-SIM_BUILD ?= build/$(BUILD_NAME)/$(SIM)
+ifeq ($(TRACES),1)
+	SIM_BUILD ?= build/$(BUILD_NAME)/$(SIM)-trace
+else
+	SIM_BUILD ?= build/$(BUILD_NAME)/$(SIM)
+endif
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = top

--- a/test/regression/cocotb/common.Makefile
+++ b/test/regression/cocotb/common.Makefile
@@ -3,14 +3,14 @@
 # defaults
 SIM ?= verilator
 TOPLEVEL_LANG ?= verilog
-SIM_BUILD ?= build/riscv-arch-test/$(SIM)
+SIM_BUILD ?= build/$(BUILD_NAME)/$(SIM)
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = top
 
 # Yosys/Amaranth borkedness workaround
 ifeq ($(SIM),verilator)
-  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN -Wno-UNOPTFLAT
+  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN -Wno-UNOPTFLAT -Wno-ALWNEVER
   BUILD_ARGS += -j`nproc`
 endif
 

--- a/test/regression/cocotb/common.Makefile
+++ b/test/regression/cocotb/common.Makefile
@@ -1,0 +1,23 @@
+# Common makefile for cocotb tests
+
+# defaults
+SIM ?= verilator
+TOPLEVEL_LANG ?= verilog
+SIM_BUILD ?= build/riscv-arch-test/$(SIM)
+
+# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
+TOPLEVEL = top
+
+# Yosys/Amaranth borkedness workaround
+ifeq ($(SIM),verilator)
+  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN -Wno-UNOPTFLAT
+  BUILD_ARGS += -j`nproc`
+endif
+
+ifeq ($(TRACES),1)
+  EXTRA_ARGS += --trace --trace-fst --trace-structs
+endif
+
+# include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim
+

--- a/test/regression/cocotb/common.Makefile
+++ b/test/regression/cocotb/common.Makefile
@@ -25,4 +25,3 @@ endif
 
 # include cocotb's make rules to take care of the simulator setup
 include $(shell cocotb-config --makefiles)/Makefile.sim
-

--- a/test/regression/cocotb/common.Makefile
+++ b/test/regression/cocotb/common.Makefile
@@ -10,12 +10,17 @@ TOPLEVEL = top
 
 # Yosys/Amaranth borkedness workaround
 ifeq ($(SIM),verilator)
-  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN -Wno-UNOPTFLAT -Wno-ALWNEVER
-  BUILD_ARGS += -j`nproc`
-endif
+	# Verilog uses MAJOR.<MINOR as 3 digits> versioning - we can safely compress the version to number
+	VERILATOR_VERSION_NUM = $(shell verilator --version | head -n 1 | cut -d ' ' -f 2 | tr -d '.')
 
-ifeq ($(TRACES),1)
-  EXTRA_ARGS += --trace --trace-fst --trace-structs
+	COMPILE_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN -Wno-UNOPTFLAT
+	COMPILE_ARGS += $(shell [ $(VERILATOR_VERSION_NUM) -ge 5040 ] && echo "-Wno-ALWNEVER")
+
+	BUILD_ARGS += -j`nproc`
+
+	ifeq ($(TRACES),1)
+		EXTRA_ARGS += --trace --trace-fst --trace-structs
+	endif
 endif
 
 # include cocotb's make rules to take care of the simulator setup

--- a/test/regression/cocotb/test.Makefile
+++ b/test/regression/cocotb/test.Makefile
@@ -1,26 +1,3 @@
-# Makefile
-
-# defaults
-SIM ?= verilator
-TOPLEVEL_LANG ?= verilog
-
-# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
-TOPLEVEL = top
-
-# MODULE is the basename of the Python test file
-MODULE = test_entrypoint
-
-SIM_BUILD = build/test
-
-# Yosys/Amaranth borkedness workaround
-ifeq ($(SIM),verilator)
-  EXTRA_ARGS += -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC -Wno-UNSIGNED -Wno-CMPCONST -Wno-LITENDIAN
-  BUILD_ARGS += -j`nproc`
-endif
-
-ifeq ($(TRACES),1)
-  EXTRA_ARGS += --trace --trace-fst --trace-structs
-endif
-
-# include cocotb's make rules to take care of the simulator setup
-include $(shell cocotb-config --makefiles)/Makefile.sim
+MODULE = arch_elf_entrypoint
+BUILD_NAME = test
+include common.Makefile

--- a/test/regression/cocotb/test.Makefile
+++ b/test/regression/cocotb/test.Makefile
@@ -1,3 +1,3 @@
-MODULE = arch_elf_entrypoint
+MODULE = test_entrypoint
 BUILD_NAME = test
 include common.Makefile

--- a/test/regression/cocotb/test.Makefile
+++ b/test/regression/cocotb/test.Makefile
@@ -19,7 +19,7 @@ ifeq ($(SIM),verilator)
 endif
 
 ifeq ($(TRACES),1)
-  EXTRA_ARGS += --trace-fst --trace-structs
+  EXTRA_ARGS += --trace --trace-fst --trace-structs
 endif
 
 # include cocotb's make rules to take care of the simulator setup


### PR DESCRIPTION
Traces with verilator according to [cocotb documentation](https://docs.cocotb.org/en/stable/simulator_support.html#sim-verilator-waveforms) for FST should include "--trace --trace-fst --trace-structs" to extra args rather than "--trace-fst --trace-structs".

This also makes wave tracing not require any changes in the verilog file