### PR TITLE
fix misa CSR value calculation

### DIFF
--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -413,7 +413,7 @@ class MachineModeCSRRegisters(Elaboratable):
         misa_ext = MisaExtension(0)
 
         for ext in gen_params.isa.extensions:
-            if ext.name in MisaExtension:
+            if ext.name in dir(MisaExtension):
                 misa_ext |= MisaExtension[ext.name]
 
         if gen_params.supervisor_mode:

--- a/coreblocks/priv/csr/csr_instances.py
+++ b/coreblocks/priv/csr/csr_instances.py
@@ -413,7 +413,7 @@ class MachineModeCSRRegisters(Elaboratable):
         misa_ext = MisaExtension(0)
 
         for ext in gen_params.isa.extensions:
-            if ext.name in dir(MisaExtension):
+            if ext.name in MisaExtension.__members__:
                 misa_ext |= MisaExtension[ext.name]
 
         if gen_params.supervisor_mode:

--- a/test/asm/csr_mmode.asm
+++ b/test/asm/csr_mmode.asm
@@ -6,6 +6,13 @@
     beq x6, x7, next
     nop
 next:
+    # I is present in misa, Y (reserved) is not
+    csrr x1, misa
+    li x2, (1 << 8) | (1 << 24)
+    and x1, x1, x2
+    li x2, (1 << 8)
+    bne x1, x2, fail
+
     # test read-only CSRs
     csrw mvendorid, 1
     csrw marchid, 1
@@ -23,6 +30,9 @@ next:
 pass:
     csrw 0x8fe, 0x10
     j pass
+fail:
+    csrw 0x8fe, 0x12
+    j .
 
 exception_handler:
    addi x15, x15, -1 # count exceptions


### PR DESCRIPTION
`misa` register had value 0x0, as `list(MisaExtension)` doesn't iterate names, but values