### PR TITLE
frontend: decouple checkpoint creation from instruction type

### DIFF
--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -35,7 +35,7 @@ class Decode(Elaboratable):
         m = TModule()
 
         @def_method(m, self.decode)
-        def _(instr, pc, rvc, access_fault, cfi_type, ftq_ptr, ftq_offset):
+        def _(instr, pc, rvc, access_fault, cfi_type, commit_checkpoint, ftq_ptr, ftq_offset):
             m.submodules.instr_decoder = instr_decoder = InstrDecoder(self.gen_params)
             m.d.top_comb += instr_decoder.instr.eq(instr)
 
@@ -96,6 +96,7 @@ class Decode(Elaboratable):
                 ),
                 "csr": instr_decoder.csr,
                 "pc": pc,
+                "commit_checkpoint": commit_checkpoint,
                 "ftq_ptr": ftq_ptr,
                 "ftq_offset": ftq_offset,
             }

--- a/coreblocks/frontend/decoder/decode_stage.py
+++ b/coreblocks/frontend/decoder/decode_stage.py
@@ -35,7 +35,7 @@ class Decode(Elaboratable):
         m = TModule()
 
         @def_method(m, self.decode)
-        def _(instr, pc, rvc, access_fault, cfi_type, commit_checkpoint, ftq_ptr, ftq_offset):
+        def _(instr, pc, rvc, access_fault, commit_checkpoint, ftq_ptr, ftq_offset):
             m.submodules.instr_decoder = instr_decoder = InstrDecoder(self.gen_params)
             m.d.top_comb += instr_decoder.instr.eq(instr)
 

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -491,7 +491,6 @@ class FetchUnit(Elaboratable):
                     raw_instrs[i].pc.eq(params.pc_from_fb(fetch_block_addr, i)),
                     raw_instrs[i].rvc.eq(s1_data.rvc[i]),
                     raw_instrs[i].access_fault.eq(s1_data.access_fault),
-                    raw_instrs[i].cfi_type.eq(predecoded_instr[i].cfi_type),
                     raw_instrs[i].commit_checkpoint.eq(commit_checkpoint_mask[i]),
                     raw_instrs[i].ftq_ptr.eq(ftq_ptr),
                     raw_instrs[i].ftq_offset.eq(i),

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -127,10 +127,12 @@ class FetchUnit(Elaboratable):
         with Transaction(name="cont").body(m):
             peek_result = serializer.peek(m)
             count = Signal(range(self.gen_params.frontend_superscalarity + 1))
-            # we want at most one branch insn in scheduling group, and only at the end (for simplicity)
+            # A checkpoint is attached to the tag of a whole scheduling group, so an instruction
+            # that creates one must be the last in its group. We allow at most one such insn
+            # per group, and only at the end (for simplicity).
             # some insts in peek_result.data might not be valid, but this is still correct
-            which_is_branch = [0] + [instr.cfi_type == CfiType.BRANCH for instr in peek_result.data][:-1]
-            m.d.comb += count.eq(count_trailing_zeros(Cat(which_is_branch)))
+            which_ends_group = [0] + [instr.commit_checkpoint for instr in peek_result.data][:-1]
+            m.d.comb += count.eq(count_trailing_zeros(Cat(which_ends_group)))
             result = serializer.read(m, count=count)
             for i in range(self.gen_params.frontend_superscalarity):
                 log.info(
@@ -470,6 +472,17 @@ class FetchUnit(Elaboratable):
             fetch_mask = Signal(fetch_width)
             m.d.av_comb += fetch_mask.eq(instr_valid & block_prefix_mask)
 
+            # A checkpoint is needed for every instruction that fetch speculatively continued
+            # past, so that a backend rollback can undo the speculation:
+            #  - a branch always is,
+            #  - a JALR only when the frontend followed a prediction; otherwise fetch stalls on
+            #    it and the backend resolves it by resuming the frontend instead
+            branch_mask = Cat(CfiType.is_branch(instr.cfi_type) for instr in predecoded_instr)
+            followed_jalr = Signal()
+            commit_checkpoint_mask = Signal(fetch_width)
+            m.d.av_comb += followed_jalr.eq(cfi_followed & ~stall_core & CfiType.is_jalr(predcheck_res.cfi_type))
+            m.d.av_comb += commit_checkpoint_mask.eq(Mux(fault_any, 0, branch_mask | (followed_jalr << exit_idx)))
+
             # Aggregate all signals that will be sent out of the fetch unit.
             raw_instrs = Signal(ArrayLayout(self.layouts.raw_instr, fetch_width))
             for i in range(fetch_width):
@@ -479,6 +492,7 @@ class FetchUnit(Elaboratable):
                     raw_instrs[i].rvc.eq(s1_data.rvc[i]),
                     raw_instrs[i].access_fault.eq(s1_data.access_fault),
                     raw_instrs[i].cfi_type.eq(predecoded_instr[i].cfi_type),
+                    raw_instrs[i].commit_checkpoint.eq(commit_checkpoint_mask[i]),
                     raw_instrs[i].ftq_ptr.eq(ftq_ptr),
                     raw_instrs[i].ftq_offset.eq(i),
                 ]

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -5,7 +5,6 @@ from transactron.lib import BasicFifo, Connect, Pipe
 from transactron.utils import assign
 from transactron.utils.dependencies import DependencyContext
 
-from coreblocks.arch.optypes import OpType
 from coreblocks.interface.layouts import ExceptionInformationRegisterLayouts
 from coreblocks.params.genparams import GenParams
 from coreblocks.frontend.ftq import FetchTargetQueue
@@ -56,16 +55,10 @@ class RollbackTagger(Elaboratable):
 
             out = Signal(self.gen_params.get(DecodeLayouts).tagged_decode_result)
             m.d.av_comb += assign(out, instrs)
-            # TODO: as branch is always the first insn, these should be per group
+            # TODO: as the checkpointing insn is always the last one, these should be per group
             for i in range(self.gen_params.frontend_superscalarity):
-                # fetcher guarantees that if branch is present, it's the last insn
-                # but computing this for each insn is simpler
-                is_branch = instrs.data[i].exec_fn.op_type == OpType.BRANCH
-                # no need to make checkpoint at JALR, we currently stall the fetch on it
-
                 m.d.av_comb += out.data[i].rollback_tag.eq(rollback_tag)
                 m.d.av_comb += out.data[i].rollback_tag_v.eq(rollback_tag_v)
-                m.d.av_comb += out.data[i].commit_checkpoint.eq(is_branch)
 
             m.d.sync += rollback_tag_v.eq(0)
 

--- a/coreblocks/func_blocks/fu/jumpbranch.py
+++ b/coreblocks/func_blocks/fu/jumpbranch.py
@@ -211,8 +211,9 @@ class JumpBranchFuncUnit(FuncUnitBase[JumpBranchFn]):
                     pc=jump_result,
                     mtval=0,
                 )
-            with m.Elif(is_jalr):
-                # JALR stalls the fetch (with unsafe reason) and doesn't create checkpoint.
+            with m.Elif(is_jalr & ~predicted_taken):
+                # The frontend didn't predict this JALR, so it stalled on it and no checkpoint was created.
+                # Nothing was speculated past it so we should just resume the frontend
                 with m.If(active_tags[instr.tag]):
                     unsafe_resolved(m, pc=jump_result, ftq_ptr=instr.ftq_ptr)
             with m.Elif(misprediction):

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -710,7 +710,6 @@ class FetchLayouts:
             fields.pc,
             self.access_fault,
             fields.rvc,
-            fields.cfi_type,
             fields.commit_checkpoint,
             fields.ftq_ptr,
             fields.ftq_offset,

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -711,6 +711,7 @@ class FetchLayouts:
             self.access_fault,
             fields.rvc,
             fields.cfi_type,
+            fields.commit_checkpoint,
             fields.ftq_ptr,
             fields.ftq_offset,
         )
@@ -777,6 +778,7 @@ class DecodeLayouts:
             fields.imm,
             fields.csr,
             fields.pc,
+            fields.commit_checkpoint,
             fields.ftq_ptr,
             fields.ftq_offset,
         )

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -115,6 +115,7 @@ class TestFetchUnit(TestCaseWithSimulator):
         jump_offset: int = 0,
         branch_taken: bool = False,
         predicted_taken: bool = False,
+        commit_checkpoint: bool = False,
     ) -> int:
         rvc = (data & 0b11) != 0b11
         if rvc:
@@ -136,6 +137,7 @@ class TestFetchUnit(TestCaseWithSimulator):
                 "predicted_taken": predicted_taken,
                 "next_pc": next_pc,
                 "rvc": rvc,
+                "commit_checkpoint": commit_checkpoint,
             }
         )
 
@@ -163,7 +165,10 @@ class TestFetchUnit(TestCaseWithSimulator):
         data = BTypeInstr(opcode=Opcode.BRANCH, imm=offset, funct3=Funct3.BEQ, rs1=0, rs2=0).encode()
 
         # Static prediction with no BPU: backward branches (negative offset) are predicted taken.
-        return self.add_instr(data, True, jump_offset=offset, branch_taken=taken, predicted_taken=offset < 0)
+        # A branch always needs a checkpoint - falling through it is speculation too.
+        return self.add_instr(
+            data, True, jump_offset=offset, branch_taken=taken, predicted_taken=offset < 0, commit_checkpoint=True
+        )
 
     def empty_prediction(self) -> dict:
         return {"branch_mask": 0, "cfi_idx": 0, "cfi_type": CfiType.INVALID, "cfi_target": 0, "cfi_target_valid": 0}
@@ -182,7 +187,9 @@ class TestFetchUnit(TestCaseWithSimulator):
     def gen_predicted_branch(self, offset: int) -> int:
         assert offset > 0
         data = BTypeInstr(opcode=Opcode.BRANCH, imm=offset, funct3=Funct3.BEQ, rs1=0, rs2=0).encode()
-        pc = self.add_instr(data, True, jump_offset=offset, branch_taken=True, predicted_taken=True)
+        pc = self.add_instr(
+            data, True, jump_offset=offset, branch_taken=True, predicted_taken=True, commit_checkpoint=True
+        )
         self.predict_block(pc, CfiType.BRANCH, pc + offset, branch=True)
         return pc
 
@@ -194,9 +201,15 @@ class TestFetchUnit(TestCaseWithSimulator):
 
     def gen_predicted_jalr(self, target_offset: int) -> int:
         data = ITypeInstr(opcode=Opcode.JALR, rd=0, funct3=Funct3.JALR, rs1=0, imm=0).encode()
-        pc = self.add_instr(data, True, jump_offset=target_offset, branch_taken=True, predicted_taken=True)
+        pc = self.add_instr(
+            data, True, jump_offset=target_offset, branch_taken=True, predicted_taken=True, commit_checkpoint=True
+        )
         self.predict_block(pc, CfiType.JALR, pc + target_offset)
         return pc
+
+    def gen_jalr(self, target_offset: int) -> int:
+        data = ITypeInstr(opcode=Opcode.JALR, rd=0, funct3=Funct3.JALR, rs1=0, imm=0).encode()
+        return self.add_instr(data, True, jump_offset=target_offset, branch_taken=True, predicted_taken=False)
 
     async def cache_process(self, sim: ProcessContext):
         while True:
@@ -298,6 +311,8 @@ class TestFetchUnit(TestCaseWithSimulator):
             print(instr, v["pc"], v["access_fault"])
             assert v["pc"] == instr["pc"]
             assert v["access_fault"] == access_fault
+            # Nothing is speculated past a faulting block - it stalls until the backend traps
+            assert v["commit_checkpoint"] == (instr["commit_checkpoint"] and not access_fault)
 
             if not access_fault:
                 instr_data = instr["instr"]
@@ -331,6 +346,8 @@ class TestFetchUnit(TestCaseWithSimulator):
             v = await self.fifo.read.call(sim)
 
             for k in range(v.count):
+                assert not v.data[k].commit_checkpoint or k == v.count - 1
+
                 instr = self.instr_queue.popleft()
                 # if fault happened, throw away rest of insns
                 if await check_instr(instr, v.data[k]):
@@ -569,6 +586,38 @@ class TestFetchUnit(TestCaseWithSimulator):
             self.gen_predicted_branch(self.gen_params.fetch_block_bytes)
             for _ in range(self.gen_params.fetch_width):
                 self.gen_non_branch_instr(rvc=False)
+
+        self.run_sim()
+
+    def test_checkpoints(self):
+        # A branch predicted taken and one predicted not-taken - both directions are
+        # speculative, so both need a checkpoint
+        self.gen_predicted_branch(self.gen_params.fetch_block_bytes)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        self.gen_branch(offset=self.gen_params.fetch_block_bytes, taken=False)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        # A JAL never needs one
+        self.gen_predicted_jal(2 * self.gen_params.fetch_block_bytes)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        self.gen_jal(offset=2 * self.gen_params.fetch_block_bytes)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        # A predicted JALR is speculated, so it does need one
+        self.gen_predicted_jalr(3 * self.gen_params.fetch_block_bytes)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
+
+        # An unpredicted JALR stalls the frontend instead, so it doesn't
+        self.gen_jalr(3 * self.gen_params.fetch_block_bytes)
+        for _ in range(self.gen_params.fetch_width):
+            self.gen_non_branch_instr(rvc=False)
 
         self.run_sim()
 


### PR DESCRIPTION
Checkpoints are currently created only for OpType.BRANCH, which works because fetch always stalls on JALR. This will no longer be the case once the branch predictor starts predicting JALR targets.