### PR TITLE
regression: separate memory segment descriptions from their emulation

### DIFF
--- a/test/regression/benchmark.py
+++ b/test/regression/benchmark.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from pathlib import Path
@@ -38,7 +39,7 @@ class BenchmarkResult:
     metric_values: dict[str, dict[str, int]]
 
 
-class MMIO(RandomAccessMemory):
+class MMIO(MMIOSegment):
     """Memory Mapped IO.
 
     The structure of the MMIO is as follows:
@@ -54,30 +55,32 @@ class MMIO(RandomAccessMemory):
     COUNTERS_OFFSET = 0x10
 
     def __init__(self, on_finish: Callable[[], None]):
-        super().__init__(
-            range(0xF0000000, 0xF0000000 + MMIO.SIZE), SegmentFlags.READ | SegmentFlags.WRITE, b"\x00" * MMIO.SIZE
-        )
+        super().__init__(range(0xF0000000, 0xF0000000 + MMIO.SIZE), SegmentFlags.READ | SegmentFlags.WRITE)
         self.on_finish = on_finish
+        self.registers = RandomAccessMemoryEmulation(b"\x00" * MMIO.SIZE)
+
+    def read(self, req: ReadRequest) -> ReadReply:
+        return self.registers.read(req)
 
     def write(self, req: WriteRequest) -> WriteReply:
         if req.addr == 0x0:
             self.on_finish()
             return WriteReply()
         else:
-            return super().write(req)
+            return self.registers.write(req)
 
     def _counter(self, index: int) -> int:
         offset = MMIO.COUNTERS_OFFSET + 8 * index
-        return int.from_bytes(self.data[offset : offset + 8], "little")
+        return int.from_bytes(self.registers.data[offset : offset + 8], "little")
 
     def return_code(self):
-        return int.from_bytes(self.data[4:8], "little", signed=True)
+        return int.from_bytes(self.registers.data[4:8], "little", signed=True)
 
     def mcause(self):
-        return int.from_bytes(self.data[8:12], "little")
+        return int.from_bytes(self.registers.data[8:12], "little")
 
     def mepc(self):
-        return int.from_bytes(self.data[12:16], "little")
+        return int.from_bytes(self.registers.data[12:16], "little")
 
     def cycle_cnt(self):
         return self._counter(0)

--- a/test/regression/benchmark.py
+++ b/test/regression/benchmark.py
@@ -5,6 +5,7 @@ from dataclasses_json import dataclass_json
 from pathlib import Path
 
 from .memory import *
+from .memory_emulation import RAMEmulation
 from .common import SimulationBackend
 
 from coreblocks.arch import ExceptionCause
@@ -57,7 +58,7 @@ class MMIO(MMIOSegment):
     def __init__(self, on_finish: Callable[[], None]):
         super().__init__(range(0xF0000000, 0xF0000000 + MMIO.SIZE), SegmentFlags.READ | SegmentFlags.WRITE)
         self.on_finish = on_finish
-        self.registers = RandomAccessMemoryEmulation(b"\x00" * MMIO.SIZE)
+        self.registers = RAMEmulation(b"\x00" * MMIO.SIZE)
 
     def read(self, req: ReadRequest) -> ReadReply:
         return self.registers.read(req)

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -2,8 +2,8 @@ from decimal import Decimal
 import inspect
 import re
 import os
-from typing import Any
-from collections.abc import Coroutine
+from typing import Any, Optional
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from pathlib import Path
 from filelock import FileLock
@@ -78,12 +78,19 @@ class WishboneBus(Bus):
 
 class WishboneSlave:
     def __init__(
-        self, entity, name: str, clock, model: CoreMemoryModel, is_instr_bus: bool, word_bits: int = 2, delay: int = 0
+        self,
+        entity,
+        name: str,
+        clock,
+        memory: CoreMemoryEmulation,
+        is_instr_bus: bool,
+        word_bits: int = 2,
+        delay: int = 0,
     ):
         self.entity = entity
         self.name = name
         self.clock = clock
-        self.model = model
+        self.memory = memory
         self.is_instr_bus = is_instr_bus
         self.word_size = 2**word_bits
         self.word_bits = word_bits
@@ -105,7 +112,7 @@ class WishboneSlave:
 
             sig_s = WishboneSlaveSignals()
             if sig_m.we:
-                resp = self.model.write(
+                resp = self.memory.write(
                     WriteRequest(
                         addr=addr,
                         data=sig_m.dat_w,
@@ -114,7 +121,7 @@ class WishboneSlave:
                     )
                 )
             else:
-                resp = self.model.read(
+                resp = self.memory.read(
                     ReadRequest(
                         addr=addr,
                         byte_count=self.word_size,
@@ -272,10 +279,12 @@ class CocotbSimulation(SimulationBackend):
         await Timer(Decimal(1), "ns")
         self.dut.rst.value = 0
 
-        instr_wb = WishboneSlave(self.dut, "wb_instr", self.dut.clk, mem_model, is_instr_bus=True)
+        memory = CoreMemoryEmulation(mem_model)
+
+        instr_wb = WishboneSlave(self.dut, "wb_instr", self.dut.clk, memory, is_instr_bus=True)
         cocotb.start_soon(instr_wb.start())
 
-        data_wb = WishboneSlave(self.dut, "wb_data", self.dut.clk, mem_model, is_instr_bus=False)
+        data_wb = WishboneSlave(self.dut, "wb_data", self.dut.clk, memory, is_instr_bus=False)
         cocotb.start_soon(data_wb.start())
 
         if get_interrupt_value is not None:

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -21,6 +21,7 @@ from cocotb_bus.bus import Bus
 from cocotb.result import SimTimeoutError
 
 from .memory import *
+from .memory_emulation import CoreMemoryEmulation
 from .common import SimulationBackend, SimulationExecutionResult, START_PC
 
 from transactron.evlog import EventLog, GeneratedEvLogSampler, SignalHandle, SignalReader

--- a/test/regression/common.py
+++ b/test/regression/common.py
@@ -31,6 +31,7 @@ class SimulationExecutionResult:
 class SimulationBackend(ABC):
     @abstractmethod
     async def run(self, mem_model: CoreMemoryModel, timeout_cycles: int) -> SimulationExecutionResult:
+        """Runs a program, described by the memory model it is loaded into."""
         raise NotImplementedError
 
     @abstractmethod

--- a/test/regression/memory.py
+++ b/test/regression/memory.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
-from collections.abc import Callable
 from enum import Enum, IntFlag, auto
-from typing import Optional, TypeVar
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from elftools.elf.constants import P_FLAGS
 from elftools.elf.elffile import ELFFile, Segment
+
 from coreblocks.params.configurations import CoreConfiguration
 from transactron.utils import align_to_power_of_two, align_down_to_power_of_two
 
@@ -15,13 +14,10 @@ __all__ = [
     "ReadReply",
     "WriteRequest",
     "WriteReply",
-    "MemoryEmulation",
     "MemorySegment",
     "RandomAccessMemory",
-    "RandomAccessMemoryEmulation",
     "MMIOSegment",
     "CoreMemoryModel",
-    "CoreMemoryEmulation",
     "load_segment",
     "load_segments_from_elf",
 ]
@@ -66,21 +62,6 @@ class WriteReply:
     status: ReplyStatus = ReplyStatus.OK
 
 
-class MemoryEmulation(ABC):
-    """Emulates the behaviour of a memory segment in Python.
-
-    Request addresses are relative to the start of the segment.
-    """
-
-    @abstractmethod
-    def read(self, req: ReadRequest) -> ReadReply:
-        raise NotImplementedError
-
-    @abstractmethod
-    def write(self, req: WriteRequest) -> WriteReply:
-        raise NotImplementedError
-
-
 @dataclass
 class MemorySegment:
     """Describes a range of the address space."""
@@ -100,40 +81,19 @@ class RandomAccessMemory(MemorySegment):
             raise ValueError("Data length must be equal to the length of the address range")
 
 
-class MMIOSegment(MemorySegment, MemoryEmulation):
-    """A segment whose accesses are handled by Python code."""
+class MMIOSegment(MemorySegment, ABC):
+    """A segment whose accesses are handled by Python code, on any backend.
 
+    Request addresses are relative to the start of the segment.
+    """
 
-class RandomAccessMemoryEmulation(MemoryEmulation):
-    """Byte-addressable storage."""
-
-    def __init__(self, data: bytes):
-        self.data = bytearray(data)
-
+    @abstractmethod
     def read(self, req: ReadRequest) -> ReadReply:
-        return ReadReply(data=int.from_bytes(self.data[req.addr : req.addr + req.byte_count], "little"))
+        raise NotImplementedError
 
+    @abstractmethod
     def write(self, req: WriteRequest) -> WriteReply:
-        mask_bytes = [b"\x00", b"\xff"]
-        mask = int.from_bytes(b"".join(mask_bytes[1 & (req.byte_sel >> i)] for i in range(4)), "little")
-        old = int.from_bytes(self.data[req.addr : req.addr + req.byte_count], "little")
-        self.data[req.addr : req.addr + req.byte_count] = (old & ~mask | req.data & mask).to_bytes(4, "little")
-        return WriteReply()
-
-
-def _emulate_segment(segment: MemorySegment) -> MemoryEmulation:
-    """Realizes a segment description in Python."""
-    match segment:
-        case RandomAccessMemory():
-            return RandomAccessMemoryEmulation(segment.contents)
-        case MMIOSegment():
-            return segment
-        case _:
-            raise RuntimeError(f"Cannot emulate {type(segment).__name__} in Python")
-
-
-TReq = TypeVar("TReq", bound=ReadRequest | WriteRequest)
-TRep = TypeVar("TRep", bound=ReadReply | WriteReply)
+        raise NotImplementedError
 
 
 @dataclass
@@ -146,49 +106,6 @@ class CoreMemoryModel:
     # The core may do undefined reads speculatively
     fail_on_undefined_read: bool = False
     fail_on_undefined_write: bool = True
-
-
-class CoreMemoryEmulation:
-    def __init__(self, model: CoreMemoryModel):
-        self.model = model
-        self.emulations = [_emulate_segment(segment) for segment in model.segments]
-
-    def _run_on_range(self, f: Callable[[MemorySegment, MemoryEmulation, TReq], TRep], req: TReq) -> Optional[TRep]:
-        for seg, emulation in zip(self.model.segments, self.emulations):
-            if req.addr in seg.address_range:
-                return f(seg, emulation, req)
-
-    def _do_read(self, seg: MemorySegment, emulation: MemoryEmulation, req: ReadRequest) -> ReadReply:
-        if SegmentFlags.READ not in seg.flags:
-            raise RuntimeError("Tried to read from non-read memory: %x" % req.addr)
-        if req.exec and SegmentFlags.EXECUTABLE not in seg.flags:
-            raise RuntimeError("Memory is not executable: %x" % req.addr)
-
-        return emulation.read(replace(req, addr=req.addr - seg.address_range.start))
-
-    def _do_write(self, seg: MemorySegment, emulation: MemoryEmulation, req: WriteRequest) -> WriteReply:
-        if SegmentFlags.WRITE not in seg.flags:
-            raise RuntimeError("Tried to write to non-writable memory: %x" % req.addr)
-
-        return emulation.write(replace(req, addr=req.addr - seg.address_range.start))
-
-    def read(self, req: ReadRequest) -> ReadReply:
-        rep = self._run_on_range(self._do_read, req)
-        if rep is not None:
-            return rep
-        if self.model.fail_on_undefined_read:
-            raise RuntimeError("Undefined read: %x" % req.addr)
-        else:
-            return ReadReply(status=ReplyStatus.ERROR)
-
-    def write(self, req: WriteRequest) -> WriteReply:
-        rep = self._run_on_range(self._do_write, req)
-        if rep is not None:
-            return rep
-        if self.model.fail_on_undefined_write:
-            raise RuntimeError("Undefined write: %x <= %x" % (req.addr, req.data))
-        else:
-            return WriteReply(status=ReplyStatus.ERROR)
 
 
 def load_segment(

--- a/test/regression/memory.py
+++ b/test/regression/memory.py
@@ -8,15 +8,22 @@ from elftools.elf.elffile import ELFFile, Segment
 from coreblocks.params.configurations import CoreConfiguration
 from transactron.utils import align_to_power_of_two, align_down_to_power_of_two
 
-all = [
+__all__ = [
     "ReplyStatus",
+    "SegmentFlags",
     "ReadRequest",
     "ReadReply",
     "WriteRequest",
     "WriteReply",
-    "MemoryModel",
-    "RAMSegment",
+    "MemoryEmulation",
+    "MemorySegment",
+    "RandomAccessMemory",
+    "RandomAccessMemoryEmulation",
+    "MMIOSegment",
     "CoreMemoryModel",
+    "CoreMemoryEmulation",
+    "load_segment",
+    "load_segments_from_elf",
 ]
 
 
@@ -59,10 +66,11 @@ class WriteReply:
     status: ReplyStatus = ReplyStatus.OK
 
 
-class MemorySegment(ABC):
-    def __init__(self, address_range: range, flags: SegmentFlags):
-        self.address_range = address_range
-        self.flags = flags
+class MemoryEmulation(ABC):
+    """Emulates the behaviour of a memory segment in Python.
+
+    Request addresses are relative to the start of the segment.
+    """
 
     @abstractmethod
     def read(self, req: ReadRequest) -> ReadReply:
@@ -73,17 +81,36 @@ class MemorySegment(ABC):
         raise NotImplementedError
 
 
-class RandomAccessMemory(MemorySegment):
-    def __init__(self, address_range: range, flags: SegmentFlags, data: bytes):
-        super().__init__(address_range, flags)
-        self.data = bytearray(data)
+@dataclass
+class MemorySegment:
+    """Describes a range of the address space."""
 
-        if len(self.data) != len(address_range):
+    address_range: range
+    flags: SegmentFlags
+
+
+@dataclass
+class RandomAccessMemory(MemorySegment):
+    """Plain memory, described by its initial contents."""
+
+    contents: bytes
+
+    def __post_init__(self):
+        if len(self.contents) != len(self.address_range):
             raise ValueError("Data length must be equal to the length of the address range")
 
+
+class MMIOSegment(MemorySegment, MemoryEmulation):
+    """A segment whose accesses are handled by Python code."""
+
+
+class RandomAccessMemoryEmulation(MemoryEmulation):
+    """Byte-addressable storage."""
+
+    def __init__(self, data: bytes):
+        self.data = bytearray(data)
+
     def read(self, req: ReadRequest) -> ReadReply:
-        if self.flags & SegmentFlags.EXECUTABLE:
-            pass  # print("Executing from address %x" % (self.address_range.start + req.addr))
         return ReadReply(data=int.from_bytes(self.data[req.addr : req.addr + req.byte_count], "little"))
 
     def write(self, req: WriteRequest) -> WriteReply:
@@ -94,40 +121,62 @@ class RandomAccessMemory(MemorySegment):
         return WriteReply()
 
 
+def _emulate_segment(segment: MemorySegment) -> MemoryEmulation:
+    """Realizes a segment description in Python."""
+    match segment:
+        case RandomAccessMemory():
+            return RandomAccessMemoryEmulation(segment.contents)
+        case MMIOSegment():
+            return segment
+        case _:
+            raise RuntimeError(f"Cannot emulate {type(segment).__name__} in Python")
+
+
 TReq = TypeVar("TReq", bound=ReadRequest | WriteRequest)
 TRep = TypeVar("TRep", bound=ReadReply | WriteReply)
 
 
+@dataclass
 class CoreMemoryModel:
-    def __init__(self, segments: list[MemorySegment], fail_on_undefined_read=False, fail_on_undefined_write=True):
-        self.segments = segments
-        self.fail_on_undefined_read = fail_on_undefined_read  # Core may do undefined reads speculatively
-        self.fail_on_undefined_write = fail_on_undefined_write
+    """The memory map of the core: the segments, plus the policy for accesses which
+    fall outside all of them.
+    """
 
-    def _run_on_range(self, f: Callable[[MemorySegment, TReq], TRep], req: TReq) -> Optional[TRep]:
-        for seg in self.segments:
+    segments: list[MemorySegment]
+    # The core may do undefined reads speculatively
+    fail_on_undefined_read: bool = False
+    fail_on_undefined_write: bool = True
+
+
+class CoreMemoryEmulation:
+    def __init__(self, model: CoreMemoryModel):
+        self.model = model
+        self.emulations = [_emulate_segment(segment) for segment in model.segments]
+
+    def _run_on_range(self, f: Callable[[MemorySegment, MemoryEmulation, TReq], TRep], req: TReq) -> Optional[TRep]:
+        for seg, emulation in zip(self.model.segments, self.emulations):
             if req.addr in seg.address_range:
-                return f(seg, req)
+                return f(seg, emulation, req)
 
-    def _do_read(self, seg: MemorySegment, req: ReadRequest) -> ReadReply:
+    def _do_read(self, seg: MemorySegment, emulation: MemoryEmulation, req: ReadRequest) -> ReadReply:
         if SegmentFlags.READ not in seg.flags:
             raise RuntimeError("Tried to read from non-read memory: %x" % req.addr)
         if req.exec and SegmentFlags.EXECUTABLE not in seg.flags:
             raise RuntimeError("Memory is not executable: %x" % req.addr)
 
-        return seg.read(replace(req, addr=req.addr - seg.address_range.start))
+        return emulation.read(replace(req, addr=req.addr - seg.address_range.start))
 
-    def _do_write(self, seg: MemorySegment, req: WriteRequest) -> WriteReply:
+    def _do_write(self, seg: MemorySegment, emulation: MemoryEmulation, req: WriteRequest) -> WriteReply:
         if SegmentFlags.WRITE not in seg.flags:
             raise RuntimeError("Tried to write to non-writable memory: %x" % req.addr)
 
-        return seg.write(replace(req, addr=req.addr - seg.address_range.start))
+        return emulation.write(replace(req, addr=req.addr - seg.address_range.start))
 
     def read(self, req: ReadRequest) -> ReadReply:
         rep = self._run_on_range(self._do_read, req)
         if rep is not None:
             return rep
-        if self.fail_on_undefined_read:
+        if self.model.fail_on_undefined_read:
             raise RuntimeError("Undefined read: %x" % req.addr)
         else:
             return ReadReply(status=ReplyStatus.ERROR)
@@ -136,7 +185,7 @@ class CoreMemoryModel:
         rep = self._run_on_range(self._do_write, req)
         if rep is not None:
             return rep
-        if self.fail_on_undefined_write:
+        if self.model.fail_on_undefined_write:
             raise RuntimeError("Undefined write: %x <= %x" % (req.addr, req.data))
         else:
             return WriteReply(status=ReplyStatus.ERROR)
@@ -155,6 +204,9 @@ def load_segment(
 
     seg_start = paddr
     seg_end = paddr + memsz
+
+    # The bus is word-addressed, so a segment cannot end in the middle of a word.
+    seg_end = align_to_power_of_two(seg_end, 2)
 
     data = segment.data()
 

--- a/test/regression/memory.py
+++ b/test/regression/memory.py
@@ -122,9 +122,6 @@ def load_segment(
     seg_start = paddr
     seg_end = paddr + memsz
 
-    # The bus is word-addressed, so a segment cannot end in the middle of a word.
-    seg_end = align_to_power_of_two(seg_end, 2)
-
     data = segment.data()
 
     # fill the rest of the segment with zeroes

--- a/test/regression/memory_emulation.py
+++ b/test/regression/memory_emulation.py
@@ -1,0 +1,127 @@
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Optional, TypeVar
+from dataclasses import replace
+
+from .memory import (
+    CoreMemoryModel,
+    MMIOSegment,
+    MemorySegment,
+    RandomAccessMemory,
+    ReadReply,
+    ReadRequest,
+    ReplyStatus,
+    SegmentFlags,
+    WriteReply,
+    WriteRequest,
+)
+
+__all__ = [
+    "SegmentEmulation",
+    "RAMEmulation",
+    "MMIOEmulation",
+    "CoreMemoryEmulation",
+]
+
+
+class SegmentEmulation(ABC):
+    """Emulates the behaviour of a memory segment in Python.
+
+    Request addresses are relative to the start of the segment.
+    """
+
+    @abstractmethod
+    def read(self, req: ReadRequest) -> ReadReply:
+        raise NotImplementedError
+
+    @abstractmethod
+    def write(self, req: WriteRequest) -> WriteReply:
+        raise NotImplementedError
+
+
+class RAMEmulation(SegmentEmulation):
+    """Byte-addressable storage."""
+
+    def __init__(self, data: bytes):
+        self.data = bytearray(data)
+
+    def read(self, req: ReadRequest) -> ReadReply:
+        return ReadReply(data=int.from_bytes(self.data[req.addr : req.addr + req.byte_count], "little"))
+
+    def write(self, req: WriteRequest) -> WriteReply:
+        mask_bytes = [b"\x00", b"\xff"]
+        mask = int.from_bytes(b"".join(mask_bytes[1 & (req.byte_sel >> i)] for i in range(4)), "little")
+        old = int.from_bytes(self.data[req.addr : req.addr + req.byte_count], "little")
+        self.data[req.addr : req.addr + req.byte_count] = (old & ~mask | req.data & mask).to_bytes(4, "little")
+        return WriteReply()
+
+
+class MMIOEmulation(SegmentEmulation):
+    """MMIO segments handle accesses in Python themselves, using the same protocol."""
+
+    def __init__(self, segment: MMIOSegment):
+        self.segment = segment
+
+    def read(self, req: ReadRequest) -> ReadReply:
+        return self.segment.read(req)
+
+    def write(self, req: WriteRequest) -> WriteReply:
+        return self.segment.write(req)
+
+
+def _emulate_segment(segment: MemorySegment) -> SegmentEmulation:
+    """Realizes a segment description in Python."""
+    match segment:
+        case RandomAccessMemory():
+            return RAMEmulation(segment.contents)
+        case MMIOSegment():
+            return MMIOEmulation(segment)
+        case _:
+            raise RuntimeError(f"Cannot emulate {type(segment).__name__} in Python")
+
+
+TReq = TypeVar("TReq", bound=ReadRequest | WriteRequest)
+TRep = TypeVar("TRep", bound=ReadReply | WriteReply)
+
+
+class CoreMemoryEmulation:
+    def __init__(self, model: CoreMemoryModel):
+        self.model = model
+        self.emulations = [_emulate_segment(segment) for segment in model.segments]
+
+    def _run_on_range(self, f: Callable[[MemorySegment, SegmentEmulation, TReq], TRep], req: TReq) -> Optional[TRep]:
+        for seg, emulation in zip(self.model.segments, self.emulations):
+            if req.addr in seg.address_range:
+                return f(seg, emulation, req)
+
+    def _do_read(self, seg: MemorySegment, emulation: SegmentEmulation, req: ReadRequest) -> ReadReply:
+        if SegmentFlags.READ not in seg.flags:
+            raise RuntimeError("Tried to read from non-read memory: %x" % req.addr)
+        if req.exec and SegmentFlags.EXECUTABLE not in seg.flags:
+            raise RuntimeError("Memory is not executable: %x" % req.addr)
+
+        return emulation.read(replace(req, addr=req.addr - seg.address_range.start))
+
+    def _do_write(self, seg: MemorySegment, emulation: SegmentEmulation, req: WriteRequest) -> WriteReply:
+        if SegmentFlags.WRITE not in seg.flags:
+            raise RuntimeError("Tried to write to non-writable memory: %x" % req.addr)
+
+        return emulation.write(replace(req, addr=req.addr - seg.address_range.start))
+
+    def read(self, req: ReadRequest) -> ReadReply:
+        rep = self._run_on_range(self._do_read, req)
+        if rep is not None:
+            return rep
+        if self.model.fail_on_undefined_read:
+            raise RuntimeError("Undefined read: %x" % req.addr)
+        else:
+            return ReadReply(status=ReplyStatus.ERROR)
+
+    def write(self, req: WriteRequest) -> WriteReply:
+        rep = self._run_on_range(self._do_write, req)
+        if rep is not None:
+            return rep
+        if self.model.fail_on_undefined_write:
+            raise RuntimeError("Undefined write: %x <= %x" % (req.addr, req.data))
+        else:
+            return WriteReply(status=ReplyStatus.ERROR)

--- a/test/regression/pysim.py
+++ b/test/regression/pysim.py
@@ -1,6 +1,8 @@
 import re
 import os
 import logging
+from collections.abc import Callable
+from typing import Optional
 
 from amaranth.utils import exact_log2
 from amaranth import *
@@ -48,7 +50,7 @@ class PySimulation(SimulationBackend):
         self.metrics_manager = HardwareMetricsManager()
 
     def _wishbone_slave(
-        self, mem_model: CoreMemoryModel, wb_ctrl: WishboneInterfaceWrapper, is_instr_bus: bool, delay: int = 0
+        self, memory: CoreMemoryEmulation, wb_ctrl: WishboneInterfaceWrapper, is_instr_bus: bool, delay: int = 0
     ):
         async def f(sim: TestbenchContext):
             while True:
@@ -64,11 +66,9 @@ class PySimulation(SimulationBackend):
                 resp_data = 0
 
                 if sim.get(wb_ctrl.wb.we):
-                    resp = mem_model.write(
-                        WriteRequest(addr=addr, data=dat_w, byte_count=word_width_bytes, byte_sel=sel)
-                    )
+                    resp = memory.write(WriteRequest(addr=addr, data=dat_w, byte_count=word_width_bytes, byte_sel=sel))
                 else:
-                    resp = mem_model.read(
+                    resp = memory.read(
                         ReadRequest(
                             addr=addr,
                             byte_count=word_width_bytes,
@@ -139,6 +139,8 @@ class PySimulation(SimulationBackend):
         timeout_cycles: int = 5000,
         get_interrupt_value: Optional[Callable[[], int]] = None,
     ) -> SimulationExecutionResult:
+        memory = CoreMemoryEmulation(mem_model)
+
         with DependencyContext(DependencyManager()):
             core = Core(gen_params=self.gp)
 
@@ -161,8 +163,8 @@ class PySimulation(SimulationBackend):
 
                 sim.add_process(interrupt_generator_process)
 
-            sim.add_testbench(self._wishbone_slave(mem_model, wb_instr_ctrl, is_instr_bus=True), background=True)
-            sim.add_testbench(self._wishbone_slave(mem_model, wb_data_ctrl, is_instr_bus=False), background=True)
+            sim.add_testbench(self._wishbone_slave(memory, wb_instr_ctrl, is_instr_bus=True), background=True)
+            sim.add_testbench(self._wishbone_slave(memory, wb_data_ctrl, is_instr_bus=False), background=True)
 
             def on_error():
                 raise RuntimeError("Simulation finished due to an error")

--- a/test/regression/pysim.py
+++ b/test/regression/pysim.py
@@ -12,6 +12,7 @@ from transactron.profiler import Profile
 from transactron.testing.tick_count import make_tick_count_process
 
 from .memory import *
+from .memory_emulation import CoreMemoryEmulation
 from .common import SimulationBackend, SimulationExecutionResult
 
 from transactron.testing import (

--- a/test/regression/test_arch_regression.py
+++ b/test/regression/test_arch_regression.py
@@ -11,7 +11,7 @@ from .pysim import PySimulation
 from .common import START_PC
 from .memory import (
     CoreMemoryModel,
-    MemorySegment,
+    MMIOSegment,
     ReadReply,
     ReadRequest,
     ReplyStatus,
@@ -30,7 +30,7 @@ INTERRUPT_GENERATOR_ADDRESS = 0xF0002000
 ACCESS_FAULT_ADDRESS = 0x00000000
 
 
-class EndTestMMIO(MemorySegment):
+class EndTestMMIO(MMIOSegment):
     def __init__(self, on_finish):
         super().__init__(range(END_TEST_ADDRESS, END_TEST_ADDRESS + 8), SegmentFlags.WRITE)
         self.on_finish = on_finish
@@ -50,7 +50,7 @@ class EndTestMMIO(MemorySegment):
         return WriteReply()
 
 
-class ConsoleMMIO(MemorySegment):
+class ConsoleMMIO(MMIOSegment):
     def __init__(self):
         super().__init__(range(CONSOLE_ADDRESS, CONSOLE_ADDRESS + 8), SegmentFlags.WRITE)
         self.buffer = bytearray()
@@ -77,7 +77,7 @@ class ConsoleMMIO(MemorySegment):
         print(self.buffer.decode(errors="replace"), end="")
 
 
-class AccessFaultAddressMMIO(MemorySegment):
+class AccessFaultAddressMMIO(MMIOSegment):
     def __init__(self):
         super().__init__(
             range(ACCESS_FAULT_ADDRESS, ACCESS_FAULT_ADDRESS + 128),
@@ -91,7 +91,7 @@ class AccessFaultAddressMMIO(MemorySegment):
         return WriteReply(status=ReplyStatus.ERROR)
 
 
-class InterruptGeneratorMMIO(MemorySegment):
+class InterruptGeneratorMMIO(MMIOSegment):
     def __init__(self):
         super().__init__(
             range(INTERRUPT_GENERATOR_ADDRESS, INTERRUPT_GENERATOR_ADDRESS + 4),

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -4,6 +4,7 @@ from .conftest import riscv_tests_dir, profile_dir, evlog_dir
 from .cocotb import run_cocotb_entrypoint
 from test.regression.pysim import PySimulation
 import asyncio
+from collections.abc import Callable
 from typing import Literal
 import os
 import pytest
@@ -18,7 +19,7 @@ exclude_write_protection = ["rv32uc-rvc"]
 force_executable_memory = ["rv32ui-fence_i"]
 
 
-class MMIO(MemorySegment):
+class MMIO(MMIOSegment):
     def __init__(self, on_finish: Callable[[], None]):
         super().__init__(range(0xF0000000, 0xF0000000 + 4), SegmentFlags.READ | SegmentFlags.WRITE)
         self.on_finish = on_finish


### PR DESCRIPTION
Separate memory segment descriptions from their Python emulation, allowing non-Python backends to consume the memory map without unused simulation state.