### PR TITLE
add missing U-bit check for non-leaf PTEs

### DIFF
--- a/coreblocks/priv/vmem/walker.py
+++ b/coreblocks/priv/vmem/walker.py
@@ -94,8 +94,8 @@ class PTEView(View):
             is_bad |= self.PBMT.any()
             is_bad |= self.N
 
-        # Non-leaf PTEs have A and D bits reserved
-        is_bad |= ~self.is_leaf() & (self.A | self.D)
+        # Non-leaf PTEs have ADU bits reserved
+        is_bad |= ~self.is_leaf() & (self.A | self.D | self.U)
 
         return is_bad
 

--- a/test/priv/vmem/test_walker.py
+++ b/test/priv/vmem/test_walker.py
@@ -128,7 +128,7 @@ class TestPageTableWalker(TestCaseWithSimulator):
                 bad_encodings = []
                 bad_encodings.append({"V": 0})
                 bad_encodings.append({"V": 1, "R": 0, "W": 1})
-                for v in ("A", "D"):
+                for v in ("A", "D", "U"):
                     bad_encodings.append({"V": 1, v: 1})  # non-leaf with A/D is reserved
                 if self.gen_params.isa.xlen == 64:
                     bad_encodings.append({"V": 1, "reserved": random.randint(1, 0x7F)})


### PR DESCRIPTION
> For non-leaf PTEs, the D, A, and U bits are reserved for future standard use. Until their use is defined by a standard extension, they must be cleared by software for forward compatibility.

The U-bit check was missing