### PR TITLE
ftq: count unpredicted JALRs as mispredictions

### DIFF
--- a/coreblocks/backend/retirement.py
+++ b/coreblocks/backend/retirement.py
@@ -20,7 +20,7 @@ from transactron.lib.metrics import *
 from coreblocks.telemetry import RobFlush, RobRetire
 
 from coreblocks.params.genparams import GenParams
-from coreblocks.arch import ExceptionCause, HPMEvent, PrivilegeLevel
+from coreblocks.arch import ExceptionCause, PrivilegeLevel
 from coreblocks.arch.csr_address import CounterEnableFieldOffsets
 from coreblocks.interface.keys import (
     ActiveTagsKey,
@@ -87,9 +87,6 @@ class Retirement(Elaboratable):
             "Number of retired instructions",
             ways=gen_params.retirement_superscalarity,
         )
-        self.perf_mispredictions = HwCounter(
-            "backend.retirement.mispredictions", "Number of committed branch mispredictions"
-        )
         self.perf_trap_latency = FIFOLatencyMeasurer(
             "backend.retirement.trap_latency",
             "Cycles spent flushing the core after a trap",
@@ -108,7 +105,7 @@ class Retirement(Elaboratable):
     def elaborate(self, platform):
         m = TModule()
 
-        m.submodules += [self.perf_instr_ret, self.perf_mispredictions, self.perf_trap_latency]
+        m.submodules += [self.perf_instr_ret, self.perf_trap_latency]
 
         csr_instances = self.dependency_manager.get_dependency(CSRInstancesKey())
         m_csr = csr_instances.m_mode
@@ -182,7 +179,6 @@ class Retirement(Elaboratable):
         first_tag_incr_mask = Signal.like(tag_incr_mask)
         limiting_instruction_mask = Signal.like(tag_incr_mask)
         free_tag = Signal()
-        last_retired_active = Signal()
 
         with Transaction().always_body(m):
             rob_entries = self.rob_peek(m)
@@ -321,25 +317,13 @@ class Retirement(Elaboratable):
 
                                 m.d.av_comb += last_commit_ftq_ptr.eq(rob_entries.entries[i].rob_data.ftq_ptr)
                                 m.d.av_comb += last_commit_ftq_ptr_v.eq(1)
-                                m.d.sync += last_retired_active.eq(1)
                             with m.Else():
                                 # flush inactive instruction - CRAT entry was already rolled back
                                 flush_instr(i, rob_entries.entries[i])
-                                m.d.sync += last_retired_active.eq(0)
 
                         with m.Elif(i < retire_count):
                             # hard flush instruction for trap handling
                             flush_instr(i, rob_entries.entries[i])
-
-                    # TODO: this is some approximation of misprediction events - looking for active -> inactive
-                    # changes in retired instructions.
-                    # More metadata needs to be stored for an accurate result, improve.
-                    active_mask_with_prev = Signal(tag_active_mask.shape().width + 1)
-                    m.d.comb += active_mask_with_prev.eq(Cat(last_retired_active, tag_active_mask))
-                    change_mask = active_mask_with_prev & ~tag_active_mask
-                    with m.If((change_mask & retiring_mask).any()):  # without last bit
-                        self.perf_mispredictions.incr(m)
-                        m_csr.hpm_event_report(m, events=1 << HPMEvent.BRANCH_MISPREDICTION)
 
                     # Commit the FTQ entry for the last retired instruction this cycle.
                     with m.If(last_commit_ftq_ptr_v):
@@ -400,7 +384,6 @@ class Retirement(Elaboratable):
                     m.d.av_comb += handler_pc.eq((tvec_base << 2) + tvec_offset)
 
                     self.fetch_redirect(m, ftq_ptr=ftq_commit_ptr, pc=handler_pc)
-                    m.d.sync += last_retired_active.eq(1)
 
                     # Release pending trap state - allow accepting new reports and unstall fetch
                     self.exception_cause_clear(m)

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -18,7 +18,7 @@ from coreblocks.interface.layouts import (
     FTQPtr,
     FetchTargetQueueLayouts,
 )
-from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey, FTQCommitKey
+from coreblocks.interface.keys import PredictedJumpTargetKey, BranchResolveKey, FTQCommitKey, CSRInstancesKey
 from coreblocks.frontend.fetch_addr_unit import FetchAddressUnit
 from coreblocks.telemetry import FetchRequest, FTQAlloc, FTQCommit, FTQRollback
 
@@ -158,11 +158,17 @@ class FetchTargetQueue(Elaboratable):
         self.dep_manager.add_dependency(BranchResolveKey(), self.resolve)
         self.dep_manager.add_dependency(FTQCommitKey(), self.commit)
 
+        self.perf_mispredictions = HwCounter("frontend.ftq.mispredictions", "Number of committed branch mispredictions")
+
     def elaborate(self, platform):
         m = TModule()
 
+        m.submodules += [self.perf_mispredictions]
+
         fields = self.gen_params.get(CommonLayoutFields)
         fetch_layouts = self.gen_params.get(FetchLayouts)
+
+        m_csr = self.dep_manager.get_dependency(CSRInstancesKey()).m_mode
 
         m.submodules.fetch_address_unit = fetch_address_unit = FetchAddressUnit(self.gen_params)
 
@@ -303,6 +309,12 @@ class FetchTargetQueue(Elaboratable):
             record = train_mem.read(m).data
             status = train_status[train_mem.read_ptr.ptr]
             with m.If(status.valid):
+                # At most one CFI per block mispredicts and `resolve` keeps the oldest one,
+                # so each committed misprediction is counted once.
+                with m.If(status.mispredict):
+                    self.perf_mispredictions.incr(m)
+                    m_csr.hpm_event_report(m, events=1 << HPMEvent.BRANCH_MISPREDICTION)
+
                 self.bpu_update(
                     m,
                     pc=record.pc,

--- a/test/frontend/test_ftq.py
+++ b/test/frontend/test_ftq.py
@@ -10,10 +10,14 @@ from transactron.testing import (
 )
 from transactron.testing.method_mock import MethodMock
 
+from transactron.utils import DependencyContext, ModuleConnector
+
 from coreblocks.arch import CfiType
 from coreblocks.frontend.ftq import FetchTargetQueue
+from coreblocks.interface.keys import CSRInstancesKey
 from coreblocks.params import GenParams
 from coreblocks.params import configurations
+from coreblocks.priv.csr.csr_instances import CSRInstances
 
 
 class TestFetchTargetQueue(TestCaseWithSimulator):
@@ -26,7 +30,11 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
         self.bpu_updates: deque = deque()
         self.bpu_flush_count: int = 0
 
+        self.csr_instances = CSRInstances(self.gen_params)
+        DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
+
         self.ftq = SimpleTestCircuit(FetchTargetQueue(self.gen_params))
+        self.dut = ModuleConnector(ftq=self.ftq, csr_instances=self.csr_instances)
 
     @def_method_mock(lambda self: self.ftq.stall_guard)
     def stall_guard_mock(self):
@@ -90,7 +98,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             assert self.ifu_requests[0]["pc"] == self.start_pc
             assert self.ifu_requests[0]["ftq_ptr"] == 0
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -105,7 +113,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
                 assert self.ifu_requests[i]["pc"] == self.start_pc + 4 * i
                 assert self.ifu_requests[i]["ftq_ptr"] == i
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -119,7 +127,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             )
             assert self.bpu_flush_count > flush_count_before
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -142,7 +150,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
                 await sim.tick()
             assert redirect_pc in [req["pc"] for req in self.ifu_requests]
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_testbench(proc)
 
     def test_backend_redirect_restarts_fetch_from_new_pc(self):
@@ -155,7 +163,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
                 await sim.tick()
             assert redirect_pc in [req["pc"] for req in self.ifu_requests]
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_testbench(proc)
 
     def test_fetch_gen_starts_at_one_and_is_unique_per_entry(self):
@@ -171,7 +179,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
                 assert self.ifu_requests[i]["ftq_ptr"] == i
                 assert self.ifu_requests[i]["fetch_gen"] == 1
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -182,7 +190,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             assert len(self.ifu_requests) >= 3
             assert await self.check_stale(sim, self.ifu_requests[0]) == 0
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -196,7 +204,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             req["fetch_gen"] = 0
             assert await self.check_stale(sim, req) == 1
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -207,7 +215,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             future = {"ftq_ptr": self.gen_params.ftq_size - 1, "parity": 0, "fetch_gen": 1}
             assert await self.check_stale(sim, future) == 1
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -254,7 +262,7 @@ class TestFetchTargetQueue(TestCaseWithSimulator):
             assert await self.check_stale(sim, reissued[0]) == 0
             assert await self.check_stale(sim, squashed) == 1
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -268,7 +276,11 @@ class TestFetchTargetQueueFull(TestCaseWithSimulator):
         self.ifu_requests: deque = deque()
         self.bpu_requests: deque = deque()
 
+        self.csr_instances = CSRInstances(self.gen_params)
+        DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
+
         self.ftq = SimpleTestCircuit(FetchTargetQueue(self.gen_params))
+        self.dut = ModuleConnector(ftq=self.ftq, csr_instances=self.csr_instances)
 
     @def_method_mock(lambda self: self.ftq.stall_guard)
     def stall_guard_mock(self):
@@ -325,7 +337,7 @@ class TestFetchTargetQueueFull(TestCaseWithSimulator):
                 await sim.tick()
             assert len(self.ifu_requests) == ftq_size + 1
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -339,7 +351,11 @@ class TestFetchTargetQueueTrain(TestCaseWithSimulator):
         self.bpu_requests: deque = deque()
         self.bpu_updates: deque = deque()
 
+        self.csr_instances = CSRInstances(self.gen_params)
+        DependencyContext.get().add_dependency(CSRInstancesKey(), self.csr_instances)
+
         self.ftq = SimpleTestCircuit(FetchTargetQueue(self.gen_params))
+        self.dut = ModuleConnector(ftq=self.ftq, csr_instances=self.csr_instances)
 
     @def_method_mock(lambda self: self.ftq.stall_guard)
     def stall_guard_mock(self):
@@ -414,7 +430,7 @@ class TestFetchTargetQueueTrain(TestCaseWithSimulator):
             assert update["taken"] == 1
             assert update["mispredict"] == 0
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -425,7 +441,7 @@ class TestFetchTargetQueueTrain(TestCaseWithSimulator):
                 await sim.tick()
             assert len(self.bpu_updates) == 0
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -441,7 +457,7 @@ class TestFetchTargetQueueTrain(TestCaseWithSimulator):
             assert update["taken"] == 1
             assert update["mispredict"] == 0
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)
 
@@ -458,6 +474,6 @@ class TestFetchTargetQueueTrain(TestCaseWithSimulator):
             assert update["taken"] == 1
             assert update["mispredict"] == 1
 
-        with self.run_simulation(self.ftq) as sim:
+        with self.run_simulation(self.dut) as sim:
             sim.add_process(self.auto_bpu_process)
             sim.add_testbench(proc)


### PR DESCRIPTION
Currently, `HPMEvent.BRANCH_MISPREDICTION` is only an approximation of the number of mispredictions. Notably, it doesn't count unpredicted JALRs as mispredictions, while arguably they should be counted towards the total. It is important to tell the difference between a predictor that doesn't predict indirect targets and a predictor that predicts perfectly - the current implementation can't capture this.

I'm moving the counter to the FTQ entirely. It happens to have enough information to accurately track mispredictions. The only drawback is that the counter will be delayed by a few cycles compared to the previous approach.