### PR TITLE
restore RVVI functionality

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           TRANSACTRON_VERBOSE: 1
         run: |
           . venv/bin/activate
-          python3 -m coreblocks.gen_verilog --verbose --config "${{ matrix.config }}" "${{ matrix.rvvi == 'true' && '--with-rvvi' || '' }}"
+          python3 -m coreblocks.gen_verilog --verbose --config "${{ matrix.config }}" ${{ matrix.rvvi == 'true' && '--with-rvvi' || '' }}
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,11 @@ on:
 
 jobs:
   build-core:
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [full]
+        rvvi: [false, true]
     name: Synthesize full core
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -33,13 +38,16 @@ jobs:
           python3 -m pip install .
 
       - name: Generate Verilog
+        env:
+          PYTHONHASHSEED: 0
+          TRANSACTRON_VERBOSE: 1
         run: |
           . venv/bin/activate
-          PYTHONHASHSEED=0 TRANSACTRON_VERBOSE=1 python3 -m coreblocks.gen_verilog --verbose --config full
+          python3 -m coreblocks.gen_verilog --verbose --config "${{ matrix.config }}" "${{ matrix.rvvi == 'true' && '--with-rvvi' || '' }}"
 
       - uses: actions/upload-artifact@v7
         with:
-          name: "verilog-full-core"
+          name: "verilog-${{ matrix.config }}-core${{ matrix.rvvi == 'true' && '-rvvi' || '' }}"
           path: |
             core.v
             core.v.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,11 @@ jobs:
           TRANSACTRON_VERBOSE: 1
         run: |
           . venv/bin/activate
-          python3 -m coreblocks.gen_verilog --verbose --config "${{ matrix.config }}" ${{ matrix.rvvi == 'true' && '--with-rvvi' || '' }}
+          python3 -m coreblocks.gen_verilog --verbose --config "${{ matrix.config }}" ${{ matrix.rvvi && '--with-rvvi' || '' }}
 
       - uses: actions/upload-artifact@v7
         with:
-          name: "verilog-${{ matrix.config }}-core${{ matrix.rvvi == 'true' && '-rvvi' || '' }}"
+          name: "verilog-${{ matrix.config }}-core${{ matrix.rvvi && '-rvvi' || '' }}"
           path: |
             core.v
             core.v.json

--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -243,10 +243,14 @@ class Retirement(Elaboratable):
                     commit_trapping = Signal()
 
                     cause_register = self.exception_cause_get(m).data
-                    arch_trap = Signal(init=1)
 
                     with m.If(exception):
                         self.perf_trap_latency.start(m)
+
+                        if rvvi is not None:
+                            # The instruction after this cycle ends will be the first instruction
+                            # of the trap handler -> inform RVVI about it.
+                            rvvi.register_next_is_trap_handler(m)
 
                         cause_entry = Signal(self.gen_params.isa.xlen)
 
@@ -306,7 +310,7 @@ class Retirement(Elaboratable):
 
                         with m.If(i - commit_trapping < no_trap_count):
                             with m.If(tag_active_mask[i]):
-                                retire_instr(i, rob_entries.entries[i])
+                                retire_instr(i, entry)
 
                                 if rvvi is not None:
                                     rvvi.finalize_retire[i](
@@ -314,22 +318,30 @@ class Retirement(Elaboratable):
                                         rob_id=entry.rob_id,
                                         rl_dst=entry.rob_data.rl_dst,
                                         rp_dst=entry.rob_data.rp_dst,
-                                        trap=entry.exception & arch_trap,
-                                        interrupt=entry.exception
-                                        & (cause_register.cause == ExceptionCause._COREBLOCKS_ASYNC_INTERRUPT),
+                                        trap=0,
                                     )
 
-                                m.d.av_comb += last_commit_ftq_ptr.eq(rob_entries.entries[i].rob_data.ftq_ptr)
+                                m.d.av_comb += last_commit_ftq_ptr.eq(entry.rob_data.ftq_ptr)
                                 m.d.av_comb += last_commit_ftq_ptr_v.eq(1)
                                 m.d.sync += last_retired_active.eq(1)
                             with m.Else():
                                 # flush inactive instruction - CRAT entry was already rolled back
-                                flush_instr(i, rob_entries.entries[i])
+                                flush_instr(i, entry)
                                 m.d.sync += last_retired_active.eq(0)
 
                         with m.Elif(i < retire_count):
                             # hard flush instruction for trap handling
-                            flush_instr(i, rob_entries.entries[i])
+                            flush_instr(i, entry)
+
+                            if rvvi is not None:
+                                with m.If(~commit_trapping & (i == no_trap_count)):
+                                    rvvi.finalize_retire[i](
+                                        m,
+                                        rob_id=entry.rob_id,
+                                        rl_dst=0,
+                                        rp_dst=0,
+                                        trap=1,
+                                    )
 
                     # TODO: this is some approximation of misprediction events - looking for active -> inactive
                     # changes in retired instructions.

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -1037,5 +1037,4 @@ class RVVILayouts:
             fields.rl_dst,
             fields.rp_dst,
             ("trap", 1),
-            ("interrupt", 1),
         )

--- a/coreblocks/telemetry/rvvi.py
+++ b/coreblocks/telemetry/rvvi.py
@@ -4,7 +4,7 @@ from amaranth.lib.data import ArrayLayout, View
 from amaranth.lib.wiring import Component, Out
 
 from transactron import *
-from transactron.utils import DependencyContext, make_layout, logging
+from transactron.utils import DependencyContext, make_layout, logging, popcount
 from transactron.utils.amaranth_ext.component_interface import ComponentInterface, COut
 
 from coreblocks.arch.isa_consts import PrivilegeLevel, XlenEncoding
@@ -78,6 +78,7 @@ class RVVIHartCollector(Component):
         self.register_ftq = Method(i=self.layouts.register_ftq)
         self.register_ftq_rob_assoc = Methods(self.frontend_ports, i=self.layouts.register_ftq_rob_assoc)
         self.register_reg_write = Methods(self.reg_write_ports, i=self.layouts.register_reg_write)
+        self.register_next_is_trap_handler = Method()
         self.finalize_retire = Methods(self.retire_ports, i=self.layouts.finalize_retire)
 
         super().__init__(
@@ -111,13 +112,6 @@ class RVVIHartCollector(Component):
             shape=self.gen_params.isa.xlen, depth=self.gen_params.phys_regs, init=[]
         )
 
-        ftq_write_ports = [ftq_mem.write_port() for _ in range(self.gen_params.fetch_width)]
-        ftq_read_ports = [ftq_mem.read_port(domain="comb") for _ in range(self.frontend_ports)]
-        rob_write_ports = [rob_mem.write_port() for _ in range(self.frontend_ports)]
-        rob_read_ports = [rob_mem.read_port(domain="comb") for _ in range(self.retire_ports)]
-        rf_write_ports = [rf_mem.write_port() for _ in range(self.reg_write_ports)]
-        rf_read_ports = [rf_mem.read_port(domain="comb") for _ in range(self.retire_ports)]
-
         ixl = XlenEncoding.from_xlen(self.gen_params.isa.xlen)
 
         order = Signal(64)
@@ -130,8 +124,7 @@ class RVVIHartCollector(Component):
             priv_mode = csr.m_mode.priv_mode.read(m)
 
             for i in range(self.gen_params.fetch_width):
-                port = ftq_write_ports[i]
-
+                port = ftq_mem.write_port()
                 m.d.av_comb += port.addr.eq(ftq_ptr.ptr * self.gen_params.fetch_width + i)
                 m.d.av_comb += port.data.info.eq(instrs[i])
                 m.d.av_comb += port.data.priv_mode.eq(priv_mode)
@@ -139,8 +132,8 @@ class RVVIHartCollector(Component):
 
         @def_methods(m, self.register_ftq_rob_assoc)
         def _(i, ftq_ptr, ftq_offset, rob_id):
-            rport = ftq_read_ports[i]
-            wport = rob_write_ports[i]
+            rport = ftq_mem.read_port(domain="comb")
+            wport = rob_mem.write_port()
 
             m.d.av_comb += rport.addr.eq(ftq_ptr.ptr * self.gen_params.fetch_width + ftq_offset)
             m.d.av_comb += wport.addr.eq(rob_id)
@@ -149,34 +142,48 @@ class RVVIHartCollector(Component):
 
         @def_methods(m, self.register_reg_write)
         def _(i, reg_id, reg_val):
-            m.d.av_comb += rf_write_ports[i].addr.eq(reg_id)
-            m.d.av_comb += rf_write_ports[i].data.eq(reg_val)
-            m.d.comb += rf_write_ports[i].en.eq(reg_id != 0)
+            port = rf_mem.write_port()
+            m.d.av_comb += port.addr.eq(reg_id)
+            m.d.av_comb += port.data.eq(reg_val)
+            m.d.comb += port.en.eq(reg_id != 0)
+
+        valids = Cat(self.retire_port[i].valid for i in range(self.retire_ports))
+        m.d.sync += order.eq(order + popcount(valids))
+        with m.If(valids.any()):
+            m.d.sync += intr_next.eq(0)
+
+        @def_method(m, self.register_next_is_trap_handler, nonexclusive=True)
+        def _():
+            # The instruction after this cycle ends will be the first instruction
+            # of the trap handler -> inform RVVI about it.
+            m.d.sync += intr_next.eq(1)
 
         @def_methods(m, self.finalize_retire)
-        def _(i, rob_id, rl_dst, rp_dst, trap, interrupt):
+        def _(i, rob_id, rl_dst, rp_dst, trap):
             port = self.retire_port[i]
 
-            rob_port = rob_read_ports[i]
+            rob_port = rob_mem.read_port(domain="comb")
             m.d.av_comb += rob_port.addr.eq(rob_id)
 
             m.d.comb += port.valid.eq(1)
-            m.d.av_comb += port.order.eq(order + i)
+            m.d.comb += port.trap.eq(trap)
+            m.d.av_comb += port.order.eq(order + popcount(Cat(0, valids[:i])))
 
             m.d.av_comb += port.insn.eq(rob_port.data.info.instr)
-            m.d.av_comb += port.trap.eq(trap)
             m.d.av_comb += port.debug_mode.eq(0)
-            m.d.av_comb += port.intr.eq(intr_next if i == 0 else 0)
+            m.d.av_comb += port.intr.eq(intr_next & (port.order == order))
             m.d.av_comb += port.halt.eq(0)  # never happens
             m.d.av_comb += port.pc_rdata.eq(rob_port.data.info.pc)
             m.d.av_comb += port.pc_wdata.eq(0)  # not implemented
 
-            rf_port = rf_read_ports[i]
+            rf_port = rf_mem.read_port(domain="comb")
             m.d.av_comb += rf_port.addr.eq(rp_dst)
             m.d.av_comb += [port.x_wdata[k].eq(rf_port.data) for k in range(32)]
-            for k in range(1, 32):
-                with m.If(k == rl_dst):
-                    m.d.av_comb += port.x_wb[k].eq(1)
+            with m.If(~trap):
+                m.d.comb += port.x_wb[0].eq(0)
+                for k in range(1, 32):
+                    with m.If(k == rl_dst):
+                        m.d.comb += port.x_wb[k].eq(1)
 
             # f_* not implemented
 
@@ -189,21 +196,28 @@ class RVVIHartCollector(Component):
             m.d.av_comb += port.mode_virt.eq(0)  # always 0
             m.d.av_comb += port.ixl.eq(ixl)
 
-            # set order/intr_next to the last retire port
-            m.d.sync += order.eq(order + (i + 1))
-            m.d.sync += intr_next.eq(interrupt | trap)
-
-            log.info(
-                m,
-                True,
-                "Retired instruction #{}: pc 0x{:x}, rl_dst x{} = 0x{:x}, rob_id 0x{:x}, instr 0x{:x}",
-                i,
-                rob_port.data.info.pc,
-                rl_dst,
-                rf_port.data,
-                rob_id,
-                rob_port.data.info.instr,
-            )
+            with m.If(~trap):
+                log.info(
+                    m,
+                    True,
+                    "Retired instruction #{}: pc 0x{:x}, rl_dst x{} = 0x{:x}, rob_id 0x{:x}, instr 0x{:x}",
+                    i,
+                    port.pc_rdata,
+                    rl_dst,
+                    rf_port.data[:],
+                    rob_id,
+                    port.insn,
+                )
+            with m.Else():
+                log.info(
+                    m,
+                    True,
+                    "Trapping instruction #{}: pc 0x{:x}, rob_id 0x{:x}, instr 0x{:x}",
+                    i,
+                    port.pc_rdata,
+                    rob_id,
+                    port.insn,
+                )
 
         return m
 

--- a/test/asm/rvvi.asm
+++ b/test/asm/rvvi.asm
@@ -1,14 +1,23 @@
-nop
-li x1, 1
-slli x2, x1, 2
-andi x3, x2, 0x4
-bnez x3, continue
+start:
+  la x5, trap
+  csrw mtvec, x5
 
-nop
+  li x1, 1
+  slli x2, x1, 2
+  andi x3, x2, 0x4
+  bnez x3, continue
+
+  nop
 
 continue:
-lw x4, 0(x0)
-j .
+  lw x4, 0(x0)
+  unimp
+
+  nop
+
+.p2align 2
+trap:
+  j .
 
 .section .data
 .word 0xDEADBEEF

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -455,12 +455,12 @@ class TestCoreSModeInterruptDelegation(TestCoreAsmSourceBase):
 
 @pytest.mark.collection_order(1)
 class TestCoreRVVI(TestCoreAsmSourceBase):
-    cycle_count: int = 200
+    cycle_count: int = 400
     expected_regvals: dict[int, int] = {}
     exit_csr: bool = False
 
     def setup_method(self):
-        self.configuration = configurations.tiny.replace(
+        self.configuration = configurations.basic.replace(
             _generate_test_hardware=True,
             with_rvvi=True,
             compressed=True,
@@ -472,22 +472,29 @@ class TestCoreRVVI(TestCoreAsmSourceBase):
         pc: int
         instr: int
         reg_write: tuple[int, int] | None = None  # (reg_id, reg_val)
+        trap: bool = False
+        intr: bool = False
 
     def test_asm_source(self):
         expected_trace = [
-            self.TraceItem(0x00, 0x0001, None),  # c.nop
-            self.TraceItem(0x02, 0x4085, (1, 0x1)),  # c.li x1, 1
-            self.TraceItem(0x04, 0x00209113, (2, 0x4)),  # slli x2, x1, 2
-            self.TraceItem(0x08, 0x00417193, (3, 0x4)),  # andi x3, x2, 0x4
-            self.TraceItem(0x0C, 0x00019363),  # bnez x3, 0x12 [continue]
-            self.TraceItem(0x12, 0x00002203, (4, 0xDEADBEEF)),  # lw x4, 0(x0)
-            self.TraceItem(0x16, 0xA001),  # c.j 0x1c [loop]
-            self.TraceItem(0x16, 0xA001),  # c.j 0x1c [loop]
-            self.TraceItem(0x16, 0xA001),  # c.j 0x1c [loop]
+            self.TraceItem(0x00, 0x00000297, (5, 0)),  # auipc x5, 0x0
+            self.TraceItem(0x04, 0x02428293, (5, 0x24)),  # addi x5, x5, 0x24
+            self.TraceItem(0x08, 0x30529073),  # csrw mtvec, x5
+            self.TraceItem(0x0c, 0x4085, (1, 1)),  # li x1, 0x1
+            self.TraceItem(0x0e, 0x00209113, (2, 4)),  # slli x2, x1, 0x2
+            self.TraceItem(0x12, 0x00417193, (3, 4)),  # andi x3, x2, 0x4
+            self.TraceItem(0x16, 0x00019363),  # bnez x3, 0x1c [continue]
+            self.TraceItem(0x1c, 0x00002203, (4, 0xDEADBEEF)),  # lw x4, 0x0
+            self.TraceItem(0x20, 0x0000, trap=True),  # unimp
+            self.TraceItem(0x24, 0xa001, intr=True),  # j 0x24 [trap]
+            self.TraceItem(0x24, 0xa001),  # j 0x24 [trap]
+            self.TraceItem(0x24, 0xa001),  # j 0x24 [trap]
+            self.TraceItem(0x24, 0xa001),  # j 0x24 [trap]
         ]
 
         async def run_and_check_rvvi(sim: TestbenchContext):
             ticks = DependencyContext.get().get_dependency(TicksKey())
+            assert len(self.m.core.rvvi_collector.retire_port) == 1
             port = self.m.core.rvvi_collector.retire_port[0]
 
             for i, trace_item in enumerate(expected_trace):
@@ -499,17 +506,20 @@ class TestCoreRVVI(TestCoreAsmSourceBase):
 
                 assert sim.get(port.valid)
                 assert sim.get(port.order) == i, "not in-order retire on RVVI port"
-
-                reg_write = None
-                for i in range(32):
-                    if sim.get(port.x_wb[i]):
-                        if reg_write is not None:
-                            assert False, "Multiple register writes in a single instruction"
-                        reg_write = (i, sim.get(port.x_wdata[i]))
-
                 assert sim.get(port.pc_rdata) == trace_item.pc
-                assert sim.get(port.insn) == trace_item.instr
-                assert reg_write == trace_item.reg_write
+                assert sim.get(port.trap) == trace_item.trap
+
+                if not trace_item.trap:
+                    reg_write = None
+                    for i in range(32):
+                        if sim.get(port.x_wb[i]):
+                            if reg_write is not None:
+                                assert False, "Multiple register writes in a single instruction"
+                            reg_write = (i, sim.get(port.x_wdata[i]))
+
+                    assert sim.get(port.insn) == trace_item.instr
+                    assert reg_write == trace_item.reg_write
+                    assert sim.get(port.intr) == trace_item.intr
 
                 await sim.tick()
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -480,16 +480,16 @@ class TestCoreRVVI(TestCoreAsmSourceBase):
             self.TraceItem(0x00, 0x00000297, (5, 0)),  # auipc x5, 0x0
             self.TraceItem(0x04, 0x02428293, (5, 0x24)),  # addi x5, x5, 0x24
             self.TraceItem(0x08, 0x30529073),  # csrw mtvec, x5
-            self.TraceItem(0x0c, 0x4085, (1, 1)),  # li x1, 0x1
-            self.TraceItem(0x0e, 0x00209113, (2, 4)),  # slli x2, x1, 0x2
+            self.TraceItem(0x0C, 0x4085, (1, 1)),  # li x1, 0x1
+            self.TraceItem(0x0E, 0x00209113, (2, 4)),  # slli x2, x1, 0x2
             self.TraceItem(0x12, 0x00417193, (3, 4)),  # andi x3, x2, 0x4
             self.TraceItem(0x16, 0x00019363),  # bnez x3, 0x1c [continue]
-            self.TraceItem(0x1c, 0x00002203, (4, 0xDEADBEEF)),  # lw x4, 0x0
+            self.TraceItem(0x1C, 0x00002203, (4, 0xDEADBEEF)),  # lw x4, 0x0
             self.TraceItem(0x20, 0x0000, trap=True),  # unimp
-            self.TraceItem(0x24, 0xa001, intr=True),  # j 0x24 [trap]
-            self.TraceItem(0x24, 0xa001),  # j 0x24 [trap]
-            self.TraceItem(0x24, 0xa001),  # j 0x24 [trap]
-            self.TraceItem(0x24, 0xa001),  # j 0x24 [trap]
+            self.TraceItem(0x24, 0xA001, intr=True),  # j 0x24 [trap]
+            self.TraceItem(0x24, 0xA001),  # j 0x24 [trap]
+            self.TraceItem(0x24, 0xA001),  # j 0x24 [trap]
+            self.TraceItem(0x24, 0xA001),  # j 0x24 [trap]
         ]
 
         async def run_and_check_rvvi(sim: TestbenchContext):


### PR DESCRIPTION
retiring ports stopped being contiguous thus breaking `order` calculations.

Additionally fixes following issues:
- `valid` signal not being set when `trap` was set
- `coreblocks --with-rvvi` not being operational (kuznia-rdzeni/transactron#238) - `ReadPort.data` was used directly in `log.info`