### PR TITLE
More double-csrs

### DIFF
--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -561,7 +561,12 @@ class CSRInstances(Elaboratable):
             self.csr_coreblocks_test = CSRRegister(CSRAddress.COREBLOCKS_TEST_CSR, gen_params)
             self.csr_coreblocks_test_exit = CSRRegister(CSRAddress.COREBLOCKS_TEST_EXIT_CSR, gen_params)
 
-        self.time = CSRRegister(None, self.gen_params, width=64)
+        self.time = CSRRegister(
+            None,
+            self.gen_params,
+            width=64,
+            ro_bits=~0,
+        )
         self.time_shadow = DoubleShadowCSR(
             self.gen_params,
             self.time,
@@ -593,7 +598,7 @@ class CSRInstances(Elaboratable):
             m.d.sync += time_source.eq(time_source + 1)
 
         with Transaction().always_body(m):
-            self.time.write(m, data=time_source)
+            self.time.write(m, time_source)
 
         m.submodules.time = self.time
         m.submodules.time_shadow = self.time_shadow

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -565,7 +565,7 @@ class CSRInstances(Elaboratable):
         self.time_shadow = DoubleShadowCSR(
             self.gen_params,
             self.time,
-            None,
+            None,  # the writeable CSR is MMIO register
             None,
             CSRAddress.TIME,
             CSRAddress.TIMEH,

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -259,7 +259,7 @@ class MachineModeCSRRegisters(Elaboratable):
         m = TModule()
 
         for name, value in vars(self).items():
-            if isinstance(value, (CSRRegisterBase, DoubleCounterCSR)):
+            if isinstance(value, (CSRRegisterBase, DoubleCounterCSR, DoubleShadowCSR)):
                 m.submodules[name] = value
 
         with Transaction().always_body(m):
@@ -543,7 +543,7 @@ class SupervisorModeCSRRegisters(Elaboratable):
         m = TModule()
 
         for name, value in vars(self).items():
-            if isinstance(value, (CSRRegisterBase, DoubleCounterCSR)):
+            if isinstance(value, (CSRRegisterBase, DoubleCounterCSR, DoubleShadowCSR)):
                 m.submodules[name] = value
 
         return m

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -23,6 +23,7 @@ from coreblocks.priv.csr.aliased import AliasedCSR
 from coreblocks.priv.csr.csr_register import CSRRegister, CSRRegisterBase
 from coreblocks.priv.csr.double_counter import DoubleCounterCSR
 from coreblocks.priv.csr.shadow import ShadowCSR
+from coreblocks.priv.csr.double_shadow import DoubleShadowCSR
 from coreblocks.socks.clint import ClintMtimeKey
 from coreblocks.interface.keys import CSRInstancesKey
 from typing import Optional
@@ -73,16 +74,23 @@ class MachineModeCSRRegisters(Elaboratable):
         self.mscratch = CSRRegister(CSRAddress.MSCRATCH, gen_params)
         self.mconfigptr = CSRRegister(CSRAddress.MCONFIGPTR, gen_params, init=0)
 
-        self.mstatus = AliasedCSR(CSRAddress.MSTATUS, gen_params)
-        self.mstatush = None
-        if gen_params.isa.xlen == 32:
-            self.mstatush = AliasedCSR(CSRAddress.MSTATUSH, gen_params)
+        self.mstatus = AliasedCSR(None, gen_params, width=64)
+        self.mstatus_shadow = DoubleShadowCSR(
+            gen_params,
+            self.mstatus,
+            CSRAddress.MSTATUS,
+            CSRAddress.MSTATUSH,
+        )
 
-        self.menvcfg = self.menvcfgh = None
+        self.menvcfg = None
         if gen_params.user_mode:
-            self.menvcfg = AliasedCSR(CSRAddress.MENVCFG, gen_params)
-            if gen_params.isa.xlen == 32:
-                self.menvcfgh = AliasedCSR(CSRAddress.MENVCFGH, gen_params)
+            self.menvcfg = AliasedCSR(None, gen_params, width=64)
+            self.menvcfg_shadow = DoubleShadowCSR(
+                gen_params,
+                self.menvcfg,
+                CSRAddress.MENVCFG,
+                CSRAddress.MENVCFGH,
+            )
 
         self.mcause = CSRRegister(CSRAddress.MCAUSE, gen_params)
         # CY/TM/IR bits are writable, unsupported HPM bits are read-only zero.
@@ -218,8 +226,8 @@ class MachineModeCSRRegisters(Elaboratable):
             self.priv_mode_public = AliasedCSR(CSRAddress.COREBLOCKS_TEST_PRIV_MODE, gen_params)
             self.priv_mode_public.add_field(0, self.priv_mode)
 
-        self._mstatus_fields_implementation(gen_params, self.mstatus, self.mstatush)
-        self._menvcfg_fields_implementation(gen_params, self.menvcfg, self.menvcfgh)
+        self._mstatus_fields_implementation(gen_params, self.mstatus)
+        self._menvcfg_fields_implementation(gen_params, self.menvcfg)
         self._mtvec_fields_implementation(gen_params, self.mtvec)
 
         self.hpm_counters_count = gen_params.hpm_counters_count
@@ -275,9 +283,7 @@ class MachineModeCSRRegisters(Elaboratable):
 
         return m
 
-    def _menvcfg_fields_implementation(
-        self, gen_params: GenParams, menvcfg: Optional[AliasedCSR], menvcfgh: Optional[AliasedCSR]
-    ):
+    def _menvcfg_fields_implementation(self, gen_params: GenParams, menvcfg: Optional[AliasedCSR]):
         self.menvcfg_fiom = None
         if menvcfg is None:
             return
@@ -306,7 +312,6 @@ class MachineModeCSRRegisters(Elaboratable):
         self,
         gen_params: GenParams,
         mstatus: AliasedCSR,
-        mstatush: Optional[AliasedCSR],
     ):
         def filter_legal_priv_mode(m: TModule, v: Value):
             legal = Signal(1)
@@ -354,13 +359,8 @@ class MachineModeCSRRegisters(Elaboratable):
 
         # Little-endianness
         mstatus.add_read_only_field(MstatusFieldOffsets.UBE, 1, 0)
-        if gen_params.isa.xlen == 32:
-            assert mstatush
-            mstatush.add_read_only_field(MstatusFieldOffsets.SBE - mstatus.width, 1, 0)
-            mstatush.add_read_only_field(MstatusFieldOffsets.MBE - mstatus.width, 1, 0)
-        elif gen_params.isa.xlen == 64:
-            mstatus.add_read_only_field(MstatusFieldOffsets.SBE, 1, 0)
-            mstatus.add_read_only_field(MstatusFieldOffsets.MBE, 1, 0)
+        mstatus.add_read_only_field(MstatusFieldOffsets.SBE, 1, 0)
+        mstatus.add_read_only_field(MstatusFieldOffsets.MBE, 1, 0)
 
         self.mstatus_mprv = CSRRegister(None, gen_params, width=1, ro_bits=0 if gen_params.user_mode else 1)
         mstatus.add_field(MstatusFieldOffsets.MPRV, self.mstatus_mprv)
@@ -404,7 +404,7 @@ class MachineModeCSRRegisters(Elaboratable):
         mstatus.add_read_only_field(MstatusFieldOffsets.XS, 2, 0)
         # SD field - set to one when one of the states is dirty
         mstatus.add_read_only_field(
-            MstatusFieldOffsets.SD % mstatus.width,  # SD is last bit of `mstatus` (depends on xlen)
+            MstatusFieldOffsets.SD % gen_params.isa.xlen,  # SD is last bit of `mstatus` (depends on xlen)
             1,
             Extension.V in gen_params.isa.extensions or Extension.F in gen_params.isa.extensions,
         )
@@ -561,17 +561,16 @@ class CSRInstances(Elaboratable):
             self.csr_coreblocks_test = CSRRegister(CSRAddress.COREBLOCKS_TEST_CSR, gen_params)
             self.csr_coreblocks_test_exit = CSRRegister(CSRAddress.COREBLOCKS_TEST_EXIT_CSR, gen_params)
 
-        self.time = CSRRegister(
-            CSRAddress.TIME,
+        self.time = CSRRegister(None, self.gen_params, width=64)
+        self.time_shadow = DoubleShadowCSR(
             self.gen_params,
-            fu_access_filter=counteren_access_filter(self.gen_params, CounterEnableFieldOffsets.TM),
+            self.time,
+            None,
+            None,
+            CSRAddress.TIME,
+            CSRAddress.TIMEH,
+            shadow_access_filter=counteren_access_filter(self.gen_params, CounterEnableFieldOffsets.TM),
         )
-        if gen_params.isa.xlen == 32:
-            self.timeh = CSRRegister(
-                CSRAddress.TIMEH,
-                self.gen_params,
-                fu_access_filter=counteren_access_filter(self.gen_params, CounterEnableFieldOffsets.TM),
-            )
 
     def elaborate(self, platform):
         m = TModule()
@@ -587,19 +586,17 @@ class CSRInstances(Elaboratable):
         # TIME CSR is a R/O alias to Memory-Mapped `mtime` value (from clint). If `mtime` is not available,
         # then fallback to providing a cycle counter source.
         clint_mtime = DependencyContext.get().get_optional_dependency(ClintMtimeKey())
-        time_counter = Signal(64)
-        m.d.sync += time_counter.eq(time_counter + 1)
-        time_source = time_counter if clint_mtime is None else clint_mtime
+        if clint_mtime is not None:
+            time_source = clint_mtime
+        else:
+            time_source = Signal(64)
+            m.d.sync += time_source.eq(time_source + 1)
 
         with Transaction().always_body(m):
-            if clint_mtime is not None:
-                self.time.write(m, data=time_source[: self.time.width])
-                if self.gen_params.isa.xlen == 32:
-                    self.timeh.write(m, data=time_source[self.time.width :])
+            self.time.write(m, data=time_source)
 
         m.submodules.time = self.time
-        if self.gen_params.isa.xlen == 32:
-            m.submodules.timeh = self.timeh
+        m.submodules.time_shadow = self.time_shadow
 
         with Transaction().always_body(m):
             priv_mode = self.m_mode.priv_mode.read(m).data

--- a/coreblocks/priv/csr/csr_register.py
+++ b/coreblocks/priv/csr/csr_register.py
@@ -109,11 +109,11 @@ class CSRRegister(CSRRegisterBase):
         # Timer register that increments on each cycle and resets if read by CSR instruction
         csr = CSRRegister(1, gen_params)
         with Transaction().body(m):
-            csr_val = csr.read()
+            csr_val = csr.read(m)
             with m.If(csr_val.read):
-                csr.write(0)
+                csr.write(m, 0)
             with m.Else():
-                csr.write(csr_val.data + 1)
+                csr.write(m, csr_val.data + 1)
     """
 
     def __init__(
@@ -228,7 +228,7 @@ class CSRRegister(CSRRegisterBase):
     def elaborate(self, platform):
         m = TModule()
 
-        internal_method_layout = StructLayout({"data": self.gen_params.isa.xlen, "active": 1})
+        internal_method_layout = StructLayout({"data": self.width, "active": 1})
         write_internal = Signal(internal_method_layout)
         fu_write_internal = Signal(internal_method_layout)
 

--- a/coreblocks/priv/csr/double_shadow.py
+++ b/coreblocks/priv/csr/double_shadow.py
@@ -3,7 +3,7 @@ from typing import Optional
 from amaranth import *
 from amaranth_types import ValueLike
 
-from transactron.core import Method, TModule
+from transactron.core import TModule
 from transactron.utils import get_src_loc, SrcLoc
 
 from coreblocks.arch import CSRAddress
@@ -57,8 +57,6 @@ class DoubleShadowCSR(Elaboratable):
 
         self.gen_params = gen_params
 
-        self.increment = Method()
-
         self.src_loc = get_src_loc(src_loc)
 
         self.register_low = self.register_high = None
@@ -66,7 +64,11 @@ class DoubleShadowCSR(Elaboratable):
 
         if low_addr is not None:
             self.register_low = ShadowCSR(
-                low_addr, gen_params, shadowed, width=gen_params.isa.xlen, offset=0, src_loc=self.src_loc
+                low_addr,
+                gen_params,
+                shadowed,
+                offset=0,
+                src_loc=self.src_loc,
             )
 
         if high_addr is not None and gen_params.isa.xlen == 32:
@@ -74,8 +76,7 @@ class DoubleShadowCSR(Elaboratable):
                 high_addr,
                 gen_params,
                 shadowed,
-                width=gen_params.isa.xlen,
-                offset=gen_params.isa.xlen,
+                offset=32,
                 src_loc=self.src_loc,
             )
 
@@ -84,7 +85,6 @@ class DoubleShadowCSR(Elaboratable):
                 shadow_low_addr,
                 gen_params,
                 shadowed,
-                width=gen_params.isa.xlen,
                 offset=0,
                 write_mask=0,
                 access_filter=shadow_access_filter,
@@ -96,8 +96,7 @@ class DoubleShadowCSR(Elaboratable):
                 shadow_high_addr,
                 gen_params,
                 shadowed,
-                width=gen_params.isa.xlen,
-                offset=gen_params.isa.xlen,
+                offset=32,
                 write_mask=0,
                 access_filter=shadow_access_filter,
                 src_loc=self.src_loc,

--- a/coreblocks/priv/csr/double_shadow.py
+++ b/coreblocks/priv/csr/double_shadow.py
@@ -4,7 +4,7 @@ from amaranth import *
 from amaranth_types import ValueLike
 
 from transactron.core import Method, TModule
-from transactron.utils import get_src_loc
+from transactron.utils import get_src_loc, SrcLoc
 
 from coreblocks.arch import CSRAddress
 from coreblocks.params.genparams import GenParams
@@ -30,6 +30,7 @@ class DoubleShadowCSR(Elaboratable):
         shadow_low_addr: Optional[CSRAddress] = None,
         shadow_high_addr: Optional[CSRAddress] = None,
         shadow_access_filter: Optional[Callable[[TModule, Value], ValueLike]] = None,
+        src_loc: SrcLoc | int = 0,
     ):
         """
         Parameters
@@ -52,42 +53,62 @@ class DoubleShadowCSR(Elaboratable):
         """
         assert (low_addr is None) == (high_addr is None)
         assert (shadow_low_addr is None) == (shadow_high_addr is None)
+        assert shadowed.width == 64
 
         self.gen_params = gen_params
 
         self.increment = Method()
 
-        self.register_low = ShadowCSR(low_addr, gen_params, shadowed, width=gen_params.isa.xlen)
-        self.register_high = (
-            ShadowCSR(high_addr, gen_params, shadowed, width=gen_params.isa.xlen, offset=gen_params.isa.xlen)
-            if gen_params.isa.xlen == 32
-            else None
-        )
+        self.src_loc = get_src_loc(src_loc)
 
+        self.register_low = self.register_high = None
         self.shadow_low = self.shadow_high = None
+
+        if low_addr is not None:
+            self.register_low = ShadowCSR(
+                low_addr, gen_params, shadowed, width=gen_params.isa.xlen, offset=0, src_loc=self.src_loc
+            )
+
+        if high_addr is not None and gen_params.isa.xlen == 32:
+            self.register_high = ShadowCSR(
+                high_addr,
+                gen_params,
+                shadowed,
+                width=gen_params.isa.xlen,
+                offset=gen_params.isa.xlen,
+                src_loc=self.src_loc,
+            )
+
         if shadow_low_addr is not None:
             self.shadow_low = ShadowCSR(
                 shadow_low_addr,
                 gen_params,
-                self.register_low,
+                shadowed,
+                width=gen_params.isa.xlen,
+                offset=0,
                 write_mask=0,
                 access_filter=shadow_access_filter,
-                src_loc=get_src_loc(1),
+                src_loc=self.src_loc,
             )
-            if self.register_high is not None:
-                self.shadow_high = ShadowCSR(
-                    shadow_high_addr,
-                    gen_params,
-                    self.register_high,
-                    write_mask=0,
-                    access_filter=shadow_access_filter,
-                    src_loc=get_src_loc(1),
-                )
+
+        if shadow_high_addr is not None and gen_params.isa.xlen == 32:
+            self.shadow_high = ShadowCSR(
+                shadow_high_addr,
+                gen_params,
+                shadowed,
+                width=gen_params.isa.xlen,
+                offset=gen_params.isa.xlen,
+                write_mask=0,
+                access_filter=shadow_access_filter,
+                src_loc=self.src_loc,
+            )
 
     def elaborate(self, platform):
         m = TModule()
 
-        m.submodules.register_low = self.register_low
+        if self.register_low is not None:
+            m.submodules.register_low = self.register_low
+
         if self.register_high is not None:
             m.submodules.register_high = self.register_high
 

--- a/coreblocks/socks/clint.py
+++ b/coreblocks/socks/clint.py
@@ -68,8 +68,10 @@ class ClintPeriph(Component, SocksPeripheral):
             m.d.comb += self.bus.ack.eq(0)
 
         for hart in range(self.hart_count):
-            gen_memory_mapped_register(m, self, self.msip_offset + self.ipi_width * hart, self.ipi[hart])
-            gen_memory_mapped_register(m, self, self.mtimecmp_offset + self.time_width * hart, self.mtimecmp[hart])
+            gen_memory_mapped_register(m, self, self.msip_offset + (self.ipi_width // 8) * hart, self.ipi[hart])
+            gen_memory_mapped_register(
+                m, self, self.mtimecmp_offset + (self.time_width // 8) * hart, self.mtimecmp[hart]
+            )
 
         gen_memory_mapped_register(m, self, self.mtime_offset, self.mtime)
 


### PR DESCRIPTION
final (?) double-csr migration.

Fixed/added:
- double shadow being able to be specified without writeable shadows
- fixed `CSRRegister().write` and `CSRRegister()._fu_write` stripping upper bits (higher than XLEN) - this was effecting all counters, but other than that every other CSR only had (currently) constant bits in the upper 32 bits. Technically this was OK, as hpm counters are not required to have full 64 bit width
- fixed address calculation of CLINT fields for multi-hart systems