### PR TITLE
fetch: cut the critical path in WideFifo

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -123,6 +123,7 @@ class FetchUnit(Elaboratable):
             depth=serializer_depth,
             read_width=self.gen_params.frontend_superscalarity,
             write_width=fetch_width,
+            write_max_count=True,
         )
 
         with Transaction(name="cont").body(m):
@@ -552,7 +553,7 @@ class FetchUnit(Elaboratable):
 
                 # Make sure this is called only once to avoid a huge mux on arguments
                 m.d.av_comb += [aligner.valids.eq(fetch_mask), aligner.inputs.eq(raw_instrs)]
-                serializer.write(m, data=aligner.outputs, count=aligner.output_cnt)
+                serializer.write(m, data=aligner.outputs, count=aligner.output_cnt, max_count=popcount(instr_valid))
 
         @def_method(m, self.flush)
         def _():


### PR DESCRIPTION
`validate_arguments` in `WideFifo.write` is a function of its arguments, so the entire fetch stage-2 datapath - predecode, prediction check, exit/unsafe resolution, aligner - feeds the grant for Fetch_Stage2, which then feeds readiness of Fetch_Stage1.

This is an attempt to cut this path by passing an upper bound (which itself is not on the critical path) of the actual count to validate_arguments.

Depends on https://github.com/kuznia-rdzeni/transactron/pull/229