### PR TITLE
great cocotb unification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,70 +44,6 @@ jobs:
             core.v
             core.v.json
 
-  build-verilated-core:
-    name: Build cocotb verilated core
-    runs-on: ubuntu-22.04  # older version for compatibility with Docker image
-    timeout-minutes: 60
-    container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install Coreblocks dependencies
-        run: |
-          python3 -m venv venv
-          . venv/bin/activate
-          python3 -m pip install --upgrade pip
-          python3 -m pip install ".[dev]"
-
-      - name: Build cocotb verilated core
-        run: |
-          . venv/bin/activate
-          python -m test.regression.cocotb
-
-      - name: Upload cocotb verilated core
-        uses: actions/upload-artifact@v7
-        with:
-          name: "verilated-core"
-          path: test/regression/cocotb/build/
-
-  build-verilated-core-traces:
-    name: Build cocotb verilated core with traces
-    runs-on: ubuntu-22.04  # older version for compatibility with Docker image
-    timeout-minutes: 60
-    container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install Coreblocks dependencies
-        run: |
-          python3 -m venv venv
-          . venv/bin/activate
-          python3 -m pip install --upgrade pip
-          python3 -m pip install ".[dev]"
-
-      - name: Build cocotb verilated core
-        run: |
-          . venv/bin/activate
-          python -m test.regression.cocotb --traces
-
-      - name: Upload cocotb verilated core
-        uses: actions/upload-artifact@v7
-        with:
-          name: "verilated-core-traces"
-          path: test/regression/cocotb/build/
-
   build-regression-tests:
     name: Build regression tests (riscv-tests)
     runs-on: ubuntu-latest
@@ -158,7 +94,7 @@ jobs:
     runs-on: ubuntu-22.04  # older version for compatibility with Docker image
     timeout-minutes: 60
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
-    needs: [ build-regression-tests, build-verilated-core ]
+    needs: [ build-regression-tests, build-core ]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -167,6 +103,24 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/coreblocks/coreblocks
           git submodule > .gitmodules-hash
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python3 -m venv venv
+          . venv/bin/activate
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ".[dev]"
+
+      - uses: actions/download-artifact@v8
+        name: Download full verilog core
+        with:
+          name: "verilog-full-core"
+          path: .
 
       - uses: actions/cache@v4
         name: Download tests from cache
@@ -182,24 +136,6 @@ jobs:
               '**/.github/workflows/main.yml'
             ) }}
           fail-on-cache-miss: true
-
-      - uses: actions/download-artifact@v8
-        name: Download verilated verilog core
-        with:
-          name: "verilated-core"
-          path: test/regression/cocotb/build/
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: |
-          python3 -m venv venv
-          . venv/bin/activate
-          python3 -m pip install --upgrade pip
-          python3 -m pip install ".[dev]"
 
       - name: Run tests
         run: |
@@ -280,7 +216,7 @@ jobs:
     runs-on: ubuntu-22.04  # older version for compatibility with Docker image
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
     timeout-minutes: 180
-    needs: [ build-arch-regression-tests, build-verilated-core ]
+    needs: [ build-arch-regression-tests ]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -305,12 +241,6 @@ jobs:
               '**/.github/workflows/main.yml'
             ) }}
           fail-on-cache-miss: true
-
-      - uses: actions/download-artifact@v8
-        name: Download verilated verilog core
-        with:
-          name: "verilated-core"
-          path: test/regression/cocotb/build/
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,38 @@ jobs:
           name: "verilated-core"
           path: test/regression/cocotb/build/
 
+  build-verilated-core-traces:
+    name: Build cocotb verilated core with traces
+    runs-on: ubuntu-22.04  # older version for compatibility with Docker image
+    timeout-minutes: 60
+    container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Coreblocks dependencies
+        run: |
+          python3 -m venv venv
+          . venv/bin/activate
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ".[dev]"
+
+      - name: Build cocotb verilated core
+        run: |
+          . venv/bin/activate
+          python -m test.regression.cocotb --traces
+
+      - name: Upload cocotb verilated core
+        uses: actions/upload-artifact@v7
+        with:
+          name: "verilated-core-traces"
+          path: test/regression/cocotb/build/
+
   build-regression-tests:
     name: Build regression tests (riscv-tests)
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,38 @@ jobs:
             core.v
             core.v.json
 
+  build-verilated-core:
+    name: Build cocotb verilated core
+    runs-on: ubuntu-22.04  # older version for compatibility with Docker image
+    timeout-minutes: 60
+    container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Coreblocks dependencies
+        run: |
+          python3 -m venv venv
+          . venv/bin/activate
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ".[dev]"
+
+      - name: Build cocotb verilated core
+        run: |
+          . venv/bin/activate
+          python -m test.regression.cocotb
+
+      - name: Upload cocotb verilated core
+        uses: actions/upload-artifact@v7
+        with:
+          name: "verilated-core"
+          path: test/regression/cocotb/build/
+
   build-regression-tests:
     name: Build regression tests (riscv-tests)
     runs-on: ubuntu-latest
@@ -94,7 +126,7 @@ jobs:
     runs-on: ubuntu-22.04  # older version for compatibility with Docker image
     timeout-minutes: 60
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
-    needs: [ build-regression-tests, build-core ]
+    needs: [ build-regression-tests, build-verilated-core ]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -103,24 +135,6 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/coreblocks/coreblocks
           git submodule > .gitmodules-hash
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: |
-          python3 -m venv venv
-          . venv/bin/activate
-          python3 -m pip install --upgrade pip
-          python3 -m pip install ".[dev]"
-
-      - uses: actions/download-artifact@v8
-        name: Download full verilog core
-        with:
-          name: "verilog-full-core"
-          path: .
 
       - uses: actions/cache@v4
         name: Download tests from cache
@@ -136,6 +150,24 @@ jobs:
               '**/.github/workflows/main.yml'
             ) }}
           fail-on-cache-miss: true
+
+      - uses: actions/download-artifact@v8
+        name: Download verilated verilog core
+        with:
+          name: "verilated-core"
+          path: test/regression/cocotb/build/
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python3 -m venv venv
+          . venv/bin/activate
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ".[dev]"
 
       - name: Run tests
         run: |
@@ -216,7 +248,7 @@ jobs:
     runs-on: ubuntu-22.04  # older version for compatibility with Docker image
     container: ghcr.io/kuznia-rdzeni/verilator:v5.008-2023.11.19_v
     timeout-minutes: 180
-    needs: [ build-arch-regression-tests ]
+    needs: [ build-arch-regression-tests, build-verilated-core ]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -241,6 +273,12 @@ jobs:
               '**/.github/workflows/main.yml'
             ) }}
           fail-on-cache-miss: true
+
+      - uses: actions/download-artifact@v8
+        name: Download verilated verilog core
+        with:
+          name: "verilated-core"
+          path: test/regression/cocotb/build/
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(topdir))
 import test.regression.benchmark  # noqa: E402
 from test.regression.benchmark import BenchmarkResult  # noqa: E402
 from test.regression.pysim import PySimulation  # noqa: E402
-from test.regression.cocotb import run_cocotb_entrypoint
+from test.regression.cocotb import run_cocotb_entrypoint  # noqa: E402
 
 
 def cd_to_topdir():
@@ -64,7 +64,7 @@ def run_benchmarks_with_cocotb(benchmarks: list[str], traces: bool) -> bool:
         additional_args=[
             "--no-print-directory",
             f"TESTCASE={','.join(benchmarks)}",
-        ]
+        ],
     )
 
 

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(topdir))
 import test.regression.benchmark  # noqa: E402
 from test.regression.benchmark import BenchmarkResult  # noqa: E402
 from test.regression.pysim import PySimulation  # noqa: E402
+from test.regression.cocotb import run_cocotb_entrypoint
 
 
 def cd_to_topdir():
@@ -57,23 +58,14 @@ def load_benchmarks():
 
 
 def run_benchmarks_with_cocotb(benchmarks: list[str], traces: bool) -> bool:
-    arglist = ["make", "-C", "test/regression/cocotb", "-f", "benchmark.Makefile", "--no-print-directory"]
-
-    test_cases = ",".join(benchmarks)
-    arglist += [f"TESTCASE={test_cases}"]
-
-    verilog_code = topdir.joinpath("core.v")
-    gen_info_path = f"{verilog_code}.json"
-
-    arglist += [f"VERILOG_SOURCES={verilog_code}"]
-    arglist += [f"_COREBLOCKS_GEN_INFO={gen_info_path}"]
-
-    if traces:
-        arglist += ["TRACES=1"]
-
-    res = subprocess.run(arglist)
-
-    return res.returncode == 0
+    return run_cocotb_entrypoint(
+        "benchmark_entrypoint",
+        traces=traces,
+        additional_args=[
+            "--no-print-directory",
+            f"TESTCASE={','.join(benchmarks)}",
+        ]
+    )
 
 
 def run_benchmarks_with_pysim(benchmarks: list[str], traces: bool) -> bool:

--- a/test/external/embench/board_config/coreblocks-sim/boardsupport.c
+++ b/test/external/embench/board_config/coreblocks-sim/boardsupport.c
@@ -19,7 +19,7 @@ typedef struct {
     uint64_t mispredict_cnt;
 } to_host;
 
-#define TO_HOST (*((volatile to_host*) (0x80000010UL)))
+#define TO_HOST (*((volatile to_host*) (0xf0000010UL)))
 
 static to_host start;
 

--- a/test/external/embench/board_config/coreblocks-sim/crt0.S
+++ b/test/external/embench/board_config/coreblocks-sim/crt0.S
@@ -62,10 +62,10 @@ _start:
 
 .inf_loop:
   // Store the return code
-  li t0, 0x80000004
+  li t0, 0xf0000004
   sw a0, 0(t0);
   // Signal that we finished the test
-  li t0, 0x80000000
+  li t0, 0xf0000000
   sw a0, 0(t0);
   j .inf_loop
 
@@ -82,7 +82,7 @@ _fill_block:
   .align 2
 trap_entry:
   // Set the start address of the MMIO
-  li t0, 0x80000000
+  li t0, 0xf0000000
 
   csrr a0, mcause
   sw a0, 8(t0)

--- a/test/external/embench/common/link.ld
+++ b/test/external/embench/common/link.ld
@@ -5,8 +5,8 @@ _STACK_SIZE = 0x1000;
 
 MEMORY
 {
-    imem (rxai!w) : ORIGIN = 0x00000000, LENGTH = 64K
-    dmem (wxa!ri) : ORIGIN = 0x10000000, LENGTH = 128K
+    imem (rxai!w) : ORIGIN = 0x80000000, LENGTH = 64K
+    dmem (wxa!ri) : ORIGIN = 0x90000000, LENGTH = 128K
 }
 
 SECTIONS

--- a/test/external/riscv-tests/environment/custom/link.ld
+++ b/test/external/riscv-tests/environment/custom/link.ld
@@ -3,8 +3,8 @@ ENTRY(_start)
 
 MEMORY
 {
-    text (rxai!w) : ORIGIN = 0x00000000, LENGTH = 64K
-    data (wxa!ri) : ORIGIN = 0x10000000, LENGTH = 128K
+    text (rxai!w) : ORIGIN = 0x80000000, LENGTH = 64K
+    data (wxa!ri) : ORIGIN = 0x90000000, LENGTH = 128K
 }
 
 PHDRS

--- a/test/external/riscv-tests/environment/custom/riscv_test.h
+++ b/test/external/riscv-tests/environment/custom/riscv_test.h
@@ -10,7 +10,7 @@
 //-----------------------------------------------------------------------
 
 #define TESTNUM gp
-#define DEBUG_REG 0x80000000
+#define DEBUG_REG 0xf0000000
 
 #define RVTEST_RV64U                                                    \
   .macro init;                                                          \

--- a/test/regression/benchmark.py
+++ b/test/regression/benchmark.py
@@ -55,7 +55,7 @@ class MMIO(RandomAccessMemory):
 
     def __init__(self, on_finish: Callable[[], None]):
         super().__init__(
-            range(0x80000000, 0x80000000 + MMIO.SIZE), SegmentFlags.READ | SegmentFlags.WRITE, b"\x00" * MMIO.SIZE
+            range(0xF0000000, 0xF0000000 + MMIO.SIZE), SegmentFlags.READ | SegmentFlags.WRITE, b"\x00" * MMIO.SIZE
         )
         self.on_finish = on_finish
 

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -370,6 +370,7 @@ def run_cocotb_entrypoint(
 
     env = os.environ.copy()
     env["PATH"] = str(TEST_ROOT.resolve()) + os.pathsep + env["PATH"]
+    env["SIM"] = os.environ.get("SIM", "verilator")
     if additional_env is not None:
         env.update(additional_env)
 

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import sys
 import xml.etree.ElementTree as eT
+import argparse
 
 import cocotb
 from cocotb.clock import Clock, Timer
@@ -342,6 +343,11 @@ def generate_tests(test_function: Callable[[Any, Any], Coroutine[Any, Any, None]
         setattr(mod, test_name, _create_test(test_function, test_name, mod, test_name))
 
 
+def get_cocotb_lock_prefix(traces: bool) -> Path:
+    sim = os.environ.get("SIM", "verilator")
+    return BUILD_ROOT / f"{sim}{'-traces' if traces else ''}"
+
+
 def run_cocotb_entrypoint(
     entrypoint_module_name: str,
     traces: bool,
@@ -412,10 +418,11 @@ def ensure_core_verilog_generated():
 def ensure_cocotb_built(traces: bool):
     ensure_core_verilog_generated()
 
-    lock = BUILD_ROOT / "cocotb.lock"
-    stamp = BUILD_ROOT / "cocotb.stamp"
+    path = get_cocotb_lock_prefix(traces)
+    lock = path.with_suffix(".lock")
+    stamp = path.with_suffix(".stamp")
 
-    BUILD_ROOT.mkdir(parents=True, exist_ok=True)
+    path.mkdir(parents=True, exist_ok=True)
 
     if stamp.exists():
         return
@@ -430,3 +437,15 @@ def ensure_cocotb_built(traces: bool):
             ensure_built=False,
         ), "Failed to build cocotb testbench"
         stamp.touch()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Prebuild cocotb testbench for coreblocks")
+    parser.add_argument("--traces", action="store_true", help="Enable cocotb trace generation")
+    args = parser.parse_args()
+
+    ensure_cocotb_built(traces=args.traces)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -348,6 +348,13 @@ def get_cocotb_lock_prefix(traces: bool) -> Path:
     return BUILD_ROOT / f"{sim}{'-traces' if traces else ''}"
 
 
+def _extend_env_path_like(value: str, to_add: str) -> str:
+    if value:
+        return to_add + os.pathsep + value
+    else:
+        return to_add
+
+
 def run_cocotb_entrypoint(
     entrypoint_module_name: str,
     traces: bool,
@@ -358,8 +365,9 @@ def run_cocotb_entrypoint(
     if ensure_built:
         ensure_cocotb_built(traces)
 
-    arglist = ["make", "-C", str(TEST_ROOT), f"MODULE={entrypoint_module_name}"]
+    arglist = ["make", "-C", str(TEST_ROOT)]
 
+    arglist += [f"MODULE={entrypoint_module_name}"]
     arglist += [f"_COREBLOCKS_GEN_INFO={CORE_V_JSON}"]
     arglist += [f"VERILOG_SOURCES={CORE_V}"]
     if traces:
@@ -369,7 +377,8 @@ def run_cocotb_entrypoint(
         arglist += additional_args
 
     env = os.environ.copy()
-    env["PATH"] = str(TEST_ROOT.resolve()) + os.pathsep + env["PATH"]
+    env["PATH"] = _extend_env_path_like(env.get("PATH", ""), str(TEST_ROOT.resolve()))
+    env["PYTHONPATH"] = _extend_env_path_like(env.get("PYTHONPATH", ""), str(REPO_ROOT.resolve()))
     env["SIM"] = os.environ.get("SIM", "verilator")
     if additional_env is not None:
         env.update(additional_env)

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -5,6 +5,12 @@ import os
 from typing import Any
 from collections.abc import Coroutine
 from dataclasses import dataclass
+from pathlib import Path
+from filelock import FileLock
+import subprocess
+import tempfile
+import sys
+import xml.etree.ElementTree as eT
 
 import cocotb
 from cocotb.clock import Clock, Timer
@@ -14,11 +20,20 @@ from cocotb_bus.bus import Bus
 from cocotb.result import SimTimeoutError
 
 from .memory import *
-from .common import SimulationBackend, SimulationExecutionResult
+from .common import SimulationBackend, SimulationExecutionResult, START_PC
 
 from transactron.evlog import EventLog, GeneratedEvLogSampler, SignalHandle, SignalReader
 from transactron.profiler import CycleProfile, MethodSamples, Profile, ProfileSamples, TransactionSamples
 from transactron.utils.gen import GenerationInfo
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_ROOT = Path(__file__).resolve().parent / "cocotb" / "build"
+TEST_ROOT = Path(__file__).resolve().parent / "cocotb"
+
+VERILOG_ROOT = BUILD_ROOT / "verilog"
+CORE_V = VERILOG_ROOT / "core.v"
+CORE_V_JSON = VERILOG_ROOT / "core.v.json"
 
 
 @dataclass
@@ -325,3 +340,93 @@ def generate_tests(test_function: Callable[[Any, Any], Coroutine[Any, Any, None]
 
     for test_name in test_names:
         setattr(mod, test_name, _create_test(test_function, test_name, mod, test_name))
+
+
+def run_cocotb_entrypoint(
+    entrypoint_module_name: str,
+    traces: bool,
+    additional_args: list[str] | None = None,
+    additional_env: dict[str, str] | None = None,
+    ensure_built: bool = True,
+) -> bool:
+    if ensure_built:
+        ensure_cocotb_built(traces)
+
+    arglist = ["make", "-C", str(TEST_ROOT), f"MODULE={entrypoint_module_name}"]
+
+    arglist += [f"_COREBLOCKS_GEN_INFO={CORE_V_JSON}"]
+    arglist += [f"VERILOG_SOURCES={CORE_V}"]
+    if traces:
+        arglist += ["TRACES=1"]
+
+    if additional_args is not None:
+        arglist += additional_args
+
+    env = os.environ.copy()
+    env["PATH"] = str(TEST_ROOT.resolve()) + os.pathsep + env["PATH"]
+    if additional_env is not None:
+        env.update(additional_env)
+
+    with tempfile.NamedTemporaryFile("r") as tmp_result_file:
+        arglist += [f"COCOTB_RESULTS_FILE={tmp_result_file.name}"]
+
+        subprocess.run(arglist, env=env, check=True)
+        tree = eT.parse(tmp_result_file.name)
+        return len(list(tree.iter("failure"))) == 0
+
+
+def ensure_core_verilog_generated():
+    lock = BUILD_ROOT / "verilog.lock"
+    stamp = BUILD_ROOT / "verilog.stamp"
+
+    VERILOG_ROOT.mkdir(parents=True, exist_ok=True)
+
+    if stamp.exists():
+        return
+
+    with FileLock(lock):
+        if stamp.exists():
+            return
+
+        command = [
+            sys.executable,
+            "-m",
+            "coreblocks.gen_verilog",
+            "--config",
+            "full",
+            "--reset-pc",
+            f"0x{START_PC:x}",
+            "--with-socks",
+            "-o",
+            str(CORE_V),
+        ]
+
+        env = os.environ.copy()
+        # always generate evlog interfaces - the choice to output them is made at runtime
+        env["__TRANSACTRON_EVLOG"] = "1"
+
+        subprocess.run(command, check=True, cwd=REPO_ROOT, env=env)
+        stamp.touch()
+
+
+def ensure_cocotb_built(traces: bool):
+    ensure_core_verilog_generated()
+
+    lock = BUILD_ROOT / "cocotb.lock"
+    stamp = BUILD_ROOT / "cocotb.stamp"
+
+    BUILD_ROOT.mkdir(parents=True, exist_ok=True)
+
+    if stamp.exists():
+        return
+
+    with FileLock(lock):
+        if stamp.exists():
+            return
+
+        assert run_cocotb_entrypoint(
+            entrypoint_module_name="empty_module",
+            traces=traces,
+            ensure_built=False,
+        ), "Failed to build cocotb testbench"
+        stamp.touch()

--- a/test/regression/cocotb/Makefile
+++ b/test/regression/cocotb/Makefile
@@ -4,9 +4,9 @@
 SIM ?= verilator
 TOPLEVEL_LANG ?= verilog
 ifeq ($(TRACES),1)
-	SIM_BUILD ?= build/$(BUILD_NAME)/$(SIM)-trace
+	SIM_BUILD ?= build/$(SIM)-trace
 else
-	SIM_BUILD ?= build/$(BUILD_NAME)/$(SIM)
+	SIM_BUILD ?= build/$(SIM)
 endif
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file

--- a/test/regression/cocotb/arch_elf_entrypoint.py
+++ b/test/regression/cocotb/arch_elf_entrypoint.py
@@ -1,8 +1,8 @@
 import os
 import cocotb
 
-from test.regression.cocotb import CocotbSimulation  # noqa: E402
-from test.regression.test_arch_regression import run_arch_elf  # noqa: E402
+from test.regression.cocotb import CocotbSimulation
+from test.regression.test_arch_regression import run_arch_elf
 
 
 @cocotb.test

--- a/test/regression/cocotb/arch_elf_entrypoint.py
+++ b/test/regression/cocotb/arch_elf_entrypoint.py
@@ -1,10 +1,5 @@
 import os
-import sys
-from pathlib import Path
 import cocotb
-
-top_dir = Path(__file__).parent.parent.parent.parent
-sys.path.insert(0, str(top_dir))
 
 from test.regression.cocotb import CocotbSimulation  # noqa: E402
 from test.regression.test_arch_regression import run_arch_elf  # noqa: E402
@@ -12,7 +7,4 @@ from test.regression.test_arch_regression import run_arch_elf  # noqa: E402
 
 @cocotb.test
 async def do_test(dut):
-    test_name = os.environ["TESTNAME"]
-    if test_name == "SKIP":
-        return
-    await run_arch_elf(CocotbSimulation(dut), test_name)
+    await run_arch_elf(CocotbSimulation(dut), os.environ["TESTNAME"])

--- a/test/regression/cocotb/arch_test.Makefile
+++ b/test/regression/cocotb/arch_test.Makefile
@@ -1,3 +1,0 @@
-MODULE = arch_elf_entrypoint
-BUILD_NAME = riscv-arch-test
-include common.Makefile

--- a/test/regression/cocotb/benchmark.Makefile
+++ b/test/regression/cocotb/benchmark.Makefile
@@ -1,3 +1,0 @@
-MODULE = benchmark_entrypoint
-BUILD_NAME = benchmark
-include common.Makefile

--- a/test/regression/cocotb/benchmark_entrypoint.py
+++ b/test/regression/cocotb/benchmark_entrypoint.py
@@ -1,11 +1,5 @@
-import sys
-from pathlib import Path
-
-top_dir = Path(__file__).parent.parent.parent.parent
-sys.path.insert(0, str(top_dir))
-
-from test.regression.cocotb import CocotbSimulation, generate_tests  # noqa: E402
-from test.regression.benchmark import run_benchmark, get_all_benchmark_names  # noqa: E402
+from test.regression.cocotb import CocotbSimulation, generate_tests
+from test.regression.benchmark import run_benchmark, get_all_benchmark_names
 
 
 async def _do_benchmark(dut, benchmark_name):

--- a/test/regression/cocotb/empty_module.py
+++ b/test/regression/cocotb/empty_module.py
@@ -1,0 +1,6 @@
+from cocotb import test
+
+
+@test
+async def test_dummy(dut):
+    return

--- a/test/regression/cocotb/test.Makefile
+++ b/test/regression/cocotb/test.Makefile
@@ -1,3 +1,0 @@
-MODULE = test_entrypoint
-BUILD_NAME = test
-include common.Makefile

--- a/test/regression/cocotb/test_entrypoint.py
+++ b/test/regression/cocotb/test_entrypoint.py
@@ -1,21 +1,8 @@
-import sys
-from pathlib import Path
-
-top_dir = Path(__file__).parent.parent.parent.parent
-sys.path.insert(0, str(top_dir))
-
-from test.regression.cocotb import CocotbSimulation, generate_tests  # noqa: E402
-from test.regression.test_regression import run_test  # noqa: E402
-from test.regression.conftest import get_all_test_names  # noqa: E402
-
-# used to build the Verilator model without starting tests
-empty_testcase_name = "SKIP"
-
+from test.regression.cocotb import CocotbSimulation, generate_tests
+from test.regression.test_regression import run_test
+from test.regression.conftest import get_all_test_names
 
 async def do_test(dut, test_name):
-    if test_name == empty_testcase_name:
-        return
     await run_test(CocotbSimulation(dut), test_name)
 
-
-generate_tests(do_test, list(get_all_test_names()) + [empty_testcase_name])
+generate_tests(do_test, list(get_all_test_names()))

--- a/test/regression/cocotb/test_entrypoint.py
+++ b/test/regression/cocotb/test_entrypoint.py
@@ -2,7 +2,9 @@ from test.regression.cocotb import CocotbSimulation, generate_tests
 from test.regression.test_regression import run_test
 from test.regression.conftest import get_all_test_names
 
+
 async def do_test(dut, test_name):
     await run_test(CocotbSimulation(dut), test_name)
+
 
 generate_tests(do_test, list(get_all_test_names()))

--- a/test/regression/common.py
+++ b/test/regression/common.py
@@ -6,6 +6,9 @@ from transactron.evlog import EventLog
 from transactron.profiler import Profile
 
 
+START_PC = 0x80000000
+
+
 @dataclass
 class SimulationExecutionResult:
     """Information about the result of the simulation.

--- a/test/regression/test_arch_regression.py
+++ b/test/regression/test_arch_regression.py
@@ -1,18 +1,14 @@
 from typing import Literal
 from pathlib import Path
-from filelock import FileLock
 import pytest
 import argparse
 import re
 import os
-import subprocess
-import sys
-import tempfile
 import asyncio
-import xml.etree.ElementTree as eT
 
 from .conftest import arch_tests_dir, profile_dir, evlog_dir
 from .pysim import PySimulation
+from .common import START_PC
 from .memory import (
     CoreMemoryModel,
     MemorySegment,
@@ -24,28 +20,14 @@ from .memory import (
     WriteRequest,
     load_segments_from_elf,
 )
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-BUILD_ROOT = Path(__file__).resolve().parent / "cocotb" / "build" / "riscv-arch-test"
-TEST_ROOT = Path(__file__).resolve().parent / "cocotb"
-
-VERILOG_LOCK_FILE = BUILD_ROOT / "verilog.lock"
-VERILOG_STAMP = BUILD_ROOT / "verilog.built"
-VERILOG_ROOT = BUILD_ROOT / "verilog"
-
-BUILT_LOCK_FILE = BUILD_ROOT / "cocotb.lock"
-
-CORE_V = VERILOG_ROOT / "core.v"
-CORE_V_JSON = VERILOG_ROOT / "core.v.json"
+from .cocotb import run_cocotb_entrypoint
 
 REGRESSION_ARCH_TESTS_PREFIX = "test.arch_regression."
 
 END_TEST_ADDRESS = 0xF0000000
 CONSOLE_ADDRESS = 0xF0001000
-ACCESS_FAULT_ADDRESS = 0x00000000
 INTERRUPT_GENERATOR_ADDRESS = 0xF0002000
-
-START_PC = 0x80000000
+ACCESS_FAULT_ADDRESS = 0x00000000
 
 
 class EndTestMMIO(MemorySegment):
@@ -131,25 +113,6 @@ class InterruptGeneratorMMIO(MemorySegment):
         return WriteReply()
 
 
-def get_arg_list(test_name: str, result_path: str, traces: bool = False) -> list[str]:
-    arglist = ["make", "-C", str(TEST_ROOT), "-f", "arch_test.Makefile"]
-    arglist += [f"_COREBLOCKS_GEN_INFO={CORE_V_JSON}"]
-    arglist += [f"VERILOG_SOURCES={CORE_V}"]
-    arglist += [f"TESTNAME={test_name}"]
-    if result_path:
-        arglist += [f"COCOTB_RESULTS_FILE={result_path}"]
-
-    if traces:
-        arglist += ["TRACES=1"]
-
-    return arglist
-
-
-def _set_transactron_env_defaults() -> None:
-    os.environ.setdefault("__TRANSACTRON_LOG_LEVEL", "WARNING")
-    os.environ.setdefault("__TRANSACTRON_LOG_FILTER", ".*")
-
-
 def build_memory_model(elf_path: str | Path, stop_callback, **kwargs):
     segments = []
     segments.extend(load_segments_from_elf(str(elf_path), **kwargs))
@@ -163,7 +126,6 @@ def build_memory_model(elf_path: str | Path, stop_callback, **kwargs):
 
 
 async def run_arch_elf(sim_backend, elf_path: str | Path, timeout_cycles: int = 2_000_000):
-    _set_transactron_env_defaults()
     elf_path = Path(elf_path).resolve()
 
     # Tests use self-modifying code for CSR access in lower privilege modes (see CSR_ACCESS)
@@ -203,67 +165,14 @@ async def run_test(sim_backend, test_name: str):
     await run_arch_elf(sim_backend, elf_path, timeout_cycles=2_000_000)
 
 
-def ensure_arch_test_cocotb_build():
-    _set_transactron_env_defaults()
-
-    VERILOG_ROOT.mkdir(parents=True, exist_ok=True)
-
-    if VERILOG_STAMP.exists():
-        return
-
-    with FileLock(VERILOG_LOCK_FILE):
-        if VERILOG_STAMP.exists():
-            return
-
-        command = [
-            sys.executable,
-            "-m",
-            "coreblocks.gen_verilog",
-            "--config",
-            "full",
-            "--reset-pc",
-            f"0x{START_PC:x}",
-            "--with-socks",
-            "-o",
-            str(CORE_V),
-        ]
-        subprocess.run(command, check=True, cwd=REPO_ROOT)
-        VERILOG_STAMP.write_text("built\n")
-
-
-def run_and_check(test_name: str, traces: bool = False, env=None):
-    with tempfile.NamedTemporaryFile("r") as tmp_result_file:
-        arglist = get_arg_list(test_name, tmp_result_file.name, traces=traces)
-        subprocess.run(arglist, env=env, check=True)
-
-        tree = eT.parse(tmp_result_file.name)
-        if len(list(tree.iter("failure"))) != 0:
-            raise RuntimeError(f"Test run {test_name} failed")
-
-
-def build_cocotb_module_under_lock(traces: bool) -> None:
-    # Ensure the Verilog sources are present
-    ensure_arch_test_cocotb_build()
-
-    try:
-        with FileLock(BUILT_LOCK_FILE):
-            run_and_check("SKIP", traces)
-    except Exception as e:
-        raise RuntimeError("Failed to build cocotb module for arch regression") from e
-
-
 def regression_body_with_cocotb(elf_paths: list[Path], traces: bool):
-    build_cocotb_module_under_lock(traces=traces)
-
-    my_env = dict(os.environ)
-    my_env["PATH"] = str(TEST_ROOT) + ":" + my_env.get("PATH", "")
-
     for elf_path in elf_paths:
-        run_and_check(str(elf_path.resolve()), traces, env=my_env)
+        assert run_cocotb_entrypoint(
+            "arch_elf_entrypoint", traces=traces, additional_args=[f"TESTNAME={elf_path}"]
+        ), f"Test failed for {elf_path}"
 
 
 def regression_body_with_pysim(elf_paths: list[Path], traces: bool):
-    _set_transactron_env_defaults()
     for elf_path in elf_paths:
         traces_file = None
         if traces:
@@ -283,24 +192,7 @@ def traces_enabled(request: pytest.FixtureRequest):
     return request.config.getoption("coreblocks_traces")
 
 
-@pytest.fixture(scope="session")
-def verilate_arch_model(worker_id, sim_backend, traces_enabled, request: pytest.FixtureRequest):
-    """
-    Fixture to prevent races when building the cocotb/Verilator model for
-    arch-regression. It runs only in distributed, cocotb mode and executes a
-    'SKIP' run via the arch Makefile to ensure the cocotb module is built.
-    """
-    if sim_backend != "cocotb" or worker_id == "master":
-        yield None
-        return
-
-    build_cocotb_module_under_lock(traces=traces_enabled)
-    yield
-
-
-def test_entrypoint(
-    arch_test_name: str, sim_backend: Literal["pysim", "cocotb"], traces_enabled: bool, verilate_arch_model
-):
+def test_entrypoint(arch_test_name: str, sim_backend: Literal["pysim", "cocotb"], traces_enabled: bool):
     path = Path(arch_tests_dir.joinpath(arch_test_name + ".elf"))
     if not path.exists():
         raise FileNotFoundError(f"ELF file not found for test {arch_test_name}: {path}")
@@ -320,6 +212,9 @@ def main():
     args = parser.parse_args()
 
     elf_paths = [path.resolve() for path in args.elf_path]
+
+    os.environ.setdefault("__TRANSACTRON_LOG_LEVEL", "WARNING")
+    os.environ.setdefault("__TRANSACTRON_LOG_FILTER", ".*")
 
     if args.backend == "cocotb":
         regression_body_with_cocotb(elf_paths, traces=args.traces)

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -1,16 +1,12 @@
 from .memory import *
 from .common import SimulationBackend
 from .conftest import riscv_tests_dir, profile_dir, evlog_dir
+from .cocotb import run_cocotb_entrypoint
 from test.regression.pysim import PySimulation
-import xml.etree.ElementTree as eT
 import asyncio
 from typing import Literal
 import os
 import pytest
-import subprocess
-import json
-import tempfile
-from filelock import FileLock
 
 REGRESSION_TESTS_PREFIX = "test.regression."
 
@@ -24,7 +20,7 @@ force_executable_memory = ["rv32ui-fence_i"]
 
 class MMIO(MemorySegment):
     def __init__(self, on_finish: Callable[[], None]):
-        super().__init__(range(0x80000000, 0x80000000 + 4), SegmentFlags.READ | SegmentFlags.WRITE)
+        super().__init__(range(0xF0000000, 0xF0000000 + 4), SegmentFlags.READ | SegmentFlags.WRITE)
         self.on_finish = on_finish
         self.failed_test = 0
 
@@ -68,28 +64,11 @@ async def run_test(sim_backend: SimulationBackend, test_name: str):
 
 
 def regression_body_with_cocotb(test_name: str, traces: bool):
-    arglist = ["make", "-C", "test/regression/cocotb", "-f", "test.Makefile"]
-    arglist += [f"TESTCASE={test_name}"]
-
-    verilog_code = os.path.join(os.getcwd(), "core.v")
-    gen_info_path = f"{verilog_code}.json"
-    arglist += [f"_COREBLOCKS_GEN_INFO={gen_info_path}"]
-    arglist += [f"VERILOG_SOURCES={verilog_code}"]
-    tmp_result_file = tempfile.NamedTemporaryFile("r")
-    arglist += [f"COCOTB_RESULTS_FILE={tmp_result_file.name}"]
-
-    if traces:
-        arglist += ["TRACES=1"]
-
-    my_env = dict(os.environ)
-    my_env["PATH"] = os.path.join(os.getcwd(), "test/regression/cocotb") + ":" + my_env["PATH"]
-
-    res = subprocess.run(arglist, env=my_env)
-
-    assert res.returncode == 0
-
-    tree = eT.parse(tmp_result_file.name)
-    assert len(list(tree.iter("failure"))) == 0
+    assert run_cocotb_entrypoint(
+        "test_entrypoint",
+        traces=traces,
+        additional_args=[f"TESTCASE={test_name}"],
+    )
 
 
 def regression_body_with_pysim(test_name: str, traces: bool):
@@ -97,44 +76,6 @@ def regression_body_with_pysim(test_name: str, traces: bool):
     if traces:
         traces_file = REGRESSION_TESTS_PREFIX + test_name
     asyncio.run(run_test(PySimulation(traces_file=traces_file), test_name))
-
-
-@pytest.fixture(scope="session")
-def verilate_model(worker_id, request: pytest.FixtureRequest):
-    """
-    Fixture to prevent races on verilating the coreblocks model. It is run only in
-    distributed, cocotb, mode. It executes a 'SKIP' regression test which verilates the model.
-    """
-    if request.session.config.getoption("coreblocks_backend") != "cocotb" or worker_id == "master":
-        # pytest expect yield on every path in fixture
-        yield None
-        return
-
-    lock_path = "_coreblocks_regression.lock"
-    counter_path = "_coreblocks_regression.counter"
-    with FileLock(lock_path):
-        regression_body_with_cocotb("SKIP", False)
-        if os.path.exists(counter_path):
-            with open(counter_path, "r") as counter_file:
-                c = json.load(counter_file)
-        else:
-            c = 0
-        with open(counter_path, "w") as counter_file:
-            json.dump(c + 1, counter_file)
-    yield
-    # Session teardown
-    deferred_remove = False
-    with FileLock(lock_path):
-        with open(counter_path, "r") as counter_file:
-            c = json.load(counter_file)
-        if c == 1:
-            deferred_remove = True
-        else:
-            with open(counter_path, "w") as counter_file:
-                json.dump(c - 1, counter_file)
-    if deferred_remove:
-        os.remove(lock_path)
-        os.remove(counter_path)
 
 
 @pytest.fixture
@@ -147,7 +88,7 @@ def traces_enabled(request: pytest.FixtureRequest):
     return request.config.getoption("coreblocks_traces")
 
 
-def test_entrypoint(test_name: str, sim_backend: Literal["pysim", "cocotb"], traces_enabled: bool, verilate_model):
+def test_entrypoint(test_name: str, sim_backend: Literal["pysim", "cocotb"], traces_enabled: bool):
     if sim_backend == "cocotb":
         regression_body_with_cocotb(test_name, traces_enabled)
     elif sim_backend == "pysim":

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -1,5 +1,5 @@
 from .memory import *
-from .common import SimulationBackend
+from .common import SimulationBackend, START_PC
 from .conftest import riscv_tests_dir, profile_dir, evlog_dir
 from .cocotb import run_cocotb_entrypoint
 from test.regression.pysim import PySimulation
@@ -75,7 +75,7 @@ def regression_body_with_pysim(test_name: str, traces: bool):
     traces_file = None
     if traces:
         traces_file = REGRESSION_TESTS_PREFIX + test_name
-    asyncio.run(run_test(PySimulation(traces_file=traces_file), test_name))
+    asyncio.run(run_test(PySimulation(traces_file=traces_file, reset_pc=START_PC), test_name))
 
 
 @pytest.fixture


### PR DESCRIPTION
make all `test/regression` tests use the same verilated module.

All tests have now:
- memory from 0x80000000
- socs peripherials from 0xE0000000
- test peripherials from 0xF0000000

1. Moved benchmark and riscv-tests to-host to 0xF0000000 (either way those should be in MMIO region).
1. Start pc is now 0x80000000.
1. Removed the "SKIP" logic by adding a common skip module
1. Made cocotb configuration in python modules rather than in the makefiles