### PR TITLE
test: replace parameterized with pytest.mark.parametrize

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dev = [
     "pytest==8.0.0",
     "pytest-xdist==3.5.0",
     "hypothesis==6.99.6",
-    "parameterized==0.8.1",
     "cocotb==1.9.2",
     "cocotb-bus==0.2.1",
     "docutils==0.21.2",

--- a/test/cache/test_icache.py
+++ b/test/cache/test_icache.py
@@ -1,5 +1,4 @@
 from collections import deque
-from parameterized import parameterized_class
 import random
 import pytest
 
@@ -21,14 +20,14 @@ from transactron.testing.testbenchio import CallTrigger
 from ..peripherals.bus_mock import BusMockParameters, MockMasterAdapter
 
 
-@parameterized_class(
-    ("name", "isa_xlen", "line_size", "fetch_block"),
+@pytest.mark.parametrize(
+    ("isa_xlen", "line_size", "fetch_block"),
     [
-        ("line16B_block4B_rv32i", 32, 4, 2),
-        ("line32B_block8B_rv32i", 32, 5, 3),
-        ("line32B_block8B_rv64i", 64, 5, 3),
-        ("line64B_block16B_rv32i", 32, 6, 4),
-        ("line16B_block16B_rv32i", 32, 4, 4),
+        (32, 4, 2),
+        (32, 5, 3),
+        (64, 5, 3),
+        (32, 6, 4),
+        (32, 4, 4),
     ],
 )
 class TestSimpleCommonBusCacheRefiller(TestCaseWithSimulator):
@@ -37,7 +36,10 @@ class TestSimpleCommonBusCacheRefiller(TestCaseWithSimulator):
     fetch_block: int
 
     @pytest.fixture(autouse=True)
-    def setup_method(self) -> None:
+    def setup(self, isa_xlen: int, line_size: int, fetch_block: int) -> None:
+        self.isa_xlen = isa_xlen
+        self.line_size = line_size
+        self.fetch_block = fetch_block
         self.gen_params = GenParams(
             configurations.test.replace(
                 xlen=self.isa_xlen, icache_line_bytes_log=self.line_size, fetch_block_bytes_log=self.fetch_block
@@ -129,18 +131,21 @@ class TestSimpleCommonBusCacheRefiller(TestCaseWithSimulator):
             sim.add_testbench(self.refiller_process)
 
 
-@parameterized_class(
-    ("name", "isa_xlen", "fetch_block"),
+@pytest.mark.parametrize(
+    ("isa_xlen", "fetch_block"),
     [
-        ("rv32i", 32, 2),
-        ("rv64i", 64, 3),
+        (32, 2),
+        (64, 3),
     ],
 )
 class TestICacheBypass(TestCaseWithSimulator):
     isa_xlen: int
     fetch_block: int
 
-    def setup_method(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self, isa_xlen: int, fetch_block: int) -> None:
+        self.isa_xlen = isa_xlen
+        self.fetch_block = fetch_block
         self.gen_params = GenParams(
             configurations.test.replace(xlen=self.isa_xlen, fetch_block_bytes_log=self.fetch_block, icache_enable=False)
         )
@@ -238,13 +243,13 @@ class MockedCacheRefiller(Elaboratable, CacheRefillerInterface):
         return Module()
 
 
-@parameterized_class(
-    ("name", "isa_xlen", "line_size", "fetch_block"),
+@pytest.mark.parametrize(
+    ("isa_xlen", "line_size", "fetch_block"),
     [
-        ("line16B_block8B_rv32i", 32, 4, 2),
-        ("line64B_block16B_rv32i", 32, 6, 4),
-        ("line32B_block16B_rv64i", 64, 5, 4),
-        ("line32B_block32B_rv64i", 64, 5, 5),
+        (32, 4, 2),
+        (32, 6, 4),
+        (64, 5, 4),
+        (64, 5, 5),
     ],
 )
 class TestICache(TestCaseWithSimulator):
@@ -252,7 +257,11 @@ class TestICache(TestCaseWithSimulator):
     line_size: int
     fetch_block: int
 
-    def setup_method(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self, isa_xlen: int, line_size: int, fetch_block: int) -> None:
+        self.isa_xlen = isa_xlen
+        self.line_size = line_size
+        self.fetch_block = fetch_block
         random.seed(42)
 
         self.mem = dict()

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -2,7 +2,6 @@ import pytest
 from typing import Optional
 from collections import deque
 from dataclasses import dataclass
-from parameterized import parameterized_class
 import random
 
 from amaranth import Elaboratable, Module
@@ -666,15 +665,15 @@ class CheckerResult:
     cfi_target: int
 
 
-@parameterized_class(
-    ("name", "fetch_block_log", "with_rvc"),
+@pytest.mark.parametrize(
+    ("fetch_block_log", "with_rvc"),
     [
-        ("block4B", 2, False),
-        ("block4B_rvc", 2, True),
-        ("block8B", 3, False),
-        ("block8B_rvc", 3, True),
-        ("block16B", 4, False),
-        ("block16B_rvc", 4, True),
+        (2, False),
+        (2, True),
+        (3, False),
+        (3, True),
+        (4, False),
+        (4, True),
     ],
 )
 class TestPredictionChecker(TestCaseWithSimulator):
@@ -682,7 +681,9 @@ class TestPredictionChecker(TestCaseWithSimulator):
     with_rvc: bool
 
     @pytest.fixture(autouse=True)
-    def setup(self, fixture_initialize_testing_env):
+    def setup(self, fixture_initialize_testing_env, fetch_block_log: int, with_rvc: bool):
+        self.fetch_block_log = fetch_block_log
+        self.with_rvc = with_rvc
         self.gen_params = GenParams(
             configurations.test.replace(compressed=self.with_rvc, fetch_block_bytes_log=self.fetch_block_log)
         )

--- a/test/frontend/test_rvc.py
+++ b/test/frontend/test_rvc.py
@@ -1,4 +1,4 @@
-from parameterized import parameterized_class
+import pytest
 
 from amaranth import *
 from amaranth_types import ValueLike
@@ -268,13 +268,18 @@ RV64_TESTS = [
 ]
 
 
-@parameterized_class(
-    ("name", "isa_xlen", "test_cases"),
-    [("rv32ic", 32, COMMON_TESTS + RV32_TESTS), ("rv64ic", 64, COMMON_TESTS + RV64_TESTS)],
+@pytest.mark.parametrize(
+    ("isa_xlen", "test_cases"),
+    [(32, COMMON_TESTS + RV32_TESTS), (64, COMMON_TESTS + RV64_TESTS)],
 )
 class TestInstrDecompress(TestCaseWithSimulator):
     isa_xlen: int
     test_cases: list[tuple[int, ValueLike]]
+
+    @pytest.fixture(autouse=True)
+    def setup(self, isa_xlen: int, test_cases: list[tuple[int, ValueLike]]):
+        self.isa_xlen = isa_xlen
+        self.test_cases = test_cases
 
     def test(self):
         self.gen_params = GenParams(
@@ -356,13 +361,18 @@ ZCB_RV64_ONLY_TESTS = [
 ]
 
 
-@parameterized_class(
-    ("name", "isa_xlen", "test_cases"),
-    [("rv32imc_zcb_zbb", 32, ZCB_COMMON_TESTS), ("rv64imc_zcb_zbb", 64, ZCB_COMMON_TESTS + ZCB_RV64_ONLY_TESTS)],
+@pytest.mark.parametrize(
+    ("isa_xlen", "test_cases"),
+    [(32, ZCB_COMMON_TESTS), (64, ZCB_COMMON_TESTS + ZCB_RV64_ONLY_TESTS)],
 )
 class TestInstrDecompressZcb(TestCaseWithSimulator):
     isa_xlen: int
     test_cases: list[tuple[int, ValueLike]]
+
+    @pytest.fixture(autouse=True)
+    def setup(self, isa_xlen: int, test_cases: list[tuple[int, ValueLike]]):
+        self.isa_xlen = isa_xlen
+        self.test_cases = test_cases
 
     def test(self):
         self.gen_params = GenParams(

--- a/test/func_blocks/fu/fpu/test_fpu_error.py
+++ b/test/func_blocks/fu/fpu/test_fpu_error.py
@@ -6,7 +6,7 @@ from coreblocks.func_blocks.fu.fpu.fpu_common import (
 )
 from transactron import TModule
 from transactron.lib import AdapterTrans
-from parameterized import parameterized
+import pytest
 from transactron.testing import *
 from amaranth import *
 
@@ -42,7 +42,7 @@ class TestFPUError(TestCaseWithSimulator):
     params = FPUParams(sig_width=24, exp_width=8)
     help_values = HelpValues(params)
 
-    @parameterized.expand([(params, help_values)])
+    @pytest.mark.parametrize("params, help_values", [(params, help_values)])
     def test_special_cases(self, params: FPUParams, help_values: HelpValues):
         fpue = TestFPUError.FPUErrorModule(params)
 
@@ -210,7 +210,8 @@ class TestFPUError(TestCaseWithSimulator):
         with self.run_simulation(fpue) as sim:
             sim.add_testbench(test_process)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "params, help_values, rm, plus_overflow_sig, plus_overflow_exp, minus_overflow_sig, minus_overflow_exp",
         [
             (
                 params,
@@ -257,7 +258,7 @@ class TestFPUError(TestCaseWithSimulator):
                 help_values.max_sig,
                 help_values.max_norm_exp,
             ),
-        ]
+        ],
     )
     def test_rounding(
         self,

--- a/test/func_blocks/fu/fpu/test_fpu_rounding.py
+++ b/test/func_blocks/fu/fpu/test_fpu_rounding.py
@@ -5,7 +5,7 @@ from coreblocks.func_blocks.fu.fpu.fpu_common import (
 )
 from transactron import TModule
 from transactron.lib import AdapterTrans
-from parameterized import parameterized
+import pytest
 from transactron.testing import *
 from amaranth import *
 
@@ -54,7 +54,8 @@ class TestFPURounding(TestCaseWithSimulator):
     round_down_inc_array = [0, 0, 0, 0, 0, 1, 1, 1]
     round_zero_inc_array = [0, 0, 0, 0, 0, 0, 0, 0]
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "params, help_values, rm, inc_arr",
         [
             (
                 params,
@@ -86,7 +87,7 @@ class TestFPURounding(TestCaseWithSimulator):
                 RoundingModes.ROUND_ZERO,
                 round_zero_inc_array,
             ),
-        ]
+        ],
     )
     def test_rounding(
         self,

--- a/test/func_blocks/fu/functional_common.py
+++ b/test/func_blocks/fu/functional_common.py
@@ -66,6 +66,8 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
     zero_imm = True
     core_config = configurations.test
 
+    unit_param_fixtures: tuple[str, ...] = ()
+
     @staticmethod
     def compute_result(i1: int, i2: int, i_imm: int, pc: int, fn: _T, xlen: int) -> dict[str, int]:
         """
@@ -89,7 +91,11 @@ class FunctionalUnitTestCase(TestCaseWithSimulator, Generic[_T]):
         raise NotImplementedError
 
     @pytest.fixture(autouse=True)
-    def setup(self, fixture_initialize_testing_env):
+    def setup(self, fixture_initialize_testing_env, request):
+        for fixture_name in self.unit_param_fixtures:
+            for key, value in request.getfixturevalue(fixture_name).items():
+                setattr(self, key, value)
+
         self.gen_params = GenParams(configurations.test)
 
         self.report_mock = TestbenchIO(Adapter(i=self.gen_params.get(ExceptionInformationRegisterLayouts).report))

--- a/test/func_blocks/fu/test_div_unit.py
+++ b/test/func_blocks/fu/test_div_unit.py
@@ -1,4 +1,4 @@
-from parameterized import parameterized_class
+import pytest
 
 from coreblocks.arch import Funct3, Funct7, OpType
 from coreblocks.func_blocks.fu.div_unit import DivFn, DivComponent
@@ -8,11 +8,10 @@ from test.func_blocks.fu.functional_common import ExecFn, FunctionalUnitTestCase
 from transactron.utils import signed_to_int, int_to_signed
 
 
-@parameterized_class(
-    ("name", "func_unit"),
-    [("ipc" + str(s), DivComponent(ipc=s)) for s in [3, 4, 5, 8]],
-)
+@pytest.mark.parametrize("func_unit", [DivComponent(ipc=s) for s in [3, 4, 5, 8]])
 class TestDivisionUnit(FunctionalUnitTestCase[DivFn.Fn]):
+    unit_param_fixtures = ("unit_params",)
+
     ops = {
         DivFn.Fn.DIVU: ExecFn(OpType.DIV_REM, Funct3.DIVU, Funct7.MULDIV),
         DivFn.Fn.DIV: ExecFn(OpType.DIV_REM, Funct3.DIV, Funct7.MULDIV),
@@ -57,6 +56,10 @@ class TestDivisionUnit(FunctionalUnitTestCase[DivFn.Fn]):
                         res = int_to_signed(-res, xlen)
 
         return {"result": res & mask}
+
+    @pytest.fixture(autouse=True)
+    def unit_params(self, func_unit):
+        return {"func_unit": func_unit}
 
     def test_fu(self):
         self.run_standard_fu_test()

--- a/test/func_blocks/fu/test_jb_unit.py
+++ b/test/func_blocks/fu/test_jb_unit.py
@@ -1,6 +1,6 @@
 from amaranth import *
 from amaranth.lib.data import StructLayout
-from parameterized import parameterized_class
+import pytest
 
 from coreblocks.params import *
 from coreblocks.func_blocks.fu.jumpbranch import JumpBranchFuncUnit, JumpBranchFn
@@ -186,17 +186,15 @@ ops_auipc = {
 }
 
 
-@parameterized_class(
-    ("name", "ops", "func_unit", "compute_result"),
+@pytest.mark.parametrize(
+    ("ops", "func_unit", "compute_result"),
     [
         (
-            "branches_and_jumps",
             ops,
             JumpBranchWrapperComponent(auipc_test=False),
             compute_result,
         ),
         (
-            "auipc",
             ops_auipc,
             JumpBranchWrapperComponent(auipc_test=True),
             compute_result_auipc,
@@ -204,8 +202,14 @@ ops_auipc = {
     ],
 )
 class TestJumpBranchUnit(FunctionalUnitTestCase[JumpBranchFn.Fn]):
+    unit_param_fixtures = ("unit_params",)
+
     compute_result = compute_result
     zero_imm = False
+
+    @pytest.fixture(autouse=True)
+    def unit_params(self, ops, func_unit, compute_result):
+        return {"ops": ops, "func_unit": func_unit, "compute_result": compute_result}
 
     def test_fu(self):
         self.run_standard_fu_test()

--- a/test/func_blocks/fu/test_mul_unit.py
+++ b/test/func_blocks/fu/test_mul_unit.py
@@ -1,4 +1,4 @@
-from parameterized import parameterized_class
+import pytest
 
 from coreblocks.arch import Funct3, Funct7, OpType
 from coreblocks.func_blocks.fu.mul_unit import MulFn, MulComponent, MulType
@@ -8,28 +8,18 @@ from transactron.utils import signed_to_int, int_to_signed
 from test.func_blocks.fu.functional_common import ExecFn, FunctionalUnitTestCase
 
 
-@parameterized_class(
-    ("name", "func_unit"),
+@pytest.mark.parametrize(
+    "func_unit",
     [
-        (
-            "recursive_multiplier",
-            MulComponent(MulType.RECURSIVE_MUL, dsp_width=8),
-        ),
-        (
-            "pipelined_multiplier",
-            MulComponent(MulType.PIPELINED_MUL, dsp_width=8, dsp_number=4),
-        ),
-        (
-            "sequential_multiplier",
-            MulComponent(MulType.SEQUENCE_MUL, dsp_width=8),
-        ),
-        (
-            "shift_multiplier",
-            MulComponent(MulType.SHIFT_MUL),
-        ),
+        MulComponent(MulType.RECURSIVE_MUL, dsp_width=8),
+        MulComponent(MulType.PIPELINED_MUL, dsp_width=8, dsp_number=4),
+        MulComponent(MulType.SEQUENCE_MUL, dsp_width=8),
+        MulComponent(MulType.SHIFT_MUL),
     ],
 )
 class TestMultiplierUnit(FunctionalUnitTestCase[MulFn.Fn]):
+    unit_param_fixtures = ("unit_params",)
+
     ops = {
         MulFn.Fn.MUL: ExecFn(OpType.MUL, Funct3.MUL, Funct7.MULDIV),
         MulFn.Fn.MULH: ExecFn(OpType.MUL, Funct3.MULH, Funct7.MULDIV),
@@ -58,6 +48,10 @@ class TestMultiplierUnit(FunctionalUnitTestCase[MulFn.Fn]):
                 signed_half_i1 = signed_to_int(i1 % (2 ** (xlen // 2)), xlen // 2)
                 signed_half_i2 = signed_to_int(i2 % (2 ** (xlen // 2)), xlen // 2)
                 return {"result": int_to_signed(signed_half_i1 * signed_half_i2, xlen)}
+
+    @pytest.fixture(autouse=True)
+    def unit_params(self, func_unit):
+        return {"func_unit": func_unit}
 
     def test_fu(self):
         self.run_standard_fu_test()

--- a/test/func_blocks/fu/test_pipelined_mul_unit.py
+++ b/test/func_blocks/fu/test_pipelined_mul_unit.py
@@ -2,7 +2,7 @@ import random
 import math
 from collections import deque
 
-from parameterized import parameterized_class
+import pytest
 
 from coreblocks.func_blocks.fu.unsigned_multiplication.pipelined import PipelinedUnsignedMul
 
@@ -13,7 +13,7 @@ from coreblocks.params import configurations
 from transactron.testing.functions import data_const_to_dict
 
 
-@parameterized_class(
+@pytest.mark.parametrize(
     ("dsp_width", "dsp_number"),
     [
         (18, 4),
@@ -26,7 +26,10 @@ class TestPipelinedUnsignedMul(TestCaseWithSimulator):
     dsp_width: int
     dsp_number: int
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, dsp_width: int, dsp_number: int):
+        self.dsp_width = dsp_width
+        self.dsp_number = dsp_number
         self.gen_params = GenParams(configurations.test)
         self.m = SimpleTestCircuit(PipelinedUnsignedMul(self.gen_params, self.dsp_width, self.dsp_number))
         self.n_padding = self.dsp_width * 2 ** (math.ceil(math.log2(self.gen_params.isa.xlen / self.dsp_width)))

--- a/test/func_blocks/fu/test_unsigned_mul_unit.py
+++ b/test/func_blocks/fu/test_unsigned_mul_unit.py
@@ -1,7 +1,7 @@
 import random
 from collections import deque
 
-from parameterized import parameterized_class
+import pytest
 
 from coreblocks.func_blocks.fu.unsigned_multiplication.common import MulBaseUnsigned
 from coreblocks.func_blocks.fu.unsigned_multiplication.fast_recursive import RecursiveUnsignedMul
@@ -16,31 +16,21 @@ from coreblocks.params import configurations
 from transactron.testing.functions import data_const_to_dict
 
 
-@parameterized_class(
-    ("name", "mul_unit"),
+@pytest.mark.parametrize(
+    "mul_unit",
     [
-        (
-            "recursive_multiplier",
-            RecursiveUnsignedMul,
-        ),
-        (
-            "sequential_multiplier",
-            SequentialUnsignedMul,
-        ),
-        (
-            "shift_multiplier",
-            ShiftUnsignedMul,
-        ),
-        (
-            "pipelined_multiplier",
-            PipelinedUnsignedMul,
-        ),
+        RecursiveUnsignedMul,
+        SequentialUnsignedMul,
+        ShiftUnsignedMul,
+        PipelinedUnsignedMul,
     ],
 )
 class TestUnsignedMultiplicationUnit(TestCaseWithSimulator):
     mul_unit: type[MulBaseUnsigned]
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mul_unit: type[MulBaseUnsigned]):
+        self.mul_unit = mul_unit
         self.gen_params = GenParams(configurations.test)
         self.m = SimpleTestCircuit(self.mul_unit(self.gen_params))
         self.waiting_time = 10

--- a/test/func_blocks/fu/test_zbc.py
+++ b/test/func_blocks/fu/test_zbc.py
@@ -1,4 +1,4 @@
-from parameterized import parameterized_class
+import pytest
 
 from coreblocks.func_blocks.fu.zbc import ZbcFn, ZbcComponent
 from coreblocks.arch import Funct3, Funct7, OpType
@@ -33,24 +33,17 @@ def clmulr(i1: int, i2: int, xlen: int) -> int:
     return output % (2**xlen)
 
 
-@parameterized_class(
-    ("name", "func_unit"),
+@pytest.mark.parametrize(
+    "func_unit",
     [
-        (
-            "iterative",
-            ZbcComponent(recursion_depth=0),
-        ),
-        (
-            "recursive_3",
-            ZbcComponent(recursion_depth=3),
-        ),
-        (
-            "recursive_full",
-            ZbcComponent(recursion_depth=configurations.test.xlen.bit_length() - 1),
-        ),
+        ZbcComponent(recursion_depth=0),
+        ZbcComponent(recursion_depth=3),
+        ZbcComponent(recursion_depth=configurations.test.xlen.bit_length() - 1),
     ],
 )
 class TestZbcUnit(FunctionalUnitTestCase[ZbcFn.Fn]):
+    unit_param_fixtures = ("unit_params",)
+
     ops = {
         ZbcFn.Fn.CLMUL: ExecFn(OpType.CLMUL, Funct3.CLMUL, Funct7.CLMUL),
         ZbcFn.Fn.CLMULH: ExecFn(OpType.CLMUL, Funct3.CLMULH, Funct7.CLMUL),
@@ -66,6 +59,10 @@ class TestZbcUnit(FunctionalUnitTestCase[ZbcFn.Fn]):
                 return {"result": clmulh(i1, i2, xlen)}
             case ZbcFn.Fn.CLMULR:
                 return {"result": clmulr(i1, i2, xlen)}
+
+    @pytest.fixture(autouse=True)
+    def unit_params(self, func_unit):
+        return {"func_unit": func_unit}
 
     def test_fu(self):
         self.run_standard_fu_test()

--- a/test/scheduler/test_scheduler.py
+++ b/test/scheduler/test_scheduler.py
@@ -4,7 +4,7 @@ from amaranth import *
 
 from collections import namedtuple, deque
 from typing import Callable, Optional, Iterable
-from parameterized import parameterized_class
+import pytest
 from coreblocks.func_blocks.interface.func_protocols import FuncBlock
 from coreblocks.interface.keys import CoreStateKey, RollbackKey
 from coreblocks.interface.layouts import RSInterfaceLayouts, RetirementLayouts
@@ -116,13 +116,12 @@ class SchedulerTestCircuit(Elaboratable):
         return m
 
 
-@parameterized_class(
-    ("name", "optype_sets", "instr_count"),
+@pytest.mark.parametrize(
+    ("optype_sets", "instr_count"),
     [
-        ("One-RS", [set(OpType)], 100),
-        ("Two-RS", [{OpType.ARITHMETIC, OpType.COMPARE}, {OpType.MUL, OpType.COMPARE}], 500),
+        ([set(OpType)], 100),
+        ([{OpType.ARITHMETIC, OpType.COMPARE}, {OpType.MUL, OpType.COMPARE}], 500),
         (
-            "Three-RS",
             [{OpType.ARITHMETIC, OpType.COMPARE}, {OpType.MUL, OpType.COMPARE}, {OpType.DIV_REM, OpType.COMPARE}],
             300,
         ),
@@ -132,7 +131,10 @@ class TestScheduler(TestCaseWithSimulator):
     optype_sets: list[set[OpType]]
     instr_count: int
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, optype_sets: list[set[OpType]], instr_count: int):
+        self.optype_sets = optype_sets
+        self.instr_count = instr_count
         self.rs_count = len(self.optype_sets)
         self.gen_params = GenParams(
             configurations.test.replace(

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -24,7 +24,6 @@ import random
 import subprocess
 import tempfile
 import pytest
-from parameterized import parameterized_class
 
 from transactron.utils.dependencies import DependencyContext
 
@@ -80,8 +79,13 @@ class TestCoreBase(TestCaseWithSimulator):
     configuration: CoreConfiguration
     gen_params: GenParams
     m: CoreTestElaboratable
+    core_param_fixtures: tuple[str, ...] = ()
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, request):
+        for fixture_name in self.core_param_fixtures:
+            for key, value in request.getfixturevalue(fixture_name).items():
+                setattr(self, key, value)
         self.configuration = self.configuration.replace(_generate_test_hardware=True)
 
     def get_phys_reg_rrat(self, sim: TestbenchContext, reg_id):
@@ -180,7 +184,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
             assert self.get_arch_reg_val(sim, reg_id) == val, "Bad register value"
 
 
-@parameterized_class(
+@pytest.mark.parametrize(
     ("name", "source_file", "cycle_count", "expected_regvals", "exit_csr", "configuration"),
     [
         ("fibonacci", "fibonacci.asm", 700, {2: 2971215073}, True, configurations.basic),
@@ -203,9 +207,30 @@ class TestCoreAsmSourceBase(TestCoreBase):
 )
 @pytest.mark.collection_order(1)
 class TestCoreBasicAsm(TestCoreAsmSourceBase):
+    core_param_fixtures = ("core_params_basic",)
+
     name: str
     source_file: str
     configuration: CoreConfiguration
+
+    @pytest.fixture(autouse=True)
+    def core_params_basic(
+        self,
+        name: str,
+        source_file: str,
+        cycle_count: int,
+        expected_regvals: dict[int, int],
+        exit_csr: bool,
+        configuration: CoreConfiguration,
+    ):
+        return {
+            "name": name,
+            "source_file": source_file,
+            "cycle_count": cycle_count,
+            "expected_regvals": expected_regvals,
+            "exit_csr": exit_csr,
+            "configuration": configuration,
+        }
 
     def test_asm_source(self):
         bin_src = self.prepare_source(self.source_file)
@@ -228,7 +253,7 @@ class TestCoreBasicAsm(TestCoreAsmSourceBase):
 
 # test interrupts with varying triggering frequency (parametrizable amount of cycles between
 # returning from an interrupt and triggering it again with 'lo' and 'hi' parameters)
-@parameterized_class(
+@pytest.mark.parametrize(
     ("source_file", "cycle_count", "start_regvals", "expected_regvals", "lo", "hi", "edge_only"),
     [
         (
@@ -258,6 +283,8 @@ class TestCoreBasicAsm(TestCoreAsmSourceBase):
 )
 @pytest.mark.collection_order(0)
 class TestCoreInterrupt(TestCoreAsmSourceBase):
+    core_param_fixtures = ("core_params_interrupt",)
+
     source_file: str
     start_regvals: dict[int, int]
     lo: int
@@ -266,12 +293,31 @@ class TestCoreInterrupt(TestCoreAsmSourceBase):
 
     reg_init_mem_offset: int = 0x100
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def core_params_interrupt(
+        self,
+        source_file: str,
+        cycle_count: int,
+        start_regvals: dict[int, int],
+        expected_regvals: dict[int, int],
+        lo: int,
+        hi: int,
+        edge_only: bool,
+    ):
         self.configuration = configurations.full.replace(
             _generate_test_hardware=True, interrupt_custom_count=2, interrupt_custom_edge_trig_mask=0b01
         )
         self.gen_params = GenParams(self.configuration)
         random.seed(1500100900)
+        return {
+            "source_file": source_file,
+            "cycle_count": cycle_count,
+            "start_regvals": start_regvals,
+            "expected_regvals": expected_regvals,
+            "lo": lo,
+            "hi": hi,
+            "edge_only": edge_only,
+        }
 
     async def clear_level_interrupt_process(self, sim: ProcessContext):
         async for *_, value in sim.tick().sample(self.m.core.csr_instances.csr_coreblocks_test.value):
@@ -351,7 +397,7 @@ class TestCoreInterrupt(TestCoreAsmSourceBase):
             sim.add_process(self.clear_level_interrupt_process)
 
 
-@parameterized_class(
+@pytest.mark.parametrize(
     ("source_file", "cycle_count", "expected_regvals", "always_mmode"),
     [
         ("user_mode.asm", 1800, {4: 6}, False),
@@ -360,15 +406,30 @@ class TestCoreInterrupt(TestCoreAsmSourceBase):
 )
 @pytest.mark.collection_order(0)
 class TestCoreInterruptOnPrivMode(TestCoreAsmSourceBase):
+    core_param_fixtures = ("core_params_priv_mode",)
+
     source_file: str
     always_mmode: bool
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def core_params_priv_mode(
+        self,
+        source_file: str,
+        cycle_count: int,
+        expected_regvals: dict[int, int],
+        always_mmode: bool,
+    ):
         self.configuration = configurations.full.replace(
             _generate_test_hardware=True, interrupt_custom_count=2, interrupt_custom_edge_trig_mask=0b01
         )
         self.gen_params = GenParams(self.configuration)
         random.seed(161453)
+        return {
+            "source_file": source_file,
+            "cycle_count": cycle_count,
+            "expected_regvals": expected_regvals,
+            "always_mmode": always_mmode,
+        }
 
     async def run_with_interrupt_process(self, sim: TestbenchContext):
         ticks = DependencyContext.get().get_dependency(TicksKey())


### PR DESCRIPTION
## Summary

Replaces `parameterized` and `parameterized_class` usage in the test suite with `pytest.mark.parametrize` and removes the `parameterized` dev dependency.

## Changes

- Converts class-level parameterization to pytest markers with autouse fixtures so setup state is preserved.
- Replaces `parameterized.expand` on FPU tests with pytest parametrize markers.
- Removes `parameterized==0.8.1` from `pyproject.toml`.

## Verification

- Formatting checks pass (`scripts/lint.sh check_format_flake8` and `check_format_black`).
- Pyright passes.
- 76 tests pass across the changed files: rvc, FPU, functional units, scheduler, prediction checker, and representative ICache parameterizations.
- `test_core.py` is collected successfully; full execution requires a RISC-V assembler that is not available in this environment.

Closes #1043