### PR TITLE
Align regression ELF segments to 64B

### DIFF
--- a/test/external/embench/common/link.ld
+++ b/test/external/embench/common/link.ld
@@ -17,10 +17,12 @@ SECTIONS
 
   .text : {
     *(.text .text.*)
+    . = ALIGN(0x40);
   } >imem
 
   .rodata : {
     *(.rodata .rodata.*)
+    . = ALIGN(0x40);
   } >dmem
 
   .data :
@@ -56,7 +58,7 @@ SECTIONS
   .stack : {
     __stack_end = .;
     . += _STACK_SIZE;
-    . = ALIGN(16);
+    . = ALIGN(0x40);
     __stack_top = .;
   } >dmem
 

--- a/test/external/riscv-arch-test/coreblocks/coreblocks-full/link.ld
+++ b/test/external/riscv-arch-test/coreblocks/coreblocks-full/link.ld
@@ -37,11 +37,12 @@ SECTIONS
     __bss_end = .;
   } > ram
 
-  . = ALIGN(16);
-  __stack_bottom = .;
-  . += __stack_size * __num_harts;
-  . = ALIGN(0x40);
-  __stack_top = .;
+  .stack (NOLOAD) : {
+    __stack_bottom = .;
+    . += __stack_size * __num_harts;
+    . = ALIGN(0x40);
+    __stack_top = .;
+  } > ram
 
   . = ALIGN(0x1000);
   .text.rvmodel . : { *(.text.rvmodel) *(.text.rvmodel.*) *(.text) *(.text.*) . = ALIGN(0x40); } > ram

--- a/test/external/riscv-arch-test/coreblocks/coreblocks-full/link.ld
+++ b/test/external/riscv-arch-test/coreblocks/coreblocks-full/link.ld
@@ -23,10 +23,10 @@ SECTIONS
   ASSERT(TEST_BASE >= ORIGIN(ram) && TEST_BASE < ORIGIN(ram) + LENGTH(ram), "TEST_BASE is outside RAM; update TEST_BASE and RAM_ORIGIN/RAM_LENGTH in link.ld, and the matching memory.regions entry in sail.json")
 
   .text.init   TEST_BASE : { *(.text.init) } > ram
-  .text.rvtest . : { *(.text.rvtest) *(.text.rvtest.*) } > ram
+  .text.rvtest . : { *(.text.rvtest) *(.text.rvtest.*) . = ALIGN(0x40); } > ram
 
   . = ALIGN(0x4000);
-  .rodata . : { *(.rodata) *(.rodata.*) *(.srodata) *(.srodata.*) } > ram
+  .rodata . : { *(.rodata) *(.rodata.*) *(.srodata) *(.srodata.*) . = ALIGN(0x40); } > ram
   .data   . : { *(.data) *(.data.*) *(.sdata) *(.sdata.*) } > ram
 
   . = ALIGN(16);
@@ -43,7 +43,7 @@ SECTIONS
   __stack_top = .;
 
   . = ALIGN(0x1000);
-  .text.rvmodel . : { *(.text.rvmodel) *(.text.rvmodel.*) *(.text) *(.text.*) } > ram
+  .text.rvmodel . : { *(.text.rvmodel) *(.text.rvmodel.*) *(.text) *(.text.*) . = ALIGN(0x40); } > ram
 
   . = ALIGN(0x1000);
   _end = .;

--- a/test/external/riscv-arch-test/coreblocks/coreblocks-full/link.ld
+++ b/test/external/riscv-arch-test/coreblocks/coreblocks-full/link.ld
@@ -40,6 +40,7 @@ SECTIONS
   . = ALIGN(16);
   __stack_bottom = .;
   . += __stack_size * __num_harts;
+  . = ALIGN(0x40);
   __stack_top = .;
 
   . = ALIGN(0x1000);

--- a/test/external/riscv-tests/Makefile
+++ b/test/external/riscv-tests/Makefile
@@ -21,7 +21,7 @@ RISCV_GCC_OPTS ?= -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostart
 
 define compile_template
 
-test-$(1)-%: $${ISA_TESTS_DIR}/$(1)/%.S
+test-$(1)-%: $${ISA_TESTS_DIR}/$(1)/%.S $${ENV_DIR}/link.ld
 	$${RISCV_GCC} $${RISCV_GCC_OPTS} $(2) -I$${ISA_TESTS_DIR}/macros/scalar -I$${ENV_DIR} -T$${ENV_DIR}/link.ld $$< -o $$@
 
 endef

--- a/test/external/riscv-tests/environment/custom/link.ld
+++ b/test/external/riscv-tests/environment/custom/link.ld
@@ -7,20 +7,11 @@ MEMORY
     data (wxa!ri) : ORIGIN = 0x90000000, LENGTH = 128K
 }
 
-PHDRS
-{
-  text PT_LOAD;
-  data_init PT_LOAD;
-  data PT_NULL;
-}
-
 SECTIONS
 {
-  .text.init : { *(.text.init) } >text AT>text :text
-  . = ALIGN(0x1000);
-  .text : { *(.text) } >text AT>text :text
-  . = ALIGN(0x1000);
-  .data : { *(.data) } >data AT>data :data_init
-  .bss : { *(.bss) } >data AT>data :data
+  .text.init : { *(.text.init) } >text
+  .text : { *(.text .text.*) . = ALIGN(0x40); } >text
+  .data : { *(.data .data.*) } >data
+  .bss : { *(.bss .bss.*) . = ALIGN(0x40); } >data
   _end = .;
 }

--- a/test/regression/memory.py
+++ b/test/regression/memory.py
@@ -5,8 +5,6 @@ from typing import Optional, TypeVar
 from dataclasses import dataclass, replace
 from elftools.elf.constants import P_FLAGS
 from elftools.elf.elffile import ELFFile, Segment
-from coreblocks.params.configurations import CoreConfiguration
-from transactron.utils import align_to_power_of_two, align_down_to_power_of_two
 
 all = [
     "ReplyStatus",
@@ -145,7 +143,6 @@ class CoreMemoryModel:
 def load_segment(
     segment: Segment,
     *,
-    do_workarounds: bool = True,
     disable_write_protection: bool = False,
     force_executable: bool = False,
 ) -> RandomAccessMemory:
@@ -155,6 +152,9 @@ def load_segment(
 
     seg_start = paddr
     seg_end = paddr + memsz
+
+    assert seg_start % 0x40 == 0, f"Segment start {seg_start:#x} is not 64-byte-aligned"
+    assert seg_end % 0x40 == 0, f"Segment end {seg_end:#x} is not 64-byte-aligned"
 
     data = segment.data()
 
@@ -169,32 +169,12 @@ def load_segment(
     if flags_raw & P_FLAGS.PF_X or force_executable:
         flags |= SegmentFlags.EXECUTABLE
 
-    if do_workarounds:
-        config = CoreConfiguration()
-        if flags & SegmentFlags.EXECUTABLE:
-            # align instruction section to full icache lines
-            align_bits = config.icache_line_bytes_log
-            # workaround for fetching/stalling issue
-            extend_end = 2**config.icache_line_bytes_log
-        else:
-            align_bits = 0
-            extend_end = 0
-
-        align_data_front = seg_start - align_down_to_power_of_two(seg_start, align_bits)
-        align_data_back = align_to_power_of_two(seg_end, align_bits) - seg_end + extend_end
-
-        data = b"\x00" * align_data_front + data + b"\x00" * align_data_back
-
-        seg_start = align_down_to_power_of_two(seg_start, align_bits)
-        seg_end = align_to_power_of_two(seg_end, align_bits) + extend_end
-
     return RandomAccessMemory(range(seg_start, seg_end), flags, data)
 
 
 def load_segments_from_elf(
     file_path: str,
     *,
-    do_workarounds: bool = True,
     disable_write_protection: bool = False,
     force_executable: bool = False,
 ) -> list[RandomAccessMemory]:
@@ -208,7 +188,6 @@ def load_segments_from_elf(
             segments.append(
                 load_segment(
                     segment,
-                    do_workarounds=do_workarounds,
                     disable_write_protection=disable_write_protection,
                     force_executable=force_executable,
                 )

--- a/test/regression/test_arch_regression.py
+++ b/test/regression/test_arch_regression.py
@@ -132,7 +132,6 @@ async def run_arch_elf(sim_backend, elf_path: str | Path, timeout_cycles: int = 
     mem_model, endtest, int_generator = build_memory_model(
         elf_path,
         sim_backend.stop,
-        do_workarounds=False,
         disable_write_protection=re.match("Zifencei", elf_path.name) is not None,
         force_executable=True,
     )


### PR DESCRIPTION
It seems reasonable to assume that ELF segment boundaries should be aligned to the cache line size. This way, we can remove the ad hoc alignment adjustments used to work around icache issues.