### PR TITLE
implement Sstc

### DIFF
--- a/coreblocks/arch/csr_address.py
+++ b/coreblocks/arch/csr_address.py
@@ -110,6 +110,10 @@ class CSRAddress(IntEnum, shape=12):
     # Supervisor Protection and Translation
     SATP = 0x180  # Supervisor address translation and protection
 
+    # Supervisor Timer Compare
+    STIMECMP = 0x14D  # Supervisor timer compare
+    STIMECMPH = 0x15D  # Upper 32 bits of `stimecmp`, RV32 only
+
     # Debug/Trace Registers
     SCONTEXT = 0x5A8  # Supervisor-mode context register
 

--- a/coreblocks/params/core_configuration.py
+++ b/coreblocks/params/core_configuration.py
@@ -117,6 +117,8 @@ class _CoreConfigurationDataClass:
         Enable User Mode.
     supervisor_mode: bool
         Enable Supervisor Mode.
+    sstc: bool
+        Enable Supervisor Mode Timer Counter (SSTC) extension. (only apllicable if supervisor_mode is enabled)
     asidlen: int
         Number of writable ASID bits in SATP.
     supported_vm_schemes: Collection[SatpMode]
@@ -124,8 +126,6 @@ class _CoreConfigurationDataClass:
     phys_addr_bits: int | None
         Width of physical addresses in bits. If not set, defaults to 34 for RV32 if supported_vm_schemes has
         SV32 enabled, 32 for RV32 with only BARE mode and 56 for RV64.
-    sstc: bool
-        Enable Supervisor Mode Timer Counter (SSTC) extension. (only apllicable if supervisor_mode is enabled)
     hpm_counters_count: int
         Number of implemented HPM counters (mhpmcounter3..mhpmcounter31).
     tlb_config: TLBCacheConfiguration
@@ -198,11 +198,11 @@ class _CoreConfigurationDataClass:
     user_mode: bool = True
     supervisor_mode: bool = True
 
+    sstc: bool = True
+
     asidlen: int | None = None
     supported_vm_schemes: Collection[SatpMode] = (SatpMode.BARE, SatpMode.SV32)
     phys_addr_bits: int | None = None
-
-    sstc: bool = True
 
     hpm_counters_count: int = 0
 

--- a/coreblocks/params/core_configuration.py
+++ b/coreblocks/params/core_configuration.py
@@ -124,6 +124,8 @@ class _CoreConfigurationDataClass:
     phys_addr_bits: int | None
         Width of physical addresses in bits. If not set, defaults to 34 for RV32 if supported_vm_schemes has
         SV32 enabled, 32 for RV32 with only BARE mode and 56 for RV64.
+    sstc: bool
+        Enable Supervisor Mode Timer Counter (SSTC) extension. (only apllicable if supervisor_mode is enabled)
     hpm_counters_count: int
         Number of implemented HPM counters (mhpmcounter3..mhpmcounter31).
     tlb_config: TLBCacheConfiguration
@@ -199,6 +201,9 @@ class _CoreConfigurationDataClass:
     asidlen: int | None = None
     supported_vm_schemes: Collection[SatpMode] = (SatpMode.BARE, SatpMode.SV32)
     phys_addr_bits: int | None = None
+
+    sstc: bool = True
+
     hpm_counters_count: int = 0
 
     tlb_config: TLBCacheConfiguration = TLBCacheConfiguration()

--- a/coreblocks/params/genparams.py
+++ b/coreblocks/params/genparams.py
@@ -129,6 +129,7 @@ class GenParams(DependentCache):
 
         self.user_mode = cfg.user_mode
         self.supervisor_mode = cfg.supervisor_mode
+        self.sstc = cfg.sstc and self.supervisor_mode
         self.hpm_counters_count = cfg.hpm_counters_count
 
         self.tlb_config = cfg.tlb_config

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -285,12 +285,15 @@ class MachineModeCSRRegisters(Elaboratable):
 
     def _menvcfg_fields_implementation(self, gen_params: GenParams, menvcfg: Optional[AliasedCSR]):
         self.menvcfg_fiom = None
+        self.menvcfg_stce = None
         if menvcfg is None:
             return
 
         fiom_ro = gen_params.vmem_params.supported_schemes == {SatpMode.BARE}
         self.menvcfg_fiom = CSRRegister(None, gen_params, width=1, ro_bits=1 if fiom_ro else 0)
         menvcfg.add_field(MenvcfgFieldOffsets.FIOM, self.menvcfg_fiom)
+        self.menvcfg_stce = CSRRegister(None, gen_params, width=1, ro_bits=1 if not gen_params.sstc else 0)
+        menvcfg.add_field(MenvcfgFieldOffsets.STCE, self.menvcfg_stce)
 
     def _mtvec_fields_implementation(self, gen_params: GenParams, mtvec: AliasedCSR):
         def filter_legal_mode(m: TModule, v: Value):

--- a/coreblocks/priv/traps/interrupt_controller.py
+++ b/coreblocks/priv/traps/interrupt_controller.py
@@ -76,7 +76,8 @@ class InternalInterruptController(Component):
         self.level_interrupts = Signal(self.gen_params.isa.xlen)
         self.new_edge_interrupts = Signal(self.gen_params.isa.xlen)
 
-        self.m_mode_csr = m_mode_csr = self.dm.get_dependency(CSRInstancesKey()).m_mode
+        self.csr_instances = self.dm.get_dependency(CSRInstancesKey())
+        self.m_mode_csr = m_mode_csr = self.csr_instances.m_mode
         self.mstatus_mie = m_mode_csr.mstatus_mie
         self.mstatus_mpie = m_mode_csr.mstatus_mpie
         self.mstatus_mpp = m_mode_csr.mstatus_mpp
@@ -99,7 +100,7 @@ class InternalInterruptController(Component):
         self.mip_writeable = self.mie_writeable & self.edge_reported_mask
 
         if gen_params.supervisor_mode:
-            # mip_stip_no_stimecmp_acc
+            # mip_stip_no_stimecmp_acc / mip_stip_stimecmp_acc (with sstc the STI gets overwritten by stimecmp logic)
             # mip_ssip_acc
             # mip_seip_acc
             self.mip_writeable |= (
@@ -190,6 +191,20 @@ class InternalInterruptController(Component):
                 write_mask=self.sip_write_mask.method,
             )
 
+            if gen_params.sstc:
+
+                def stimecmp_access_filter(m, arg):
+                    assert m_mode_csr.menvcfg_stce
+                    priv = m_mode_csr.priv_mode.read(m).data
+                    stce = m_mode_csr.menvcfg_stce.read(m).data
+                    mcounteren_tm = m_mode_csr.mcounteren.read(m).data[1]
+                    return (priv == PrivilegeLevel.MACHINE) | (stce & mcounteren_tm)
+
+                self.stimecmp = CSRRegister(None, gen_params, width=64, fu_access_filter=stimecmp_access_filter)
+                self.stimecmp_shadow = DoubleShadowCSR(
+                    gen_params, self.stimecmp, CSRAddress.STIMECMP, CSRAddress.STIMECMPH
+                )
+
         self.interrupt_insert = Signal()
         self.dm.add_dependency(AsyncInterruptInsertSignalKey(), self.interrupt_insert)
 
@@ -218,7 +233,10 @@ class InternalInterruptController(Component):
         if self.gen_params.supervisor_mode:
             m.submodules += [self.sie, self.sip, self.mideleg, self.medeleg, self.medeleg_shadow, self.sip_write_mask]
 
-        priv_mode = self.dm.get_dependency(CSRInstancesKey()).m_mode.priv_mode
+        if self.gen_params.sstc:
+            m.submodules += [self.stimecmp, self.stimecmp_shadow]
+
+        priv_mode = self.m_mode_csr.priv_mode
 
         interrupt_enable_m = Signal()
         interrupt_enable_s = Signal()
@@ -231,6 +249,7 @@ class InternalInterruptController(Component):
             self.internal_report_level,
             self.custom_report,
         )
+
         for i in range(ISA_RESERVED_INTERRUPTS + self.gen_params.interrupt_custom_count):
             if self.edge_reported_mask & (1 << i):
                 m.d.comb += self.new_edge_interrupts[i].eq(all_interrupts[i])
@@ -289,6 +308,14 @@ class InternalInterruptController(Component):
             mip_value = self.mip.read_comb(m).data
             new_data = Signal(self.gen_params.isa.xlen)
             m.d.av_comb += new_data.eq(mip_value | self.new_edge_interrupts)
+
+            if self.gen_params.sstc:
+                stce = self.m_mode_csr.menvcfg_stce.read(m).data
+                stimecmp = self.stimecmp.read(m).data
+                time = self.csr_instances.time.read(m).data
+                with m.If(stce):
+                    m.d.av_comb += new_data[InterruptCauseNumber.STI].eq(time >= stimecmp)
+
             self.mip.write(m, {"data": new_data})
 
         @def_method(m, self.mret)

--- a/coreblocks/priv/traps/interrupt_controller.py
+++ b/coreblocks/priv/traps/interrupt_controller.py
@@ -305,7 +305,7 @@ class InternalInterruptController(Component):
         m.d.comb += self.wfi_resume.eq(interrupt_pending)
 
         with Transaction().always_body(m):
-            mip_value = self.mip.read_comb(m).data & ~self.mip.ro_bits
+            mip_value = (self.mip.read_comb(m).data & ~self.mip.ro_bits) | (self.mip.read(m).data & self.mip.ro_bits)
             new_data = Signal(self.gen_params.isa.xlen)
             m.d.av_comb += new_data.eq(mip_value | self.new_edge_interrupts)
 

--- a/coreblocks/priv/traps/interrupt_controller.py
+++ b/coreblocks/priv/traps/interrupt_controller.py
@@ -305,7 +305,7 @@ class InternalInterruptController(Component):
         m.d.comb += self.wfi_resume.eq(interrupt_pending)
 
         with Transaction().always_body(m):
-            mip_value = self.mip.read_comb(m).data
+            mip_value = self.mip.read_comb(m).data & ~self.mip.ro_bits
             new_data = Signal(self.gen_params.isa.xlen)
             m.d.av_comb += new_data.eq(mip_value | self.new_edge_interrupts)
 

--- a/coreblocks/priv/traps/interrupt_controller.py
+++ b/coreblocks/priv/traps/interrupt_controller.py
@@ -310,6 +310,7 @@ class InternalInterruptController(Component):
             m.d.av_comb += new_data.eq(mip_value | self.new_edge_interrupts)
 
             if self.gen_params.sstc:
+                assert self.m_mode_csr.menvcfg_stce is not None
                 stce = self.m_mode_csr.menvcfg_stce.read(m).data
                 stimecmp = self.stimecmp.read(m).data
                 time = self.csr_instances.time.read(m).data

--- a/test/external/riscv-arch-test/coreblocks/coreblocks-full/coreblocks.yaml
+++ b/test/external/riscv-arch-test/coreblocks/coreblocks-full/coreblocks.yaml
@@ -30,6 +30,7 @@ implemented_extensions:
   - { name: Sm, version: "= 1.13.0" }
   - { name: Zihpm, version: "= 2.0.0" }
   - { name: Sscounterenw, version: "= 1.0.0" }
+  - { name: Sstc, version: "= 1.0.0" }
   - { name: Sstvala, version: "= 1.0.0" }
   - { name: Sstvecd, version: "= 1.0.0" }
   - { name: Sstvecv, version: "= 1.0.0" }

--- a/test/external/riscv-arch-test/coreblocks/coreblocks-full/sail.json
+++ b/test/external/riscv-arch-test/coreblocks/coreblocks-full/sail.json
@@ -640,7 +640,7 @@
       "supported": true
     },
     "Sstc": {
-      "supported": false
+      "supported": true
     },
     "Sstvala": {
       "supported": true


### PR DESCRIPTION
implements Sstc extension (supervisor counter compare)

It allows for better OS support (no M-mode in the hot-path of the OS). It also is nicely supported in the riscv-arch-test.

Contains a bonus fix for:
```asm
li x1, -1
csrs mip, x1
```
writing to the read only bits, because of the `read_comb`+`write` combo used to set edge triggered bits didn't account for `read_comb` not being masked by `ro_bits`