### PR TITLE
Change all shebangs to /usr/bin/env

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/ci/push_gh_pages.sh
+++ b/ci/push_gh_pages.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -e
 

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 MAX_LINE_LENGTH=120
 

--- a/test/regression/cocotb/cocotb-config
+++ b/test/regression/cocotb/cocotb-config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 COCOTB_CONFIG=`which -a cocotb-config | tail -n 1`
 


### PR DESCRIPTION
Change all shebangs in scripts to `#!/usr/bin/env <name>`.
This is a standard scripting practice to help systems with non-fixed paths (like nix) and replacing executables in PATH to alternative ones. It is already done in all other places in our repo. 