### PR TITLE
Instr decoding fixes

### DIFF
--- a/coreblocks/frontend/decoder/instr_decoder.py
+++ b/coreblocks/frontend/decoder/instr_decoder.py
@@ -223,6 +223,7 @@ class InstrDecoder(Elaboratable):
 
         rd_invalid = Signal()
         rs1_invalid = Signal()
+        rs2_invalid = Signal()
 
         m.d.comb += self.optype.eq(OpType.UNKNOWN)
 
@@ -237,6 +238,7 @@ class InstrDecoder(Elaboratable):
                 & (self.funct12 == enc.funct12 if enc.funct12 is not None else 1)
                 & (self.rd == 0 if enc.rd_zero else 1)
                 & (self.rs1 == 0 if enc.rs1_zero else 1)
+                & (self.rs2 == 0 if enc.rs2_zero else 1)
             ):
                 m.d.comb += self.optype.eq(encoding_to_optype[enc])
 
@@ -245,6 +247,7 @@ class InstrDecoder(Elaboratable):
 
                 m.d.comb += rd_invalid.eq(enc.rd_zero)
                 m.d.comb += rs1_invalid.eq(enc.rs1_zero)
+                m.d.comb += rs2_invalid.eq(enc.rs2_zero or enc.funct12 is not None)
 
                 m.d.comb += self.funct3_v.eq(enc.funct3 is not None)
                 m.d.comb += self.funct7_v.eq(enc.funct7 is not None)
@@ -255,8 +258,18 @@ class InstrDecoder(Elaboratable):
         m.d.comb += [
             self.rd_v.eq(reduce(or_, (instruction_type == t for t in _rd_itypes)) & ~rd_invalid),
             self.rs1_v.eq(reduce(or_, (instruction_type == t for t in _rs1_itypes)) & ~rs1_invalid),
-            self.rs2_v.eq(reduce(or_, (instruction_type == t for t in _rs2_itypes)) & ~self.funct12_v),
+            self.rs2_v.eq(reduce(or_, (instruction_type == t for t in _rs2_itypes)) & ~rs2_invalid),
         ]
+
+        with m.If(self.optype == OpType.FENCEI):
+            # The unused fields in the FENCE.I instruction, funct12, rs1, and rd, are
+            # reserved for finer-grain fences in future extensions. For forward compatibility,
+            # base implementations shall ignore these fields, and standard software shall zero these fields.
+            m.d.comb += [
+                self.rd_v.eq(0),
+                self.rs1_v.eq(0),
+                self.rs2_v.eq(0),
+            ]
 
         # Immediate
 

--- a/coreblocks/frontend/decoder/instr_description.py
+++ b/coreblocks/frontend/decoder/instr_description.py
@@ -38,6 +38,7 @@ class Encoding:
     instr_type_override: Optional[InstrType] = None
     rd_zero: bool = False
     rs1_zero: bool = False
+    rs2_zero: bool = False
 
 
 #
@@ -224,7 +225,7 @@ instructions_by_optype = {
         Encoding(Opcode.AMO, Funct3.W, Funct7.AMOMIN),
     ],
     OpType.ATOMIC_LR_SC: [
-        Encoding(Opcode.AMO, Funct3.W, Funct7.LR),
+        Encoding(Opcode.AMO, Funct3.W, Funct7.LR, rs2_zero=True),
         Encoding(Opcode.AMO, Funct3.W, Funct7.SC),
     ],
 }

--- a/test/frontend/test_instr_decoder.py
+++ b/test/frontend/test_instr_decoder.py
@@ -112,7 +112,10 @@ class TestDecoder(TestCaseWithSimulator):
         InstrTest(0x00100073, Opcode.SYSTEM, Funct3.PRIV, funct12=Funct12.EBREAK, op=OpType.EBREAK),
     ]
     DECODER_TESTS_ZIFENCEI = [
-        InstrTest(0x0000100F, Opcode.MISC_MEM, Funct3.FENCEI, rd=0, rs1=0, imm=0, op=OpType.FENCEI),
+        InstrTest(0x0000100F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI),
+        InstrTest(0x00001b0F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI), # non-zero rd
+        InstrTest(0x000a100F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI), # non-zero rs1
+        InstrTest(0x1e50100F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI), # non-zero funct12
     ]
     DECODER_TESTS_ZICSR = [
         InstrTest(0x001A9A73, Opcode.SYSTEM, Funct3.CSRRW, rd=20, rs1=21, csr=0x01, op=OpType.CSR_REG),

--- a/test/frontend/test_instr_decoder.py
+++ b/test/frontend/test_instr_decoder.py
@@ -113,9 +113,9 @@ class TestDecoder(TestCaseWithSimulator):
     ]
     DECODER_TESTS_ZIFENCEI = [
         InstrTest(0x0000100F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI),
-        InstrTest(0x00001b0F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI), # non-zero rd
-        InstrTest(0x000a100F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI), # non-zero rs1
-        InstrTest(0x1e50100F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI), # non-zero funct12
+        InstrTest(0x00001B0F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI),  # non-zero rd
+        InstrTest(0x000A100F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI),  # non-zero rs1
+        InstrTest(0x1E50100F, Opcode.MISC_MEM, Funct3.FENCEI, op=OpType.FENCEI),  # non-zero funct12
     ]
     DECODER_TESTS_ZICSR = [
         InstrTest(0x001A9A73, Opcode.SYSTEM, Funct3.CSRRW, rd=20, rs1=21, csr=0x01, op=OpType.CSR_REG),

--- a/test/regression/conftest.py
+++ b/test/regression/conftest.py
@@ -24,8 +24,6 @@ ARCH_EXPECTED_FAIL = {
     "pmpzaamo_cfg_wr",
     # [?] ?????
     "InterruptsU",
-    # coreblocks assertion
-    r"Zifencei-.*",
 }
 
 ARCH_EXPECTED_TIMEOUT = {


### PR DESCRIPTION
closes #1086
closes #1089

With this:
- Zifencei test from riscv-arch-test passes
- ignoring lack of `mcountinhibit` (see #1095) - we pass Ssstrict tests: aka. all instructions and CSRs that are not supported cause instruction illegal exceptions.