### PR TITLE
fix addr translation lockup

### DIFF
--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -211,8 +211,8 @@ class AddressTranslator(Elaboratable):
                 m.d.av_comb += page_fault.eq(0)
             with m.Else():
                 m.d.av_comb += ppn.eq(tlb_ppn)
-                m.d.av_comb += page_fault.eq(tlb_page_fault)
                 m.d.av_comb += access_fault.eq(tlb_access_fault)
+                m.d.av_comb += page_fault.eq(tlb_page_fault & ~tlb_access_fault)
 
             return {
                 "vaddr": data.vaddr,

--- a/coreblocks/priv/vmem/translation.py
+++ b/coreblocks/priv/vmem/translation.py
@@ -51,6 +51,7 @@ class AddressTranslator(Elaboratable):
         bits_per_level = SatpMode.bits_per_page_table_level(self.gen_params.isa.xlen)
 
         fwd_layout = make_layout(
+            ("is_bare", 1),
             ("vaddr", self.gen_params.isa.xlen),
             ("access_fault", 1),
             ("vpn_invalid", 1),
@@ -126,6 +127,7 @@ class AddressTranslator(Elaboratable):
 
             resp_fwd.write(
                 m,
+                is_bare=effective_satp_mode == SatpMode.BARE,
                 vaddr=addr,
                 vpn_invalid=vpn_invalid,
                 access_fault=access_fault,
@@ -148,7 +150,7 @@ class AddressTranslator(Elaboratable):
 
             if tlb is not None:
                 with condition(m, nonblocking=True) as branch:
-                    with branch((effective_satp_mode != SatpMode.BARE) & ~data.vpn_invalid):
+                    with branch(~data.is_bare & ~data.vpn_invalid):
                         m.d.av_comb += tlb_data.eq(tlb.accept(m))
 
                 with m.If(data.vpn_invalid):
@@ -203,7 +205,7 @@ class AddressTranslator(Elaboratable):
             page_fault = Signal()
             access_fault = Signal()
 
-            with m.If(effective_satp_mode == SatpMode.BARE):
+            with m.If(data.is_bare):
                 m.d.av_comb += ppn.eq(vpn)
                 m.d.av_comb += access_fault.eq(data.access_fault)
                 m.d.av_comb += page_fault.eq(0)

--- a/test/regression/conftest.py
+++ b/test/regression/conftest.py
@@ -31,7 +31,6 @@ ARCH_EXPECTED_FAIL = {
 ARCH_EXPECTED_TIMEOUT = {
     "InterruptsS",
     "InterruptsSSm",
-    "sv32_pmp_on_pte_(S|U)mode",
     "U",
 }
 


### PR DESCRIPTION
Fixes the TOCTOU on `priv_mode` in addr translator and tlb permission miss incorrectly being applied when entry was not hit (e.g on access faults)