### PR TITLE
frontend: clean up unsafe stall logic

### DIFF
--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -60,9 +60,6 @@ class FetchUnit(Elaboratable):
     cont: Required[Method]
     """Should be invoked to send fetched instruction to the next step."""
 
-    stall_unsafe: Required[Method]
-    """Called when an unsafe instruction is fetched."""
-
     check_stale: Required[Methods]
     """
     Asks the FTQ whether a fetch request is stale. One instance per stage (1 and 2).
@@ -83,7 +80,6 @@ class FetchUnit(Elaboratable):
         """
         self.gen_params = gen_params
         self.icache = icache
-        self.stall_unsafe = Method()
 
         self.layouts = self.gen_params.get(FetchLayouts)
 
@@ -509,9 +505,6 @@ class FetchUnit(Elaboratable):
                         )
 
             with m.If(~s2_stale):
-                with m.If(fault_any | stall_core):
-                    self.stall_unsafe(m)
-
                 self.fetch_writeback(
                     m,
                     ftq_ptr=ftq_ptr,

--- a/coreblocks/frontend/fetch_addr_unit.py
+++ b/coreblocks/frontend/fetch_addr_unit.py
@@ -21,7 +21,10 @@ class FetchAddressUnit(Elaboratable):
     read: Provided[Method]
     """Consume the current fetch PC. Blocks until a valid PC is available."""
     ifu_redirect: Provided[Method]
-    """Redirect the fetch PC after a misprediction detected by the IFU."""
+    """
+    Redirect the fetch PC after a misprediction detected by the IFU, or - when `pc_valid` is
+    low - invalidate it, because the IFU doesn't know where to fetch next.
+    """
     backend_redirect: Provided[Method]
     """Redirect the fetch PC after a misprediction resolved by the backend."""
 
@@ -33,7 +36,7 @@ class FetchAddressUnit(Elaboratable):
 
         self.write = Method(i=make_layout(fields.pc))
         self.read = Method(o=layouts.fetch_request)
-        self.ifu_redirect = Method(i=layouts.redirect)
+        self.ifu_redirect = Method(i=layouts.ifu_redirect)
         self.backend_redirect = Method(i=layouts.redirect)
 
     def elaborate(self, platform):
@@ -61,9 +64,9 @@ class FetchAddressUnit(Elaboratable):
             return next_fetch_addr_fwd
 
         @def_method(m, self.ifu_redirect)
-        def _(pc):
+        def _(pc, pc_valid):
             m.d.sync += next_fetch_addr.eq(pc)
-            m.d.sync += next_fetch_addr_v.eq(1)
+            m.d.sync += next_fetch_addr_v.eq(pc_valid)
 
         @def_method(m, self.backend_redirect)
         def _(pc):

--- a/coreblocks/frontend/frontend.py
+++ b/coreblocks/frontend/frontend.py
@@ -1,8 +1,11 @@
+from typing import Sequence
+
 from amaranth import *
 
 from transactron.core import *
 from transactron.lib import BasicFifo, Connect, Pipe
-from transactron.utils import assign
+from transactron.utils import assign, logging, popcount, MethodStruct, OneHotMux
+from transactron.utils.assign import AssignArg
 from transactron.utils.dependencies import DependencyContext
 
 from coreblocks.interface.layouts import ExceptionInformationRegisterLayouts
@@ -15,8 +18,10 @@ from coreblocks.frontend.bpu.bpu import BranchPredictionUnit
 from coreblocks.cache.icache import ICache, ICacheBypass
 from coreblocks.cache.refiller import SimpleCommonBusCacheRefiller
 from coreblocks.interface.layouts import *
-from coreblocks.interface.keys import FlushICacheKey, RollbackKey
+from coreblocks.interface.keys import FlushICacheKey, RollbackKey, UnsafeInstructionResolvedKey
 from coreblocks.peripherals.bus_adapter import BusMasterInterface
+
+log = logging.HardwareLogger("frontend")
 
 
 class RollbackTagger(Elaboratable):
@@ -116,6 +121,9 @@ class CoreFrontend(Elaboratable):
         self.consume_instr = Method(o=self.gen_params.get(SchedulerLayouts).scheduler_in)
         self.redirect = Method(i=layouts.backend_redirect)
 
+        self._resume_from_unsafe = Method(i=layouts.backend_redirect)
+        self.connections.add_dependency(UnsafeInstructionResolvedKey(), self._resume_from_unsafe)
+
         self.get_exception_information = Method(o=gen_params.get(ExceptionInformationRegisterLayouts).get)
 
     def elaborate(self, platform):
@@ -130,7 +138,6 @@ class CoreFrontend(Elaboratable):
 
         m.submodules.fetch = self.fetch
         self.fetch.cont.provide(self.instr_buffer.write)
-        self.fetch.stall_unsafe.provide(self.stall_ctrl.stall_unsafe)
         m.submodules.instr_buffer = self.instr_buffer
 
         m.submodules.ftq = self.ftq
@@ -161,7 +168,6 @@ class CoreFrontend(Elaboratable):
         m.submodules.output_pipe = self.output_pipe
 
         m.submodules.stall_ctrl = self.stall_ctrl
-        self.stall_ctrl.redirect_frontend.provide(self.redirect)
         self.stall_ctrl.get_exception_information.provide(self.get_exception_information)
 
         rollback = Method(i=self.gen_params.get(RATLayouts).rollback_in)
@@ -171,10 +177,20 @@ class CoreFrontend(Elaboratable):
         def _(ftq_ptr, pc):
             flush(m)
             self.ftq.backend_redirect(m, ftq_ptr=ftq_ptr, pc=pc)
-            self.stall_ctrl.on_redirect_frontend(m)
 
         @def_method(m, rollback)
         def _(tag, pc, ftq_ptr):
+            self.redirect(m, ftq_ptr=ftq_ptr, pc=pc)
+
+        def resume_combiner(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
+            # Make sure that there is at most one caller - there can be only one unsafe instruction
+            log.assertion(m, popcount(runs) <= 1)
+            return OneHotMux.create(m, [(runs[i], args[i]) for i in range(len(args))])
+
+        @def_method(m, self._resume_from_unsafe, nonexclusive=True, combiner=resume_combiner)
+        def _(ftq_ptr, pc):
+            log.info(m, True, "Unsafe instruction resolved to pc=0x{:x}", pc)
+
             self.redirect(m, ftq_ptr=ftq_ptr, pc=pc)
 
         @def_method(m, flush, nonexclusive=True)

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -99,8 +99,9 @@ class FetchTargetQueue(Elaboratable):
 
     ifu_writeback: Provided[Method]
     """
-    Handle an IFU-detected misprediction/unsafe instruction: flush the BPU and optionally
-    redirect fetch to a new PC.
+    Handle an IFU-detected misprediction/unsafe instruction: flush the BPU and either
+    redirect fetch to a new PC or invalidate the fetch PC, which stalls fetching until the
+    backend resumes it.
     """
     check_stale: Provided[Methods]
     """
@@ -299,8 +300,7 @@ class FetchTargetQueue(Elaboratable):
 
                 evlog.emit(m, FTQRollback.hw(ftq_ptr=ftq_ptr_plus_one, cause="ifu_writeback"))
 
-                with m.If(redirect):
-                    fetch_address_unit.ifu_redirect(m, pc=cfi_target)
+                fetch_address_unit.ifu_redirect(m, pc=cfi_target, pc_valid=redirect)
 
         # Commits arrive in order, so training simply walks the queue behind the commit
         # pointer. An entry is trained once commit moves past it, i.e. once all of its

--- a/coreblocks/frontend/stall_controller.py
+++ b/coreblocks/frontend/stall_controller.py
@@ -1,41 +1,26 @@
-from typing import Sequence
-
 from amaranth import *
 
-from transactron.utils import OneHotMux, logging
+from transactron.utils import logging
 from transactron.lib.metrics import *
-from transactron.utils import popcount, DependencyContext, MethodStruct
-from transactron.utils.assign import AssignArg
+from transactron.utils import DependencyContext
 from transactron import *
 
 from coreblocks.params import *
 from coreblocks.interface.layouts import *
-from coreblocks.interface.keys import CoreStateKey, UnsafeInstructionResolvedKey
+from coreblocks.interface.keys import CoreStateKey
 
 log = logging.HardwareLogger("frontend.stall_ctrl")
 
 
 class StallController(Elaboratable):
     """
-    The stall controller is responsible for managing all stall/unstall signals
-    that may be triggered in the core and based on them deciding if and where
-    the frontend should be resumed.
-    """
-
-    stall_unsafe: Provided[Method]
-    """
-    Signals that the frontend should be stalled because an unsafe (i.e. causing
-    difficult to handle side effects) instruction was just fetched.
+    The stall controller watches for exceptions raised on the speculative path and stalls the
+    frontend until the backend redirects it to the trap handler (or a rollback invalidates the
+    exception and redirects the frontend itself).
     """
 
     stall_guard: Provided[Method]
     """A non-exclusive method whose readiness denotes if the frontend is currently stalled."""
-
-    resume_from_exception: Provided[Method]
-    """Signals that the backend handled the exception and the frontend can be resumed."""
-
-    redirect_frontend: Required[Method]
-    """A method that will be called when the frontend needs to be redirected. Should be always ready."""
 
     get_exception_information: Required[Method]
     """Gets information from `ExceptionInformationRegister`."""
@@ -45,23 +30,13 @@ class StallController(Elaboratable):
     def __init__(self, gen_params: GenParams):
         self.gen_params = gen_params
 
-        self.stall_unsafe = Method()
         self.stall_guard = Method()
 
         self.frontend_flush = Method()
 
-        self.on_redirect_frontend = Method()
-
         self.get_exception_information = Method(o=gen_params.get(ExceptionInformationRegisterLayouts).get)
 
-        layouts = gen_params.get(FetchLayouts)
-
-        self.redirect_frontend = Method(i=layouts.backend_redirect)
-        self._resume_from_unsafe = Method(i=layouts.backend_redirect)
-
         self.dm = DependencyContext.get()
-
-        self.dm.add_dependency(UnsafeInstructionResolvedKey(), self._resume_from_unsafe)
 
     def elaborate(self, platform):
         m = TModule()
@@ -69,12 +44,9 @@ class StallController(Elaboratable):
         with Transaction().always_body(m):
             core_state = self.dm.get_dependency(CoreStateKey())(m)
 
-        # Fetch can be resumed to unstall from 'unsafe' instructions, and stalled because
-        # of exception report, both can happen at any time during normal execution.
-        stalled_unsafe = Signal()
         stalled_exception = Signal()
 
-        @def_method(m, self.stall_guard, ready=~(stalled_unsafe | stalled_exception), nonexclusive=True)
+        @def_method(m, self.stall_guard, ready=~stalled_exception, nonexclusive=True)
         def _():
             pass
 
@@ -93,27 +65,5 @@ class StallController(Elaboratable):
                 # * retirement finished flushing the core - it will also call the redirect
                 log.debug(m, True, "Removing frontend exception stalled state - exception got invalidated")
                 m.d.sync += stalled_exception.eq(0)
-
-        def resume_combiner(m: Module, args: Sequence[MethodStruct], runs: Value) -> AssignArg:
-            # Make sure that there is at most one caller - there can be only one unsafe instruction
-            log.assertion(m, popcount(runs) <= 1)
-            return OneHotMux.create(m, [(runs[i], args[i]) for i in range(len(args))])
-
-        @def_method(m, self._resume_from_unsafe, nonexclusive=True, combiner=resume_combiner)
-        def _(ftq_ptr, pc):
-            log.info(m, True, "Unsafe instruction resolved to pc=0x{:x}", pc)
-
-            self.redirect_frontend(m, ftq_ptr=ftq_ptr, pc=pc)
-
-        @def_method(m, self.stall_unsafe)
-        def _():
-            log.assertion(m, ~stalled_unsafe, "Can't be stalled twice because of an unsafe instruction")
-            log.info(m, True, "Stalling frontend - unsafe instruction")
-            m.d.sync += stalled_unsafe.eq(1)
-
-        @def_method(m, self.on_redirect_frontend)
-        def _():
-            # All redirections change execuction point so clear unsafe state
-            m.d.sync += stalled_unsafe.eq(0)
 
         return m

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -728,6 +728,8 @@ class FetchLayouts:
         to resume (fault or unsafe instruction). Both drop the FTQ entries after ftq_ptr."""
         self.redirect = make_layout(fields.pc)
 
+        self.ifu_redirect = make_layout(fields.pc, ("pc_valid", 1))
+
         # The ftq_ptr points to an FTQ entry such that no newer entries contain instructions that will be
         # (or have already been) committed before the instruction the core is being redirected to.
         self.backend_redirect = make_layout(fields.ftq_ptr, fields.pc)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -258,10 +258,6 @@ class TestFetchUnit(TestCaseWithSimulator):
         if self.output_q:
             return self.output_q[0]
 
-    @def_method_mock(lambda self: self.fetch.stall_unsafe)
-    def stall_guard_unsafe(self):
-        pass
-
     @def_method_mock(lambda self: self.fetch.fetch_writeback)
     def fetch_writeback_mock(self, ftq_ptr, redirect, stall, cfi_idx, cfi_type, cfi_target):
         # Mirror the FTQ: redirect to `cfi_target` when there is a known target,


### PR DESCRIPTION
The stall controller changed a bit recently, and the logic for stalling the frontend on unsafe instructions now looks somewhat redundant to me. This is my attempt to clean it up.

Conceptually, once we hit an unsafe instruction we drop the next PC from the Fetch Address Unit, and the frontend stops producing new fetch blocks until it gets redirected. I believe exception stalls could move to the same approach (no next PC -> stall), but that would probably take more massaging.