### PR TITLE
[DO NOT MERGE] failing fence.i case from riscv-arch-test

### DIFF
--- a/test/asm/fencei.asm
+++ b/test/asm/fencei.asm
@@ -1,0 +1,30 @@
+# Testcase: fence.i with nonzero rd
+  li x10, 3
+  la x13, insn1
+  lw x12, 0(x13)
+  la x14, selfmodify_1
+  sw x12, 0(x14)
+Zifencei_fence_i_cg_cp_custom_fencei_fence_i_with_nonzero_rd:
+  .insn 0x0000108f # fence.i with nonzero rd
+selfmodify_1:
+  addi x10, x10, 1 # original code
+  # x10 = 3 + 9
+
+# Testcase: fence.i with nonzero funct12
+  li x16, 3
+  la x13, insn2
+  lw x1, 0(x13)
+  la x14, selfmodify_2
+  sw x1, 0(x14)
+Zifencei_fence_i_cg_cp_custom_fencei_fence_i_with_nonzero_funct12:
+  .insn 0x0010100f # fence.i with nonzero funct12
+selfmodify_2:
+  addi x16, x16, 1 # original code
+  # x16 = 3 + 13
+
+pass:
+csrw 0x8fe, 0x10
+j pass
+
+insn1: addi x10, x10, 9
+insn2: addi x16, x16, 13

--- a/test/asm/fencei.asm
+++ b/test/asm/fencei.asm
@@ -1,9 +1,3 @@
-  li x12, 0x00950513  # addi x10, x10, 9
-  sw x12, (4 * 3)(x0)
   .insn 0x0000108f # fence.i with nonzero rd
-selfmodify_1:
-  addi x10, x10, 1 # original code
-  # x10 = 3 + 9
-
   lw x1, 0(x0)
   csrw 0x8fe, 0x10

--- a/test/asm/fencei.asm
+++ b/test/asm/fencei.asm
@@ -1,30 +1,9 @@
-# Testcase: fence.i with nonzero rd
-  li x10, 3
-  la x13, insn1
-  lw x12, 0(x13)
-  la x14, selfmodify_1
-  sw x12, 0(x14)
-Zifencei_fence_i_cg_cp_custom_fencei_fence_i_with_nonzero_rd:
+  li x12, 0x00950513  # addi x10, x10, 9
+  sw x12, (4 * 3)(x0)
   .insn 0x0000108f # fence.i with nonzero rd
 selfmodify_1:
   addi x10, x10, 1 # original code
   # x10 = 3 + 9
 
-# Testcase: fence.i with nonzero funct12
-  li x16, 3
-  la x13, insn2
-  lw x1, 0(x13)
-  la x14, selfmodify_2
-  sw x1, 0(x14)
-Zifencei_fence_i_cg_cp_custom_fencei_fence_i_with_nonzero_funct12:
-  .insn 0x0010100f # fence.i with nonzero funct12
-selfmodify_2:
-  addi x16, x16, 1 # original code
-  # x16 = 3 + 13
-
-pass:
-csrw 0x8fe, 0x10
-j pass
-
-insn1: addi x10, x10, 9
-insn2: addi x16, x16, 13
+  lw x1, 0(x0)
+  csrw 0x8fe, 0x10

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -16,7 +16,7 @@ from coreblocks.params import GenParams
 from coreblocks.params.instr import *
 from coreblocks.params import configurations
 from coreblocks.params.core_configuration import CoreConfiguration
-from coreblocks.peripherals.wishbone import WishboneMemorySlave
+from coreblocks.peripherals.wishbone import WishboneArbiter, WishboneMemorySlave
 from coreblocks.priv.traps.interrupt_controller import ISA_RESERVED_INTERRUPTS
 from coreblocks.socks.socks import Socks
 
@@ -34,24 +34,21 @@ TEST_EXIT_FAILURE = 0x12
 
 class CoreTestElaboratable(Elaboratable):
     def __init__(
-        self, gen_params: GenParams, instr_mem: list[int] = [0], data_mem: list[int] = [], with_socks: bool = False
+        self,
+        gen_params: GenParams,
+        instr_mem: list[int] = [0],
+        data_mem: list[int] = [],
+        with_socks: bool = False,
+        shared_instr_data: bool = False,
     ):
         self.gen_params = gen_params
         self.instr_mem = instr_mem
         self.data_mem = data_mem
         self.with_socks = with_socks
+        self.shared_instr_data = shared_instr_data
 
     def elaborate(self, platform):
         m = Module()
-
-        # Align the size of the memory to the length of a cache line.
-        instr_mem_depth = align_to_power_of_two(len(self.instr_mem), self.gen_params.icache_params.line_bytes_log)
-        self.wb_mem_slave = WishboneMemorySlave(
-            wb_params=self.gen_params.wb_params, shape=32, depth=instr_mem_depth, init=self.instr_mem
-        )
-        self.wb_mem_slave_data = WishboneMemorySlave(
-            wb_params=self.gen_params.wb_params, shape=32, depth=len(self.data_mem), init=self.data_mem
-        )
 
         self.core = Core(gen_params=self.gen_params)
         self.top = Socks(self.core, self.gen_params) if self.with_socks else self.core
@@ -66,12 +63,32 @@ class CoreTestElaboratable(Elaboratable):
                 Cat(self.interrupt_edge, self.interrupt_level) << ISA_RESERVED_INTERRUPTS
             )
 
-        m.submodules.wb_mem_slave = self.wb_mem_slave
-        m.submodules.wb_mem_slave_data = self.wb_mem_slave_data
         m.submodules.c = self.top
 
-        connect(m, self.top.wb_instr, self.wb_mem_slave.bus)
-        connect(m, self.top.wb_data, self.wb_mem_slave_data.bus)
+        # Align the size of the memory to the length of a cache line.
+        instr_mem_depth = align_to_power_of_two(len(self.instr_mem), self.gen_params.icache_params.line_bytes_log)
+        if self.shared_instr_data:
+            # shared address space
+            assert len(self.data_mem) == 0
+            m.submodules.wb_mem_slave_all = self.wb_mem_slave_all = WishboneMemorySlave(
+                wb_params=self.gen_params.wb_params, shape=32, depth=instr_mem_depth, init=self.instr_mem
+            )
+            m.submodules.wb_mem_arbiter = self.wb_mem_arbiter = WishboneArbiter(
+                wb_params=self.gen_params.wb_params, num_masters=2
+            )
+            connect(m, self.wb_mem_slave_all.bus, self.wb_mem_arbiter.slave_wb)
+            connect(m, self.top.wb_instr, self.wb_mem_arbiter.masters[0])
+            connect(m, self.top.wb_data, self.wb_mem_arbiter.masters[1])
+        else:
+            m.submodules.wb_mem_slave = self.wb_mem_slave = WishboneMemorySlave(
+                wb_params=self.gen_params.wb_params, shape=32, depth=instr_mem_depth, init=self.instr_mem
+            )
+            m.submodules.wb_mem_slave_data = self.wb_mem_slave_data = WishboneMemorySlave(
+                wb_params=self.gen_params.wb_params, shape=32, depth=len(self.data_mem), init=self.data_mem
+            )
+
+            connect(m, self.top.wb_instr, self.wb_mem_slave.bus)
+            connect(m, self.top.wb_data, self.wb_mem_slave_data.bus)
 
         return m
 
@@ -112,7 +129,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
                     "-mabi=ilp32",
                     # Specified manually, because toolchains from most distributions don't support new extensioins
                     # and this test should be accessible locally.
-                    f"-march=rv32im{'c' if c_extension else ''}_zicsr",
+                    f"-march=rv32im{'c' if c_extension else ''}_zicsr_zifencei",
                     "-I",
                     self.base_dir,
                     "-o",
@@ -190,6 +207,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
         ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, False, configurations.basic),
         ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, False, configurations.tiny),
         ("csr", "csr.asm", 400, {1: 1, 2: 4}, True, configurations.full),
+        ("fencei", "fencei.asm", 1500, {10: 12, 16: 13}, True, configurations.full),
         ("csr_mmode", "csr_mmode.asm", 1000, {1: 0, 2: 44, 3: 0, 4: 0, 5: 0, 6: 4, 15: 0}, True, configurations.full),
         ("exception", "exception.asm", 200, {1: 1, 2: 2}, False, configurations.basic),
         ("exception_mem", "exception_mem.asm", 200, {1: 1, 2: 2}, False, configurations.basic),
@@ -222,7 +240,11 @@ class TestCoreBasicAsm(TestCoreAsmSourceBase):
         self.gen_params = GenParams(self.configuration)
 
         self.m = CoreTestElaboratable(
-            self.gen_params, instr_mem=bin_src["text"], data_mem=bin_src["data"], with_socks=socks_test
+            self.gen_params,
+            instr_mem=bin_src["text"],
+            data_mem=bin_src["data"],
+            with_socks=socks_test,
+            shared_instr_data=self.name == "fencei",
         )
 
         with self.run_simulation(self.m) as sim:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -207,7 +207,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
         ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, False, configurations.basic),
         ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, False, configurations.tiny),
         ("csr", "csr.asm", 400, {1: 1, 2: 4}, True, configurations.full),
-        ("fencei", "fencei.asm", 1500, {10: 12, 16: 16}, True, configurations.full),
+        ("fencei", "fencei.asm", 1500, {10: 9}, True, configurations.full),
         ("csr_mmode", "csr_mmode.asm", 1000, {1: 0, 2: 44, 3: 0, 4: 0, 5: 0, 6: 4, 15: 0}, True, configurations.full),
         ("exception", "exception.asm", 200, {1: 1, 2: 2}, False, configurations.basic),
         ("exception_mem", "exception_mem.asm", 200, {1: 1, 2: 2}, False, configurations.basic),

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -207,7 +207,7 @@ class TestCoreAsmSourceBase(TestCoreBase):
         ("fibonacci_mem", "fibonacci_mem.asm", 400, {3: 55}, False, configurations.basic),
         ("fibonacci_mem_tiny", "fibonacci_mem.asm", 250, {3: 55}, False, configurations.tiny),
         ("csr", "csr.asm", 400, {1: 1, 2: 4}, True, configurations.full),
-        ("fencei", "fencei.asm", 1500, {10: 12, 16: 13}, True, configurations.full),
+        ("fencei", "fencei.asm", 1500, {10: 12, 16: 16}, True, configurations.full),
         ("csr_mmode", "csr_mmode.asm", 1000, {1: 0, 2: 44, 3: 0, 4: 0, 5: 0, 6: 4, 15: 0}, True, configurations.full),
         ("exception", "exception.asm", 200, {1: 1, 2: 2}, False, configurations.basic),
         ("exception_mem", "exception_mem.asm", 200, {1: 1, 2: 2}, False, configurations.basic),


### PR DESCRIPTION
I have reduced the `fence.i` test from riscv-arch-test that raises assert in the core.

The execution ends with an assertion in RF, when retirement tries to free an unallocated register

full log
```
0 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:178] [IFU] request pc=0x0
1 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:178] [IFU] request pc=0x10
128 DEBUG frontend.icache [coreblocks/cache/icache.py:212] Refilling line 0x0
129 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x0 data=0x0 sel=0xf write=0
132 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x108f err=0
132 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x1 data=0x0 sel=0xf write=0
134 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x2083 err=0
134 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x2 data=0x0 sel=0xf write=0
136 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x8fe85073 err=0
136 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x3 data=0x0 sel=0xf write=0
138 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
138 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x4 data=0x0 sel=0xf write=0
140 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
140 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x5 data=0x0 sel=0xf write=0
142 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
142 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x6 data=0x0 sel=0xf write=0
144 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
144 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x7 data=0x0 sel=0xf write=0
146 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
147 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:178] [IFU] request pc=0x20
148 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:178] [IFU] request pc=0x30
149 DEBUG frontend.icache [coreblocks/cache/icache.py:212] Refilling line 0x20
149 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:136] Sending an instr to the backend pc=0x0 instr=0x108f
150 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x8 data=0x0 sel=0xf write=0
151 DEBUG structs.core_counter [coreblocks/priv/traps/instr_counter.py:54] 0 instructions in core
153 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
153 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x9 data=0x0 sel=0xf write=0
153 DEBUG core_structs.crat [coreblocks/core_structs/crat.py:217] frat write 0 for rl 1 -> rp 1
153 DEBUG core_structs.crat [coreblocks/core_structs/crat.py:223] frat rename 0 r_s1: 0 -> 0 r_s2 0 -> 0 tag 0x0 [0] (1)
155 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
155 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xa data=0x0 sel=0xf write=0
155 DEBUG backend.rs.1 [coreblocks/func_blocks/fu/common/rs.py:157] inserted entry 0, rob_id 0x0, s1: p0 v 0x0, s2: p0 v 0x0
156 DEBUG backend.rs.1 [coreblocks/func_blocks/fu/common/rs.py:188] taken entry 0 at idx 0, rob_id 0x0, rp_dst p1
157 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
157 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xb data=0x0 sel=0xf write=0
159 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
159 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xc data=0x0 sel=0xf write=0
161 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
161 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xd data=0x0 sel=0xf write=0
163 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
163 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xe data=0x0 sel=0xf write=0
165 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
165 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xf data=0x0 sel=0xf write=0
167 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
168 INFO frontend.icache [coreblocks/cache/icache.py:247] Flushing the cache...
169 INFO frontend [coreblocks/frontend/frontend.py:192] Unsafe instruction resolved to pc=0x4
169 DEBUG frontend.ftq [coreblocks/frontend/ftq.py:348] Backend redirected to pc=0x4
169 DEBUG backend.announcement [coreblocks/backend/announcement.py:65] announce p0 = 0x0 for rob_id 0x0
169 INFO backend.fu.priv [coreblocks/func_blocks/fu/priv.py:272] Unstalling fetch from the priv unit new_pc=0x4
170 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:178] [IFU] request pc=0x4
170 INFO telemetry.rvvi [coreblocks/telemetry/rvvi.py:200] Retired instruction #0: pc 0x0, rl_dst x1 = 0x0, rob_id 0x0, instr 0x108f
170 DEBUG structs.core_counter [coreblocks/priv/traps/instr_counter.py:54] 1 instructions in core
297 DEBUG frontend.icache [coreblocks/cache/icache.py:212] Refilling line 0x20
298 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x8 data=0x0 sel=0xf write=0
301 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
301 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x9 data=0x0 sel=0xf write=0
303 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
303 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xa data=0x0 sel=0xf write=0
305 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
305 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xb data=0x0 sel=0xf write=0
307 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
307 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xc data=0x0 sel=0xf write=0
309 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
309 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xd data=0x0 sel=0xf write=0
311 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
311 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xe data=0x0 sel=0xf write=0
313 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
313 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0xf data=0x0 sel=0xf write=0
315 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
316 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:178] [IFU] request pc=0x10
317 DEBUG frontend.icache [coreblocks/cache/icache.py:212] Refilling line 0x0
318 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x0 data=0x0 sel=0xf write=0
321 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x108f err=0
321 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x1 data=0x0 sel=0xf write=0
323 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x2083 err=0
323 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x2 data=0x0 sel=0xf write=0
325 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x8fe85073 err=0
325 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x3 data=0x0 sel=0xf write=0
327 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
327 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x4 data=0x0 sel=0xf write=0
329 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
329 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x5 data=0x0 sel=0xf write=0
331 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
331 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x6 data=0x0 sel=0xf write=0
333 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
333 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:195] request addr=0x7 data=0x0 sel=0xf write=0
335 DEBUG bus.wishbone.instr [coreblocks/peripherals/wishbone.py:179] response data=0x0 err=0
336 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:178] [IFU] request pc=0x20
337 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:178] [IFU] request pc=0x30
338 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:136] Sending an instr to the backend pc=0x4 instr=0x2083
338 INFO frontend.fetch [coreblocks/frontend/fetch/fetch.py:136] Sending an instr to the backend pc=0x8 instr=0x8fe85073
340 DEBUG structs.core_counter [coreblocks/priv/traps/instr_counter.py:54] 0 instructions in core
342 DEBUG core_structs.crat [coreblocks/core_structs/crat.py:217] frat write 0 for rl 1 -> rp 2
342 DEBUG core_structs.crat [coreblocks/core_structs/crat.py:223] frat rename 0 r_s1: 0 -> 0 r_s2 0 -> 0 tag 0x0 [0] (1)
342 DEBUG core_structs.crat [coreblocks/core_structs/crat.py:223] frat rename 1 r_s1: 0 -> 0 r_s2 0 -> 0 tag 0x0 [0] (1)
344 DEBUG backend.rs.3 [coreblocks/func_blocks/fu/common/rs.py:157] inserted entry 0, rob_id 0x1, s1: p0 v 0x0, s2: p0 v 0x0
345 DEBUG backend.rs.3 [coreblocks/func_blocks/fu/common/rs.py:188] taken entry 0 at idx 0, rob_id 0x1, rp_dst p2
345 DEBUG backend.lsu.dummylsu [coreblocks/func_blocks/fu/lsu/dummyLsu.py:85] issue rob_id=1 funct3=2 op_type=4
347 DEBUG bus.wishbone.data [coreblocks/peripherals/wishbone.py:195] request addr=0x0 data=0x0 sel=0xf write=0
347 DEBUG backend.lsu.requester [coreblocks/func_blocks/fu/lsu/lsu_requester.py:128] issue addr=0x00000000 data=0x00000000 funct3=2 store=0 aligned=1
350 DEBUG bus.wishbone.data [coreblocks/peripherals/wishbone.py:179] response data=0x108f err=0
350 DEBUG backend.announcement [coreblocks/backend/announcement.py:65] announce p2 = 0x108f for rob_id 0x1
350 DEBUG backend.lsu.dummylsu [coreblocks/func_blocks/fu/lsu/dummyLsu.py:186] accept rob_id=1 result=0x0000108f exception=0
350 DEBUG backend.lsu.requester [coreblocks/func_blocks/fu/lsu/lsu_requester.py:163] accept data=0x0000108f exception=0 cause=0
351 ERROR core_structs.rf [coreblocks/core_structs/rf.py:102] Invalid register 1 freed
```