### PR TITLE
 regression: one core configuration  & benchmark improvements

### DIFF
--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import unittest
 import asyncio
 import argparse
 import json
@@ -9,6 +8,8 @@ import sys
 import os
 import subprocess
 import tabulate
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Literal
 from pathlib import Path
 
@@ -17,8 +18,10 @@ sys.path.insert(0, str(topdir))
 
 import test.regression.benchmark  # noqa: E402
 from test.regression.benchmark import BenchmarkResult  # noqa: E402
+from test.regression.common import SimulationBackend  # noqa: E402
 from test.regression.pysim import PySimulation  # noqa: E402
-from test.regression.cocotb import run_cocotb_entrypoint  # noqa: E402
+from test.regression.cocotb import clean_cocotb_build, run_cocotb_entrypoint  # noqa: E402
+from test.regression.verilog import clean_core_verilog  # noqa: E402
 
 
 def cd_to_topdir():
@@ -57,6 +60,16 @@ def load_benchmarks():
     return ret
 
 
+def clean_build_artifacts(backend: Literal["pysim", "cocotb"]):
+    if backend == "pysim":
+        return
+
+    print("Discarding the generated Verilog and the built testbench...")
+
+    clean_core_verilog()
+    clean_cocotb_build()
+
+
 def run_benchmarks_with_cocotb(benchmarks: list[str], traces: bool) -> bool:
     return run_cocotb_entrypoint(
         "benchmark_entrypoint",
@@ -68,35 +81,50 @@ def run_benchmarks_with_cocotb(benchmarks: list[str], traces: bool) -> bool:
     )
 
 
-def run_benchmarks_with_pysim(benchmarks: list[str], traces: bool) -> bool:
-    suite = unittest.TestSuite()
+def run_benchmarks_with_backend(
+    benchmarks: list[str], make_backend: Callable[[str], SimulationBackend], jobs: int
+) -> bool:
+    failures: list[str] = []
 
-    def _gen_test(test_name: str):
-        def test_fn():
-            traces_file = None
-            if traces:
-                traces_file = "benchmark." + test_name
-            asyncio.run(test.regression.benchmark.run_benchmark(PySimulation(traces_file=traces_file), test_name))
+    def run_one(benchmark_name: str):
+        asyncio.run(test.regression.benchmark.run_benchmark(make_backend(benchmark_name), benchmark_name))
 
-        test_fn.__name__ = test_name
-        test_fn.__qualname__ = test_name
+    with ThreadPoolExecutor(max_workers=jobs) as executor:
+        futures = {executor.submit(run_one, name): name for name in benchmarks}
 
-        return test_fn
+        for done, future in enumerate(as_completed(futures), start=1):
+            name = futures[future]
+            progress = f"[{done}/{len(benchmarks)}]"
+            try:
+                future.result()
+            except Exception as e:
+                failures.append(name)
+                print(f"{progress} FAIL {name}: {e}")
+            else:
+                print(f"{progress} ok   {name}")
 
-    for test_name in benchmarks:
-        suite.addTest(unittest.FunctionTestCase(_gen_test(test_name)))
+    if failures:
+        print(f"{len(failures)} of {len(benchmarks)} benchmarks failed: {', '.join(sorted(failures))}")
 
-    runner = unittest.TextTestRunner(verbosity=2)
-    result = runner.run(suite)
-
-    return result.wasSuccessful()
+    return not failures
 
 
-def run_benchmarks(benchmarks: list[str], backend: Literal["pysim", "cocotb"], traces: bool) -> bool:
+def run_benchmarks_with_pysim(benchmarks: list[str], traces: bool, jobs: int) -> bool:
+    def make_backend(benchmark_name: str) -> SimulationBackend:
+        return PySimulation(traces_file="benchmark." + benchmark_name if traces else None)
+
+    return run_benchmarks_with_backend(benchmarks, make_backend, jobs)
+
+
+def run_benchmarks(benchmarks: list[str], backend: Literal["pysim", "cocotb"], traces: bool, jobs: int) -> bool:
+    # The cocotb backend schedules the benchmarks inside its own testbench.
+    parallelism = "" if backend == "cocotb" else f", {jobs} at a time"
+    print(f"Running {len(benchmarks)} benchmarks with the {backend} backend{parallelism}", flush=True)
+
     if backend == "cocotb":
         return run_benchmarks_with_cocotb(benchmarks, traces)
     elif backend == "pysim":
-        return run_benchmarks_with_pysim(benchmarks, traces)
+        return run_benchmarks_with_pysim(benchmarks, traces, jobs)
     return False
 
 
@@ -104,7 +132,15 @@ def build_result_table(results: dict[str, BenchmarkResult], tablefmt: str) -> st
     if len(results) == 0:
         return ""
 
-    header = ["Testbench name", "Cycles", "Instructions", "IPC", "Mispredicts/1k instr"]
+    header = [
+        "Testbench name",
+        "Cycles",
+        "Instructions",
+        "IPC",
+        "Mispredicts/1k instr",
+        "Wall time [s]",
+        "Sim speed [kcycles/s]",
+    ]
 
     # First fetch all metrics names to build the header
     result = next(iter(results.values()))
@@ -118,7 +154,9 @@ def build_result_table(results: dict[str, BenchmarkResult], tablefmt: str) -> st
         ipc = result.instr / result.cycles
         mpki = result.mispredicts / result.instr * 1000
 
-        column = [benchmark_name, result.cycles, result.instr, ipc, mpki]
+        speed = result.simulated_cycles / result.wall_time / 1000 if result.wall_time else 0
+
+        column = [benchmark_name, result.cycles, result.instr, ipc, mpki, result.wall_time, speed]
 
         for metric_name in sorted(result.metric_values.keys()):
             regs = result.metric_values[metric_name]
@@ -142,6 +180,18 @@ def main():
     parser.add_argument("-p", "--profile", action="store_true", help="Write execution profiles")
     parser.add_argument("--evlog", action="store_true", help="Write captured event logs")
     parser.add_argument("-b", "--backend", default="cocotb", choices=["cocotb", "pysim"], help="Simulation backend")
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Discard the generated Verilog and the built testbench",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=len(os.sched_getaffinity(0)),
+        help="Number of benchmarks to run in parallel. Default: all cores",
+    )
     parser.add_argument(
         "-o",
         "--output",
@@ -177,7 +227,10 @@ def main():
     if args.evlog:
         os.environ["__TRANSACTRON_EVLOG"] = "1"
 
-    success = run_benchmarks(benchmarks, args.backend, args.trace)
+    if args.clean:
+        clean_build_artifacts(args.backend)
+
+    success = run_benchmarks(benchmarks, args.backend, args.trace, args.jobs)
     if not success:
         print("Benchmark execution failed")
         sys.exit(1)

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -189,7 +189,7 @@ def main():
         "-j",
         "--jobs",
         type=int,
-        default=len(os.sched_getaffinity(0)),
+        default=0,
         help="Number of benchmarks to run in parallel. Default: all cores",
     )
     parser.add_argument(
@@ -230,7 +230,9 @@ def main():
     if args.clean:
         clean_build_artifacts(args.backend)
 
-    success = run_benchmarks(benchmarks, args.backend, args.trace, args.jobs)
+    jobs = len(os.sched_getaffinity(0)) if args.jobs == 0 else args.jobs
+
+    success = run_benchmarks(benchmarks, args.backend, args.trace, jobs)
     if not success:
         print("Benchmark execution failed")
         sys.exit(1)

--- a/test/regression/benchmark.py
+++ b/test/regression/benchmark.py
@@ -1,4 +1,5 @@
 import os
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
@@ -32,12 +33,18 @@ class BenchmarkResult:
         A count of branch mispredictions during the benchmark, from the HPM counter.
     metric_values: dict[str, dict[str, int]]
         Values of the core metrics taken at the end of the simulation.
+    wall_time: float
+        How long running the benchmark took, in seconds.
+    simulated_cycles: int
+        A count of cycles which were simulated.
     """
 
     cycles: int
     instr: int
     mispredicts: int
     metric_values: dict[str, dict[str, int]]
+    wall_time: float = 0.0
+    simulated_cycles: int = 0
 
 
 class MMIO(MMIOSegment):
@@ -106,7 +113,9 @@ async def run_benchmark(sim_backend: SimulationBackend, benchmark_name: str):
 
     mem_model = CoreMemoryModel(mem_segments)
 
-    result = await sim_backend.run(mem_model, timeout_cycles=2000000)
+    start_time = time.monotonic()
+    result = await sim_backend.run(mem_model, timeout_cycles=10000000)
+    wall_time = time.monotonic() - start_time
 
     if result.profile is not None:
         os.makedirs(profile_dir, exist_ok=True)
@@ -133,6 +142,8 @@ async def run_benchmark(sim_backend: SimulationBackend, benchmark_name: str):
         instr=mmio.instr_cnt(),
         mispredicts=mmio.mispredict_cnt(),
         metric_values=result.metric_values,
+        wall_time=wall_time,
+        simulated_cycles=result.simulated_cycles,
     )
 
     os.makedirs(str(results_dir), exist_ok=True)

--- a/test/regression/cocotb.py
+++ b/test/regression/cocotb.py
@@ -6,10 +6,10 @@ from typing import Any, Optional
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from pathlib import Path
+import shutil
 from filelock import FileLock
 import subprocess
 import tempfile
-import sys
 import xml.etree.ElementTree as eT
 import argparse
 
@@ -17,25 +17,21 @@ import cocotb
 from cocotb.clock import Clock, Timer
 from cocotb.handle import ModifiableObject
 from cocotb.triggers import FallingEdge, Event, RisingEdge, with_timeout
+from cocotb.utils import get_sim_time
 from cocotb_bus.bus import Bus
 from cocotb.result import SimTimeoutError
 
 from .memory import *
 from .memory_emulation import CoreMemoryEmulation
-from .common import SimulationBackend, SimulationExecutionResult, START_PC
+from .common import SimulationBackend, SimulationExecutionResult
+from .verilog import BUILD_ROOT, CORE_V, CORE_V_JSON, REPO_ROOT, ensure_core_verilog_generated
 
 from transactron.evlog import EventLog, GeneratedEvLogSampler, SignalHandle, SignalReader
 from transactron.profiler import CycleProfile, MethodSamples, Profile, ProfileSamples, TransactionSamples
 from transactron.utils.gen import GenerationInfo
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-BUILD_ROOT = Path(__file__).resolve().parent / "cocotb" / "build"
 TEST_ROOT = Path(__file__).resolve().parent / "cocotb"
-
-VERILOG_ROOT = BUILD_ROOT / "verilog"
-CORE_V = VERILOG_ROOT / "core.v"
-CORE_V_JSON = VERILOG_ROOT / "core.v.json"
 
 
 @dataclass
@@ -276,6 +272,8 @@ class CocotbSimulation(SimulationBackend):
         clk = Clock(self.dut.clk, 1, "ns")
         cocotb.start_soon(clk.start())
 
+        start_time = get_sim_time("ns")
+
         self.dut.rst.value = 1
         await Timer(Decimal(1), "ns")
         self.dut.rst.value = 0
@@ -320,6 +318,7 @@ class CocotbSimulation(SimulationBackend):
 
         result.profile = profile
         result.evlog = evlog
+        result.simulated_cycles = int(get_sim_time("ns") - start_time)
 
         for metric_name, metric_loc in self.gen_info.metrics_location.items():
             result.metric_values[metric_name] = {}
@@ -401,39 +400,17 @@ def run_cocotb_entrypoint(
         return len(list(tree.iter("failure"))) == 0
 
 
-def ensure_core_verilog_generated():
-    lock = BUILD_ROOT / "verilog.lock"
-    stamp = BUILD_ROOT / "verilog.stamp"
+def clean_cocotb_build():
+    sim = os.environ.get("SIM", "verilator")
 
-    VERILOG_ROOT.mkdir(parents=True, exist_ok=True)
+    for traces in [False, True]:
+        prefix = get_cocotb_lock_prefix(traces)
+        prefix.parent.mkdir(parents=True, exist_ok=True)
 
-    if stamp.exists():
-        return
-
-    with FileLock(lock):
-        if stamp.exists():
-            return
-
-        command = [
-            sys.executable,
-            "-m",
-            "coreblocks.gen_verilog",
-            "--config",
-            "full",
-            "--reset-pc",
-            f"0x{START_PC:x}",
-            "--with-socks",
-            "--with-rvvi",
-            "-o",
-            str(CORE_V),
-        ]
-
-        env = os.environ.copy()
-        # always generate evlog interfaces - the choice to output them is made at runtime
-        env["__TRANSACTRON_EVLOG"] = "1"
-
-        subprocess.run(command, check=True, cwd=REPO_ROOT, env=env)
-        stamp.touch()
+        with FileLock(prefix.with_suffix(".lock")):
+            prefix.with_suffix(".stamp").unlink(missing_ok=True)
+            shutil.rmtree(prefix, ignore_errors=True)
+            shutil.rmtree(BUILD_ROOT / f"{sim}{'-trace' if traces else ''}", ignore_errors=True)
 
 
 def ensure_cocotb_built(traces: bool):

--- a/test/regression/common.py
+++ b/test/regression/common.py
@@ -6,9 +6,6 @@ from transactron.evlog import EventLog
 from transactron.profiler import Profile
 
 
-START_PC = 0x80000000
-
-
 @dataclass
 class SimulationExecutionResult:
     """Information about the result of the simulation.
@@ -20,12 +17,15 @@ class SimulationExecutionResult:
         no exceptions, no failed assertions etc.
     metric_values: dict[str, dict[str, int]]
         Values of the core metrics taken at the end of the simulation.
+    simulated_cycles: Optional[int]
+        The number of cycles which were simulated.
     """
 
     success: bool
     metric_values: dict[str, dict[str, int]] = field(default_factory=dict)
     profile: Optional[Profile] = None
     evlog: Optional[EventLog] = None
+    simulated_cycles: int = 0
 
 
 class SimulationBackend(ABC):

--- a/test/regression/core.py
+++ b/test/regression/core.py
@@ -1,0 +1,56 @@
+"""The core which the regression suites run on."""
+
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional
+
+from coreblocks.core import Core
+from coreblocks.gen_verilog import gen_verilog
+from coreblocks.params import GenParams, configurations
+from coreblocks.params.core_configuration import CoreConfiguration
+from coreblocks.socks.socks import Socks
+
+START_PC = 0x80000000
+
+
+@contextmanager
+def _environment(**variables: Optional[str]) -> Iterator[None]:
+    """Sets environment variables for the duration of the block."""
+    previous = {name: os.environ.get(name) for name in variables}
+    try:
+        os.environ.update({name: value for name, value in variables.items() if value is not None})
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+@dataclass(frozen=True)
+class SimulatedCore:
+    """A core configuration, and the two ways of turning it into something runnable."""
+
+    config: CoreConfiguration
+    with_socks: bool = True
+
+    def gen_params(self) -> GenParams:
+        return GenParams(self.config)
+
+    def elaborate(self, gen_params: GenParams) -> Core | Socks:
+        core = Core(gen_params=gen_params)
+        if self.with_socks:
+            return Socks(core, core_gen_params=gen_params)
+        return core
+
+    def generate_verilog(self, output_path: Path):
+        # The same variable makes a simulation capture event logs, so it must not
+        # leak into the rest of the process.
+        with _environment(__TRANSACTRON_EVLOG="1"):
+            gen_verilog(self.config, str(output_path), wrap_socks=self.with_socks)
+
+
+REGRESSION_CORE = SimulatedCore(config=configurations.full.replace(start_pc=START_PC, with_rvvi=True))

--- a/test/regression/pysim.py
+++ b/test/regression/pysim.py
@@ -11,6 +11,7 @@ from transactron.core.keys import TransactionManagerKey
 from transactron.profiler import Profile
 from transactron.testing.tick_count import make_tick_count_process
 
+from .core import REGRESSION_CORE
 from .memory import *
 from .memory_emulation import CoreMemoryEmulation
 from .common import SimulationBackend, SimulationExecutionResult
@@ -28,22 +29,14 @@ from transactron.utils.dependencies import DependencyContext, DependencyManager
 from transactron.lib.metrics import HardwareMetricsManager
 from ..peripherals.test_wishbone import WishboneInterfaceWrapper
 
-from coreblocks.core import Core
-from coreblocks.socks.socks import Socks
-from coreblocks.params import GenParams
-from coreblocks.params import configurations
-
 
 class PySimulation(SimulationBackend):
-    def __init__(self, traces_file: Optional[str] = None, with_socks: bool = False, reset_pc: Optional[int] = None):
-        conf = configurations.full
-        if reset_pc is not None:
-            conf = conf.replace(start_pc=reset_pc)
-        self.gp = GenParams(conf)
+    def __init__(self, traces_file: Optional[str] = None):
+        self.core = REGRESSION_CORE
+        self.gp = self.core.gen_params()
         self.running = False
         self.cycle_cnt = 0
         self.traces_file = traces_file
-        self.with_socks = with_socks
 
         self.log_level = parse_logging_level(os.environ["__TRANSACTRON_LOG_LEVEL"])
         self.log_filter = os.environ["__TRANSACTRON_LOG_FILTER"]
@@ -143,10 +136,7 @@ class PySimulation(SimulationBackend):
         memory = CoreMemoryEmulation(mem_model)
 
         with DependencyContext(DependencyManager()):
-            core = Core(gen_params=self.gp)
-
-            if self.with_socks:
-                core = Socks(core, core_gen_params=self.gp)
+            core = self.core.elaborate(self.gp)
 
             wb_instr_ctrl = WishboneInterfaceWrapper(core.wb_instr)
             wb_data_ctrl = WishboneInterfaceWrapper(core.wb_data)
@@ -209,7 +199,7 @@ class PySimulation(SimulationBackend):
 
             self.pretty_dump_metrics(metric_values)
 
-            return SimulationExecutionResult(success, metric_values, profile, evlog)
+            return SimulationExecutionResult(success, metric_values, profile, evlog, self.cycle_cnt)
 
     def stop(self):
         self.running = False

--- a/test/regression/test_arch_regression.py
+++ b/test/regression/test_arch_regression.py
@@ -8,7 +8,6 @@ import asyncio
 
 from .conftest import arch_tests_dir, profile_dir, evlog_dir
 from .pysim import PySimulation
-from .common import START_PC
 from .memory import (
     CoreMemoryModel,
     MMIOSegment,
@@ -178,7 +177,7 @@ def regression_body_with_pysim(elf_paths: list[Path], traces: bool):
         if traces:
             traces_file = REGRESSION_ARCH_TESTS_PREFIX + elf_path.stem
 
-        pysim = PySimulation(reset_pc=START_PC, with_socks=True, traces_file=traces_file)
+        pysim = PySimulation(traces_file=traces_file)
         asyncio.run(run_arch_elf(pysim, elf_path, timeout_cycles=2_000_000))
 
 

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -1,5 +1,5 @@
 from .memory import *
-from .common import SimulationBackend, START_PC
+from .common import SimulationBackend
 from .conftest import riscv_tests_dir, profile_dir, evlog_dir
 from .cocotb import run_cocotb_entrypoint
 from test.regression.pysim import PySimulation
@@ -76,7 +76,7 @@ def regression_body_with_pysim(test_name: str, traces: bool):
     traces_file = None
     if traces:
         traces_file = REGRESSION_TESTS_PREFIX + test_name
-    asyncio.run(run_test(PySimulation(traces_file=traces_file, reset_pc=START_PC), test_name))
+    asyncio.run(run_test(PySimulation(traces_file=traces_file), test_name))
 
 
 @pytest.fixture

--- a/test/regression/verilog.py
+++ b/test/regression/verilog.py
@@ -1,0 +1,40 @@
+import shutil
+from pathlib import Path
+
+from filelock import FileLock
+
+from .core import REGRESSION_CORE
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_ROOT = Path(__file__).resolve().parent / "cocotb" / "build"
+
+VERILOG_ROOT = BUILD_ROOT / "verilog"
+CORE_V = VERILOG_ROOT / "core.v"
+CORE_V_JSON = VERILOG_ROOT / "core.v.json"
+
+VERILOG_LOCK = BUILD_ROOT / "verilog.lock"
+VERILOG_STAMP = BUILD_ROOT / "verilog.stamp"
+
+
+def clean_core_verilog():
+    BUILD_ROOT.mkdir(parents=True, exist_ok=True)
+
+    with FileLock(VERILOG_LOCK):
+        VERILOG_STAMP.unlink(missing_ok=True)
+        shutil.rmtree(VERILOG_ROOT, ignore_errors=True)
+
+
+def ensure_core_verilog_generated():
+    VERILOG_ROOT.mkdir(parents=True, exist_ok=True)
+
+    if VERILOG_STAMP.exists():
+        return
+
+    with FileLock(VERILOG_LOCK):
+        if VERILOG_STAMP.exists():
+            return
+
+        print("Generating the core Verilog...", flush=True)
+
+        REGRESSION_CORE.generate_verilog(CORE_V)
+        VERILOG_STAMP.touch()


### PR DESCRIPTION
- use a single core configuration across all simulation backends
- benchmarks now run in parallel, report simulation speed, and can rebuild generated artifacts with --clean

Depends on #1083 