### PR TITLE
Fix konata wakeup deps

### DIFF
--- a/coreblocks/func_blocks/fu/common/rs.py
+++ b/coreblocks/func_blocks/fu/common/rs.py
@@ -12,7 +12,7 @@ from transactron.utils.amaranth_ext.elaboratables import OneHotMux
 from coreblocks.params import GenParams
 from coreblocks.arch import OpType
 from coreblocks.interface.layouts import RSLayouts
-from coreblocks.telemetry.events import Update
+from coreblocks.telemetry.events import OperandWakeup
 from transactron.lib.metrics import HwExpHistogram, TaggedLatencyMeasurer
 from transactron.evlog import EventSource
 from transactron.utils import ReturnDict
@@ -111,7 +111,9 @@ class RSBase(Elaboratable):
                 m.d.comb += matches_s1[i][k].eq(record.rs_data.rp_s1 == reg_id)
                 m.d.comb += matches_s2[i][k].eq(record.rs_data.rp_s2 == reg_id)
                 evlog.emit(
-                    m, Update.hw(rob_id=record.rs_data.rob_id, reg_id=reg_id), when=matches_s1[i][k] | matches_s2[i][k]
+                    m,
+                    OperandWakeup.hw(rob_id=record.rs_data.rob_id, reg_id=reg_id),
+                    when=matches_s1[i][k] | matches_s2[i][k],
                 )
 
         # It is assumed that two simultaneous update calls never update the same physical register.

--- a/coreblocks/telemetry/events.py
+++ b/coreblocks/telemetry/events.py
@@ -15,6 +15,7 @@ __all__ = [
     "RobFlush",
     "FuIssue",
     "ExecComplete",
+    "OperandWakeup",
     "func_unit_kind",
 ]
 
@@ -134,8 +135,8 @@ class ExecComplete(Event):
     rob_id: int
 
 
-@event("backend.update")
-class Update(Event):
+@event("backend.operand_wakeup")
+class OperandWakeup(Event):
     """The instruction is waiting for execution and one of its operands
     was just announced."""
 

--- a/coreblocks/telemetry/konata.py
+++ b/coreblocks/telemetry/konata.py
@@ -19,21 +19,7 @@ import capstone
 
 from transactron.evlog import DecodedEvent, EventConsumer, EventLogReader, handles
 
-from .events import (
-    ExecComplete,
-    FetchRequest,
-    FTQAlloc,
-    FTQCommit,
-    FTQRollback,
-    FuIssue,
-    InstrDecoded,
-    InstrFetched,
-    RobAllocate,
-    RobFlush,
-    RobRetire,
-    SchedulerEnter,
-    Update,
-)
+from .events import *
 
 
 __all__ = ["KonataParser"]
@@ -106,6 +92,13 @@ class KonataParser(EventConsumer):
 
     def _command(self, cycle: int, *columns) -> None:
         self.timeline.append((cycle, len(self.timeline), "\t".join(str(col) for col in columns)))
+
+    def _forget_dst(self, insn_id: int) -> None:
+        """Drops the destination register mapping of a terminated instruction,
+        unless the register was already reallocated to a younger one."""
+        rp_dst = self.rp_dst.pop(insn_id, None)
+        if rp_dst is not None and self.by_rp_dst.get(rp_dst) == insn_id:
+            del self.by_rp_dst[rp_dst]
 
     @handles(FTQAlloc)
     def on_alloc(self, rec: DecodedEvent):
@@ -193,14 +186,15 @@ class KonataParser(EventConsumer):
             return
         self._command(rec.cycle, "S", insn_id, 0, "Cm")
 
-    @handles(Update)
+    @handles(OperandWakeup)
     def on_update(self, rec: DecodedEvent):
         ev = rec.event
-        assert isinstance(ev, Update)
+        assert isinstance(ev, OperandWakeup)
         insn_id = self.rob.get(ev.rob_id)
-        if insn_id is None or insn_id in self.terminated:
+        producer_id = self.by_rp_dst.get(ev.reg_id)
+        if insn_id is None or producer_id is None or insn_id in self.terminated:
             return
-        self._command(rec.cycle, "W", insn_id, self.by_rp_dst[ev.reg_id], 0)
+        self._command(rec.cycle, "W", insn_id, producer_id, 0)
 
     @handles(RobRetire)
     def on_rob_retire(self, rec: DecodedEvent):
@@ -212,9 +206,7 @@ class KonataParser(EventConsumer):
         self._command(rec.cycle, "R", insn_id, self.next_retire_id, 0)
         self.next_retire_id += 1
         self.terminated.add(insn_id)
-        if insn_id in self.rp_dst:
-            del self.by_rp_dst[self.rp_dst[insn_id]]
-            del self.rp_dst[insn_id]
+        self._forget_dst(insn_id)
 
     @handles(RobFlush)
     def on_rob_flush(self, rec: DecodedEvent):
@@ -225,9 +217,7 @@ class KonataParser(EventConsumer):
             return
         self._command(rec.cycle, "R", insn_id, 0, 1)
         self.terminated.add(insn_id)
-        if insn_id in self.rp_dst:
-            del self.by_rp_dst[self.rp_dst[insn_id]]
-            del self.rp_dst[insn_id]
+        self._forget_dst(insn_id)
 
     @handles(FTQCommit)
     def on_commit(self, rec: DecodedEvent):
@@ -251,6 +241,7 @@ class KonataParser(EventConsumer):
         for key in self._entries_from(ev.ftq_ptr):
             for insn_id in self.blocks.pop(key).instr_ids.values():
                 flushed.add(insn_id)
+                self._forget_dst(insn_id)
                 if insn_id in self.terminated:
                     continue
                 self._command(rec.cycle, "R", insn_id, 0, 1)

--- a/test/telemetry/test_konata.py
+++ b/test/telemetry/test_konata.py
@@ -3,20 +3,7 @@ from textwrap import dedent
 
 from transactron.evlog import DecodedEvent, Event, EventSiteSchema
 
-from coreblocks.telemetry import (
-    ExecComplete,
-    FetchRequest,
-    FTQAlloc,
-    FTQCommit,
-    FTQRollback,
-    FuIssue,
-    InstrDecoded,
-    InstrFetched,
-    RobAllocate,
-    RobFlush,
-    RobRetire,
-    SchedulerEnter,
-)
+from coreblocks.telemetry import *
 from coreblocks.telemetry.konata import KonataParser
 
 DUMMY_SITE = EventSiteSchema(source_name="frontend", event_name="dummy", location=("x.py", 1), fields=[], statics={})
@@ -177,6 +164,35 @@ class TestKonataParser:
         KonataParser(out).run(records)
 
         assert "L\t0\t0\t00000100: ffffffff" in out.getvalue().splitlines()
+
+    def test_update_draws_dependency_arrow(self):
+        # An operand announcement links the waiting instruction to the producer
+        records = [
+            dec(0, FTQAlloc(ftq_ptr=0, pc=0x100)),
+            dec(1, InstrFetched(ftq_ptr=0, pc=0x100, instr=0x13, ftq_offset=0)),
+            dec(1, InstrFetched(ftq_ptr=0, pc=0x104, instr=0x93, ftq_offset=1)),
+            dec(2, RobAllocate(ftq_ptr=0, ftq_offset=0, rob_id=0, rp_dst=12)),
+            dec(2, RobAllocate(ftq_ptr=0, ftq_offset=1, rob_id=1, rp_dst=13)),
+            dec(3, OperandWakeup(rob_id=1, reg_id=12)),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        assert "W\t1\t0\t0" in out.getvalue().splitlines()
+
+    def test_update_with_untracked_producer_is_ignored(self):
+        records = [
+            dec(0, FTQAlloc(ftq_ptr=0, pc=0x100)),
+            dec(1, InstrFetched(ftq_ptr=0, pc=0x100, instr=0x13, ftq_offset=0)),
+            dec(2, RobAllocate(ftq_ptr=0, ftq_offset=0, rob_id=1, rp_dst=5)),
+            dec(3, OperandWakeup(rob_id=1, reg_id=12)),
+        ]
+
+        out = StringIO()
+        KonataParser(out).run(records)
+
+        assert not any(line.startswith("W") for line in out.getvalue().splitlines())
 
     def test_decode_of_squashed_instruction_is_ignored(self):
         # A decode event arriving after its FTQ entry was squashed (or for an


### PR DESCRIPTION
The operand wakeup event can arrive after its producer is already flushed (https://github.com/kuznia-rdzeni/coreblocks/actions/runs/32077746048/job/95534681965), so let's make sure we handle this in konata.py.

I also renamed `Update` event to `OperandWakeup`. Arguably, it was not the most descriptive name.