### PR TITLE
arch: narrow CfiType to the CFI type alone & add return-address-stack action

### DIFF
--- a/coreblocks/arch/optypes.py
+++ b/coreblocks/arch/optypes.py
@@ -9,6 +9,7 @@ __all__ = [
     "OpType",
     "impure_optypes",
     "CfiType",
+    "RasAction",
 ]
 
 
@@ -66,43 +67,35 @@ impure_optypes = frozenset(optype for optype in range(OpType.JAL, OpType.ARITHME
 
 
 @unique
-class CfiType(Enum, shape=3):
+class CfiType(Enum, shape=2):
     """
     Types of control flow instructions.
-
-    There are 4 main types: invalid, branch, JAL, and JALR. CALL and RET are
-    just special cases of respectively JAL and JALR and thus the encoding
-    was chosen in the way that it is sufficient to check the lowest two bits to
-    get the main type and the third bit is just a hint about the specialized type.
-
-    Because of these encoding tweaks, helper functions should be preferred to use
-    to get the CFI type.
     """
 
-    INVALID = 0b000  # Not a CFI
-    BRANCH = 0b001
+    INVALID = 0b00  # Not a CFI
+    BRANCH = 0b01
+    JALR = 0b10  # Jump and Link Register
+    JAL = 0b11  # Jump and Link
 
-    JALR = 0b010  # Jump and Link Register
-    RET = 0b110  # Return from a function (JALR with rs1 equal to x1 or x5)
 
-    JAL = 0b011  # Jump and Link
-    CALL = 0b111  # Call a function (JAL with rd equal to x1 or x5))
+@unique
+class RasAction(Enum, shape=2):
+    """
+    Effect a control flow instruction has on the return address stack.
+    """
 
-    @staticmethod
-    def valid(val: ValueLike) -> Value:
-        return Value.cast(val)[0:2] != CfiType.INVALID
-
-    @staticmethod
-    def is_branch(val: ValueLike) -> Value:
-        return Value.cast(val)[0:2] == CfiType.BRANCH
-
-    @staticmethod
-    def is_jal(val: ValueLike) -> Value:
-        return Value.cast(val)[0:2] == CfiType.JAL
+    NONE = 0b00
+    POP = 0b01  # a return: jumps to the address on top of the stack
+    PUSH = 0b10  # a call: leaves its own return address on the stack
+    POP_AND_PUSH = 0b11  # returns and calls at once, e.g. jalr x1, 0(x5)
 
     @staticmethod
-    def is_jalr(val: ValueLike) -> Value:
-        return Value.cast(val)[0:2] == CfiType.JALR
+    def has_push(val: ValueLike) -> Value:
+        return Value.cast(val)[1]
+
+    @staticmethod
+    def has_pop(val: ValueLike) -> Value:
+        return Value.cast(val)[0]
 
 
 #

--- a/coreblocks/arch/optypes.py
+++ b/coreblocks/arch/optypes.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from amaranth.lib.enum import unique, Enum, IntEnum, auto
+from amaranth.lib.enum import unique, Enum, Flag, IntEnum, auto
 
 from amaranth_types import ValueLike
 
@@ -78,8 +78,7 @@ class CfiType(Enum, shape=2):
     JAL = 0b11  # Jump and Link
 
 
-@unique
-class RasAction(Enum, shape=2):
+class RasAction(Flag, shape=2):
     """
     Effect a control flow instruction has on the return address stack.
     """
@@ -87,7 +86,7 @@ class RasAction(Enum, shape=2):
     NONE = 0b00
     POP = 0b01  # a return: jumps to the address on top of the stack
     PUSH = 0b10  # a call: leaves its own return address on the stack
-    POP_AND_PUSH = 0b11  # returns and calls at once, e.g. jalr x1, 0(x5)
+    POP_AND_PUSH = POP | PUSH  # returns and calls at once, e.g. jalr x1, 0(x5)
 
     @staticmethod
     def has_push(val: ValueLike) -> Value:

--- a/coreblocks/frontend/bpu/bpu.py
+++ b/coreblocks/frontend/bpu/bpu.py
@@ -69,7 +69,7 @@ class BranchPredictionUnit(Elaboratable):
                 pred.cfi_target_valid.eq(hit),
                 pred.cfi_idx.eq(Mux(hit, prediction.cfi_idx, 0)),
                 pred.cfi_type.eq(Mux(hit, prediction.cfi_type, CfiType.INVALID)),
-                pred.branch_mask.eq(Mux(hit & CfiType.is_branch(prediction.cfi_type), 1 << prediction.cfi_idx, 0)),
+                pred.branch_mask.eq(Mux(hit & (prediction.cfi_type == CfiType.BRANCH), 1 << prediction.cfi_idx, 0)),
             ]
             self.write_prediction(m, pc=next_pc, ftq_ptr=stage.ftq_ptr, prediction=pred)
 

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -425,7 +425,7 @@ class FetchUnit(Elaboratable):
 
             # Is there any control flow instruction that we should follow?
             cfi_followed = Signal()
-            m.d.av_comb += cfi_followed.eq(CfiType.valid(predcheck_res.cfi_type))
+            m.d.av_comb += cfi_followed.eq(predcheck_res.cfi_type != CfiType.INVALID)
 
             # The point where control leaves the block (its "exit")
             # If we didn't follow any CFI, then our exit point is the last instruction
@@ -444,7 +444,7 @@ class FetchUnit(Elaboratable):
             # can't redirect - we stall until the backend executes it instead
             eff_cfi_valid = Signal()
             eff_redirect_target = Signal(self.gen_params.isa.xlen)
-            m.d.av_comb += eff_cfi_valid.eq(~CfiType.is_jalr(predcheck_res.cfi_type))
+            m.d.av_comb += eff_cfi_valid.eq(predcheck_res.cfi_type != CfiType.JALR)
             m.d.av_comb += eff_redirect_target.eq(exit_target)
 
             mispredict = Signal()
@@ -475,10 +475,10 @@ class FetchUnit(Elaboratable):
             #  - a branch always is,
             #  - a JALR only when the frontend followed a prediction; otherwise fetch stalls on
             #    it and the backend resolves it by resuming the frontend instead
-            branch_mask = Cat(CfiType.is_branch(instr.cfi_type) for instr in predecoded_instr)
+            branch_mask = Cat(instr.cfi_type == CfiType.BRANCH for instr in predecoded_instr)
             followed_jalr = Signal()
             commit_checkpoint_mask = Signal(fetch_width)
-            m.d.av_comb += followed_jalr.eq(cfi_followed & ~stall_core & CfiType.is_jalr(predcheck_res.cfi_type))
+            m.d.av_comb += followed_jalr.eq(cfi_followed & ~stall_core & (predcheck_res.cfi_type == CfiType.JALR))
             m.d.av_comb += commit_checkpoint_mask.eq(Mux(fault_any, 0, branch_mask | (followed_jalr << exit_idx)))
 
             # Aggregate all signals that will be sent out of the fetch unit.
@@ -521,7 +521,7 @@ class FetchUnit(Elaboratable):
                 # INVALID) steers to the next sequential block, so this whole block is on-path
                 # and the carry must be re-established instead.
                 if Extension.ZCA in self.gen_params.isa.extensions:
-                    with m.If(redirect & s1_data.ends_mid_instr & ~CfiType.valid(predcheck_res.cfi_type)):
+                    with m.If(redirect & s1_data.ends_mid_instr & (predcheck_res.cfi_type == CfiType.INVALID)):
                         m.d.sync += [
                             prev_half_v.eq(1),
                             prev_half.eq(s1_data.last_half),
@@ -591,6 +591,15 @@ class Predecoder(Elaboratable):
             rd = instr[7:12]
             rs1 = instr[15:20]
 
+            # The section "Return-address stack prediction hints” of RISC-V specification
+            # says that x1 and x5 are treated specially as link registers for return-address prediction.
+            rd_is_link = Signal()
+            rs1_is_link = Signal()
+            m.d.av_comb += [
+                rd_is_link.eq((rd == Registers.X1) | (rd == Registers.X5)),
+                rs1_is_link.eq((rs1 == Registers.X1) | (rs1 == Registers.X5)),
+            ]
+
             bimm = Signal(signed(13))
             jimm = Signal(signed(21))
             iimm = Signal(signed(12))
@@ -608,20 +617,26 @@ class Predecoder(Elaboratable):
                     m.d.av_comb += ret.cfi_type.eq(CfiType.BRANCH)
                     m.d.av_comb += ret.cfi_offset.eq(bimm)
                 with m.Case(Opcode.JAL):
-                    m.d.av_comb += ret.cfi_type.eq(
-                        Mux((rd == Registers.X1) | (rd == Registers.X5), CfiType.CALL, CfiType.JAL)
-                    )
+                    m.d.av_comb += ret.cfi_type.eq(CfiType.JAL)
                     m.d.av_comb += ret.cfi_offset.eq(jimm)
+                    m.d.av_comb += ret.ras_action.eq(Mux(rd_is_link, RasAction.PUSH, RasAction.NONE))
                 with m.Case(Opcode.JALR):
-                    m.d.av_comb += ret.cfi_type.eq(
-                        Mux((rs1 == Registers.X1) | (rs1 == Registers.X5), CfiType.RET, CfiType.JALR)
-                    )
+                    m.d.av_comb += ret.cfi_type.eq(CfiType.JALR)
                     m.d.av_comb += ret.cfi_offset.eq(iimm)
+                    with m.If(rd_is_link & rs1_is_link & (rd != rs1)):
+                        m.d.av_comb += ret.ras_action.eq(RasAction.POP_AND_PUSH)
+                    with m.Elif(rd_is_link):
+                        m.d.av_comb += ret.ras_action.eq(RasAction.PUSH)
+                    with m.Elif(rs1_is_link):
+                        m.d.av_comb += ret.ras_action.eq(RasAction.POP)
+                    with m.Else():
+                        m.d.av_comb += ret.ras_action.eq(RasAction.NONE)
                 with m.Default():
                     m.d.av_comb += ret.cfi_type.eq(CfiType.INVALID)
 
             with m.If(quadrant != 0b11):
                 m.d.av_comb += ret.cfi_type.eq(CfiType.INVALID)
+                m.d.av_comb += ret.ras_action.eq(RasAction.NONE)
 
             m.d.av_comb += ret.unsafe.eq(
                 (opcode == Opcode.SYSTEM) | ((opcode == Opcode.MISC_MEM) & (funct3 == Funct3.FENCEI))
@@ -693,10 +708,10 @@ class PredictionChecker(Elaboratable):
                 # taken. This prediction will be used if the branch prediction unit
                 # didn't detect the branch at all.
                 m.d.av_comb += decoded_redirections[i].eq(
-                    CfiType.is_jal(predecoded[i].cfi_type)
-                    | CfiType.is_jalr(predecoded[i].cfi_type)
+                    (predecoded[i].cfi_type == CfiType.JAL)
+                    | (predecoded[i].cfi_type == CfiType.JALR)
                     | (
-                        CfiType.is_branch(predecoded[i].cfi_type)
+                        (predecoded[i].cfi_type == CfiType.BRANCH)
                         & ~prediction.branch_mask[i]
                         & (predecoded[i].cfi_offset < 0)
                     )
@@ -747,8 +762,8 @@ class PredictionChecker(Elaboratable):
             )
 
             preceding_redirection = ~pd_redirection_enc.n & (
-                ((CfiType.valid(prediction.cfi_type) & (pd_redirect_idx < prediction.cfi_idx)))
-                | ~CfiType.valid(prediction.cfi_type)
+                ((prediction.cfi_type != CfiType.INVALID) & (pd_redirect_idx < prediction.cfi_idx))
+                | (prediction.cfi_type == CfiType.INVALID)
             )
 
             decoded_cfi_type_at_pred = mux(
@@ -757,13 +772,13 @@ class PredictionChecker(Elaboratable):
                 CfiType.INVALID,
             )
 
-            mispredicted_cfi_type = CfiType.valid(prediction.cfi_type) & (
+            mispredicted_cfi_type = (prediction.cfi_type != CfiType.INVALID) & (
                 prediction.cfi_type != decoded_cfi_type_at_pred
             )
 
-            mispredicted_cfi_target = (CfiType.is_branch(prediction.cfi_type) | CfiType.is_jal(prediction.cfi_type)) & (
-                ~prediction.cfi_target_valid | (decoded_target_for_predicted_cfi != prediction.cfi_target)
-            )
+            mispredicted_cfi_target = (
+                (prediction.cfi_type == CfiType.BRANCH) | (prediction.cfi_type == CfiType.JAL)
+            ) & (~prediction.cfi_target_valid | (decoded_target_for_predicted_cfi != prediction.cfi_target))
 
             ret = Signal.like(self.check.data_out)
 

--- a/coreblocks/frontend/fetch/fetch.py
+++ b/coreblocks/frontend/fetch/fetch.py
@@ -623,14 +623,10 @@ class Predecoder(Elaboratable):
                 with m.Case(Opcode.JALR):
                     m.d.av_comb += ret.cfi_type.eq(CfiType.JALR)
                     m.d.av_comb += ret.cfi_offset.eq(iimm)
-                    with m.If(rd_is_link & rs1_is_link & (rd != rs1)):
-                        m.d.av_comb += ret.ras_action.eq(RasAction.POP_AND_PUSH)
-                    with m.Elif(rd_is_link):
-                        m.d.av_comb += ret.ras_action.eq(RasAction.PUSH)
-                    with m.Elif(rs1_is_link):
-                        m.d.av_comb += ret.ras_action.eq(RasAction.POP)
-                    with m.Else():
-                        m.d.av_comb += ret.ras_action.eq(RasAction.NONE)
+                    m.d.av_comb += ret.ras_action.eq(
+                        Mux(rd_is_link, RasAction.PUSH, RasAction.NONE)
+                        | Mux(rs1_is_link & (rd != rs1), RasAction.POP, RasAction.NONE)
+                    )
                 with m.Default():
                     m.d.av_comb += ret.cfi_type.eq(CfiType.INVALID)
 

--- a/coreblocks/frontend/ftq.py
+++ b/coreblocks/frontend/ftq.py
@@ -159,7 +159,9 @@ class FetchTargetQueue(Elaboratable):
         self.dep_manager.add_dependency(BranchResolveKey(), self.resolve)
         self.dep_manager.add_dependency(FTQCommitKey(), self.commit)
 
-        self.perf_mispredictions = HwCounter("frontend.ftq.mispredictions", "Number of committed branch mispredictions")
+        self.perf_mispredictions = TaggedCounter(
+            "frontend.ftq.mispredictions", "Number of committed branch mispredictions", tags=CfiType
+        )
 
     def elaborate(self, platform):
         m = TModule()
@@ -287,7 +289,7 @@ class FetchTargetQueue(Elaboratable):
                 m,
                 addr=ftq_ptr.ptr,
                 data={
-                    "valid": CfiType.valid(cfi_type) & ~stall,
+                    "valid": (cfi_type != CfiType.INVALID) & ~stall,
                     "cfi_idx": cfi_idx,
                     "cfi_target": cfi_target,
                 },
@@ -312,7 +314,7 @@ class FetchTargetQueue(Elaboratable):
                 # At most one CFI per block mispredicts and `resolve` keeps the oldest one,
                 # so each committed misprediction is counted once.
                 with m.If(status.mispredict):
-                    self.perf_mispredictions.incr(m)
+                    self.perf_mispredictions.incr(m, record.cfi_type)
                     m_csr.hpm_event_report(m, events=1 << HPMEvent.BRANCH_MISPREDICTION)
 
                 self.bpu_update(

--- a/coreblocks/interface/layouts.py
+++ b/coreblocks/interface/layouts.py
@@ -164,6 +164,9 @@ class CommonLayoutFields:
         self.cfi_type: LayoutListField = ("cfi_type", CfiType)
         """Type of a CFI instruction"""
 
+        self.ras_action: LayoutListField = ("ras_action", RasAction)
+        """Effect a CFI instruction has on the return address stack."""
+
         self.branch_mask: LayoutListField = ("branch_mask", gen_params.fetch_width)
         """A mask denoting which instruction in a fetch blocks is a branch."""
 
@@ -737,7 +740,9 @@ class FetchLayouts:
         # (or have already been) committed before the instruction the core is being redirected to.
         self.backend_redirect = make_layout(fields.ftq_ptr, fields.pc)
 
-        self.predecoded_instr = make_layout(fields.cfi_type, ("cfi_offset", signed(21)), ("unsafe", 1))
+        self.predecoded_instr = make_layout(
+            fields.cfi_type, fields.ras_action, ("cfi_offset", signed(21)), ("unsafe", 1)
+        )
 
         self.bpu_prediction = make_layout(
             fields.branch_mask, fields.cfi_idx, fields.cfi_type, fields.cfi_target, ("cfi_target_valid", 1)

--- a/test/frontend/test_fetch.py
+++ b/test/frontend/test_fetch.py
@@ -750,7 +750,12 @@ class TestPredictionChecker(TestCaseWithSimulator):
         for _ in range(self.gen_params.fetch_width - len(predecoded)):
             predecoded.append((CfiType.INVALID, 0))
         predecoded_raw = [
-            {"cfi_type": predecoded[i][0], "cfi_offset": predecoded[i][1], "unsafe": 0}
+            {
+                "cfi_type": predecoded[i][0],
+                "ras_action": RasAction.NONE,
+                "cfi_offset": predecoded[i][1],
+                "unsafe": 0,
+            }
             for i in range(self.gen_params.fetch_width)
         ]
 

--- a/test/frontend/test_predecoder.py
+++ b/test/frontend/test_predecoder.py
@@ -1,0 +1,67 @@
+import pytest
+
+from transactron.testing import TestCaseWithSimulator, SimpleTestCircuit, TestbenchContext
+
+from coreblocks.arch import CfiType, Funct3, Opcode, RasAction, Registers
+from coreblocks.frontend.fetch.fetch import Predecoder
+from coreblocks.params import GenParams
+from coreblocks.params import configurations
+from coreblocks.params.instr import BTypeInstr, ITypeInstr, JTypeInstr
+
+
+def jal(rd: Registers) -> int:
+    return JTypeInstr(opcode=Opcode.JAL, rd=rd, imm=0).encode()
+
+
+def jalr(rd: Registers, rs1: Registers) -> int:
+    return ITypeInstr(opcode=Opcode.JALR, funct3=Funct3.JALR, rd=rd, rs1=rs1, imm=0).encode()
+
+
+def beq(rs1: Registers, rs2: Registers) -> int:
+    return BTypeInstr(opcode=Opcode.BRANCH, funct3=Funct3.BEQ, rs1=rs1, rs2=rs2, imm=0).encode()
+
+
+NOP = ITypeInstr(opcode=Opcode.OP_IMM, funct3=Funct3.ADD, rd=Registers.ZERO, rs1=Registers.ZERO, imm=0).encode()
+
+X0, X1, X5, X6 = Registers.X0, Registers.X1, Registers.X5, Registers.X6
+
+
+class TestPredecoderRasAction(TestCaseWithSimulator):
+    """The cases below are the RAS hint table from the unprivileged specification"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, fixture_initialize_testing_env):
+        self.gen_params = GenParams(configurations.test)
+        self.m = SimpleTestCircuit(Predecoder(self.gen_params))
+
+    @pytest.mark.parametrize(
+        "instr, cfi_type, ras_action",
+        [
+            pytest.param(jal(X0), CfiType.JAL, RasAction.NONE, id="jal-no-link"),
+            pytest.param(jal(X1), CfiType.JAL, RasAction.PUSH, id="jal-x1"),
+            pytest.param(jal(X5), CfiType.JAL, RasAction.PUSH, id="jal-x5"),
+            pytest.param(jal(X6), CfiType.JAL, RasAction.NONE, id="jal-non-link-rd"),
+            pytest.param(jalr(X0, X6), CfiType.JALR, RasAction.NONE, id="jalr-neither"),
+            pytest.param(jalr(X0, X1), CfiType.JALR, RasAction.POP, id="jalr-ret"),
+            pytest.param(jalr(X0, X5), CfiType.JALR, RasAction.POP, id="jalr-ret-x5"),
+            pytest.param(jalr(X1, X6), CfiType.JALR, RasAction.PUSH, id="jalr-indirect-call"),
+            pytest.param(jalr(X1, X5), CfiType.JALR, RasAction.POP_AND_PUSH, id="jalr-coroutine"),
+            pytest.param(jalr(X5, X1), CfiType.JALR, RasAction.POP_AND_PUSH, id="jalr-coroutine-swapped"),
+            # Reading and writing one register cancels out
+            pytest.param(jalr(X1, X1), CfiType.JALR, RasAction.PUSH, id="jalr-same-link-reg"),
+            pytest.param(jalr(X5, X5), CfiType.JALR, RasAction.PUSH, id="jalr-same-link-reg-x5"),
+            # Nothing else touches the stack
+            pytest.param(beq(X1, X5), CfiType.BRANCH, RasAction.NONE, id="branch"),
+            pytest.param(NOP, CfiType.INVALID, RasAction.NONE, id="nop"),
+            # Compressed instructions are not predecoded at all
+            pytest.param(0x8082, CfiType.INVALID, RasAction.NONE, id="compressed-ret"),
+        ],
+    )
+    def test_ras_action(self, instr: int, cfi_type: CfiType, ras_action: RasAction):
+        async def proc(sim: TestbenchContext):
+            res = await self.m.predecode.call(sim, instr=instr)
+            assert res["cfi_type"] == cfi_type
+            assert res["ras_action"] == ras_action
+
+        with self.run_simulation(self.m) as sim:
+            sim.add_testbench(proc)


### PR DESCRIPTION
`CfiType` currently packs two orthogonal facts into one enum: what kind of CFI an instruction is, and whether it acts on the return address stack. This PR narrows `CfiType` to the four real CFI types and moves the stack effect into a separate `RasAction` field.